### PR TITLE
fix: cron job manual trigger sending wrong params

### DIFF
--- a/src/components/panels/cron-management-panel.tsx
+++ b/src/components/panels/cron-management-panel.tsx
@@ -98,7 +98,8 @@ export function CronManagementPanel() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           action: 'trigger',
-          command: job.command
+          jobId: job.id,
+          jobName: job.name,
         })
       })
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -31,6 +31,7 @@ export interface LogEntry {
 }
 
 export interface CronJob {
+  id?: string
   name: string
   schedule: string
   command: string


### PR DESCRIPTION
## Summary
- Fixed `triggerJob` in the cron management panel sending `{ command: job.command }` instead of `{ jobId: job.id, jobName: job.name }` to the `/api/cron` endpoint
- The backend expects `jobId` or `jobName` to identify the job — sending `command` caused all manual triggers to fail with "Job ID required" (400)
- Added missing `id?: string` field to the `CronJob` store interface to match the data already returned by the API

## Root Cause
`cron-management-panel.tsx:99-101` was constructing the trigger request body with the wrong field (`command` — the payload description text) instead of the job identifier fields the API actually checks (`jobId` or `jobName`).

## Test plan
- [ ] Open Cron Management panel
- [ ] Click "Run" on any cron job — should no longer fail with 400
- [ ] Verify toggle and remove still work (they were unaffected)
- [ ] `pnpm typecheck` passes