### PR TITLE
Fix gateway auth handshake + coordinator alias + notifications nav

### DIFF
--- a/src/app/api/chat/messages/route.ts
+++ b/src/app/api/chat/messages/route.ts
@@ -268,7 +268,13 @@ export async function POST(request: NextRequest) {
           }
         }
         if (!openclawAgentId && typeof to === 'string') {
-          openclawAgentId = to.toLowerCase().replace(/\s+/g, '-')
+          const normalizedTo = to.toLowerCase().replace(/\s+/g, '-')
+          // Legacy compatibility: route old "coordinator" references to configured coordinator agent.
+          if (normalizedTo === 'coordinator' && COORDINATOR_AGENT) {
+            openclawAgentId = COORDINATOR_AGENT.toLowerCase().replace(/\s+/g, '-')
+          } else {
+            openclawAgentId = normalizedTo
+          }
         }
 
         if (!sessionKey && !openclawAgentId) {

--- a/src/components/layout/nav-rail.tsx
+++ b/src/components/layout/nav-rail.tsx
@@ -31,6 +31,7 @@ const navGroups: NavGroup[] = [
     label: 'OBSERVE',
     items: [
       { id: 'activity', label: 'Activity', icon: <ActivityIcon />, priority: true },
+      { id: 'notifications', label: 'Notifications', icon: <AlertIcon />, priority: true },
       { id: 'logs', label: 'Logs', icon: <LogsIcon />, priority: false },
       { id: 'tokens', label: 'Tokens', icon: <TokensIcon />, priority: false },
       { id: 'memory', label: 'Memory', icon: <MemoryIcon />, priority: false },

--- a/src/lib/websocket.ts
+++ b/src/lib/websocket.ts
@@ -146,7 +146,7 @@ export function useWebSocket() {
         role: 'operator',
         scopes: ['operator.admin'],
         auth: authTokenRef.current
-          ? { password: authTokenRef.current }
+          ? { token: authTokenRef.current, password: authTokenRef.current }
           : undefined
       }
     }


### PR DESCRIPTION
## Summary
This resumes the local handoff patch and restores three production-critical UI/gateway fixes:

- include `token` in websocket `auth` payload while keeping `password` for backward compatibility
- map legacy `to=coordinator` references to the configured `COORDINATOR_AGENT` in chat route resolution
- add the missing `Notifications` item back to the left nav rail

## Validation
- `pnpm -s typecheck`
- `pnpm -s lint`

## Notes
These were previously uncommitted local changes on the running Mission Control instance.