### PR TITLE
fix: correct model display logic in session details panel

### DIFF
--- a/src/components/panels/session-details-panel.tsx
+++ b/src/components/panels/session-details-panel.tsx
@@ -32,13 +32,14 @@ export function SessionDetailsPanel() {
   const [expandedSession, setExpandedSession] = useState<string | null>(null)
 
   const getModelInfo = (modelName: string) => {
-    const modelAliases = availableModels.map(m => m.alias)
-    const providerAliases = modelAliases.find(alias => modelName.toLowerCase().includes(alias.toLowerCase()))
-    
-    return availableModels.find(m => 
-      m.name === modelName || 
+    const matchedAlias = availableModels
+      .map(m => m.alias)
+      .find(alias => modelName.toLowerCase().includes(alias.toLowerCase()))
+
+    return availableModels.find(m =>
+      m.name === modelName ||
       m.alias === modelName ||
-      providerAliases
+      m.alias === matchedAlias
     ) || { alias: modelName, name: modelName, provider: 'unknown', description: 'Unknown model' }
   }
 


### PR DESCRIPTION
## Summary

- Fix `getModelInfo()` always returning the first model (haiku) for unrecognized model names
- Root cause: `providerAliases` was a truthy string used directly as a `.find()` predicate, so every model matched and the first entry was returned
- Fix: compare `m.alias === matchedAlias` instead

Credit: @TGLTommy (PR #67) identified both this bug and the websocket auth field issue. The websocket fix was already merged in PR #54; this PR cherry-picks the model display fix.

Closes #67

## Test plan

- [x] `pnpm typecheck` — zero errors
- [ ] Sessions with non-Anthropic models (e.g. `deepseek-ai/DeepSeek-V3.2`) should display correct model name, not `haiku`


🤖 Generated with [Claude Code](https://claude.com/claude-code)