### PR TITLE
feat: workspace-isolate workflows and webhooks (issue #75)

### DIFF
--- a/src/app/api/webhooks/deliveries/route.ts
+++ b/src/app/api/webhooks/deliveries/route.ts
@@ -12,6 +12,7 @@ export async function GET(request: NextRequest) {
 
   try {
     const db = getDatabase()
+    const workspaceId = auth.user.workspace_id ?? 1
     const { searchParams } = new URL(request.url)
     const webhookId = searchParams.get('webhook_id')
     const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 200)
@@ -20,12 +21,13 @@ export async function GET(request: NextRequest) {
     let query = `
       SELECT wd.*, w.name as webhook_name, w.url as webhook_url
       FROM webhook_deliveries wd
-      JOIN webhooks w ON wd.webhook_id = w.id
+      JOIN webhooks w ON wd.webhook_id = w.id AND w.workspace_id = wd.workspace_id
+      WHERE wd.workspace_id = ?
     `
-    const params: any[] = []
+    const params: any[] = [workspaceId]
 
     if (webhookId) {
-      query += ' WHERE wd.webhook_id = ?'
+      query += ' AND wd.webhook_id = ?'
       params.push(webhookId)
     }
 
@@ -35,10 +37,10 @@ export async function GET(request: NextRequest) {
     const deliveries = db.prepare(query).all(...params)
 
     // Get total count
-    let countQuery = 'SELECT COUNT(*) as count FROM webhook_deliveries'
-    const countParams: any[] = []
+    let countQuery = 'SELECT COUNT(*) as count FROM webhook_deliveries WHERE workspace_id = ?'
+    const countParams: any[] = [workspaceId]
     if (webhookId) {
-      countQuery += ' WHERE webhook_id = ?'
+      countQuery += ' AND webhook_id = ?'
       countParams.push(webhookId)
     }
     const { count: total } = db.prepare(countQuery).get(...countParams) as { count: number }

--- a/src/app/api/webhooks/retry/route.ts
+++ b/src/app/api/webhooks/retry/route.ts
@@ -13,6 +13,7 @@ export async function POST(request: NextRequest) {
 
   try {
     const db = getDatabase()
+    const workspaceId = auth.user.workspace_id ?? 1
     const { delivery_id } = await request.json()
 
     if (!delivery_id) {
@@ -21,11 +22,11 @@ export async function POST(request: NextRequest) {
 
     const delivery = db.prepare(`
       SELECT wd.*, w.id as w_id, w.name as w_name, w.url as w_url, w.secret as w_secret,
-             w.events as w_events, w.enabled as w_enabled
+             w.events as w_events, w.enabled as w_enabled, w.workspace_id as w_workspace_id
       FROM webhook_deliveries wd
-      JOIN webhooks w ON w.id = wd.webhook_id
-      WHERE wd.id = ?
-    `).get(delivery_id) as any
+      JOIN webhooks w ON w.id = wd.webhook_id AND w.workspace_id = wd.workspace_id
+      WHERE wd.id = ? AND wd.workspace_id = ?
+    `).get(delivery_id, workspaceId) as any
 
     if (!delivery) {
       return NextResponse.json({ error: 'Delivery not found' }, { status: 404 })
@@ -38,6 +39,7 @@ export async function POST(request: NextRequest) {
       secret: delivery.w_secret,
       events: delivery.w_events,
       enabled: delivery.w_enabled,
+      workspace_id: delivery.w_workspace_id,
     }
 
     // Parse the original payload

--- a/src/app/api/webhooks/route.ts
+++ b/src/app/api/webhooks/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getDatabase } from '@/lib/db'
 import { requireRole } from '@/lib/auth'
-import { randomBytes, createHmac } from 'crypto'
+import { randomBytes } from 'crypto'
 import { mutationLimiter } from '@/lib/rate-limit'
 import { logger } from '@/lib/logger'
 import { validateBody, createWebhookSchema } from '@/lib/validation'
@@ -15,14 +15,16 @@ export async function GET(request: NextRequest) {
 
   try {
     const db = getDatabase()
+    const workspaceId = auth.user.workspace_id ?? 1
     const webhooks = db.prepare(`
       SELECT w.*,
-        (SELECT COUNT(*) FROM webhook_deliveries wd WHERE wd.webhook_id = w.id) as total_deliveries,
-        (SELECT COUNT(*) FROM webhook_deliveries wd WHERE wd.webhook_id = w.id AND wd.status_code BETWEEN 200 AND 299) as successful_deliveries,
-        (SELECT COUNT(*) FROM webhook_deliveries wd WHERE wd.webhook_id = w.id AND (wd.error IS NOT NULL OR wd.status_code NOT BETWEEN 200 AND 299)) as failed_deliveries
+        (SELECT COUNT(*) FROM webhook_deliveries wd WHERE wd.webhook_id = w.id AND wd.workspace_id = w.workspace_id) as total_deliveries,
+        (SELECT COUNT(*) FROM webhook_deliveries wd WHERE wd.webhook_id = w.id AND wd.workspace_id = w.workspace_id AND wd.status_code BETWEEN 200 AND 299) as successful_deliveries,
+        (SELECT COUNT(*) FROM webhook_deliveries wd WHERE wd.webhook_id = w.id AND wd.workspace_id = w.workspace_id AND (wd.error IS NOT NULL OR wd.status_code NOT BETWEEN 200 AND 299)) as failed_deliveries
       FROM webhooks w
+      WHERE w.workspace_id = ?
       ORDER BY w.created_at DESC
-    `).all() as any[]
+    `).all(workspaceId) as any[]
 
     // Parse events JSON, mask secret, add circuit breaker status
     const maxRetries = parseInt(process.env.MC_WEBHOOK_MAX_RETRIES || '5', 10) || 5
@@ -54,6 +56,7 @@ export async function POST(request: NextRequest) {
 
   try {
     const db = getDatabase()
+    const workspaceId = auth.user.workspace_id ?? 1
     const validated = await validateBody(request, createWebhookSchema)
     if ('error' in validated) return validated.error
     const body = validated.data
@@ -63,9 +66,9 @@ export async function POST(request: NextRequest) {
     const eventsJson = JSON.stringify(events || ['*'])
 
     const dbResult = db.prepare(`
-      INSERT INTO webhooks (name, url, secret, events, created_by)
-      VALUES (?, ?, ?, ?, ?)
-    `).run(name, url, secret, eventsJson, auth.user.username)
+      INSERT INTO webhooks (name, url, secret, events, created_by, workspace_id)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run(name, url, secret, eventsJson, auth.user.username, workspaceId)
 
     return NextResponse.json({
       id: dbResult.lastInsertRowid,
@@ -94,6 +97,7 @@ export async function PUT(request: NextRequest) {
 
   try {
     const db = getDatabase()
+    const workspaceId = auth.user.workspace_id ?? 1
     const body = await request.json()
     const { id, name, url, events, enabled, regenerate_secret, reset_circuit } = body
 
@@ -101,7 +105,7 @@ export async function PUT(request: NextRequest) {
       return NextResponse.json({ error: 'Webhook ID is required' }, { status: 400 })
     }
 
-    const existing = db.prepare('SELECT * FROM webhooks WHERE id = ?').get(id) as any
+    const existing = db.prepare('SELECT * FROM webhooks WHERE id = ? AND workspace_id = ?').get(id, workspaceId) as any
     if (!existing) {
       return NextResponse.json({ error: 'Webhook not found' }, { status: 404 })
     }
@@ -133,8 +137,8 @@ export async function PUT(request: NextRequest) {
       params.push(newSecret)
     }
 
-    params.push(id)
-    db.prepare(`UPDATE webhooks SET ${updates.join(', ')} WHERE id = ?`).run(...params)
+    params.push(id, workspaceId)
+    db.prepare(`UPDATE webhooks SET ${updates.join(', ')} WHERE id = ? AND workspace_id = ?`).run(...params)
 
     return NextResponse.json({
       success: true,
@@ -158,6 +162,7 @@ export async function DELETE(request: NextRequest) {
 
   try {
     const db = getDatabase()
+    const workspaceId = auth.user.workspace_id ?? 1
     let body: any
     try { body = await request.json() } catch { return NextResponse.json({ error: 'Request body required' }, { status: 400 }) }
     const id = body.id
@@ -167,8 +172,8 @@ export async function DELETE(request: NextRequest) {
     }
 
     // Delete deliveries first (cascade should handle it, but be explicit)
-    db.prepare('DELETE FROM webhook_deliveries WHERE webhook_id = ?').run(id)
-    const result = db.prepare('DELETE FROM webhooks WHERE id = ?').run(id)
+    db.prepare('DELETE FROM webhook_deliveries WHERE webhook_id = ? AND workspace_id = ?').run(id, workspaceId)
+    const result = db.prepare('DELETE FROM webhooks WHERE id = ? AND workspace_id = ?').run(id, workspaceId)
 
     if (result.changes === 0) {
       return NextResponse.json({ error: 'Webhook not found' }, { status: 404 })

--- a/src/app/api/webhooks/test/route.ts
+++ b/src/app/api/webhooks/test/route.ts
@@ -13,13 +13,14 @@ export async function POST(request: NextRequest) {
 
   try {
     const db = getDatabase()
+    const workspaceId = auth.user.workspace_id ?? 1
     const { id } = await request.json()
 
     if (!id) {
       return NextResponse.json({ error: 'Webhook ID is required' }, { status: 400 })
     }
 
-    const webhook = db.prepare('SELECT * FROM webhooks WHERE id = ?').get(id) as any
+    const webhook = db.prepare('SELECT * FROM webhooks WHERE id = ? AND workspace_id = ?').get(id, workspaceId) as any
     if (!webhook) {
       return NextResponse.json({ error: 'Webhook not found' }, { status: 404 })
     }

--- a/src/app/api/workflows/route.ts
+++ b/src/app/api/workflows/route.ts
@@ -30,7 +30,10 @@ export async function GET(request: NextRequest) {
 
   try {
     const db = getDatabase()
-    const templates = db.prepare('SELECT * FROM workflow_templates ORDER BY use_count DESC, updated_at DESC').all() as WorkflowTemplate[]
+    const workspaceId = auth.user.workspace_id ?? 1
+    const templates = db
+      .prepare('SELECT * FROM workflow_templates WHERE workspace_id = ? ORDER BY use_count DESC, updated_at DESC')
+      .all(workspaceId) as WorkflowTemplate[]
 
     const parsed = templates.map(t => ({
       ...t,
@@ -61,15 +64,36 @@ export async function POST(request: NextRequest) {
 
     const db = getDatabase()
     const user = auth.user
+    const workspaceId = auth.user.workspace_id ?? 1
 
     const insertResult = db.prepare(`
-      INSERT INTO workflow_templates (name, description, model, task_prompt, timeout_seconds, agent_role, tags, created_by)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(name, description || null, model, task_prompt, timeout_seconds, agent_role || null, JSON.stringify(tags), user?.username || 'system')
+      INSERT INTO workflow_templates (name, description, model, task_prompt, timeout_seconds, agent_role, tags, created_by, workspace_id)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      name,
+      description || null,
+      model,
+      task_prompt,
+      timeout_seconds,
+      agent_role || null,
+      JSON.stringify(tags),
+      user?.username || 'system',
+      workspaceId
+    )
 
-    const template = db.prepare('SELECT * FROM workflow_templates WHERE id = ?').get(insertResult.lastInsertRowid) as WorkflowTemplate
+    const template = db
+      .prepare('SELECT * FROM workflow_templates WHERE id = ? AND workspace_id = ?')
+      .get(insertResult.lastInsertRowid, workspaceId) as WorkflowTemplate
 
-    db_helpers.logActivity('workflow_created', 'workflow', Number(insertResult.lastInsertRowid), user?.username || 'system', `Created workflow template: ${name}`)
+    db_helpers.logActivity(
+      'workflow_created',
+      'workflow',
+      Number(insertResult.lastInsertRowid),
+      user?.username || 'system',
+      `Created workflow template: ${name}`,
+      undefined,
+      workspaceId
+    )
 
     return NextResponse.json({
       template: { ...template, tags: template.tags ? JSON.parse(template.tags) : [] }
@@ -89,6 +113,7 @@ export async function PUT(request: NextRequest) {
 
   try {
     const db = getDatabase()
+    const workspaceId = auth.user.workspace_id ?? 1
     const body = await request.json()
     const { id, ...updates } = body
 
@@ -96,7 +121,9 @@ export async function PUT(request: NextRequest) {
       return NextResponse.json({ error: 'Template ID is required' }, { status: 400 })
     }
 
-    const existing = db.prepare('SELECT * FROM workflow_templates WHERE id = ?').get(id) as WorkflowTemplate
+    const existing = db
+      .prepare('SELECT * FROM workflow_templates WHERE id = ? AND workspace_id = ?')
+      .get(id, workspaceId) as WorkflowTemplate
     if (!existing) {
       return NextResponse.json({ error: 'Template not found' }, { status: 404 })
     }
@@ -121,11 +148,13 @@ export async function PUT(request: NextRequest) {
 
     fields.push('updated_at = ?')
     params.push(Math.floor(Date.now() / 1000))
-    params.push(id)
+    params.push(id, workspaceId)
 
-    db.prepare(`UPDATE workflow_templates SET ${fields.join(', ')} WHERE id = ?`).run(...params)
+    db.prepare(`UPDATE workflow_templates SET ${fields.join(', ')} WHERE id = ? AND workspace_id = ?`).run(...params)
 
-    const updated = db.prepare('SELECT * FROM workflow_templates WHERE id = ?').get(id) as WorkflowTemplate
+    const updated = db
+      .prepare('SELECT * FROM workflow_templates WHERE id = ? AND workspace_id = ?')
+      .get(id, workspaceId) as WorkflowTemplate
     return NextResponse.json({ template: { ...updated, tags: updated.tags ? JSON.parse(updated.tags) : [] } })
   } catch (error) {
     logger.error({ err: error }, 'PUT /api/workflows error')
@@ -142,6 +171,7 @@ export async function DELETE(request: NextRequest) {
 
   try {
     const db = getDatabase()
+    const workspaceId = auth.user.workspace_id ?? 1
     let body: any
     try { body = await request.json() } catch { return NextResponse.json({ error: 'Request body required' }, { status: 400 }) }
     const id = body.id
@@ -150,7 +180,10 @@ export async function DELETE(request: NextRequest) {
       return NextResponse.json({ error: 'Template ID is required' }, { status: 400 })
     }
 
-    db.prepare('DELETE FROM workflow_templates WHERE id = ?').run(parseInt(id))
+    const result = db.prepare('DELETE FROM workflow_templates WHERE id = ? AND workspace_id = ?').run(parseInt(id), workspaceId)
+    if (result.changes === 0) {
+      return NextResponse.json({ error: 'Template not found' }, { status: 404 })
+    }
     return NextResponse.json({ success: true })
   } catch (error) {
     logger.error({ err: error }, 'DELETE /api/workflows error')

--- a/src/lib/migrations.ts
+++ b/src/lib/migrations.ts
@@ -643,6 +643,39 @@ const migrations: Migration[] = [
       db.exec(`CREATE INDEX IF NOT EXISTS idx_workflow_pipelines_workspace_id ON workflow_pipelines(workspace_id)`)
       db.exec(`CREATE INDEX IF NOT EXISTS idx_pipeline_runs_workspace_id ON pipeline_runs(workspace_id)`)
     }
+  },
+  {
+    id: '023_workspace_isolation_phase3',
+    up: (db) => {
+      const addWorkspaceIdColumn = (table: string) => {
+        const tableExists = db
+          .prepare(`SELECT 1 as ok FROM sqlite_master WHERE type = 'table' AND name = ?`)
+          .get(table) as { ok?: number } | undefined
+        if (!tableExists?.ok) return
+
+        const cols = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>
+        if (!cols.some((c) => c.name === 'workspace_id')) {
+          db.exec(`ALTER TABLE ${table} ADD COLUMN workspace_id INTEGER NOT NULL DEFAULT 1`)
+        }
+        db.exec(`UPDATE ${table} SET workspace_id = COALESCE(workspace_id, 1)`)
+      }
+
+      const scopedTables = [
+        'workflow_templates',
+        'webhooks',
+        'webhook_deliveries',
+        'token_usage',
+      ]
+
+      for (const table of scopedTables) {
+        addWorkspaceIdColumn(table)
+      }
+
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_workflow_templates_workspace_id ON workflow_templates(workspace_id)`)
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_webhooks_workspace_id ON webhooks(workspace_id)`)
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_workspace_id ON webhook_deliveries(workspace_id)`)
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_token_usage_workspace_id ON token_usage(workspace_id)`)
+    }
   }
 ]
 

--- a/src/lib/webhooks.ts
+++ b/src/lib/webhooks.ts
@@ -9,6 +9,7 @@ interface Webhook {
   secret: string | null
   events: string // JSON array
   enabled: number
+  workspace_id?: number
   consecutive_failures?: number
 }
 
@@ -103,13 +104,14 @@ export function initWebhookListener() {
 
     // Also fire agent.error for error status specifically
     const isAgentError = event.type === 'agent.status_changed' && event.data?.status === 'error'
+    const workspaceId = typeof event.data?.workspace_id === 'number' ? event.data.workspace_id : 1
 
-    fireWebhooksAsync(webhookEventType, event.data).catch((err) => {
+    fireWebhooksAsync(webhookEventType, event.data, workspaceId).catch((err) => {
       logger.error({ err }, 'Webhook dispatch error')
     })
 
     if (isAgentError) {
-      fireWebhooksAsync('agent.error', event.data).catch((err) => {
+      fireWebhooksAsync('agent.error', event.data, workspaceId).catch((err) => {
         logger.error({ err }, 'Webhook dispatch error')
       })
     }
@@ -119,21 +121,23 @@ export function initWebhookListener() {
 /**
  * Fire all matching webhooks for an event type (public for test endpoint).
  */
-export function fireWebhooks(eventType: string, payload: Record<string, any>) {
-  fireWebhooksAsync(eventType, payload).catch((err) => {
+export function fireWebhooks(eventType: string, payload: Record<string, any>, workspaceId?: number) {
+  fireWebhooksAsync(eventType, payload, workspaceId).catch((err) => {
     logger.error({ err }, 'Webhook dispatch error')
   })
 }
 
-async function fireWebhooksAsync(eventType: string, payload: Record<string, any>) {
+async function fireWebhooksAsync(eventType: string, payload: Record<string, any>, workspaceId?: number) {
+  const resolvedWorkspaceId =
+    workspaceId ?? (typeof payload?.workspace_id === 'number' ? payload.workspace_id : 1)
   let webhooks: Webhook[]
   try {
     // Lazy import to avoid circular dependency
     const { getDatabase } = await import('./db')
     const db = getDatabase()
     webhooks = db.prepare(
-      'SELECT * FROM webhooks WHERE enabled = 1'
-    ).all() as Webhook[]
+      'SELECT * FROM webhooks WHERE enabled = 1 AND workspace_id = ?'
+    ).all(resolvedWorkspaceId) as Webhook[]
   } catch {
     return // DB not ready or table doesn't exist yet
   }
@@ -229,8 +233,8 @@ async function deliverWebhook(
     const db = getDatabase()
 
     const insertResult = db.prepare(`
-      INSERT INTO webhook_deliveries (webhook_id, event_type, payload, status_code, response_body, error, duration_ms, attempt, is_retry, parent_delivery_id)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO webhook_deliveries (webhook_id, event_type, payload, status_code, response_body, error, duration_ms, attempt, is_retry, parent_delivery_id, workspace_id)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       webhook.id,
       eventType,
@@ -241,24 +245,25 @@ async function deliverWebhook(
       durationMs,
       attempt,
       attempt > 0 ? 1 : 0,
-      parentDeliveryId
+      parentDeliveryId,
+      webhook.workspace_id ?? 1
     )
     deliveryId = Number(insertResult.lastInsertRowid)
 
     // Update webhook last_fired
     db.prepare(`
       UPDATE webhooks SET last_fired_at = unixepoch(), last_status = ?, updated_at = unixepoch()
-      WHERE id = ?
-    `).run(statusCode ?? -1, webhook.id)
+      WHERE id = ? AND workspace_id = ?
+    `).run(statusCode ?? -1, webhook.id, webhook.workspace_id ?? 1)
 
     // Circuit breaker + retry scheduling (skip for test deliveries)
     if (allowRetry) {
       if (success) {
         // Reset consecutive failures on success
-        db.prepare(`UPDATE webhooks SET consecutive_failures = 0 WHERE id = ?`).run(webhook.id)
+        db.prepare(`UPDATE webhooks SET consecutive_failures = 0 WHERE id = ? AND workspace_id = ?`).run(webhook.id, webhook.workspace_id ?? 1)
       } else {
         // Increment consecutive failures
-        db.prepare(`UPDATE webhooks SET consecutive_failures = consecutive_failures + 1 WHERE id = ?`).run(webhook.id)
+        db.prepare(`UPDATE webhooks SET consecutive_failures = consecutive_failures + 1 WHERE id = ? AND workspace_id = ?`).run(webhook.id, webhook.workspace_id ?? 1)
 
         if (attempt < MAX_RETRIES - 1) {
           // Schedule retry
@@ -267,9 +272,9 @@ async function deliverWebhook(
           db.prepare(`UPDATE webhook_deliveries SET next_retry_at = ? WHERE id = ?`).run(nextRetryAt, deliveryId)
         } else {
           // Exhausted retries — trip circuit breaker
-          const wh = db.prepare(`SELECT consecutive_failures FROM webhooks WHERE id = ?`).get(webhook.id) as { consecutive_failures: number } | undefined
+          const wh = db.prepare(`SELECT consecutive_failures FROM webhooks WHERE id = ? AND workspace_id = ?`).get(webhook.id, webhook.workspace_id ?? 1) as { consecutive_failures: number } | undefined
           if (wh && wh.consecutive_failures >= MAX_RETRIES) {
-            db.prepare(`UPDATE webhooks SET enabled = 0, updated_at = unixepoch() WHERE id = ?`).run(webhook.id)
+            db.prepare(`UPDATE webhooks SET enabled = 0, updated_at = unixepoch() WHERE id = ? AND workspace_id = ?`).run(webhook.id, webhook.workspace_id ?? 1)
             logger.warn({ webhookId: webhook.id, name: webhook.name }, 'Webhook circuit breaker tripped — disabled after exhausting retries')
           }
         }
@@ -279,10 +284,10 @@ async function deliverWebhook(
     // Prune old deliveries (keep last 200 per webhook)
     db.prepare(`
       DELETE FROM webhook_deliveries
-      WHERE webhook_id = ? AND id NOT IN (
-        SELECT id FROM webhook_deliveries WHERE webhook_id = ? ORDER BY created_at DESC LIMIT 200
+      WHERE webhook_id = ? AND workspace_id = ? AND id NOT IN (
+        SELECT id FROM webhook_deliveries WHERE webhook_id = ? AND workspace_id = ? ORDER BY created_at DESC LIMIT 200
       )
-    `).run(webhook.id, webhook.id)
+    `).run(webhook.id, webhook.workspace_id ?? 1, webhook.id, webhook.workspace_id ?? 1)
   } catch (logErr) {
     logger.error({ err: logErr, webhookId: webhook.id }, 'Webhook delivery logging/pruning failed')
   }
@@ -304,15 +309,16 @@ export async function processWebhookRetries(): Promise<{ ok: boolean; message: s
     const pendingRetries = db.prepare(`
       SELECT wd.id, wd.webhook_id, wd.event_type, wd.payload, wd.attempt,
              w.id as w_id, w.name as w_name, w.url as w_url, w.secret as w_secret,
-             w.events as w_events, w.enabled as w_enabled, w.consecutive_failures as w_consecutive_failures
+             w.events as w_events, w.enabled as w_enabled, w.consecutive_failures as w_consecutive_failures,
+             wd.workspace_id as wd_workspace_id
       FROM webhook_deliveries wd
-      JOIN webhooks w ON w.id = wd.webhook_id AND w.enabled = 1
+      JOIN webhooks w ON w.id = wd.webhook_id AND w.workspace_id = wd.workspace_id AND w.enabled = 1
       WHERE wd.next_retry_at IS NOT NULL AND wd.next_retry_at <= ?
       LIMIT 50
     `).all(now) as Array<{
       id: number; webhook_id: number; event_type: string; payload: string; attempt: number
       w_id: number; w_name: string; w_url: string; w_secret: string | null
-      w_events: string; w_enabled: number; w_consecutive_failures: number
+      w_events: string; w_enabled: number; w_consecutive_failures: number; wd_workspace_id: number
     }>
 
     if (pendingRetries.length === 0) {
@@ -320,9 +326,9 @@ export async function processWebhookRetries(): Promise<{ ok: boolean; message: s
     }
 
     // Clear next_retry_at immediately to prevent double-processing
-    const clearStmt = db.prepare(`UPDATE webhook_deliveries SET next_retry_at = NULL WHERE id = ?`)
+    const clearStmt = db.prepare(`UPDATE webhook_deliveries SET next_retry_at = NULL WHERE id = ? AND workspace_id = ?`)
     for (const row of pendingRetries) {
-      clearStmt.run(row.id)
+      clearStmt.run(row.id, row.wd_workspace_id)
     }
 
     // Re-deliver each
@@ -337,6 +343,7 @@ export async function processWebhookRetries(): Promise<{ ok: boolean; message: s
         events: row.w_events,
         enabled: row.w_enabled,
         consecutive_failures: row.w_consecutive_failures,
+        workspace_id: row.wd_workspace_id,
       }
 
       // Parse the original payload from the stored JSON body

--- a/tests/csrf-validation.spec.ts
+++ b/tests/csrf-validation.spec.ts
@@ -6,7 +6,9 @@ import { test, expect } from '@playwright/test'
  */
 
 test.describe('CSRF Origin Validation (Issue #20)', () => {
-  const TEST_PASS = 'testpass1234!'
+  const TEST_USER = process.env.AUTH_USER || 'testadmin'
+  const TEST_PASS = process.env.AUTH_PASS || 'testpass1234!'
+  const TEST_API_KEY = process.env.API_KEY || 'test-api-key-e2e-12345'
 
   test('POST with mismatched Origin is rejected', async ({ request }) => {
     const res = await request.post('/api/auth/login', {
@@ -23,7 +25,7 @@ test.describe('CSRF Origin Validation (Issue #20)', () => {
 
   test('POST with matching Origin is allowed', async ({ request }) => {
     const res = await request.post('/api/auth/login', {
-      data: { username: 'testadmin', password: TEST_PASS },
+      data: { username: TEST_USER, password: TEST_PASS },
       headers: {
         'origin': 'http://127.0.0.1:3005',
         'host': '127.0.0.1:3005'
@@ -35,7 +37,7 @@ test.describe('CSRF Origin Validation (Issue #20)', () => {
 
   test('POST without Origin header is allowed (non-browser client)', async ({ request }) => {
     const res = await request.post('/api/auth/login', {
-      data: { username: 'testadmin', password: TEST_PASS },
+      data: { username: TEST_USER, password: TEST_PASS },
     })
     // No Origin = non-browser client, should be allowed through CSRF check
     expect(res.status()).not.toBe(403)
@@ -45,7 +47,7 @@ test.describe('CSRF Origin Validation (Issue #20)', () => {
     const res = await request.get('/api/agents', {
       headers: {
         'origin': 'https://evil.example.com',
-        'x-api-key': 'test-api-key-e2e-12345'
+        'x-api-key': TEST_API_KEY
       }
     })
     // GET is exempt from CSRF — should not be 403

--- a/tests/login-flow.spec.ts
+++ b/tests/login-flow.spec.ts
@@ -6,7 +6,25 @@ import { test, expect } from '@playwright/test'
  */
 
 test.describe('Login Flow', () => {
+  const TEST_API_KEY = process.env.API_KEY || 'test-api-key-e2e-12345'
   const TEST_PASS = 'testpass1234!'
+  const TEST_USER = `login-e2e-${Date.now()}`
+
+  test.beforeAll(async ({ request }) => {
+    const createRes = await request.post('/api/auth/users', {
+      data: {
+        username: TEST_USER,
+        password: TEST_PASS,
+        display_name: 'Login E2E User',
+        role: 'admin',
+      },
+      headers: {
+        'x-api-key': TEST_API_KEY,
+      },
+    })
+
+    expect([201, 409]).toContain(createRes.status())
+  })
 
   test('login page loads', async ({ page }) => {
     await page.goto('/login')
@@ -20,7 +38,7 @@ test.describe('Login Flow', () => {
 
   test('login API returns session cookie on success', async ({ request }) => {
     const res = await request.post('/api/auth/login', {
-      data: { username: 'testadmin', password: TEST_PASS },
+      data: { username: TEST_USER, password: TEST_PASS },
       headers: { 'x-forwarded-for': '10.88.88.1' }
     })
     expect(res.status()).toBe(200)
@@ -32,7 +50,7 @@ test.describe('Login Flow', () => {
 
   test('login API rejects wrong password', async ({ request }) => {
     const res = await request.post('/api/auth/login', {
-      data: { username: 'testadmin', password: 'wrongpassword' },
+      data: { username: TEST_USER, password: 'wrongpassword' },
       headers: { 'x-forwarded-for': '10.77.77.77' }
     })
     expect(res.status()).toBe(401)
@@ -41,7 +59,7 @@ test.describe('Login Flow', () => {
   test('session cookie grants API access', async ({ request }) => {
     // Login to get a session
     const loginRes = await request.post('/api/auth/login', {
-      data: { username: 'testadmin', password: TEST_PASS },
+      data: { username: TEST_USER, password: TEST_PASS },
       headers: { 'x-forwarded-for': '10.88.88.2' }
     })
     expect(loginRes.status()).toBe(200)
@@ -58,6 +76,6 @@ test.describe('Login Flow', () => {
     })
     expect(meRes.status()).toBe(200)
     const body = await meRes.json()
-    expect(body.user?.username).toBe('testadmin')
+    expect(body.user?.username).toBe(TEST_USER)
   })
 })

--- a/tests/rate-limiting.spec.ts
+++ b/tests/rate-limiting.spec.ts
@@ -6,7 +6,8 @@ import { test, expect } from '@playwright/test'
  */
 
 test.describe('Login Rate Limiting (Issue #8)', () => {
-  const TEST_PASS = 'testpass1234!'
+  const TEST_USER = process.env.AUTH_USER || 'testadmin'
+  const TEST_PASS = process.env.AUTH_PASS || 'testpass1234!'
 
   test('blocks login after 5 rapid failed attempts', async ({ request }) => {
     const results: number[] = []
@@ -14,7 +15,7 @@ test.describe('Login Rate Limiting (Issue #8)', () => {
     // Send 7 rapid login attempts with wrong password
     for (let i = 0; i < 7; i++) {
       const res = await request.post('/api/auth/login', {
-        data: { username: 'testadmin', password: 'wrongpassword' },
+        data: { username: TEST_USER, password: 'wrongpassword' },
         headers: { 'x-real-ip': '10.99.99.99' }
       })
       results.push(res.status())
@@ -27,7 +28,7 @@ test.describe('Login Rate Limiting (Issue #8)', () => {
 
   test('successful login is not blocked for fresh IP', async ({ request }) => {
     const res = await request.post('/api/auth/login', {
-      data: { username: 'testadmin', password: TEST_PASS },
+      data: { username: TEST_USER, password: TEST_PASS },
       headers: { 'x-real-ip': '10.88.88.88' }
     })
     // Should succeed (200) or at least not be rate limited


### PR DESCRIPTION
## Summary\n- adds migration  to add/index  on , , , and \n- scopes  CRUD to authenticated user workspace\n- scopes  CRUD plus deliveries/retry/test routes to authenticated user workspace\n- scopes webhook dispatch/retry internals in  to \n- hardens login/csrf/rate-limit E2E specs to avoid env-specific credential drift\n\n## Validation\n- 
> mission-control@1.3.0 typecheck /Users/nyk/work/products/mission-control
> tsc --noEmit\n- 
> mission-control@1.3.0 lint /Users/nyk/work/products/mission-control
> eslint .\n- 
> mission-control@1.3.0 test /Users/nyk/work/products/mission-control
> vitest run


 RUN  v2.1.9 /Users/nyk/work/products/mission-control

 ✓ src/lib/google-auth.test.ts (5 tests) 4ms
 ✓ src/lib/__tests__/db-helpers.test.ts (11 tests) 5ms
 ✓ src/lib/__tests__/auth.test.ts (11 tests) 6ms
 ✓ src/lib/__tests__/webhooks.test.ts (9 tests) 4ms
 ✓ src/lib/__tests__/rate-limit.test.ts (6 tests) 9ms
 ✓ src/lib/__tests__/validation.test.ts (27 tests) 7ms

 Test Files  6 passed (6)
      Tests  69 passed (69)
   Start at  09:14:25
   Duration  2.03s (transform 237ms, setup 586ms, collect 577ms, tests 35ms, environment 3.40s, prepare 676ms)\n- 
> mission-control@1.3.0 test:e2e /Users/nyk/work/products/mission-control
> playwright test


Running 171 tests using 1 worker

  ✓    1 [chromium] › tests/agent-costs.spec.ts:5:7 › Agent Costs API › GET action=stats includes agents field (33ms)
  ✓    2 [chromium] › tests/agent-costs.spec.ts:20:7 › Agent Costs API › GET action=agent-costs returns per-agent breakdown (168ms)
  ✓    3 [chromium] › tests/agent-costs.spec.ts:45:7 › Agent Costs API › GET action=agent-costs respects timeframe filtering (24ms)
  ✓    4 [chromium] › tests/agent-costs.spec.ts:74:7 › Agent Costs API › POST /api/tokens records data that appears in agent-costs (21ms)
  ✓    5 [chromium] › tests/agent-costs.spec.ts:96:7 › Agent Costs API › GET action=agent-costs requires auth (7ms)
  ✓    6 [chromium] › tests/agents-crud.spec.ts:16:7 › Agents CRUD › POST creates agent with name and role (21ms)
  ✓    7 [chromium] › tests/agents-crud.spec.ts:27:7 › Agents CRUD › POST rejects missing name (6ms)
  ✓    8 [chromium] › tests/agents-crud.spec.ts:35:7 › Agents CRUD › POST rejects duplicate name (12ms)
  ✓    9 [chromium] › tests/agents-crud.spec.ts:48:7 › Agents CRUD › GET list returns agents with pagination and taskStats (14ms)
  ✓   10 [chromium] › tests/agents-crud.spec.ts:70:7 › Agents CRUD › GET single by numeric id (14ms)
  ✓   11 [chromium] › tests/agents-crud.spec.ts:80:7 › Agents CRUD › GET single by name (12ms)
  ✓   12 [chromium] › tests/agents-crud.spec.ts:90:7 › Agents CRUD › GET single returns 404 for missing (5ms)
  ✓   13 [chromium] › tests/agents-crud.spec.ts:97:7 › Agents CRUD › PUT by id updates role (18ms)
  ✓   14 [chromium] › tests/agents-crud.spec.ts:110:7 › Agents CRUD › PUT by id returns 404 for missing (5ms)
  ✓   15 [chromium] › tests/agents-crud.spec.ts:120:7 › Agents CRUD › PUT by name updates status (14ms)
  ✓   16 [chromium] › tests/agents-crud.spec.ts:133:7 › Agents CRUD › PUT by name returns 404 for missing (6ms)
  ✓   17 [chromium] › tests/agents-crud.spec.ts:141:7 › Agents CRUD › PUT by name returns 400 when no fields provided (12ms)
  ✓   18 [chromium] › tests/agents-crud.spec.ts:154:7 › Agents CRUD › DELETE removes agent (admin via API key) (9ms)
  ✓   19 [chromium] › tests/agents-crud.spec.ts:164:7 › Agents CRUD › DELETE returns 404 for missing agent (6ms)
  ✓   20 [chromium] › tests/agents-crud.spec.ts:171:7 › Agents CRUD › full lifecycle: create → read → update → delete (21ms)
  ✓   21 [chromium] › tests/alerts-crud.spec.ts:16:7 › Alerts CRUD › POST creates alert rule with all required fields (21ms)
  ✓   22 [chromium] › tests/alerts-crud.spec.ts:27:7 › Alerts CRUD › POST rejects missing required fields (7ms)
  ✓   23 [chromium] › tests/alerts-crud.spec.ts:35:7 › Alerts CRUD › POST rejects invalid entity_type (5ms)
  ✓   24 [chromium] › tests/alerts-crud.spec.ts:51:7 › Alerts CRUD › GET returns rules array (12ms)
  ✓   25 [chromium] › tests/alerts-crud.spec.ts:64:7 › Alerts CRUD › PUT updates alert rule fields (14ms)
  ✓   26 [chromium] › tests/alerts-crud.spec.ts:78:7 › Alerts CRUD › PUT returns 404 for missing rule (7ms)
  ✓   27 [chromium] › tests/alerts-crud.spec.ts:88:7 › Alerts CRUD › DELETE removes alert rule (11ms)
  ✓   28 [chromium] › tests/alerts-crud.spec.ts:102:7 › Alerts CRUD › full lifecycle: create → list → update → delete (17ms)
  ✓   29 [chromium] › tests/auth-guards.spec.ts:32:9 › Auth Guards (Issue #4) › GET /api/agents returns 401 without auth (4ms)
  ✓   30 [chromium] › tests/auth-guards.spec.ts:32:9 › Auth Guards (Issue #4) › GET /api/tasks returns 401 without auth (4ms)
  ✓   31 [chromium] › tests/auth-guards.spec.ts:32:9 › Auth Guards (Issue #4) › GET /api/activities returns 401 without auth (6ms)
  ✓   32 [chromium] › tests/auth-guards.spec.ts:32:9 › Auth Guards (Issue #4) › GET /api/notifications?recipient=test returns 401 without auth (4ms)
  ✓   33 [chromium] › tests/auth-guards.spec.ts:32:9 › Auth Guards (Issue #4) › GET /api/status returns 401 without auth (5ms)
  ✓   34 [chromium] › tests/auth-guards.spec.ts:32:9 › Auth Guards (Issue #4) › GET /api/logs returns 401 without auth (4ms)
  ✓   35 [chromium] › tests/auth-guards.spec.ts:32:9 › Auth Guards (Issue #4) › GET /api/chat/conversations returns 401 without auth (9ms)
  ✓   36 [chromium] › tests/auth-guards.spec.ts:32:9 › Auth Guards (Issue #4) › GET /api/chat/messages returns 401 without auth (7ms)
  ✓   37 [chromium] › tests/auth-guards.spec.ts:32:9 › Auth Guards (Issue #4) › GET /api/standup returns 401 without auth (7ms)
  ✓   38 [chromium] › tests/auth-guards.spec.ts:32:9 › Auth Guards (Issue #4) › GET /api/spawn returns 401 without auth (5ms)
  ✓   39 [chromium] › tests/auth-guards.spec.ts:32:9 › Auth Guards (Issue #4) › GET /api/pipelines returns 401 without auth (4ms)
  ✓   40 [chromium] › tests/auth-guards.spec.ts:32:9 › Auth Guards (Issue #4) › GET /api/pipelines/run returns 401 without auth (4ms)
  ✓   41 [chromium] › tests/auth-guards.spec.ts:32:9 › Auth Guards (Issue #4) › GET /api/webhooks returns 401 without auth (5ms)
  ✓   42 [chromium] › tests/auth-guards.spec.ts:32:9 › Auth Guards (Issue #4) › GET /api/webhooks/deliveries returns 401 without auth (5ms)
  ✓   43 [chromium] › tests/auth-guards.spec.ts:32:9 › Auth Guards (Issue #4) › GET /api/workflows returns 401 without auth (4ms)
  ✓   44 [chromium] › tests/auth-guards.spec.ts:32:9 › Auth Guards (Issue #4) › GET /api/settings returns 401 without auth (3ms)
  ✓   45 [chromium] › tests/auth-guards.spec.ts:32:9 › Auth Guards (Issue #4) › GET /api/tokens returns 401 without auth (6ms)
  ✓   46 [chromium] › tests/auth-guards.spec.ts:32:9 › Auth Guards (Issue #4) › GET /api/search?q=test returns 401 without auth (4ms)
  ✓   47 [chromium] › tests/auth-guards.spec.ts:32:9 › Auth Guards (Issue #4) › GET /api/audit returns 401 without auth (4ms)
  ✓   48 [chromium] › tests/auth-guards.spec.ts:38:7 › Auth Guards (Issue #4) › GET endpoint returns 200 with valid API key (8ms)
  ✓   49 [chromium] › tests/csrf-validation.spec.ts:13:7 › CSRF Origin Validation (Issue #20) › POST with mismatched Origin is rejected (12ms)
  ✓   50 [chromium] › tests/csrf-validation.spec.ts:26:7 › CSRF Origin Validation (Issue #20) › POST with matching Origin is allowed (39ms)
  ✓   51 [chromium] › tests/csrf-validation.spec.ts:38:7 › CSRF Origin Validation (Issue #20) › POST without Origin header is allowed (non-browser client) (35ms)
  ✓   52 [chromium] › tests/csrf-validation.spec.ts:46:7 › CSRF Origin Validation (Issue #20) › GET requests are not subject to CSRF check (6ms)
  ✓   53 [chromium] › tests/delete-body.spec.ts:11:7 › DELETE Body Standardization (Issue #18) › DELETE /api/pipelines rejects without body (7ms)
  ✓   54 [chromium] › tests/delete-body.spec.ts:20:7 › DELETE Body Standardization (Issue #18) › DELETE /api/pipelines accepts body with id (4ms)
  ✓   55 [chromium] › tests/delete-body.spec.ts:29:7 › DELETE Body Standardization (Issue #18) › DELETE /api/webhooks rejects without body (8ms)
  ✓   56 [chromium] › tests/delete-body.spec.ts:38:7 › DELETE Body Standardization (Issue #18) › DELETE /api/settings rejects without body (9ms)
  ✓   57 [chromium] › tests/delete-body.spec.ts:47:7 › DELETE Body Standardization (Issue #18) › DELETE /api/workflows rejects without body (8ms)
  ✓   58 [chromium] › tests/delete-body.spec.ts:56:7 › DELETE Body Standardization (Issue #18) › DELETE /api/backup rejects without body (9ms)
  ✓   59 [chromium] › tests/delete-body.spec.ts:65:7 › DELETE Body Standardization (Issue #18) › DELETE /api/auth/users rejects without body (7ms)
  ✓   60 [chromium] › tests/delete-body.spec.ts:73:7 › DELETE Body Standardization (Issue #18) › old query param style no longer works for DELETE (6ms)
  ✓   61 [chromium] › tests/device-identity.spec.ts:23:7 › Device Identity — Ed25519 key management › generates Ed25519 key pair and stores in localStorage (142ms)
  ✓   62 [chromium] › tests/device-identity.spec.ts:80:7 › Device Identity — Ed25519 key management › signs a nonce and produces a valid Ed25519 signature (100ms)
  ✓   63 [chromium] › tests/device-identity.spec.ts:114:7 › Device Identity — Ed25519 key management › persisted key pair survives page reload (127ms)
  ✓   64 [chromium] › tests/device-identity.spec.ts:155:7 › Device Identity — Ed25519 key management › reimported private key can sign and verify (104ms)
  ✓   65 [chromium] › tests/device-identity.spec.ts:212:7 › Device Identity — Ed25519 key management › device token cache read/write (114ms)
  ✓   66 [chromium] › tests/device-identity.spec.ts:226:7 › Device Identity — Ed25519 key management › clearDeviceIdentity removes all storage keys (111ms)
  ✓   67 [chromium] › tests/direct-cli.spec.ts:25:7 › Direct CLI Integration › POST /api/connect creates connection and auto-creates agent (24ms)
  ✓   68 [chromium] › tests/direct-cli.spec.ts:60:7 › Direct CLI Integration › GET /api/connect lists connections (23ms)
  ✓   69 [chromium] › tests/direct-cli.spec.ts:83:7 › Direct CLI Integration › POST heartbeat with inline token_usage (31ms)
  ✓   70 [chromium] › tests/direct-cli.spec.ts:121:7 › Direct CLI Integration › DELETE /api/connect disconnects and sets agent offline (16ms)
  ✓   71 [chromium] › tests/direct-cli.spec.ts:149:7 › Direct CLI Integration › POST /api/connect requires auth (5ms)
  ✓   72 [chromium] › tests/github-sync.spec.ts:7:7 › GitHub Sync API › GET /api/github?action=issues requires auth (4ms)
  ✓   73 [chromium] › tests/github-sync.spec.ts:12:7 › GitHub Sync API › GET /api/github?action=issues returns error without GITHUB_TOKEN (4.6s)
  ✓   74 [chromium] › tests/github-sync.spec.ts:22:7 › GitHub Sync API › GET /api/github rejects invalid action (7ms)
  ✓   75 [chromium] › tests/github-sync.spec.ts:33:7 › GitHub Sync API › POST /api/github with action=status returns sync history (10ms)
  ✓   76 [chromium] › tests/github-sync.spec.ts:44:7 › GitHub Sync API › POST /api/github with action=sync requires repo param (5ms)
  ✓   77 [chromium] › tests/github-sync.spec.ts:53:7 › GitHub Sync API › POST /api/github rejects invalid repo format (5ms)
  ✓   78 [chromium] › tests/legacy-cookie-removed.spec.ts:9:7 › Legacy Cookie Auth Removed (Issue #7) › legacy cookie does not authenticate API requests (11ms)
  ✓   79 [chromium] › tests/legacy-cookie-removed.spec.ts:18:7 › Legacy Cookie Auth Removed (Issue #7) › legacy cookie does not authenticate page requests (99ms)
  ✓   80 [chromium] › tests/limit-caps.spec.ts:22:9 › Limit Caps (Issue #19) › /api/agents?limit=9999 does not return more than 200 items (5ms)
  ✓   81 [chromium] › tests/limit-caps.spec.ts:22:9 › Limit Caps (Issue #19) › /api/tasks?limit=9999 does not return more than 200 items (7ms)
  ✓   82 [chromium] › tests/limit-caps.spec.ts:22:9 › Limit Caps (Issue #19) › /api/activities?limit=9999 does not return more than 500 items (10ms)
  ✓   83 [chromium] › tests/limit-caps.spec.ts:22:9 › Limit Caps (Issue #19) › /api/logs?limit=9999 does not return more than 200 items (6ms)
  ✓   84 [chromium] › tests/limit-caps.spec.ts:22:9 › Limit Caps (Issue #19) › /api/chat/conversations?limit=9999 does not return more than 200 items (9ms)
  ✓   85 [chromium] › tests/limit-caps.spec.ts:22:9 › Limit Caps (Issue #19) › /api/spawn?limit=9999 does not return more than 200 items (8ms)
  ✓   86 [chromium] › tests/limit-caps.spec.ts:48:7 › Limit Caps (Issue #19) › search endpoint has its own cap of 100 (10ms)
  ✓   87 [chromium] › tests/login-flow.spec.ts:29:7 › Login Flow › login page loads (108ms)
  ✓   88 [chromium] › tests/login-flow.spec.ts:34:7 › Login Flow › unauthenticated access redirects to login (108ms)
  ✓   89 [chromium] › tests/login-flow.spec.ts:39:7 › Login Flow › login API returns session cookie on success (38ms)
  ✓   90 [chromium] › tests/login-flow.spec.ts:51:7 › Login Flow › login API rejects wrong password (36ms)
  ✓   91 [chromium] › tests/login-flow.spec.ts:59:7 › Login Flow › session cookie grants API access (42ms)
  ✓   92 [chromium] › tests/notifications.spec.ts:16:7 › Notifications › GET returns notifications for recipient (18ms)
  ✓   93 [chromium] › tests/notifications.spec.ts:32:7 › Notifications › GET returns 400 without recipient param (5ms)
  ✓   94 [chromium] › tests/notifications.spec.ts:37:7 › Notifications › GET filters by unread_only (8ms)
  ✓   95 [chromium] › tests/notifications.spec.ts:51:7 › Notifications › POST marks notifications as delivered (12ms)
  ✓   96 [chromium] › tests/notifications.spec.ts:65:7 › Notifications › POST rejects missing agent (7ms)
  ✓   97 [chromium] › tests/notifications.spec.ts:75:7 › Notifications › PUT marks specific notification ids as read (13ms)
  ✓   98 [chromium] › tests/notifications.spec.ts:98:7 › Notifications › PUT marks all as read for recipient (5ms)
  ✓   99 [chromium] › tests/openapi.spec.ts:4:7 › OpenAPI Documentation › GET /api/docs returns valid OpenAPI 3.1 JSON (13ms)
  ✓  100 [chromium] › tests/openapi.spec.ts:17:7 › OpenAPI Documentation › GET /api/docs includes key paths (6ms)
  ✓  101 [chromium] › tests/openapi.spec.ts:29:7 › OpenAPI Documentation › GET /api/docs is accessible without auth (6ms)
  ✓  102 [chromium] › tests/quality-review.spec.ts:16:7 › Quality Review › POST creates review for existing task (14ms)
  ✓  103 [chromium] › tests/quality-review.spec.ts:35:7 › Quality Review › POST returns 404 for non-existent task (8ms)
  ✓  104 [chromium] › tests/quality-review.spec.ts:48:7 › Quality Review › POST rejects missing required fields (12ms)
  ✓  105 [chromium] › tests/quality-review.spec.ts:61:7 › Quality Review › GET returns reviews for taskId (15ms)
  ✓  106 [chromium] › tests/quality-review.spec.ts:86:7 › Quality Review › GET batch lookup by taskIds (20ms)
  ✓  107 [chromium] › tests/quality-review.spec.ts:107:7 › Quality Review › GET returns 400 without taskId (4ms)
  ✓  108 [chromium] › tests/rate-limiting.spec.ts:12:7 › Login Rate Limiting (Issue #8) › blocks login after 5 rapid failed attempts (181ms)
  ✓  109 [chromium] › tests/rate-limiting.spec.ts:29:7 › Login Rate Limiting (Issue #8) › successful login is not blocked for fresh IP (38ms)
  ✓  110 [chromium] › tests/search-and-export.spec.ts:16:7 › Search and Export › search returns results for valid query (15ms)
  ✓  111 [chromium] › tests/search-and-export.spec.ts:32:7 › Search and Export › search returns 400 for short query (8ms)
  ✓  112 [chromium] › tests/search-and-export.spec.ts:37:7 › Search and Export › search returns 400 for empty query (6ms)
  ✓  113 [chromium] › tests/search-and-export.spec.ts:44:7 › Search and Export › export returns tasks as JSON (8ms)
  ✓  114 [chromium] › tests/search-and-export.spec.ts:56:7 › Search and Export › export rejects missing type (7ms)
  ✓  115 [chromium] › tests/search-and-export.spec.ts:61:7 › Search and Export › export rejects invalid type (6ms)
  ✓  116 [chromium] › tests/search-and-export.spec.ts:68:7 › Search and Export › activities returns activity feed (6ms)
  ✓  117 [chromium] › tests/task-comments.spec.ts:16:7 › Task Comments › POST adds comment to existing task (14ms)
  ✓  118 [chromium] › tests/task-comments.spec.ts:31:7 › Task Comments › POST rejects empty content (14ms)
  ✓  119 [chromium] › tests/task-comments.spec.ts:42:7 › Task Comments › POST returns 404 for non-existent task (6ms)
  ✓  120 [chromium] › tests/task-comments.spec.ts:50:7 › Task Comments › POST creates threaded reply (14ms)
  ✓  121 [chromium] › tests/task-comments.spec.ts:74:7 › Task Comments › GET returns comments array for task (14ms)
  ✓  122 [chromium] › tests/task-comments.spec.ts:93:7 › Task Comments › GET returns empty array for task with no comments (12ms)
  ✓  123 [chromium] › tests/task-comments.spec.ts:104:7 › Task Comments › GET returns 404 for non-existent task (7ms)
  ✓  124 [chromium] › tests/tasks-crud.spec.ts:16:7 › Tasks CRUD › POST creates task with minimal fields (title only) (12ms)
  ✓  125 [chromium] › tests/tasks-crud.spec.ts:27:7 › Tasks CRUD › POST creates task with all fields (9ms)
  ✓  126 [chromium] › tests/tasks-crud.spec.ts:47:7 › Tasks CRUD › POST rejects empty title (7ms)
  ✓  127 [chromium] › tests/tasks-crud.spec.ts:55:7 › Tasks CRUD › POST rejects duplicate title (10ms)
  ✓  128 [chromium] › tests/tasks-crud.spec.ts:68:7 › Tasks CRUD › GET list returns tasks with pagination shape (15ms)
  ✓  129 [chromium] › tests/tasks-crud.spec.ts:82:7 › Tasks CRUD › GET list filters by status (15ms)
  ✓  130 [chromium] › tests/tasks-crud.spec.ts:93:7 › Tasks CRUD › GET list filters by priority (10ms)
  ✓  131 [chromium] › tests/tasks-crud.spec.ts:104:7 › Tasks CRUD › GET list respects limit and offset (6ms)
  ✓  132 [chromium] › tests/tasks-crud.spec.ts:113:7 › Tasks CRUD › GET single returns task by id (11ms)
  ✓  133 [chromium] › tests/tasks-crud.spec.ts:124:7 › Tasks CRUD › GET single returns 404 for missing task (6ms)
  ✓  134 [chromium] › tests/tasks-crud.spec.ts:129:7 › Tasks CRUD › GET single returns 400 for non-numeric id (8ms)
  ✓  135 [chromium] › tests/tasks-crud.spec.ts:136:7 › Tasks CRUD › PUT updates task fields (18ms)
  ✓  136 [chromium] › tests/tasks-crud.spec.ts:150:7 › Tasks CRUD › PUT returns 404 for missing task (10ms)
  ✓  137 [chromium] › tests/tasks-crud.spec.ts:158:7 › Tasks CRUD › PUT with empty body still succeeds (Zod defaults fill fields) (15ms)
  ✓  138 [chromium] › tests/tasks-crud.spec.ts:171:7 › Tasks CRUD › PUT returns 403 when moving to done without Aegis approval (13ms)
  ✓  139 [chromium] › tests/tasks-crud.spec.ts:186:7 › Tasks CRUD › DELETE removes task (8ms)
  ✓  140 [chromium] › tests/tasks-crud.spec.ts:195:7 › Tasks CRUD › DELETE returns 404 for missing task (5ms)
  ✓  141 [chromium] › tests/tasks-crud.spec.ts:202:7 › Tasks CRUD › full lifecycle: create → read → update → delete → confirm gone (19ms)
  ✓  142 [chromium] › tests/timing-safe-auth.spec.ts:9:7 › Timing-Safe Auth (Issue #5) › valid API key authenticates successfully (99ms)
  ✓  143 [chromium] › tests/timing-safe-auth.spec.ts:16:7 › Timing-Safe Auth (Issue #5) › wrong API key is rejected (4ms)
  ✓  144 [chromium] › tests/timing-safe-auth.spec.ts:23:7 › Timing-Safe Auth (Issue #5) › empty API key is rejected (4ms)
  ✓  145 [chromium] › tests/timing-safe-auth.spec.ts:30:7 › Timing-Safe Auth (Issue #5) › no auth header is rejected (4ms)
  ✓  146 [chromium] › tests/user-management.spec.ts:16:7 › User Management › POST creates user (42ms)
  ✓  147 [chromium] › tests/user-management.spec.ts:26:7 › User Management › POST rejects duplicate username (75ms)
  ✓  148 [chromium] › tests/user-management.spec.ts:40:7 › User Management › POST rejects missing username (6ms)
  ✓  149 [chromium] › tests/user-management.spec.ts:48:7 › User Management › POST rejects missing password (6ms)
  ✓  150 [chromium] › tests/user-management.spec.ts:58:7 › User Management › GET returns users list (5ms)
  ✓  151 [chromium] › tests/user-management.spec.ts:68:7 › User Management › PUT updates display_name and role (43ms)
  ✓  152 [chromium] › tests/user-management.spec.ts:82:7 › User Management › PUT returns 404 for missing user (7ms)
  ✓  153 [chromium] › tests/user-management.spec.ts:92:7 › User Management › DELETE removes user (40ms)
  ✓  154 [chromium] › tests/user-management.spec.ts:104:7 › User Management › DELETE returns 404 for missing user (4ms)
  ✓  155 [chromium] › tests/webhooks-crud.spec.ts:16:7 › Webhooks CRUD › POST creates webhook with name and valid URL (9ms)
  ✓  156 [chromium] › tests/webhooks-crud.spec.ts:28:7 › Webhooks CRUD › POST rejects invalid URL (5ms)
  ✓  157 [chromium] › tests/webhooks-crud.spec.ts:36:7 › Webhooks CRUD › POST rejects missing name (5ms)
  ✓  158 [chromium] › tests/webhooks-crud.spec.ts:46:7 › Webhooks CRUD › GET returns webhooks with masked secrets (13ms)
  ✓  159 [chromium] › tests/webhooks-crud.spec.ts:64:7 › Webhooks CRUD › PUT updates webhook name (11ms)
  ✓  160 [chromium] › tests/webhooks-crud.spec.ts:77:7 › Webhooks CRUD › PUT regenerates secret (12ms)
  ✓  161 [chromium] › tests/webhooks-crud.spec.ts:91:7 › Webhooks CRUD › PUT returns 404 for missing webhook (5ms)
  ✓  162 [chromium] › tests/webhooks-crud.spec.ts:101:7 › Webhooks CRUD › DELETE removes webhook (11ms)
  ✓  163 [chromium] › tests/webhooks-crud.spec.ts:115:7 › Webhooks CRUD › full lifecycle: create → read (masked) → update → delete (14ms)
  ✓  164 [chromium] › tests/workflows-crud.spec.ts:16:7 › Workflows CRUD › POST creates workflow template (11ms)
  ✓  165 [chromium] › tests/workflows-crud.spec.ts:27:7 › Workflows CRUD › POST rejects missing name (7ms)
  ✓  166 [chromium] › tests/workflows-crud.spec.ts:35:7 › Workflows CRUD › POST rejects missing task_prompt (5ms)
  ✓  167 [chromium] › tests/workflows-crud.spec.ts:45:7 › Workflows CRUD › GET returns templates array (14ms)
  ✓  168 [chromium] › tests/workflows-crud.spec.ts:58:7 › Workflows CRUD › PUT updates template fields (10ms)
  ✓  169 [chromium] › tests/workflows-crud.spec.ts:72:7 › Workflows CRUD › PUT returns 404 for missing template (6ms)
  ✓  170 [chromium] › tests/workflows-crud.spec.ts:82:7 › Workflows CRUD › DELETE removes template (7ms)
  ✓  171 [chromium] › tests/workflows-crud.spec.ts:96:7 › Workflows CRUD › full lifecycle: create → list → update → delete (12ms)

  171 passed (11.2s) (171 passed)\n- 
> mission-control@1.3.0 build /Users/nyk/work/products/mission-control
> next build

▲ Next.js 16.1.6 (Turbopack)
- Environments: .env.local

  Creating an optimized production build ...
✓ Compiled successfully in 12.6s
  Running TypeScript ...
  Collecting page data using 9 workers ...
{"level":30,"time":1772590503127,"pid":59054,"hostname":"192.168.2.5","msg":"Database migrations applied successfully"}
{"level":30,"time":1772590503127,"pid":59050,"hostname":"192.168.2.5","msg":"Database migrations applied successfully"}
{"level":30,"time":1772590503127,"pid":59056,"hostname":"192.168.2.5","msg":"Database migrations applied successfully"}
{"level":30,"time":1772590503128,"pid":59058,"hostname":"192.168.2.5","msg":"Database migrations applied successfully"}
{"level":30,"time":1772590503128,"pid":59051,"hostname":"192.168.2.5","msg":"Database migrations applied successfully"}
{"level":30,"time":1772590503129,"pid":59057,"hostname":"192.168.2.5","msg":"Database migrations applied successfully"}
{"level":30,"time":1772590503129,"pid":59053,"hostname":"192.168.2.5","msg":"Database migrations applied successfully"}
{"level":30,"time":1772590503129,"pid":59055,"hostname":"192.168.2.5","msg":"Database migrations applied successfully"}
{"level":30,"time":1772590503129,"pid":59052,"hostname":"192.168.2.5","msg":"Database migrations applied successfully"}
  Generating static pages using 9 workers (0/55) ...
  Generating static pages using 9 workers (13/55) 
  Generating static pages using 9 workers (27/55) 
  Generating static pages using 9 workers (41/55) 
✓ Generating static pages using 9 workers (55/55) in 320.0ms
  Finalizing page optimization ...

Route (app)
┌ ○ /_not-found
├ ƒ /[[...panel]]
├ ƒ /api/activities
├ ƒ /api/agents
├ ƒ /api/agents/[id]
├ ƒ /api/agents/[id]/heartbeat
├ ƒ /api/agents/[id]/memory
├ ƒ /api/agents/[id]/soul
├ ƒ /api/agents/[id]/wake
├ ƒ /api/agents/comms
├ ƒ /api/agents/message
├ ƒ /api/agents/sync
├ ƒ /api/alerts
├ ƒ /api/audit
├ ƒ /api/auth/access-requests
├ ƒ /api/auth/google
├ ƒ /api/auth/login
├ ƒ /api/auth/logout
├ ƒ /api/auth/me
├ ƒ /api/auth/users
├ ƒ /api/backup
├ ƒ /api/chat/conversations
├ ƒ /api/chat/messages
├ ƒ /api/chat/messages/[id]
├ ƒ /api/claude/sessions
├ ƒ /api/cleanup
├ ƒ /api/connect
├ ƒ /api/cron
├ ƒ /api/docs
├ ƒ /api/events
├ ƒ /api/export
├ ƒ /api/gateway-config
├ ƒ /api/gateways
├ ƒ /api/gateways/health
├ ƒ /api/github
├ ƒ /api/integrations
├ ƒ /api/logs
├ ƒ /api/memory
├ ƒ /api/notifications
├ ƒ /api/notifications/deliver
├ ƒ /api/pipelines
├ ƒ /api/pipelines/run
├ ƒ /api/quality-review
├ ƒ /api/releases/check
├ ƒ /api/scheduler
├ ƒ /api/search
├ ƒ /api/sessions
├ ƒ /api/sessions/[id]/control
├ ƒ /api/settings
├ ƒ /api/spawn
├ ƒ /api/standup
├ ƒ /api/status
├ ƒ /api/super/provision-jobs
├ ƒ /api/super/provision-jobs/[id]
├ ƒ /api/super/provision-jobs/[id]/run
├ ƒ /api/super/tenants
├ ƒ /api/super/tenants/[id]/decommission
├ ƒ /api/tasks
├ ƒ /api/tasks/[id]
├ ƒ /api/tasks/[id]/broadcast
├ ƒ /api/tasks/[id]/comments
├ ƒ /api/tokens
├ ƒ /api/webhooks
├ ƒ /api/webhooks/deliveries
├ ƒ /api/webhooks/retry
├ ƒ /api/webhooks/test
├ ƒ /api/webhooks/verify-docs
├ ƒ /api/workflows
├ ○ /docs
└ ○ /login


ƒ Proxy (Middleware)

○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand\n\nCloses #75