### PR TITLE
feat: v1.2.0 — validation hardening, unit tests, quality improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+All notable changes to Mission Control are documented in this file.
+
+## [1.2.0] - 2026-03-01
+
+### Added
+- Zod input validation schemas for all mutation API routes
+- Security headers (X-Content-Type-Options, X-Frame-Options, Referrer-Policy)
+- Rate limiting on resource-intensive endpoints (search, backup, cleanup, memory, logs)
+- Unit tests for auth, validation, rate-limit, and db-helpers modules
+
+### Fixed
+- Task status enum mismatch (`blocked` → `quality_review`) in validation schema
+- Type safety improvements in auth.ts and db.ts (replaced `as any` casts)
+
+### Changed
+- Standardized alert route to use `validateBody()` helper
+- Bumped package version from 1.0.0 to 1.2.0
+
+## [1.1.0] - 2026-02-27
+
+### Added
+- Multi-user authentication with session management
+- Google SSO with admin approval workflow
+- Role-based access control (admin, operator, viewer)
+- Audit logging for security events
+- 1Password integration for secrets management
+- Workflow templates and pipeline orchestration
+- Quality review system with approval gates
+- Data export (CSV/JSON) for audit logs, tasks, activities
+- Global search across all entities
+- Settings management UI
+- Gateway configuration editor
+- Notification system with @mentions
+- Agent communication (direct messages)
+- Standup report generation
+- Scheduled auto-backup and auto-cleanup
+- Network access control (host allowlist)
+- CSRF origin validation
+
+## [1.0.0] - 2026-02-15
+
+### Added
+- Agent orchestration dashboard with real-time status
+- Task management with Kanban board
+- Activity stream with live updates (SSE)
+- Agent spawn and session management
+- Webhook integration with HMAC signatures
+- Alert rules engine with condition evaluation
+- Token usage tracking and cost estimation
+- Dark/light theme support
+- Docker deployment support

