### PR TITLE
docs(#146, #143): improve workspace creation discoverability and memory tab UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ Inter-agent communication via the comms API. Agents can send messages to each ot
 ### Integrations
 Outbound webhooks with delivery history, configurable alert rules with cooldowns, and multi-gateway connection management. Optional 1Password CLI integration for secret management.
 
+### Workspace Management
+Workspaces (tenant instances) are created and managed through the **Super Admin** panel, accessible from the sidebar under **Admin > Super Admin**. From there, admins can:
+- **Create** new client instances (slug, display name, Linux user, gateway port, plan tier)
+- **Monitor** provisioning jobs and their step-by-step progress
+- **Decommission** tenants with optional cleanup of state directories and Linux users
+
+Each workspace gets its own isolated environment with a dedicated OpenClaw gateway, state directory, and workspace root. See the [Super Admin API](#api-overview) endpoints under `/api/super/*` for programmatic access.
+
 ### Update Checker
 Automatic GitHub release check notifies you when a new version is available, displayed as a banner in the dashboard.
 
@@ -274,6 +282,20 @@ All endpoints require authentication unless noted. Full reference below.
 | `GET/POST/PUT/DELETE` | `/api/gateways` | admin | Gateway connections |
 | `GET/PUT/DELETE/POST` | `/api/integrations` | admin | Integration management |
 | `POST` | `/api/github` | admin | Trigger GitHub Issues sync |
+
+</details>
+
+<details>
+<summary><strong>Super Admin (Workspace/Tenant Management)</strong></summary>
+
+| Method | Path | Role | Description |
+|--------|------|------|-------------|
+| `GET` | `/api/super/tenants` | admin | List all tenants with latest provisioning status |
+| `POST` | `/api/super/tenants` | admin | Create tenant and queue bootstrap job |
+| `POST` | `/api/super/tenants/[id]/decommission` | admin | Queue tenant decommission job |
+| `GET` | `/api/super/provision-jobs` | admin | List provisioning jobs (filter: `?tenant_id=`, `?status=`) |
+| `POST` | `/api/super/provision-jobs` | admin | Queue additional job for existing tenant |
+| `POST` | `/api/super/provision-jobs/[id]/action` | admin | Approve, reject, or cancel a provisioning job |
 
 </details>
 

--- a/src/components/panels/agent-detail-tabs.tsx
+++ b/src/components/panels/agent-detail-tabs.tsx
@@ -514,7 +514,7 @@ export function MemoryTab({
         <div>
           <h4 className="text-lg font-medium text-foreground">Working Memory</h4>
           <p className="text-xs text-muted-foreground mt-1">
-            Agent-level scratchpad only. Use the global Memory page to browse all workspace memory files.
+            This is <strong className="text-foreground">agent-level</strong> scratchpad memory (stored as WORKING.md in the database), not the workspace memory folder.
           </p>
         </div>
         <div className="flex gap-2">
@@ -538,6 +538,14 @@ export function MemoryTab({
             </>
           )}
         </div>
+      </div>
+
+      {/* Info Banner */}
+      <div className="bg-blue-500/10 border border-blue-500/20 rounded-lg p-3 text-xs text-blue-300">
+        <strong className="text-blue-200">Agent Memory vs Workspace Memory:</strong>{' '}
+        This tab edits only this agent&apos;s private working memory (a scratchpad stored in the database).
+        To browse or edit all workspace memory files (daily logs, knowledge base, MEMORY.md, etc.), visit the{' '}
+        <Link href="/memory" className="text-blue-400 underline hover:text-blue-300">Memory Browser</Link> page.
       </div>
 
       {/* Memory Content */}

--- a/src/components/panels/settings-panel.tsx
+++ b/src/components/panels/settings-panel.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import { useMissionControl } from '@/store'
+import { useNavigateToPanel } from '@/lib/navigation'
 
 interface Setting {
   key: string
@@ -24,6 +25,7 @@ const categoryOrder = ['general', 'retention', 'gateway', 'custom']
 
 export function SettingsPanel() {
   const { currentUser } = useMissionControl()
+  const navigateToPanel = useNavigateToPanel()
   const [settings, setSettings] = useState<Setting[]>([])
   const [grouped, setGrouped] = useState<Record<string, Setting[]>>({})
   const [loading, setLoading] = useState(true)
@@ -179,6 +181,21 @@ export function SettingsPanel() {
           </button>
         </div>
       </div>
+
+      {/* Workspace Info */}
+      {currentUser?.role === 'admin' && (
+        <div className="bg-blue-500/10 border border-blue-500/20 rounded-lg p-3 text-xs text-blue-300">
+          <strong className="text-blue-200">Workspace Management:</strong>{' '}
+          To create or manage workspaces (tenant instances), go to the{' '}
+          <button
+            onClick={() => navigateToPanel('super-admin')}
+            className="text-blue-400 underline hover:text-blue-300 cursor-pointer"
+          >
+            Super Admin
+          </button>{' '}
+          panel under Admin &gt; Super Admin in the sidebar. From there you can create new client instances, manage tenants, and monitor provisioning jobs.
+        </div>
+      )}
 
       {/* Feedback */}
       {feedback && (


### PR DESCRIPTION
## Issue #146 — How to add workspace?

The workspace creation flow was not discoverable in the UI. Changes:

- **README**: Added Workspace Management section documenting the Super Admin panel workflow
- **README**: Added Super Admin API endpoints table
- **Settings panel**: Added info banner (admin-only) with clickable link to Super Admin panel

## Issue #143 — Memory tab in agent view

Users were confused about agent Memory tab vs global Memory Browser. Changes:

- **Agent Memory tab**: Added info banner distinguishing agent working memory (DB scratchpad) from workspace memory files
- **Agent Memory tab**: Added clickable Link to Memory Browser page
- **Agent Memory tab**: Improved subtitle text with WORKING.md storage detail

All checks pass (typecheck, lint, 80/80 tests).

Fixes #146
Fixes #143