### PR TITLE
Fix SQLite foreign keys and add missing indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ mission-control/
 │   ├── lib/
 │   │   ├── auth.ts            # Session + API key auth, RBAC
 │   │   ├── db.ts              # SQLite (better-sqlite3, WAL mode)
-│   │   ├── migrations.ts      # 14 schema migrations
+│   │   ├── migrations.ts      # 15 schema migrations
 │   │   ├── scheduler.ts       # Background task scheduler
 │   │   ├── webhooks.ts        # Outbound webhook delivery
 │   │   └── websocket.ts       # Gateway WebSocket client

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -23,6 +23,7 @@ export function getDatabase(): Database.Database {
     db.pragma('journal_mode = WAL');
     db.pragma('synchronous = NORMAL');
     db.pragma('cache_size = 1000');
+    db.pragma('foreign_keys = ON');
     
     // Initialize schema if needed
     initializeSchema();

--- a/src/lib/migrations.ts
+++ b/src/lib/migrations.ts
@@ -424,6 +424,18 @@ const migrations: Migration[] = [
       db.exec(`CREATE INDEX IF NOT EXISTS idx_users_provider ON users(provider)`)
       db.exec(`CREATE INDEX IF NOT EXISTS idx_users_email ON users(email)`)
     }
+  },
+  {
+    id: '015_missing_indexes',
+    up: (db) => {
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_notifications_read_at ON notifications(read_at);
+        CREATE INDEX IF NOT EXISTS idx_notifications_recipient_read ON notifications(recipient, read_at);
+        CREATE INDEX IF NOT EXISTS idx_activities_actor ON activities(actor);
+        CREATE INDEX IF NOT EXISTS idx_activities_entity ON activities(entity_type, entity_id);
+        CREATE INDEX IF NOT EXISTS idx_messages_read_at ON messages(read_at);
+      `)
+    }
   }
 ]
 


### PR DESCRIPTION
## Summary

Two database bugs found during release audit:

- **`PRAGMA foreign_keys = ON` missing** — SQLite disables foreign keys by default, so all `ON DELETE CASCADE` constraints across 7 tables (comments, task_subscriptions, quality_reviews, user_sessions, webhook_deliveries, pipeline_runs, provision_events) were silently ignored. Deleting a task left orphaned comments and subscriptions.
- **Missing indexes on hot query paths** — `notifications.read_at`, `activities.actor`, `activities(entity_type, entity_id)`, and `messages.read_at` had no indexes, causing full table scans on every unread-count and activity-feed query.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] Migration 015 creates indexes idempotently (`IF NOT EXISTS`)