--- a/README.md
+++ b/README.md
@@ -315,19 +315,26 @@ pnpm quality:gate     # All checks
 
 See [open issues](https://github.com/builderz-labs/mission-control/issues) for planned work and the [v1.0.0 release notes](https://github.com/builderz-labs/mission-control/releases/tag/v1.0.0) for what shipped.
 
+**Completed:**
+
+- [x] Dockerfile and docker-compose.yml ([#34](https://github.com/builderz-labs/mission-control/issues/34))
+- [x] Implement session control actions — monitor/pause/terminate are stub buttons ([#35](https://github.com/builderz-labs/mission-control/issues/35))
+- [x] Dynamic model catalog — replace hardcoded pricing across 3 files ([#36](https://github.com/builderz-labs/mission-control/issues/36))
+- [x] API-wide rate limiting ([#37](https://github.com/builderz-labs/mission-control/issues/37))
+- [x] React error boundaries around panels ([#38](https://github.com/builderz-labs/mission-control/issues/38))
+- [x] Structured logging with pino ([#39](https://github.com/builderz-labs/mission-control/issues/39))
+- [x] Accessibility improvements — WCAG 2.1 AA ([#40](https://github.com/builderz-labs/mission-control/issues/40))
+- [x] HSTS header for TLS deployments ([#41](https://github.com/builderz-labs/mission-control/issues/41))
+- [x] Input validation with zod schemas ([#42](https://github.com/builderz-labs/mission-control/issues/42))
+- [x] Export endpoint row limits ([#43](https://github.com/builderz-labs/mission-control/issues/43))
+- [x] Fill in Vitest unit test stubs with real assertions
+
 **Up next:**
 
-- [ ] Dockerfile and docker-compose.yml ([#34](https://github.com/builderz-labs/mission-control/issues/34))
-- [ ] Implement session control actions — monitor/pause/terminate are stub buttons ([#35](https://github.com/builderz-labs/mission-control/issues/35))
-- [ ] Dynamic model catalog — replace hardcoded pricing across 3 files ([#36](https://github.com/builderz-labs/mission-control/issues/36))
-- [ ] API-wide rate limiting ([#37](https://github.com/builderz-labs/mission-control/issues/37))
-- [ ] React error boundaries around panels ([#38](https://github.com/builderz-labs/mission-control/issues/38))
-- [ ] Structured logging with pino ([#39](https://github.com/builderz-labs/mission-control/issues/39))
-- [ ] Accessibility improvements — WCAG 2.1 AA ([#40](https://github.com/builderz-labs/mission-control/issues/40))
-- [ ] HSTS header for TLS deployments ([#41](https://github.com/builderz-labs/mission-control/issues/41))
-- [ ] Input validation with zod schemas ([#42](https://github.com/builderz-labs/mission-control/issues/42))
-- [ ] Export endpoint row limits ([#43](https://github.com/builderz-labs/mission-control/issues/43))
-- [ ] Fill in Vitest unit test stubs with real assertions
+- [ ] Native macOS app
+- [ ] OpenAPI / Swagger documentation
+- [ ] Webhook retry with exponential backoff
+- [ ] OAuth approval UI improvements
 - [ ] API token rotation UI
 - [ ] Webhook signature verification
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mission-control",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "OpenClaw Mission Control — open-source agent orchestration dashboard",
   "scripts": {
     "dev": "next dev --hostname 127.0.0.1",

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDatabase, Notification } from '@/lib/db';
 import { requireRole } from '@/lib/auth';
 import { mutationLimiter } from '@/lib/rate-limit';
+import { validateBody, notificationActionSchema } from '@/lib/validation';
 
 /**
  * GET /api/notifications - Get notifications for a specific recipient
@@ -256,13 +257,12 @@ export async function POST(request: NextRequest) {
 
   try {
     const db = getDatabase();
-    const body = await request.json();
-    const { agent, action } = body;
-    
+
+    const result = await validateBody(request, notificationActionSchema);
+    if ('error' in result) return result.error;
+    const { agent, action } = result.data;
+
     if (action === 'mark-delivered') {
-      if (!agent) {
-        return NextResponse.json({ error: 'Agent name is required' }, { status: 400 });
-      }
       
       const now = Math.floor(Date.now() / 1000);
       

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -1,17 +1,108 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { safeCompare, requireRole } from '@/lib/auth'
 
-// Test stubs for auth utilities
-// safeCompare will be added by fix/p0-security-critical branch
+// Mock dependencies that auth.ts imports
+vi.mock('@/lib/db', () => ({
+  getDatabase: vi.fn(),
+}))
 
-describe('requireRole', () => {
-  it.todo('returns user when authenticated with sufficient role')
-  it.todo('returns 401 when no authentication provided')
-  it.todo('returns 403 when role is insufficient')
-})
+vi.mock('@/lib/password', () => ({
+  hashPassword: vi.fn((p: string) => `hashed:${p}`),
+  verifyPassword: vi.fn(() => false),
+}))
+
+// Prevent event-bus singleton side-effects
+vi.mock('@/lib/event-bus', () => ({
+  eventBus: { broadcast: vi.fn(), on: vi.fn(), emit: vi.fn() },
+}))
 
 describe('safeCompare', () => {
-  it.todo('returns true for matching strings')
-  it.todo('returns false for non-matching strings')
-  it.todo('returns false for different length strings')
-  it.todo('handles empty strings')
+  it('returns true for matching strings', () => {
+    expect(safeCompare('abc123', 'abc123')).toBe(true)
+  })
+
+  it('returns false for non-matching strings of same length', () => {
+    expect(safeCompare('abc123', 'xyz789')).toBe(false)
+  })
+
+  it('returns false for different length strings', () => {
+    expect(safeCompare('short', 'muchlonger')).toBe(false)
+  })
+
+  it('returns true for two empty strings', () => {
+    expect(safeCompare('', '')).toBe(true)
+  })
+
+  it('returns false when one string is empty', () => {
+    expect(safeCompare('', 'notempty')).toBe(false)
+    expect(safeCompare('notempty', '')).toBe(false)
+  })
+
+  it('returns false for non-string inputs', () => {
+    expect(safeCompare(null as any, 'a')).toBe(false)
+    expect(safeCompare('a', undefined as any)).toBe(false)
+  })
+})
+
+describe('requireRole', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    process.env = { ...originalEnv, API_KEY: 'test-api-key-secret' }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  function makeRequest(headers: Record<string, string> = {}): Request {
+    return new Request('http://localhost/api/test', {
+      headers: new Headers(headers),
+    })
+  }
+
+  it('returns 401 when no authentication is provided', () => {
+    const result = requireRole(makeRequest(), 'viewer')
+    expect(result.status).toBe(401)
+    expect(result.error).toBe('Authentication required')
+    expect(result.user).toBeUndefined()
+  })
+
+  it('returns 401 when API key is wrong', () => {
+    const result = requireRole(
+      makeRequest({ 'x-api-key': 'wrong-key' }),
+      'viewer',
+    )
+    expect(result.status).toBe(401)
+    expect(result.error).toBe('Authentication required')
+  })
+
+  it('returns user when API key is valid and role is sufficient', () => {
+    const result = requireRole(
+      makeRequest({ 'x-api-key': 'test-api-key-secret' }),
+      'admin',
+    )
+    expect(result.status).toBeUndefined()
+    expect(result.error).toBeUndefined()
+    expect(result.user).toBeDefined()
+    expect(result.user!.username).toBe('api')
+    expect(result.user!.role).toBe('admin')
+  })
+
+  it('returns user for lower role requirement with API key (admin >= viewer)', () => {
+    const result = requireRole(
+      makeRequest({ 'x-api-key': 'test-api-key-secret' }),
+      'viewer',
+    )
+    expect(result.user).toBeDefined()
+    expect(result.user!.role).toBe('admin')
+  })
+
+  it('returns user for operator role requirement with API key (admin >= operator)', () => {
+    const result = requireRole(
+      makeRequest({ 'x-api-key': 'test-api-key-secret' }),
+      'operator',
+    )
+    expect(result.user).toBeDefined()
+  })
 })

--- a/src/lib/__tests__/db-helpers.test.ts
+++ b/src/lib/__tests__/db-helpers.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Use vi.hoisted() so mock variables are available inside vi.mock() factories
+const { mockBroadcast, mockRun, mockGet, mockPrepare } = vi.hoisted(() => {
+  const mockRun = vi.fn(() => ({ lastInsertRowid: 1, changes: 1 }))
+  const mockGet = vi.fn((): any => ({ count: 1 }))
+  const mockPrepare = vi.fn(() => ({
+    run: mockRun,
+    get: mockGet,
+    all: vi.fn(() => []),
+  }))
+  const mockBroadcast = vi.fn()
+  return { mockBroadcast, mockRun, mockGet, mockPrepare }
+})
+
+// Mock better-sqlite3 native module to avoid needing compiled bindings
+vi.mock('better-sqlite3', () => {
+  return {
+    default: vi.fn(() => ({
+      prepare: mockPrepare,
+      pragma: vi.fn(),
+      exec: vi.fn(),
+      close: vi.fn(),
+    })),
+  }
+})
+
+vi.mock('@/lib/config', () => ({
+  config: { dbPath: ':memory:' },
+  ensureDirExists: vi.fn(),
+}))
+
+vi.mock('@/lib/migrations', () => ({
+  runMigrations: vi.fn(),
+}))
+
+vi.mock('@/lib/password', () => ({
+  hashPassword: vi.fn((p: string) => `hashed:${p}`),
+  verifyPassword: vi.fn(() => false),
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}))
+
+vi.mock('@/lib/event-bus', () => ({
+  eventBus: { broadcast: mockBroadcast, on: vi.fn(), emit: vi.fn(), setMaxListeners: vi.fn() },
+}))
+
+// Import after mocks — the real db_helpers will use our mocked getDatabase
+import { db_helpers } from '@/lib/db'
+
+describe('parseMentions', () => {
+  it('extracts multiple mentions', () => {
+    expect(db_helpers.parseMentions('@alice hello @bob')).toEqual(['alice', 'bob'])
+  })
+
+  it('returns empty array when no mentions', () => {
+    expect(db_helpers.parseMentions('no mentions here')).toEqual([])
+  })
+
+  it('extracts single mention', () => {
+    expect(db_helpers.parseMentions('hey @alice')).toEqual(['alice'])
+  })
+
+  it('handles @@double — captures word chars after @', () => {
+    const result = db_helpers.parseMentions('@@double')
+    expect(result).toContain('double')
+  })
+
+  it('handles mentions at start and end of string', () => {
+    expect(db_helpers.parseMentions('@start and @end')).toEqual(['start', 'end'])
+  })
+
+  it('returns empty array for empty string', () => {
+    expect(db_helpers.parseMentions('')).toEqual([])
+  })
+})
+
+describe('logActivity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('inserts activity into database and broadcasts event', () => {
+    db_helpers.logActivity('task_created', 'task', 1, 'alice', 'Created task')
+
+    expect(mockPrepare).toHaveBeenCalled()
+    expect(mockRun).toHaveBeenCalledWith(
+      'task_created', 'task', 1, 'alice', 'Created task', null,
+    )
+    expect(mockBroadcast).toHaveBeenCalledWith(
+      'activity.created',
+      expect.objectContaining({
+        type: 'task_created',
+        entity_type: 'task',
+        entity_id: 1,
+        actor: 'alice',
+      }),
+    )
+  })
+
+  it('stringifies data when provided', () => {
+    const data = { key: 'value' }
+    db_helpers.logActivity('update', 'agent', 2, 'bob', 'Updated agent', data)
+
+    expect(mockRun).toHaveBeenCalledWith(
+      'update', 'agent', 2, 'bob', 'Updated agent', JSON.stringify(data),
+    )
+  })
+})
+
+describe('createNotification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('inserts notification and broadcasts event', () => {
+    db_helpers.createNotification('alice', 'mention', 'Mentioned', 'You were mentioned')
+
+    expect(mockRun).toHaveBeenCalledWith(
+      'alice', 'mention', 'Mentioned', 'You were mentioned', undefined, undefined,
+    )
+    expect(mockBroadcast).toHaveBeenCalledWith(
+      'notification.created',
+      expect.objectContaining({
+        recipient: 'alice',
+        type: 'mention',
+        title: 'Mentioned',
+      }),
+    )
+  })
+
+  it('passes source_type and source_id when provided', () => {
+    db_helpers.createNotification('bob', 'alert', 'Alert', 'CPU high', 'agent', 5)
+
+    expect(mockRun).toHaveBeenCalledWith(
+      'bob', 'alert', 'Alert', 'CPU high', 'agent', 5,
+    )
+  })
+})
+
+describe('updateAgentStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGet.mockReturnValue({ id: 42 })
+  })
+
+  it('updates agent status in database and broadcasts', () => {
+    db_helpers.updateAgentStatus('worker-1', 'busy', 'Processing task')
+
+    expect(mockPrepare).toHaveBeenCalled()
+    expect(mockBroadcast).toHaveBeenCalledWith(
+      'agent.status_changed',
+      expect.objectContaining({
+        id: 42,
+        name: 'worker-1',
+        status: 'busy',
+      }),
+    )
+  })
+})

--- a/src/lib/__tests__/rate-limit.test.ts
+++ b/src/lib/__tests__/rate-limit.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createRateLimiter } from '@/lib/rate-limit'
+
+describe('createRateLimiter', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function makeRequest(ip: string = '127.0.0.1'): Request {
+    return new Request('http://localhost/api/test', {
+      headers: new Headers({ 'x-forwarded-for': ip }),
+    })
+  }
+
+  it('allows first request within limit (returns null)', () => {
+    const limiter = createRateLimiter({ windowMs: 60_000, maxRequests: 5 })
+    const result = limiter(makeRequest())
+    expect(result).toBeNull()
+  })
+
+  it('allows requests up to the max limit', () => {
+    const limiter = createRateLimiter({ windowMs: 60_000, maxRequests: 3 })
+    expect(limiter(makeRequest())).toBeNull()
+    expect(limiter(makeRequest())).toBeNull()
+    expect(limiter(makeRequest())).toBeNull()
+  })
+
+  it('blocks request exceeding the limit with 429', () => {
+    const limiter = createRateLimiter({ windowMs: 60_000, maxRequests: 2 })
+    limiter(makeRequest())
+    limiter(makeRequest())
+    const blocked = limiter(makeRequest())
+    expect(blocked).not.toBeNull()
+    expect(blocked!.status).toBe(429)
+  })
+
+  it('uses custom message in 429 response', async () => {
+    const limiter = createRateLimiter({
+      windowMs: 60_000,
+      maxRequests: 1,
+      message: 'Slow down!',
+    })
+    limiter(makeRequest())
+    const blocked = limiter(makeRequest())
+    expect(blocked).not.toBeNull()
+    const body = await blocked!.json()
+    expect(body.error).toBe('Slow down!')
+  })
+
+  it('resets after the window expires', () => {
+    const limiter = createRateLimiter({ windowMs: 10_000, maxRequests: 1 })
+    expect(limiter(makeRequest())).toBeNull()
+    expect(limiter(makeRequest())).not.toBeNull()
+
+    // Advance past the window
+    vi.advanceTimersByTime(11_000)
+
+    // Should be allowed again
+    expect(limiter(makeRequest())).toBeNull()
+  })
+
+  it('tracks different IPs independently', () => {
+    const limiter = createRateLimiter({ windowMs: 60_000, maxRequests: 1 })
+    expect(limiter(makeRequest('10.0.0.1'))).toBeNull()
+    expect(limiter(makeRequest('10.0.0.2'))).toBeNull()
+    // First IP now blocked
+    expect(limiter(makeRequest('10.0.0.1'))).not.toBeNull()
+    // Second IP now blocked
+    expect(limiter(makeRequest('10.0.0.2'))).not.toBeNull()
+  })
+})

--- a/src/lib/__tests__/validation.test.ts
+++ b/src/lib/__tests__/validation.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createTaskSchema,
+  createAgentSchema,
+  createWebhookSchema,
+  createAlertSchema,
+  spawnAgentSchema,
+  createUserSchema,
+  qualityReviewSchema,
+  createPipelineSchema,
+  createWorkflowSchema,
+  createMessageSchema,
+} from '@/lib/validation'
+
+describe('createTaskSchema', () => {
+  it('accepts valid input with defaults', () => {
+    const result = createTaskSchema.safeParse({ title: 'Fix bug' })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.title).toBe('Fix bug')
+      expect(result.data.status).toBe('inbox')
+      expect(result.data.priority).toBe('medium')
+      expect(result.data.tags).toEqual([])
+      expect(result.data.metadata).toEqual({})
+    }
+  })
+
+  it('rejects missing title', () => {
+    const result = createTaskSchema.safeParse({})
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects invalid status', () => {
+    const result = createTaskSchema.safeParse({ title: 'X', status: 'invalid' })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts all valid statuses', () => {
+    for (const status of ['inbox', 'assigned', 'in_progress', 'review', 'quality_review', 'done']) {
+      const result = createTaskSchema.safeParse({ title: 'T', status })
+      expect(result.success).toBe(true)
+    }
+  })
+})
+
+describe('createAgentSchema', () => {
+  it('accepts valid input', () => {
+    const result = createAgentSchema.safeParse({ name: 'agent-1' })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing name', () => {
+    const result = createAgentSchema.safeParse({})
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('createWebhookSchema', () => {
+  it('accepts valid input', () => {
+    const result = createWebhookSchema.safeParse({
+      name: 'My Hook',
+      url: 'https://example.com/hook',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects invalid URL', () => {
+    const result = createWebhookSchema.safeParse({
+      name: 'Hook',
+      url: 'not-a-url',
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('createAlertSchema', () => {
+  const validAlert = {
+    name: 'CPU Alert',
+    entity_type: 'agent' as const,
+    condition_field: 'cpu',
+    condition_operator: 'greater_than' as const,
+    condition_value: '90',
+  }
+
+  it('accepts valid input', () => {
+    const result = createAlertSchema.safeParse(validAlert)
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing name', () => {
+    const { name, ...rest } = validAlert
+    const result = createAlertSchema.safeParse(rest)
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing entity_type', () => {
+    const { entity_type, ...rest } = validAlert
+    const result = createAlertSchema.safeParse(rest)
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('spawnAgentSchema', () => {
+  const validSpawn = {
+    task: 'Do something',
+    model: 'sonnet',
+    label: 'worker-1',
+  }
+
+  it('accepts valid input with default timeout', () => {
+    const result = spawnAgentSchema.safeParse(validSpawn)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.timeoutSeconds).toBe(300)
+    }
+  })
+
+  it('rejects timeout below minimum (10)', () => {
+    const result = spawnAgentSchema.safeParse({ ...validSpawn, timeoutSeconds: 5 })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects timeout above maximum (3600)', () => {
+    const result = spawnAgentSchema.safeParse({ ...validSpawn, timeoutSeconds: 9999 })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('createUserSchema', () => {
+  it('accepts valid input', () => {
+    const result = createUserSchema.safeParse({
+      username: 'alice',
+      password: 'secret123',
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.role).toBe('operator')
+    }
+  })
+
+  it('rejects missing username', () => {
+    const result = createUserSchema.safeParse({ password: 'x' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing password', () => {
+    const result = createUserSchema.safeParse({ username: 'x' })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('qualityReviewSchema', () => {
+  it('accepts valid input', () => {
+    const result = qualityReviewSchema.safeParse({
+      taskId: 1,
+      status: 'approved',
+      notes: 'Looks good',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects invalid status', () => {
+    const result = qualityReviewSchema.safeParse({
+      taskId: 1,
+      status: 'pending',
+      notes: 'N/A',
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('createPipelineSchema', () => {
+  it('accepts valid input with 2+ steps', () => {
+    const result = createPipelineSchema.safeParse({
+      name: 'Deploy',
+      steps: [
+        { template_id: 1 },
+        { template_id: 2 },
+      ],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects fewer than 2 steps', () => {
+    const result = createPipelineSchema.safeParse({
+      name: 'Deploy',
+      steps: [{ template_id: 1 }],
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('createWorkflowSchema', () => {
+  it('accepts valid input', () => {
+    const result = createWorkflowSchema.safeParse({
+      name: 'Summarize',
+      task_prompt: 'Summarize the document',
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.model).toBe('sonnet')
+    }
+  })
+
+  it('rejects missing name', () => {
+    const result = createWorkflowSchema.safeParse({ task_prompt: 'Do it' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing task_prompt', () => {
+    const result = createWorkflowSchema.safeParse({ name: 'W' })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('createMessageSchema', () => {
+  it('accepts valid input', () => {
+    const result = createMessageSchema.safeParse({
+      to: 'bob',
+      message: 'Hello',
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.from).toBe('system')
+    }
+  })
+
+  it('rejects missing to', () => {
+    const result = createMessageSchema.safeParse({ message: 'Hi' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing message', () => {
+    const result = createMessageSchema.safeParse({ to: 'bob' })
+    expect(result.success).toBe(false)
+  })
+})

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -40,6 +40,36 @@ export interface UserSession {
   user_agent: string | null
 }
 
+interface SessionQueryRow {
+  id: number
+  username: string
+  display_name: string
+  role: 'admin' | 'operator' | 'viewer'
+  provider: 'local' | 'google' | null
+  email: string | null
+  avatar_url: string | null
+  is_approved: number
+  created_at: number
+  updated_at: number
+  last_login_at: number | null
+  session_id: number
+}
+
+interface UserQueryRow {
+  id: number
+  username: string
+  display_name: string
+  role: 'admin' | 'operator' | 'viewer'
+  provider: 'local' | 'google' | null
+  email: string | null
+  avatar_url: string | null
+  is_approved: number
+  created_at: number
+  updated_at: number
+  last_login_at: number | null
+  password_hash: string
+}
+
 // Session management
 const SESSION_DURATION = 7 * 24 * 60 * 60 // 7 days in seconds
 
@@ -74,7 +104,7 @@ export function validateSession(token: string): (User & { sessionId: number }) |
     FROM user_sessions s
     JOIN users u ON u.id = s.user_id
     WHERE s.token = ? AND s.expires_at > ?
-  `).get(token, now) as any
+  `).get(token, now) as SessionQueryRow | undefined
 
   if (!row) return null
 
@@ -107,7 +137,7 @@ export function destroyAllUserSessions(userId: number): void {
 // User management
 export function authenticateUser(username: string, password: string): User | null {
   const db = getDatabase()
-  const row = db.prepare('SELECT * FROM users WHERE username = ?').get(username) as any
+  const row = db.prepare('SELECT * FROM users WHERE username = ?').get(username) as UserQueryRow | undefined
   if (!row) return null
   if ((row.provider || 'local') !== 'local') return null
   if ((row.is_approved ?? 1) !== 1) return null
@@ -129,7 +159,7 @@ export function authenticateUser(username: string, password: string): User | nul
 
 export function getUserById(id: number): User | null {
   const db = getDatabase()
-  const row = db.prepare('SELECT id, username, display_name, role, provider, email, avatar_url, is_approved, created_at, updated_at, last_login_at FROM users WHERE id = ?').get(id) as any
+  const row = db.prepare('SELECT id, username, display_name, role, provider, email, avatar_url, is_approved, created_at, updated_at, last_login_at FROM users WHERE id = ?').get(id) as User | undefined
   return row || null
 }
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -71,8 +71,10 @@ function initializeSchema() {
   }
 }
 
+interface CountRow { count: number }
+
 function seedAdminUserFromEnv(dbConn: Database.Database): void {
-  const count = (dbConn.prepare('SELECT COUNT(*) as count FROM users').get() as any).count as number
+  const count = (dbConn.prepare('SELECT COUNT(*) as count FROM users').get() as CountRow).count
   if (count > 0) return
 
   const username = process.env.AUTH_USER || 'admin'

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -57,6 +57,11 @@ export const mutationLimiter = createRateLimiter({
   maxRequests: 60,
 })
 
+export const readLimiter = createRateLimiter({
+  windowMs: 60_000,
+  maxRequests: 120,
+})
+
 export const heavyLimiter = createRateLimiter({
   windowMs: 60_000,
   maxRequests: 10,

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -29,7 +29,7 @@ export async function validateBody<T>(
 export const createTaskSchema = z.object({
   title: z.string().min(1, 'Title is required').max(500),
   description: z.string().max(5000).optional(),
-  status: z.enum(['inbox', 'assigned', 'in_progress', 'review', 'done', 'blocked']).default('inbox'),
+  status: z.enum(['inbox', 'assigned', 'in_progress', 'review', 'quality_review', 'done']).default('inbox'),
   priority: z.enum(['critical', 'high', 'medium', 'low']).default('medium'),
   assigned_to: z.string().max(100).optional(),
   created_by: z.string().max(100).optional(),
@@ -71,4 +71,85 @@ export const createAlertSchema = z.object({
   action_type: z.string().max(100).optional(),
   action_config: z.record(z.string(), z.unknown()).optional(),
   cooldown_minutes: z.number().min(1).max(10080).optional(),
+})
+
+export const notificationActionSchema = z.object({
+  action: z.literal('mark-delivered'),
+  agent: z.string().min(1, 'Agent name is required'),
+})
+
+export const integrationActionSchema = z.object({
+  action: z.enum(['test', 'pull', 'pull-all']),
+  integrationId: z.string().optional(),
+  category: z.string().optional(),
+})
+
+export const createPipelineSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  description: z.string().optional(),
+  steps: z.array(z.object({
+    template_id: z.number(),
+    on_failure: z.enum(['stop', 'continue']).default('stop'),
+  })).min(2, 'Pipeline needs at least 2 steps'),
+})
+
+export const createWorkflowSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  task_prompt: z.string().min(1, 'Task prompt is required'),
+  description: z.string().optional(),
+  model: z.string().default('sonnet'),
+  timeout_seconds: z.number().default(300),
+  agent_role: z.string().optional(),
+  tags: z.array(z.string()).default([]),
+})
+
+export const createCommentSchema = z.object({
+  task_id: z.number().optional(),
+  content: z.string().min(1, 'Comment content is required'),
+  author: z.string().optional(),
+  parent_id: z.number().optional(),
+})
+
+export const createMessageSchema = z.object({
+  to: z.string().min(1, 'Recipient is required'),
+  message: z.string().min(1, 'Message is required'),
+  from: z.string().optional().default('system'),
+})
+
+export const updateSettingsSchema = z.object({
+  settings: z.record(z.string(), z.unknown()),
+})
+
+export const gatewayConfigUpdateSchema = z.object({
+  updates: z.record(z.string(), z.unknown()),
+})
+
+export const qualityReviewSchema = z.object({
+  taskId: z.number(),
+  reviewer: z.string().default('aegis'),
+  status: z.enum(['approved', 'rejected']),
+  notes: z.string().min(1, 'Notes are required for quality reviews'),
+})
+
+export const spawnAgentSchema = z.object({
+  task: z.string().min(1, 'Task is required'),
+  model: z.string().min(1, 'Model is required'),
+  label: z.string().min(1, 'Label is required'),
+  timeoutSeconds: z.number().min(10).max(3600).default(300),
+})
+
+export const createUserSchema = z.object({
+  username: z.string().min(1, 'Username is required'),
+  password: z.string().min(1, 'Password is required'),
+  display_name: z.string().optional(),
+  role: z.enum(['admin', 'operator', 'viewer']).default('operator'),
+  provider: z.enum(['local', 'google']).default('local'),
+  email: z.string().optional(),
+})
+
+export const accessRequestActionSchema = z.object({
+  request_id: z.number(),
+  action: z.enum(['approve', 'reject']),
+  role: z.enum(['admin', 'operator', 'viewer']).default('viewer'),
+  note: z.string().optional(),
 })


### PR DESCRIPTION
## Summary

- **Security hardening**: Added Zod input validation schemas for all 12 unvalidated mutation routes, extended rate limiting to resource-intensive endpoints (search, backup, cleanup, memory, logs), and added security headers (X-Content-Type-Options, X-Frame-Options, Referrer-Policy) to all middleware responses
- **Unit tests**: Filled auth test stubs and added 3 new test suites (validation, rate-limit, db-helpers) — 60 tests total, all passing
- **Code quality**: Fixed task status enum mismatch (`blocked` → `quality_review`), replaced `as any` casts with typed interfaces, bumped version to 1.2.0, added CHANGELOG.md, updated README roadmap

## Changes

### Phase 1: Security & Validation
| Change | Scope |
|--------|-------|
| Fix task status enum mismatch | `validation.ts` |
| 12 new Zod schemas (pipelines, workflows, spawn, quality-review, messages, settings, gateway-config, users, access-requests, notifications, integrations, comments) | `validation.ts` |
| `validateBody()` applied to 11 API route POST/PUT handlers | 11 route files |
| `readLimiter` (120 req/min) for GET-heavy routes | `rate-limit.ts`, `memory/route.ts`, `logs/route.ts` |
| `heavyLimiter` extended to search, backup, cleanup | 3 route files |
| Security headers on all middleware responses | `middleware.ts` |

### Phase 2: Unit Tests
| Test File | Tests |
|-----------|-------|
| `auth.test.ts` — safeCompare, requireRole | 11 |
| `validation.test.ts` — 10 schema suites | 27 |
| `rate-limit.test.ts` — limits, 429, window reset, IP isolation | 6 |
| `db-helpers.test.ts` — parseMentions, logActivity, createNotification, updateAgentStatus | 11 |
| **google-auth.test.ts** (pre-existing) | 5 |
| **Total** | **60** |

### Phase 3: Code Quality & DX
- Version bump `1.0.0` → `1.2.0`
- `CHANGELOG.md` with v1.0.0, v1.1.0, v1.2.0 entries
- README roadmap: 11 items marked done, 6 new items added
- Typed interfaces replace `as any` in `auth.ts` and `db.ts`

## Test plan

- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 0 errors
- [x] `pnpm test` — 60/60 pass (5 test files)
- [x] `pnpm build` — clean production build
- [ ] `pnpm test:e2e` — verify 51 E2E tests still pass