### PR TITLE
fix: patch security and build bugs in v1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /app
 
 FROM base AS deps
 COPY package.json pnpm-lock.yaml ./
+# better-sqlite3 requires native compilation tools
+RUN apt-get update && apt-get install -y python3 make g++ --no-install-recommends && rm -rf /var/lib/apt/lists/*
 RUN pnpm install --frozen-lockfile
 
 FROM base AS build
@@ -17,7 +19,8 @@ ENV NODE_ENV=production
 RUN addgroup --system --gid 1001 nodejs && adduser --system --uid 1001 nextjs
 COPY --from=build /app/.next/standalone ./
 COPY --from=build /app/.next/static ./.next/static
-COPY --from=build /app/public ./public
+# Copy public directory if it exists (may not exist in all setups)
+COPY --from=build /app/public* ./public/
 USER nextjs
 EXPOSE 3000
 CMD ["node", "server.js"]

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,8 +1,19 @@
 import pino from 'pino'
 
+function hasPinoPretty(): boolean {
+  try {
+    require.resolve('pino-pretty')
+    return true
+  } catch {
+    return false
+  }
+}
+
+const usePretty = process.env.NODE_ENV !== 'production' && hasPinoPretty()
+
 export const logger = pino({
   level: process.env.LOG_LEVEL || 'info',
-  ...(process.env.NODE_ENV !== 'production' && {
+  ...(usePretty && {
     transport: {
       target: 'pino-pretty',
       options: { colorize: true },


### PR DESCRIPTION
## Summary

- **Command injection fix**: Session control route (`/api/sessions/[id]/control`) was interpolating URL param `id` directly into shell command strings (`sessions_kill("${id}")`). Added regex validation (`/^[a-zA-Z0-9_-]+$/`) to reject malicious session IDs before they reach the shell.
- **Missing rate limiter**: Added `mutationLimiter` to the session control POST endpoint (was the only mutation endpoint without one).
- **Missing structured logging**: Added `logger.error` to the session control catch block (was using no logging at all).
- **Docker native build tools**: `better-sqlite3` requires `python3`, `make`, `g++` for `node-gyp` compilation. Added `apt-get install` in the deps stage.
- **Docker COPY fix**: `public/` directory doesn't exist in all setups — changed to glob pattern `public*` so the build doesn't fail.
- **Logger crash prevention**: `pino-pretty` is a devDependency not installed in production. If `NODE_ENV` wasn't exactly `'production'`, the logger would crash trying to load it. Added `require.resolve()` guard.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm build` succeeds (Next.js standalone output)
- [ ] Verify Docker build: `docker build -t mission-control .`
- [ ] Verify session control rejects IDs with special characters (400 response)
- [ ] Verify logger doesn't crash when `pino-pretty` is absent