### PR TITLE
docs: clarify OPENCLAW_MEMORY_DIR — memory browser shows only .sqlite without it

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,12 @@ NEXT_PUBLIC_GATEWAY_URL=
 # === OpenClaw Paths (derived from OPENCLAW_HOME if not set) ===
 # OPENCLAW_LOG_DIR=/path/to/.openclaw/logs
 # OPENCLAW_MEMORY_DIR=/path/to/.openclaw/memory
+#
+# NOTE: OpenClaw does NOT store agent memory markdown files under OPENCLAW_HOME/memory/.
+# That directory does not exist by default. Agent memory lives in each agent's workspace
+# (e.g. ~/clawd-agents/{agent}/memory/). Point this at your agents root to make the
+# Memory Browser useful:
+#   OPENCLAW_MEMORY_DIR=/home/you/clawd-agents
 # OPENCLAW_SOUL_TEMPLATES_DIR=/path/to/.openclaw/templates/souls
 # OPENCLAW_BIN=openclaw
 

--- a/README.md
+++ b/README.md
@@ -282,9 +282,19 @@ See [`.env.example`](.env.example) for the complete list. Key variables:
 | `OPENCLAW_HOME` | Yes* | Path to `.openclaw` directory |
 | `OPENCLAW_GATEWAY_HOST` | No | Gateway host (default: `127.0.0.1`) |
 | `OPENCLAW_GATEWAY_PORT` | No | Gateway WebSocket port (default: `18789`) |
+| `OPENCLAW_MEMORY_DIR` | No | Memory browser root (see note below) |
 | `MC_ALLOWED_HOSTS` | No | Host allowlist for production |
 
 *Memory browser, log viewer, and gateway config require `OPENCLAW_HOME`.
+
+> **Memory Browser note:** OpenClaw does not store agent memory markdown files under
+> `$OPENCLAW_HOME/memory/` — that directory does not exist by default. Agent memory lives
+> in each agent's workspace (e.g. `~/clawd-agents/{agent}/memory/`). Set
+> `OPENCLAW_MEMORY_DIR` to your agents root directory to make the Memory Browser show
+> daily logs, `MEMORY.md`, and other markdown files:
+> ```
+> OPENCLAW_MEMORY_DIR=/home/you/clawd-agents
+> ```
 
 ## Deployment
 


### PR DESCRIPTION
## Problem

The Memory Browser shows only `.sqlite` files and nothing in daily logs or knowledge files.

**Root cause:** `OPENCLAW_MEMORY_DIR` defaults to `$OPENCLAW_HOME/memory/` which doesn't exist. Agent memory markdown files live in each agent's workspace (e.g. `~/clawd-agents/{agent}/memory/`), not inside `~/.openclaw/`. Without this set, the browser scans `OPENCLAW_HOME` root — only `.sqlite` internal files.

## Fix

- Add `OPENCLAW_MEMORY_DIR` to the README env table with a usage note
- Add an inline note to `.env.example`

No code changes — `src/lib/config.ts` already reads the env var correctly, it just needs documenting.

```
OPENCLAW_MEMORY_DIR=/home/you/clawd-agents
```