### PR TITLE
chore: P3 cleanup — CoC, templates, DELETE patterns, limits, CSRF

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug Report
+about: Report a bug in Mission Control
+title: '[Bug] '
+labels: bug
+assignees: ''
+---
+
+## Describe the Bug
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+## Expected Behavior
+What you expected to happen.
+
+## Screenshots
+If applicable, add screenshots.
+
+## Environment
+- OS: [e.g. macOS 14]
+- Browser: [e.g. Chrome 120]
+- Mission Control Version: [e.g. 1.0.0]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature Request
+about: Suggest an idea for Mission Control
+title: '[Feature] '
+labels: enhancement
+assignees: ''
+---
+
+## Problem Statement
+A clear description of the problem this feature would solve.
+
+## Proposed Solution
+Describe the solution you'd like.
+
+## Alternatives Considered
+Any alternative solutions or features you've considered.
+
+## Additional Context
+Any other context or screenshots about the feature request.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at conduct@openclaw.dev. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/middleware.ts
+++ b/middleware.ts
@@ -68,6 +68,20 @@ export function middleware(request: NextRequest) {
 
   const { pathname } = request.nextUrl
 
+  // CSRF Origin validation for mutating requests
+  const method = request.method.toUpperCase()
+  if (['POST', 'PUT', 'DELETE', 'PATCH'].includes(method)) {
+    const origin = request.headers.get('origin')
+    if (origin) {
+      let originHost: string
+      try { originHost = new URL(origin).host } catch { originHost = '' }
+      const requestHost = request.headers.get('host') || ''
+      if (originHost && requestHost && originHost !== requestHost.split(',')[0].trim()) {
+        return NextResponse.json({ error: 'CSRF origin mismatch' }, { status: 403 })
+      }
+    }
+  }
+
   // Allow login page and auth API without session
   if (pathname === '/login' || pathname.startsWith('/api/auth/')) {
     return NextResponse.next()

--- a/src/app/api/activities/route.ts
+++ b/src/app/api/activities/route.ts
@@ -38,7 +38,7 @@ async function handleActivitiesRequest(request: NextRequest) {
     const type = searchParams.get('type');
     const actor = searchParams.get('actor');
     const entity_type = searchParams.get('entity_type');
-    const limit = parseInt(searchParams.get('limit') || '50');
+    const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 200);
     const offset = parseInt(searchParams.get('offset') || '0');
     const since = searchParams.get('since'); // Unix timestamp for real-time updates
     

--- a/src/app/api/agents/route.ts
+++ b/src/app/api/agents/route.ts
@@ -21,7 +21,7 @@ export async function GET(request: NextRequest) {
     // Parse query parameters
     const status = searchParams.get('status');
     const role = searchParams.get('role');
-    const limit = parseInt(searchParams.get('limit') || '50');
+    const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 200);
     const offset = parseInt(searchParams.get('offset') || '0');
     
     // Build dynamic query

--- a/src/app/api/auth/users/route.ts
+++ b/src/app/api/auth/users/route.ts
@@ -132,8 +132,9 @@ export async function DELETE(request: NextRequest) {
     return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
   }
 
-  const { searchParams } = new URL(request.url)
-  const id = searchParams.get('id')
+  let body: any
+  try { body = await request.json() } catch { return NextResponse.json({ error: 'Request body required' }, { status: 400 }) }
+  const id = body.id
 
   if (!id) {
     return NextResponse.json({ error: 'User ID is required' }, { status: 400 })

--- a/src/app/api/backup/route.ts
+++ b/src/app/api/backup/route.ts
@@ -87,8 +87,9 @@ export async function DELETE(request: NextRequest) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
 
-  const { searchParams } = new URL(request.url)
-  const name = searchParams.get('name')
+  let body: any
+  try { body = await request.json() } catch { return NextResponse.json({ error: 'Request body required' }, { status: 400 }) }
+  const name = body.name
 
   if (!name || !name.endsWith('.db') || name.includes('/') || name.includes('..')) {
     return NextResponse.json({ error: 'Invalid backup name' }, { status: 400 })

--- a/src/app/api/chat/conversations/route.ts
+++ b/src/app/api/chat/conversations/route.ts
@@ -15,7 +15,7 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url)
 
     const agent = searchParams.get('agent')
-    const limit = parseInt(searchParams.get('limit') || '50')
+    const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 200)
     const offset = parseInt(searchParams.get('offset') || '0')
 
     let query: string

--- a/src/app/api/chat/messages/route.ts
+++ b/src/app/api/chat/messages/route.ts
@@ -106,7 +106,7 @@ export async function GET(request: NextRequest) {
     const conversation_id = searchParams.get('conversation_id')
     const from_agent = searchParams.get('from_agent')
     const to_agent = searchParams.get('to_agent')
-    const limit = parseInt(searchParams.get('limit') || '50')
+    const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 200)
     const offset = parseInt(searchParams.get('offset') || '0')
     const since = searchParams.get('since')
 

--- a/src/app/api/integrations/route.ts
+++ b/src/app/api/integrations/route.ts
@@ -305,13 +305,14 @@ export async function DELETE(request: NextRequest) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
 
-  const { searchParams } = new URL(request.url)
-  const keysParam = searchParams.get('keys')
+  let body: any
+  try { body = await request.json() } catch { return NextResponse.json({ error: 'Request body required' }, { status: 400 }) }
+  const keysParam = Array.isArray(body.keys) ? body.keys.join(',') : body.keys
   if (!keysParam) {
-    return NextResponse.json({ error: 'keys parameter required (comma-separated)' }, { status: 400 })
+    return NextResponse.json({ error: 'keys parameter required (comma-separated string or array)' }, { status: 400 })
   }
 
-  const keysToRemove = new Set(keysParam.split(',').map(k => k.trim()).filter(Boolean))
+  const keysToRemove = new Set<string>(keysParam.split(',').map((k: string) => k.trim()).filter(Boolean))
   if (keysToRemove.size === 0) {
     return NextResponse.json({ error: 'At least one key required' }, { status: 400 })
   }

--- a/src/app/api/logs/route.ts
+++ b/src/app/api/logs/route.ts
@@ -181,7 +181,7 @@ export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url)
     const action = searchParams.get('action') || 'recent'
-    const limit = parseInt(searchParams.get('limit') || '100')
+    const limit = Math.min(parseInt(searchParams.get('limit') || '100'), 200)
     const level = searchParams.get('level')
     const session = searchParams.get('session')
     const search = searchParams.get('search')

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -18,7 +18,7 @@ export async function GET(request: NextRequest) {
     const recipient = searchParams.get('recipient');
     const unread_only = searchParams.get('unread_only') === 'true';
     const type = searchParams.get('type');
-    const limit = parseInt(searchParams.get('limit') || '50');
+    const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 200);
     const offset = parseInt(searchParams.get('offset') || '0');
     
     if (!recipient) {

--- a/src/app/api/pipelines/route.ts
+++ b/src/app/api/pipelines/route.ts
@@ -167,8 +167,9 @@ export async function DELETE(request: NextRequest) {
 
   try {
     const db = getDatabase()
-    const { searchParams } = new URL(request.url)
-    const id = searchParams.get('id')
+    let body: any
+    try { body = await request.json() } catch { return NextResponse.json({ error: 'Request body required' }, { status: 400 }) }
+    const id = body.id
     if (!id) return NextResponse.json({ error: 'Pipeline ID required' }, { status: 400 })
 
     db.prepare('DELETE FROM workflow_pipelines WHERE id = ?').run(parseInt(id))

--- a/src/app/api/pipelines/run/route.ts
+++ b/src/app/api/pipelines/run/route.ts
@@ -43,7 +43,7 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url)
     const pipelineId = searchParams.get('pipeline_id')
     const runId = searchParams.get('id')
-    const limit = parseInt(searchParams.get('limit') || '20')
+    const limit = Math.min(parseInt(searchParams.get('limit') || '20'), 200)
 
     if (runId) {
       const run = db.prepare('SELECT * FROM pipeline_runs WHERE id = ?').get(parseInt(runId)) as PipelineRun | undefined

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -157,8 +157,9 @@ export async function DELETE(request: NextRequest) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
 
-  const { searchParams } = new URL(request.url)
-  const key = searchParams.get('key')
+  let body: any
+  try { body = await request.json() } catch { return NextResponse.json({ error: 'Request body required' }, { status: 400 }) }
+  const key = body.key
 
   if (!key) {
     return NextResponse.json({ error: 'key parameter required' }, { status: 400 })

--- a/src/app/api/spawn/route.ts
+++ b/src/app/api/spawn/route.ts
@@ -104,7 +104,7 @@ export async function GET(request: NextRequest) {
 
   try {
     const { searchParams } = new URL(request.url)
-    const limit = parseInt(searchParams.get('limit') || '50')
+    const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 200)
 
     // In a real implementation, you'd store spawn history in a database
     // For now, we'll try to read recent spawn activity from logs

--- a/src/app/api/standup/route.ts
+++ b/src/app/api/standup/route.ts
@@ -214,7 +214,7 @@ export async function GET(request: NextRequest) {
     const db = getDatabase();
     const { searchParams } = new URL(request.url);
 
-    const limit = parseInt(searchParams.get('limit') || '10');
+    const limit = Math.min(parseInt(searchParams.get('limit') || '10'), 200);
     const offset = parseInt(searchParams.get('offset') || '0');
     
     const standupRows = db.prepare(`

--- a/src/app/api/super/provision-jobs/route.ts
+++ b/src/app/api/super/provision-jobs/route.ts
@@ -13,7 +13,7 @@ export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url)
   const tenant_id = searchParams.get('tenant_id')
   const status = searchParams.get('status') || undefined
-  const limit = parseInt(searchParams.get('limit') || '100', 10)
+  const limit = Math.min(parseInt(searchParams.get('limit') || '100', 10), 200)
 
   const jobs = listProvisionJobs({
     tenant_id: tenant_id ? parseInt(tenant_id, 10) : undefined,

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -29,7 +29,7 @@ export async function GET(request: NextRequest) {
     const status = searchParams.get('status');
     const assigned_to = searchParams.get('assigned_to');
     const priority = searchParams.get('priority');
-    const limit = parseInt(searchParams.get('limit') || '50');
+    const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 200);
     const offset = parseInt(searchParams.get('offset') || '0');
     
     // Build dynamic query

--- a/src/app/api/webhooks/deliveries/route.ts
+++ b/src/app/api/webhooks/deliveries/route.ts
@@ -13,7 +13,7 @@ export async function GET(request: NextRequest) {
     const db = getDatabase()
     const { searchParams } = new URL(request.url)
     const webhookId = searchParams.get('webhook_id')
-    const limit = parseInt(searchParams.get('limit') || '50')
+    const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 200)
     const offset = parseInt(searchParams.get('offset') || '0')
 
     let query = `

--- a/src/app/api/webhooks/route.ts
+++ b/src/app/api/webhooks/route.ts
@@ -146,8 +146,9 @@ export async function DELETE(request: NextRequest) {
 
   try {
     const db = getDatabase()
-    const { searchParams } = new URL(request.url)
-    const id = searchParams.get('id')
+    let body: any
+    try { body = await request.json() } catch { return NextResponse.json({ error: 'Request body required' }, { status: 400 }) }
+    const id = body.id
 
     if (!id) {
       return NextResponse.json({ error: 'Webhook ID is required' }, { status: 400 })

--- a/src/app/api/workflows/route.ts
+++ b/src/app/api/workflows/route.ts
@@ -139,8 +139,9 @@ export async function DELETE(request: NextRequest) {
 
   try {
     const db = getDatabase()
-    const { searchParams } = new URL(request.url)
-    const id = searchParams.get('id')
+    let body: any
+    try { body = await request.json() } catch { return NextResponse.json({ error: 'Request body required' }, { status: 400 }) }
+    const id = body.id
 
     if (!id) {
       return NextResponse.json({ error: 'Template ID is required' }, { status: 400 })


### PR DESCRIPTION
## Summary
- **#16** — Add Contributor Covenant 2.1 Code of Conduct
- **#17** — Add bug report and feature request GitHub issue templates
- **#18** — Standardize 7 DELETE handlers to use request body instead of query params
- **#19** — Cap unbounded `limit` query params to `Math.min(limit, 200)` on 12 endpoints
- **#20** — Add CSRF Origin header validation for mutating requests (POST/PUT/DELETE/PATCH) in middleware

Closes #16, Closes #17, Closes #18, Closes #19, Closes #20

## Test plan
- [ ] CODE_OF_CONDUCT.md and issue templates render correctly on GitHub
- [ ] DELETE endpoints reject requests without JSON body
- [ ] DELETE endpoints accept `{ "id": "..." }` body format
- [ ] Endpoints respect 200 limit cap (e.g., `?limit=9999` returns max 200)
- [ ] Mutating requests with mismatched Origin header return 403
- [ ] Same-origin requests pass CSRF check normally
- [ ] `pnpm typecheck && pnpm build` passes