### PR TITLE
fix: use correct auth field in gateway WebSocket handshake

### DIFF
--- a/src/lib/websocket.ts
+++ b/src/lib/websocket.ts
@@ -146,7 +146,7 @@ export function useWebSocket() {
         role: 'operator',
         scopes: ['operator.admin'],
         auth: authTokenRef.current
-          ? { password: authTokenRef.current }
+          ? { token: authTokenRef.current }
           : undefined
       }
     }


### PR DESCRIPTION
## Problem

When connecting to an OpenClaw gateway configured with `auth.mode = 'token'`, the WebSocket handshake fails immediately because the client sends:

```json
{ "auth": { "password": "<token>" } }
```

But the gateway expects:

```json
{ "auth": { "token": "<token>" } }
```

The gateway rejects the handshake, triggering a reconnect loop. Every failed attempt is logged as an error, so the Errors (24h) counter climbs rapidly (100+ errors/minute) even though the underlying system is healthy.

## Fix

One-character change in `src/lib/websocket.ts`: `password` → `token` in the auth payload of `sendConnectHandshake`.

## Tested

Against OpenClaw gateway v2026.2.25 with `gateway.auth.mode = 'token'`. Gateway connects successfully and the error flood stops.