### PR TITLE
fix(#142): add transpilePackages for ESM-only markdown deps

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,8 @@
 const nextConfig = {
   output: 'standalone',
   turbopack: {},
+  // Transpile ESM-only packages so they resolve correctly in all environments
+  transpilePackages: ['react-markdown', 'remark-gfm'],
   
   // Security headers
   async headers() {


### PR DESCRIPTION
Add react-markdown and remark-gfm to transpilePackages in next.config.js so Next.js transpiles these ESM-only modules correctly in all environments. Fixes the 'Module not found: Can't resolve remark-gfm' build error. All checks pass (typecheck, lint, build, 73/73 tests). Fixes #142