### PR TITLE
fix(#134): handle special characters in .env AUTH_PASS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,13 @@
 # === Authentication ===
 # Admin user seeded on first run (only if no users exist in DB)
+# IMPORTANT: Wrap values in double quotes if they contain special characters
+# such as #, $, spaces, or backslashes. An unquoted # is treated as a comment
+# by dotenv and silently truncates the value.
 AUTH_USER=admin
-AUTH_PASS=change-me-on-first-login
+AUTH_PASS="change-me-on-first-login"
 
 # API key for headless/external access (x-api-key header)
-API_KEY=generate-a-random-key
+API_KEY="generate-a-random-key"
 
 # Primary gateway defaults (used by /api/gateways seeding if DB is empty)
 MC_DEFAULT_GATEWAY_NAME=primary
@@ -30,7 +33,7 @@ GOOGLE_CLIENT_ID=
 NEXT_PUBLIC_GOOGLE_CLIENT_ID=
 
 # Legacy cookie auth (backward compat, can be removed once all clients use session auth)
-AUTH_SECRET=random-secret-for-legacy-cookies
+AUTH_SECRET="random-secret-for-legacy-cookies"
 
 # Coordinator identity (used for coordinator chat status replies and comms UI)
 MC_COORDINATOR_AGENT=coordinator

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -101,6 +101,16 @@ function seedAdminUserFromEnv(dbConn: Database.Database): void {
     return
   }
 
+  // Detect passwords likely truncated by an unquoted # in .env
+  // (dotenv treats # as an inline comment unless the value is quoted)
+  if (password.length <= 3 || (/^\w+$/.test(password) && password.length < 6)) {
+    logger.warn(
+      'AUTH_PASS appears suspiciously short — if your password contains ' +
+      'special characters like #, wrap it in double quotes in your .env file: ' +
+      'AUTH_PASS="my#secure#pass"'
+    )
+  }
+
   if (INSECURE_PASSWORDS.has(password)) {
     logger.warn(
       `AUTH_PASS matches a known insecure default ("${password}"). ` +


### PR DESCRIPTION
## Summary
Fix for `#` characters in `AUTH_PASS` being silently truncated by dotenv's inline comment parsing.

## Changes
- **`.env.example`**: Quote `AUTH_PASS`, `API_KEY`, and `AUTH_SECRET` values; add prominent warning about special characters (`#`, `$`, spaces) requiring double quotes
- **`src/lib/db.ts`**: Add runtime warning when `AUTH_PASS` appears suspiciously short, guiding users to quote their `.env` value

## Root Cause
Dotenv treats unquoted `#` as an inline comment. A password like `mypass#123` becomes `mypass` silently, causing authentication failures.

## Risk Level
Low

## Tests
```
pnpm typecheck  # ✅ pass
pnpm lint       # ✅ pass
pnpm test       # ✅ 69/69 pass
```

Fixes #134