### PR TITLE
fix: migrate middleware.ts → proxy.ts for Next.js 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Outbound webhooks with delivery history, configurable alert rules with cooldowns
 ```
 mission-control/
 ├── src/
-│   ├── middleware.ts          # Auth gate + CSRF + network access control
+│   ├── proxy.ts               # Auth gate + CSRF + network access control
 │   ├── app/
 │   │   ├── page.tsx           # SPA shell — routes all panels
 │   │   ├── login/page.tsx     # Login page

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,18 +1,14 @@
+import crypto from 'node:crypto'
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
-/** Edge-compatible constant-time string comparison. */
+/** Constant-time string comparison using Node.js crypto. */
 function safeCompare(a: string, b: string): boolean {
   if (typeof a !== 'string' || typeof b !== 'string') return false
-  const encoder = new TextEncoder()
-  const bufA = encoder.encode(a)
-  const bufB = encoder.encode(b)
+  const bufA = Buffer.from(a)
+  const bufB = Buffer.from(b)
   if (bufA.length !== bufB.length) return false
-  let result = 0
-  for (let i = 0; i < bufA.length; i++) {
-    result |= bufA[i] ^ bufB[i]
-  }
-  return result === 0
+  return crypto.timingSafeEqual(bufA, bufB)
 }
 
 function envFlag(name: string): boolean {
@@ -56,7 +52,7 @@ function applySecurityHeaders(response: NextResponse): NextResponse {
   return response
 }
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   // Network access control.
   // In production: default-deny unless explicitly allowed.
   // In dev/test: allow all hosts unless overridden.


### PR DESCRIPTION
## Summary

- Migrates `src/middleware.ts` → `src/proxy.ts` per the Next.js 16 convention (closes #88)
- Renames exported function `middleware()` → `proxy()`
- Upgrades `safeCompare` from manual TextEncoder XOR loop to `crypto.timingSafeEqual` (proxy runs on Node.js runtime, not Edge)
- Updates README architecture tree to reflect the rename

## What's unchanged

All auth logic, CSRF origin validation, host allowlisting, security headers, and route matchers are preserved exactly as-is.

## Test plan

- [x] `pnpm typecheck` — zero errors
- [x] `pnpm lint` — clean
- [x] `pnpm build` — succeeds with **no** middleware deprecation warning
- [x] `pnpm test` — all 69 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)