### PR TITLE
fix: correct gateway auth format and model display logic

### DIFF
--- a/src/components/panels/session-details-panel.tsx
+++ b/src/components/panels/session-details-panel.tsx
@@ -32,13 +32,14 @@ export function SessionDetailsPanel() {
   const [expandedSession, setExpandedSession] = useState<string | null>(null)
 
   const getModelInfo = (modelName: string) => {
-    const modelAliases = availableModels.map(m => m.alias)
-    const providerAliases = modelAliases.find(alias => modelName.toLowerCase().includes(alias.toLowerCase()))
-    
-    return availableModels.find(m => 
-      m.name === modelName || 
+    const matchedAlias = availableModels
+      .map(m => m.alias)
+      .find(alias => modelName.toLowerCase().includes(alias.toLowerCase()))
+
+    return availableModels.find(m =>
+      m.name === modelName ||
       m.alias === modelName ||
-      providerAliases
+      m.alias === matchedAlias
     ) || { alias: modelName, name: modelName, provider: 'unknown', description: 'Unknown model' }
   }
 

--- a/src/lib/websocket.ts
+++ b/src/lib/websocket.ts
@@ -146,7 +146,7 @@ export function useWebSocket() {
         role: 'operator',
         scopes: ['operator.admin'],
         auth: authTokenRef.current
-          ? { password: authTokenRef.current }
+          ? { token: authTokenRef.current }
           : undefined
       }
     }


### PR DESCRIPTION
## Summary

- **`src/lib/websocket.ts`**: Fix gateway WebSocket handshake — OpenClaw gateway requires `auth: { token }` not `auth: { password }`, causing all connection attempts to fail with `INVALID_REQUEST`.

- **`src/components/panels/session-details-panel.tsx`**: Fix `getModelInfo()` always returning the first model catalog entry (`haiku`) for any unrecognized model name. The bug: `providerAliases` (a truthy string) was used directly as a `.find()` predicate, so every model in the array matched and the first entry was always returned. Fixed by comparing `m.alias === matchedAlias` instead.

## Root Cause (model display bug)

```js
// Before: providerAliases is a truthy string → matches every element → returns first (haiku)
availableModels.find(m =>
  m.name === modelName ||
  m.alias === modelName ||
  providerAliases          // ← always truthy if any alias substring matched
)

// After: precise comparison
availableModels.find(m =>
  m.name === modelName ||
  m.alias === modelName ||
  m.alias === matchedAlias  // ← correct
)
```

## Test plan

- [ ] Connect Mission Control to an OpenClaw gateway with token auth — gateway status should show **Online**
- [ ] Sessions using non-Anthropic models (e.g. `deepseek-ai/DeepSeek-V3.2`) should display the correct model name, not `haiku`

🤖 Generated with [Claude Code](https://claude.com/claude-code)