### PR TITLE
docs: update API route count, credit contributor

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ mission-control/
 │   ├── app/
 │   │   ├── page.tsx           # SPA shell — routes all panels
 │   │   ├── login/page.tsx     # Login page
-│   │   └── api/               # 30+ REST API routes
+│   │   └── api/               # 64 REST API routes
 │   ├── components/
 │   │   ├── layout/            # NavRail, HeaderBar, LiveFeed
 │   │   ├── dashboard/         # Overview dashboard


### PR DESCRIPTION
## Summary

- Update architecture section: "30+ REST API routes" → "64 REST API routes" (accurate count after recent additions)
- Adds @TGLTommy as a co-author to credit their model display bug fix from PR #67

## Test plan

- [x] Docs-only change, no code affected