### PR TITLE
fix(#129): improve Docker build reliability and layer caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,19 +3,21 @@ RUN corepack enable && corepack prepare pnpm@latest --activate
 WORKDIR /app
 
 FROM base AS deps
+# Copy only dependency manifests first for better layer caching
 COPY package.json ./
-COPY . .
+COPY pnpm-lock.yaml* ./
 # better-sqlite3 requires native compilation tools
 RUN apt-get update && apt-get install -y python3 make g++ --no-install-recommends && rm -rf /var/lib/apt/lists/*
 RUN if [ -f pnpm-lock.yaml ]; then \
       pnpm install --frozen-lockfile; \
     else \
-      echo "WARN: pnpm-lock.yaml not found in build context; running non-frozen install"; \
+      echo "WARN: pnpm-lock.yaml not found in build context; running non-frozen install" && \
       pnpm install --no-frozen-lockfile; \
     fi
 
 FROM base AS build
-COPY --from=deps /app ./
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
 RUN pnpm build
 
 FROM node:20-slim AS runtime
@@ -24,8 +26,8 @@ ENV NODE_ENV=production
 RUN addgroup --system --gid 1001 nodejs && adduser --system --uid 1001 nextjs
 COPY --from=build /app/.next/standalone ./
 COPY --from=build /app/.next/static ./.next/static
-# Copy public directory if it exists (may not exist in all setups)
-COPY --from=build /app/public* ./public/
+# Copy schema.sql needed by migration 001_init at runtime
+COPY --from=build /app/src/lib/schema.sql ./src/lib/schema.sql
 # Create data directory with correct ownership for SQLite
 RUN mkdir -p .data && chown nextjs:nodejs .data
 RUN apt-get update && apt-get install -y curl --no-install-recommends && rm -rf /var/lib/apt/lists/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,12 @@
 services:
   mission-control:
     build: .
+    container_name: mission-control
     ports:
-      - "3000:3000"
-    env_file: .env
+      - "${MC_PORT:-3000}:3000"
+    env_file:
+      - path: .env
+        required: false
     volumes:
       - mc-data:/app/.data
     restart: unless-stopped


### PR DESCRIPTION
- Fix deps stage: copy only package.json + pnpm-lock.yaml* for proper layer caching instead of COPY . . which invalidates cache on any change
- Copy node_modules from deps into build stage separately from source
- Copy schema.sql into runtime stage (migration 001_init reads it at runtime via process.cwd(), but standalone output omits source files)
- Remove broken public* glob COPY (no public/ dir exists; Docker COPY fails silently with incorrect glob syntax)
- docker-compose: add container_name, configurable port via MC_PORT, mark .env as optional to avoid startup failure if missing

Fixes #129

# Summary
Describe what changed and why.

# Risk Level
Low / Medium / High (pick one)

# Tests
List commands run and results.

# Contribution Checklist
- [ ] Tests added/updated for behavior changes
- [ ] Lint/typecheck/build passing
- [ ] Security review done if auth/data/crypto touched
- [ ] DB migration tested if schema changed

# Notes
Anything reviewers should know.
