### PR TITLE
fix: P1 security high — legacy auth, rate limit, SSRF, SQL injection

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -83,23 +83,11 @@ export function middleware(request: NextRequest) {
       return NextResponse.next()
     }
 
-    // Backward compat: accept legacy cookie during migration
-    const legacyCookie = request.cookies.get('mission-control-auth')
-    if (safeCompare(legacyCookie?.value || '', process.env.AUTH_SECRET || '')) {
-      return NextResponse.next()
-    }
-
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
   // Page routes: redirect to login if no session
   if (sessionToken) {
-    return NextResponse.next()
-  }
-
-  // Backward compat: accept legacy cookie
-  const legacyCookie = request.cookies.get('mission-control-auth')
-  if (safeCompare(legacyCookie?.value || '', process.env.AUTH_SECRET || '')) {
     return NextResponse.next()
   }
 

--- a/src/lib/migrations.ts
+++ b/src/lib/migrations.ts
@@ -348,14 +348,14 @@ const migrations: Migration[] = [
         String(process.env.MC_DEFAULT_OWNER_GATEWAY || process.env.MC_DEFAULT_GATEWAY_NAME || 'primary').trim() ||
         'primary'
 
-      db.exec(`
+      db.prepare(`
         UPDATE tenants
         SET owner_gateway = COALESCE(
           (SELECT name FROM gateways ORDER BY is_primary DESC, id ASC LIMIT 1),
-          '${defaultGatewayName.replace(/'/g, "''")}'
+          ?
         )
         WHERE owner_gateway IS NULL OR trim(owner_gateway) = ''
-      `)
+      `).run(defaultGatewayName)
 
       db.exec(`CREATE INDEX IF NOT EXISTS idx_tenants_owner_gateway ON tenants(owner_gateway)`)
     }


### PR DESCRIPTION
## Summary
- **#7** — Remove legacy `mission-control-auth` cookie auth blocks from middleware
- **#8** — Add in-memory IP-based rate limiter to login endpoint (5 attempts/min)
- **#9** — Block SSRF cloud metadata IPs (169.254.x.x) in gateway health probe
- **#10** — Parameterize SQL in migration 013 to prevent SQL injection via `db.prepare().run()`

Closes #7, Closes #8, Closes #9, Closes #10

## Test plan
- [ ] Verify legacy cookie no longer authenticates
- [ ] Verify login rate limiting blocks after 5 rapid attempts from same IP
- [ ] Verify gateway health probe rejects 169.254.x.x URLs but allows localhost
- [ ] Verify migration 013 still creates default gateway correctly
- [ ] `pnpm typecheck && pnpm build` passes