### PR TITLE
fix: P0 security critical — auth guards, timing-safe compare, XSS

### DIFF
--- a/src/app/api/activities/route.ts
+++ b/src/app/api/activities/route.ts
@@ -1,11 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDatabase, Activity } from '@/lib/db';
+import { requireRole } from '@/lib/auth'
 
 /**
  * GET /api/activities - Get activity stream or stats
  * Query params: type, actor, entity_type, limit, offset, since, hours (for stats)
  */
 export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
   try {
     const { searchParams, pathname } = new URL(request.url);
     

--- a/src/app/api/agents/[id]/heartbeat/route.ts
+++ b/src/app/api/agents/[id]/heartbeat/route.ts
@@ -16,6 +16,9 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
   try {
     const db = getDatabase();
     const resolvedParams = await params;

--- a/src/app/api/agents/[id]/route.ts
+++ b/src/app/api/agents/[id]/route.ts
@@ -11,6 +11,9 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
   try {
     const db = getDatabase()
     const { id } = await params

--- a/src/app/api/agents/[id]/soul/route.ts
+++ b/src/app/api/agents/[id]/soul/route.ts
@@ -13,6 +13,9 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
   try {
     const db = getDatabase();
     const resolvedParams = await params;

--- a/src/app/api/agents/comms/route.ts
+++ b/src/app/api/agents/comms/route.ts
@@ -1,11 +1,15 @@
 import { NextRequest, NextResponse } from "next/server"
 import { getDatabase, Message } from "@/lib/db"
+import { requireRole } from '@/lib/auth'
 
 /**
  * GET /api/agents/comms - Inter-agent communication stats and timeline
  * Query params: limit, offset, since, agent
  */
 export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
   try {
     const db = getDatabase()
     const { searchParams } = new URL(request.url)

--- a/src/app/api/agents/route.ts
+++ b/src/app/api/agents/route.ts
@@ -11,6 +11,9 @@ import { getUserFromRequest, requireRole } from '@/lib/auth';
  * Query params: status, role, limit, offset
  */
 export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
   try {
     const db = getDatabase();
     const { searchParams } = new URL(request.url);

--- a/src/app/api/auth/access-requests/route.ts
+++ b/src/app/api/auth/access-requests/route.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from 'crypto'
 import { NextRequest, NextResponse } from 'next/server'
-import { createUser, getUserFromRequest } from '@/lib/auth'
+import { createUser, getUserFromRequest , requireRole } from '@/lib/auth'
 import { getDatabase, logAuditEvent } from '@/lib/db'
 
 function makeUsernameFromEmail(email: string): string {
@@ -20,6 +20,9 @@ function ensureUniqueUsername(base: string): string {
 }
 
 export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
   const user = getUserFromRequest(request)
   if (!user || user.role !== 'admin') {
     return NextResponse.json({ error: 'Admin access required' }, { status: 403 })

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -1,9 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getUserFromRequest, updateUser } from '@/lib/auth'
+import { getUserFromRequest, updateUser , requireRole } from '@/lib/auth'
 import { logAuditEvent } from '@/lib/db'
 import { verifyPassword } from '@/lib/password'
 
 export async function GET(request: Request) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
   const user = getUserFromRequest(request)
 
   if (!user) {

--- a/src/app/api/auth/users/route.ts
+++ b/src/app/api/auth/users/route.ts
@@ -1,11 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getUserFromRequest, getAllUsers, createUser, updateUser, deleteUser } from '@/lib/auth'
+import { getUserFromRequest, getAllUsers, createUser, updateUser, deleteUser , requireRole } from '@/lib/auth'
 import { logAuditEvent } from '@/lib/db'
 
 /**
  * GET /api/auth/users - List all users (admin only)
  */
 export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
   const user = getUserFromRequest(request)
   if (!user || user.role !== 'admin') {
     return NextResponse.json({ error: 'Admin access required' }, { status: 403 })

--- a/src/app/api/chat/conversations/route.ts
+++ b/src/app/api/chat/conversations/route.ts
@@ -1,11 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getDatabase } from '@/lib/db'
+import { requireRole } from '@/lib/auth'
 
 /**
  * GET /api/chat/conversations - List conversations derived from messages
  * Query params: agent (filter by participant), limit, offset
  */
 export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
   try {
     const db = getDatabase()
     const { searchParams } = new URL(request.url)

--- a/src/app/api/chat/messages/[id]/route.ts
+++ b/src/app/api/chat/messages/[id]/route.ts
@@ -9,6 +9,9 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
   try {
     const db = getDatabase()
     const { id } = await params

--- a/src/app/api/chat/messages/route.ts
+++ b/src/app/api/chat/messages/route.ts
@@ -96,6 +96,9 @@ function extractReplyText(waitPayload: any): string | null {
  * Query params: conversation_id, from_agent, to_agent, limit, offset, since
  */
 export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
   try {
     const db = getDatabase()
     const { searchParams } = new URL(request.url)

--- a/src/app/api/cron/route.ts
+++ b/src/app/api/cron/route.ts
@@ -131,6 +131,9 @@ function mapOpenClawJob(job: OpenClawCronJob): CronJob {
 }
 
 export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'admin')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
   try {
     const { searchParams } = new URL(request.url)
     const action = searchParams.get('action')

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,4 +1,6 @@
+import { NextRequest , NextResponse } from 'next/server'
 import { eventBus, ServerEvent } from '@/lib/event-bus'
+import { requireRole } from '@/lib/auth'
 
 export const dynamic = 'force-dynamic'
 export const runtime = 'nodejs'
@@ -7,7 +9,10 @@ export const runtime = 'nodejs'
  * GET /api/events - Server-Sent Events stream for real-time DB mutations.
  * Clients connect via EventSource and receive JSON-encoded events.
  */
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
   const encoder = new TextEncoder()
 
   // Cleanup function, set in start(), called in cancel()

--- a/src/app/api/logs/route.ts
+++ b/src/app/api/logs/route.ts
@@ -175,6 +175,9 @@ async function readLogFile(filePath: string, source: string, maxLines: number): 
 }
 
 export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
   try {
     const { searchParams } = new URL(request.url)
     const action = searchParams.get('action') || 'recent'

--- a/src/app/api/notifications/deliver/route.ts
+++ b/src/app/api/notifications/deliver/route.ts
@@ -182,6 +182,9 @@ export async function POST(request: NextRequest) {
  * GET /api/notifications/deliver - Get delivery status and statistics
  */
 export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
   try {
     const db = getDatabase();
     const { searchParams } = new URL(request.url);

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -7,6 +7,9 @@ import { requireRole } from '@/lib/auth';
  * Query params: recipient, unread_only, type, limit, offset
  */
 export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
   try {
     const db = getDatabase();
     const { searchParams } = new URL(request.url);

--- a/src/app/api/pipelines/route.ts
+++ b/src/app/api/pipelines/route.ts
@@ -23,7 +23,10 @@ export interface Pipeline {
 /**
  * GET /api/pipelines - List all pipelines with enriched step data
  */
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
   try {
     const db = getDatabase()
     const pipelines = db.prepare(

--- a/src/app/api/pipelines/run/route.ts
+++ b/src/app/api/pipelines/run/route.ts
@@ -35,6 +35,9 @@ interface PipelineRun {
  * GET /api/pipelines/run - Get pipeline runs
  */
 export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
   try {
     const db = getDatabase()
     const { searchParams } = new URL(request.url)

--- a/src/app/api/quality-review/route.ts
+++ b/src/app/api/quality-review/route.ts
@@ -3,6 +3,9 @@ import { getDatabase, db_helpers } from '@/lib/db'
 import { requireRole } from '@/lib/auth'
 
 export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
   try {
     const db = getDatabase()
     const { searchParams } = new URL(request.url)

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -1,7 +1,11 @@
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { getAllGatewaySessions } from '@/lib/sessions'
+import { requireRole } from '@/lib/auth'
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
   try {
     const gatewaySessions = getAllGatewaySessions()
 

--- a/src/app/api/spawn/route.ts
+++ b/src/app/api/spawn/route.ts
@@ -99,6 +99,9 @@ export async function POST(request: NextRequest) {
 
 // Get spawn history
 export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
   try {
     const { searchParams } = new URL(request.url)
     const limit = parseInt(searchParams.get('limit') || '50')

--- a/src/app/api/standup/route.ts
+++ b/src/app/api/standup/route.ts
@@ -211,10 +211,13 @@ export async function POST(request: NextRequest) {
  * Query params: limit, offset
  */
 export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer');
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status });
+
   try {
     const db = getDatabase();
     const { searchParams } = new URL(request.url);
-    
+
     const limit = parseInt(searchParams.get('limit') || '10');
     const offset = parseInt(searchParams.get('offset') || '0');
     

--- a/src/app/api/status/route.ts
+++ b/src/app/api/status/route.ts
@@ -5,8 +5,12 @@ import { runCommand, runOpenClaw, runClawdbot } from '@/lib/command'
 import { config } from '@/lib/config'
 import { getDatabase } from '@/lib/db'
 import { getAllGatewaySessions, getAgentLiveStatuses } from '@/lib/sessions'
+import { requireRole } from '@/lib/auth'
 
 export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
   try {
     const { searchParams } = new URL(request.url)
     const action = searchParams.get('action') || 'overview'

--- a/src/app/api/tasks/[id]/comments/route.ts
+++ b/src/app/api/tasks/[id]/comments/route.ts
@@ -9,11 +9,14 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const auth = requireRole(request, 'viewer');
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status });
+
   try {
     const db = getDatabase();
     const resolvedParams = await params;
     const taskId = parseInt(resolvedParams.id);
-    
+
     if (isNaN(taskId)) {
       return NextResponse.json({ error: 'Invalid task ID' }, { status: 400 });
     }

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -20,11 +20,14 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const auth = requireRole(request, 'viewer');
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status });
+
   try {
     const db = getDatabase();
     const resolvedParams = await params;
     const taskId = parseInt(resolvedParams.id);
-    
+
     if (isNaN(taskId)) {
       return NextResponse.json({ error: 'Invalid task ID' }, { status: 400 });
     }

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -18,10 +18,13 @@ function hasAegisApproval(db: ReturnType<typeof getDatabase>, taskId: number): b
  * Query params: status, assigned_to, priority, limit, offset
  */
 export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer');
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status });
+
   try {
     const db = getDatabase();
     const { searchParams } = new URL(request.url);
-    
+
     // Parse query parameters
     const status = searchParams.get('status');
     const assigned_to = searchParams.get('assigned_to');

--- a/src/app/api/tokens/route.ts
+++ b/src/app/api/tokens/route.ts
@@ -170,6 +170,9 @@ function filterByTimeframe(records: TokenUsageRecord[], timeframe: string): Toke
 }
 
 export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
   try {
     const { searchParams } = new URL(request.url)
     const action = searchParams.get('action') || 'list'

--- a/src/app/api/workflows/route.ts
+++ b/src/app/api/workflows/route.ts
@@ -21,7 +21,10 @@ export interface WorkflowTemplate {
 /**
  * GET /api/workflows - List all workflow templates
  */
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
   try {
     const db = getDatabase()
     const templates = db.prepare('SELECT * FROM workflow_templates ORDER BY use_count DESC, updated_at DESC').all() as WorkflowTemplate[]

--- a/src/components/panels/memory-browser-panel.tsx
+++ b/src/components/panels/memory-browser-panel.tsx
@@ -321,11 +321,16 @@ export function MemoryBrowserPanel() {
         elements.push(<div key={`${i}-space`} className="mb-2"></div>)
       } else if (trimmedLine.length > 0) {
         if (inList) inList = false
-        // Handle inline formatting
+        // Handle inline formatting — escape HTML entities first to prevent XSS
         let content = trimmedLine
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;')
+          .replace(/'/g, '&#039;')
         // Simple bold formatting
         content = content.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
-        // Simple italic formatting  
+        // Simple italic formatting
         content = content.replace(/\*(.*?)\*/g, '<em>$1</em>')
         
         elements.push(


### PR DESCRIPTION
## Summary
- **#4** — Add `requireRole(request, 'viewer')` auth guards to all 25+ unprotected GET handlers
- **#5** — Add `safeCompare()` using `crypto.timingSafeEqual` to prevent API key timing attacks (Node + Edge middleware)
- **#6** — HTML entity escaping before innerHTML regex in memory browser panel to prevent stored XSS

Closes #4, Closes #5, Closes #6

## Test plan
- [ ] Verify GET endpoints return 401 without valid session/API key
- [ ] Verify timing-safe comparison doesn't break login or API key auth
- [ ] Verify memory browser panel renders markdown-like text without XSS vectors
- [ ] `pnpm typecheck && pnpm build` passes