### PR TITLE
Harden OpenClaw durability + Nova office workflow

### DIFF
--- a/docs/OPENCLAW_SETUP.md
+++ b/docs/OPENCLAW_SETUP.md
@@ -1,0 +1,86 @@
+# OpenClaw Deployment + Mission Control Setup (Current Working Pattern)
+
+This document captures the working deployment model used in production-like OpenClaw environments.
+
+## 1) Runtime persistence (critical)
+
+Mission Control **must** use a stable DB path outside `.next/standalone`.
+
+Required env:
+
+```env
+MISSION_CONTROL_DATA_DIR=/root/.openclaw/workspace/research/mission-control/.data
+MISSION_CONTROL_DB_PATH=/root/.openclaw/workspace/research/mission-control/.data/mission-control.db
+MISSION_CONTROL_TOKENS_PATH=/root/.openclaw/workspace/research/mission-control/.data/mission-control-tokens.json
+```
+
+Systemd should also set these explicitly to avoid drift.
+
+## 2) Standalone build asset sync
+
+When running `node .next/standalone/server.js`, static assets must exist under:
+
+- `.next/standalone/.next/static`
+- `.next/standalone/public`
+
+Build step now includes a `prepare:standalone` sync to prevent broken login UI / missing CSS/JS.
+
+## 3) OpenClaw integration model
+
+- Agent catalog sync from `openclaw.json`
+- Session scanning from `OPENCLAW_HOME/agents/*/sessions/sessions.json`
+- Optional task mirroring from OpenClaw session-key conventions
+
+### Identity aliasing
+
+`main` runtime identity is aliased to `nova` in Mission Control for front-door UX.
+
+## 4) Data safety for mirrored external tasks
+
+Mirrored OpenClaw tasks can be intentionally deleted by users.
+
+To prevent resurrection on next sync, Mission Control stores tombstones in:
+
+- `external_task_tombstones(source, external_id, deleted_by, ...)`
+
+Sync skips tombstoned external IDs.
+
+## 5) Task workflow and approvals
+
+Current enterprise statuses:
+
+- inbox
+- backlog
+- todo
+- in-progress
+- review
+- blocked
+- needs-approval
+- done
+
+Approval gates:
+
+- Main/high-level task `review -> done` requires explicit approval.
+- External action tasks (`publish`, `email`, `webhook`, `external_call`) route to `needs-approval` until approved.
+
+## 6) Office autopilot (continuous progress)
+
+Scheduler task `office_autopilot`:
+
+- triages inbox/backlog to Conductor (`todo` + assignment)
+- detects blockers + approvals pending
+- records decision cycles in `office_autopilot_runs`
+
+## 7) Reliability defaults
+
+Recommended settings:
+
+- `general.auto_backup=true`
+- `general.agent_heartbeat=true`
+- `office.autopilot_enabled=true`
+- `webhooks.retry_enabled=true`
+
+## 8) Security note
+
+Never commit secrets (`AUTH_PASS`, `API_KEY`, OAuth secrets, etc.).
+Use `.env` only in deployment environment.

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,8 @@
+const path = require('path')
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
+  outputFileTracingRoot: path.join(__dirname),
   turbopack: {},
   
   // Security headers

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "OpenClaw Mission Control — open-source agent orchestration dashboard",
   "scripts": {
     "dev": "next dev --hostname 127.0.0.1",
-    "build": "next build",
+    "build": "next build && pnpm run prepare:standalone",
+    "prepare:standalone": "bash -lc 'mkdir -p .next/standalone/.next && rsync -a --delete .next/static/ .next/standalone/.next/static/ && if [ -d public ]; then rsync -a public/ .next/standalone/public/; fi'",
     "start": "next start --hostname 0.0.0.0 --port 3005",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",

--- a/src/app/api/agents/[id]/heartbeat/route.ts
+++ b/src/app/api/agents/[id]/heartbeat/route.ts
@@ -72,7 +72,7 @@ export async function GET(
     const assignedTasks = db.prepare(`
       SELECT * FROM tasks 
       WHERE assigned_to = ?
-      AND status IN ('assigned', 'in_progress')
+      AND status IN ('todo', 'assigned', 'in-progress', 'in_progress')
       ORDER BY priority DESC, created_at ASC
       LIMIT 10
     `).all(agent.name);

--- a/src/app/api/agents/[id]/memory/route.ts
+++ b/src/app/api/agents/[id]/memory/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDatabase, db_helpers } from '@/lib/db';
 import { requireRole } from '@/lib/auth';
 import { logger } from '@/lib/logger';
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
 
 /**
  * GET /api/agents/[id]/memory - Get agent's working memory
@@ -42,12 +44,47 @@ export async function GET(
       db.exec("ALTER TABLE agents ADD COLUMN working_memory TEXT DEFAULT ''");
     }
     
-    // Get working memory content
+    // Get working memory content (DB first)
     const memoryStmt = db.prepare(`SELECT working_memory FROM agents WHERE ${isNaN(Number(agentId)) ? 'name' : 'id'} = ?`);
     const result = memoryStmt.get(agentId) as any;
-    
-    const workingMemory = result?.working_memory || '';
-    
+
+    let workingMemory = result?.working_memory || '';
+    let source: 'db' | 'workspace' | 'empty' = 'db'
+
+    // Fallback to workspace files if DB memory is empty
+    if (!workingMemory) {
+      try {
+        const cfg = agent.config ? JSON.parse(agent.config) : {}
+        const workspacePath = cfg?.workspace
+        if (workspacePath && typeof workspacePath === 'string') {
+          const memoryMainPath = join(workspacePath, 'MEMORY.md')
+          const dailyPath = join(workspacePath, 'memory', `${new Date().toISOString().slice(0, 10)}.md`)
+
+          const parts: string[] = []
+          if (existsSync(memoryMainPath)) {
+            const raw = readFileSync(memoryMainPath, 'utf-8').trim()
+            if (raw) parts.push(raw)
+          }
+          if (existsSync(dailyPath)) {
+            const daily = readFileSync(dailyPath, 'utf-8').trim()
+            if (daily) parts.push(`\n\n---\n\n# Daily Memory\n\n${daily}`)
+          }
+
+          if (parts.length > 0) {
+            workingMemory = parts.join('\n')
+            source = 'workspace'
+
+            // Cache into DB working_memory for faster subsequent reads
+            db.prepare(`UPDATE agents SET working_memory = ? WHERE id = ?`).run(workingMemory, agent.id)
+          }
+        }
+      } catch (e) {
+        logger.warn({ err: e }, 'Failed to load workspace memory fallback')
+      }
+    }
+
+    if (!workingMemory) source = 'empty'
+
     return NextResponse.json({
       agent: {
         id: agent.id,
@@ -55,6 +92,7 @@ export async function GET(
         role: agent.role
       },
       working_memory: workingMemory,
+      source,
       updated_at: agent.updated_at,
       size: workingMemory.length
     });

--- a/src/app/api/agents/[id]/soul/route.ts
+++ b/src/app/api/agents/[id]/soul/route.ts
@@ -48,13 +48,42 @@ export async function GET(
       logger.warn({ err: error }, 'Could not read soul templates directory');
     }
     
+    let soulContent = agent.soul_content || ''
+    let source: 'db' | 'workspace' | 'empty' = 'db'
+
+    if (!soulContent) {
+      try {
+        const cfg = agent.config ? JSON.parse(agent.config) : {}
+        const workspacePath = cfg?.workspace
+        if (workspacePath && typeof workspacePath === 'string') {
+          const soulPath = join(workspacePath, 'SOUL.md')
+          if (existsSync(soulPath)) {
+            soulContent = readFileSync(soulPath, 'utf-8')
+            source = soulContent ? 'workspace' : 'empty'
+            if (soulContent) {
+              db.prepare('UPDATE agents SET soul_content = ?, updated_at = ? WHERE id = ?').run(
+                soulContent,
+                Math.floor(Date.now() / 1000),
+                agent.id,
+              )
+            }
+          }
+        }
+      } catch (e) {
+        logger.warn({ err: e }, 'Failed to load SOUL fallback from workspace')
+      }
+    }
+
+    if (!soulContent) source = 'empty'
+
     return NextResponse.json({
       agent: {
         id: agent.id,
         name: agent.name,
         role: agent.role
       },
-      soul_content: agent.soul_content || '',
+      soul_content: soulContent,
+      source,
       available_templates: availableTemplates,
       updated_at: agent.updated_at
     });
@@ -135,6 +164,22 @@ export async function PUT(
     
     updateStmt.run(newSoulContent, now, agentId);
     
+    // Also write to OpenClaw workspace file (true control plane)
+    try {
+      const cfg = agent.config ? JSON.parse(agent.config) : {}
+      const openclawHome = process.env.OPENCLAW_HOME || '/root/.openclaw'
+      const workspacePath = cfg?.workspace
+
+      if (workspacePath && typeof workspacePath === 'string' && workspacePath.startsWith(openclawHome)) {
+        const { writeFile, mkdir } = require('fs/promises')
+        const soulPath = join(workspacePath, 'SOUL.md')
+        await mkdir(workspacePath, { recursive: true })
+        await writeFile(soulPath, String(newSoulContent || ''), 'utf-8')
+      }
+    } catch (e) {
+      logger.warn({ err: e }, 'Failed to write SOUL.md back to OpenClaw workspace')
+    }
+
     // Log activity
     db_helpers.logActivity(
       'agent_soul_updated',

--- a/src/app/api/agents/comms/route.ts
+++ b/src/app/api/agents/comms/route.ts
@@ -21,7 +21,7 @@ export async function GET(request: NextRequest) {
     const agent = searchParams.get("agent")
 
     // Filter out human/system messages - only agent-to-agent
-    const humanNames = ["human", "system", "operator"]
+    const humanNames = ["human", "system", "operator", "api"]
     const humanPlaceholders = humanNames.map(() => "?").join(",")
 
     // 1. Get inter-agent messages

--- a/src/app/api/agents/route.ts
+++ b/src/app/api/agents/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDatabase, Agent, db_helpers } from '@/lib/db';
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
 import { eventBus } from '@/lib/event-bus';
 import { getTemplate, buildAgentConfig } from '@/lib/agent-templates';
 import { writeAgentToConfig } from '@/lib/agent-sync';
@@ -20,6 +22,13 @@ export async function GET(request: NextRequest) {
   try {
     const db = getDatabase();
     const { searchParams } = new URL(request.url);
+
+    // Ensure working_memory column exists for legacy DBs
+    const columns = db.prepare('PRAGMA table_info(agents)').all() as Array<{ name: string }>
+    const hasWorkingMemory = columns.some((c) => c.name === 'working_memory')
+    if (!hasWorkingMemory) {
+      db.exec("ALTER TABLE agents ADD COLUMN working_memory TEXT DEFAULT ''")
+    }
     
     // Parse query parameters
     const status = searchParams.get('status');
@@ -47,18 +56,53 @@ export async function GET(request: NextRequest) {
     const stmt = db.prepare(query);
     const agents = stmt.all(...params) as Agent[];
     
-    // Parse JSON config field
-    const agentsWithParsedData = agents.map(agent => ({
-      ...agent,
-      config: agent.config ? JSON.parse(agent.config) : {}
-    }));
+    // Parse JSON config field + hydrate soul/memory from workspace when DB fields are empty
+    const agentsWithParsedData = agents.map(agent => {
+      const parsedConfig = agent.config ? JSON.parse(agent.config) : {}
+      let soulContent = agent.soul_content || ''
+      let workingMemory = (agent as any).working_memory || ''
+
+      try {
+        const workspacePath = parsedConfig?.workspace
+        if (workspacePath && typeof workspacePath === 'string') {
+          if (!soulContent) {
+            const soulPath = join(workspacePath, 'SOUL.md')
+            if (existsSync(soulPath)) soulContent = readFileSync(soulPath, 'utf-8')
+          }
+
+          if (!workingMemory) {
+            const memoryMainPath = join(workspacePath, 'MEMORY.md')
+            const dailyPath = join(workspacePath, 'memory', `${new Date().toISOString().slice(0, 10)}.md`)
+            const parts: string[] = []
+            if (existsSync(memoryMainPath)) {
+              const m = readFileSync(memoryMainPath, 'utf-8').trim()
+              if (m) parts.push(m)
+            }
+            if (existsSync(dailyPath)) {
+              const d = readFileSync(dailyPath, 'utf-8').trim()
+              if (d) parts.push(`\n\n---\n\n# Daily Memory\n\n${d}`)
+            }
+            if (parts.length > 0) workingMemory = parts.join('\n')
+          }
+        }
+      } catch {
+        // best-effort hydration only
+      }
+
+      return {
+        ...agent,
+        soul_content: soulContent,
+        working_memory: workingMemory,
+        config: parsedConfig
+      }
+    });
     
     // Get task counts for each agent (prepare once, reuse per agent)
     const taskCountStmt = db.prepare(`
       SELECT
         COUNT(*) as total,
-        SUM(CASE WHEN status = 'assigned' THEN 1 ELSE 0 END) as assigned,
-        SUM(CASE WHEN status = 'in_progress' THEN 1 ELSE 0 END) as in_progress,
+        SUM(CASE WHEN status IN ('todo', 'assigned') THEN 1 ELSE 0 END) as assigned,
+        SUM(CASE WHEN status IN ('in-progress', 'in_progress') THEN 1 ELSE 0 END) as in_progress,
         SUM(CASE WHEN status = 'done' THEN 1 ELSE 0 END) as completed
       FROM tasks
       WHERE assigned_to = ?

--- a/src/app/api/approvals/route.ts
+++ b/src/app/api/approvals/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getDatabase } from '@/lib/db'
+import { requireRole } from '@/lib/auth'
+import { logger } from '@/lib/logger'
+import { isMainTask, normalizeTaskStatus } from '@/lib/task-workflow'
+
+/**
+ * GET /api/approvals
+ * Returns tasks requiring explicit user decision.
+ */
+export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  try {
+    const db = getDatabase()
+    const { searchParams } = new URL(request.url)
+    const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 200)
+
+    const tasks = db.prepare(`
+      SELECT * FROM tasks
+      WHERE status IN ('needs-approval', 'review')
+      ORDER BY updated_at DESC
+      LIMIT ?
+    `).all(limit) as any[]
+
+    const latestApprovalStmt = db.prepare(`
+      SELECT id, action, summary, rationale, actor, created_at
+      FROM task_approvals
+      WHERE task_id = ?
+      ORDER BY created_at DESC, id DESC
+      LIMIT 1
+    `)
+
+    const pending = tasks
+      .map((task) => {
+        const metadata = task.metadata ? JSON.parse(task.metadata) : {}
+        const normalizedStatus = normalizeTaskStatus(task.status)
+        const latest = latestApprovalStmt.get(task.id) as any
+        const requiresDecision =
+          normalizedStatus === 'needs-approval' ||
+          (normalizedStatus === 'review' && isMainTask(metadata) && latest?.action !== 'approve')
+
+        return {
+          ...task,
+          status: normalizedStatus,
+          tags: task.tags ? JSON.parse(task.tags) : [],
+          metadata,
+          latestApproval: latest || null,
+          requiresDecision,
+        }
+      })
+      .filter((task) => task.requiresDecision)
+
+    return NextResponse.json({ approvals: pending, total: pending.length })
+  } catch (error) {
+    logger.error({ err: error }, 'GET /api/approvals error')
+    return NextResponse.json({ error: 'Failed to fetch approvals' }, { status: 500 })
+  }
+}

--- a/src/app/api/cron/route.ts
+++ b/src/app/api/cron/route.ts
@@ -322,9 +322,13 @@ export async function POST(request: NextRequest) {
       // Prevent duplicates: remove existing jobs with the same name
       cronFile.jobs = cronFile.jobs.filter(j => j.name !== name)
 
+      // Smart model routing: infer tier from job name + command
+      const { suggestCronRoute } = await import('@/lib/cron-routing')
+      const route = suggestCronRoute(`${name} ${command}`)
+
       const newJob: OpenClawCronJob = {
         id: `mc-${Date.now().toString(36)}`,
-        agentId: String(process.env.MC_CRON_AGENT_ID || process.env.MC_COORDINATOR_AGENT || 'system'),
+        agentId: route.agentId,
         name,
         enabled: true,
         createdAtMs: Date.now(),
@@ -336,6 +340,8 @@ export async function POST(request: NextRequest) {
         payload: {
           kind: 'agentTurn',
           message: command,
+          model: route.model,
+          ...(route.thinking ? { thinking: route.thinking } : {}),
         },
         delivery: {
           mode: 'none',

--- a/src/app/api/office/autopilot/route.ts
+++ b/src/app/api/office/autopilot/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getDatabase } from '@/lib/db'
+import { requireRole } from '@/lib/auth'
+import { logger } from '@/lib/logger'
+
+export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  try {
+    const db = getDatabase()
+    const { searchParams } = new URL(request.url)
+    const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 200)
+
+    const runs = db.prepare(`
+      SELECT id, cycle_type, routed_model, routed_agent, summary,
+             tasks_scanned, blocked_found, approvals_pending, escalations_created,
+             metadata, created_at
+      FROM office_autopilot_runs
+      ORDER BY created_at DESC, id DESC
+      LIMIT ?
+    `).all(limit) as any[]
+
+    return NextResponse.json({
+      runs: runs.map((r) => ({
+        ...r,
+        metadata: r.metadata ? JSON.parse(r.metadata) : null,
+      })),
+      total: runs.length,
+    })
+  } catch (error) {
+    logger.error({ err: error }, 'GET /api/office/autopilot error')
+    return NextResponse.json({ error: 'Failed to fetch office autopilot runs' }, { status: 500 })
+  }
+}

--- a/src/app/api/scheduler/route.ts
+++ b/src/app/api/scheduler/route.ts
@@ -14,7 +14,7 @@ export async function GET(request: NextRequest) {
 
 /**
  * POST /api/scheduler - Manually trigger a scheduled task
- * Body: { task_id: 'auto_backup' | 'auto_cleanup' | 'agent_heartbeat' }
+ * Body: { task_id: 'auto_backup' | 'auto_cleanup' | 'agent_heartbeat' | 'office_autopilot' }
  */
 export async function POST(request: NextRequest) {
   const auth = requireRole(request, 'admin')
@@ -23,8 +23,8 @@ export async function POST(request: NextRequest) {
   const body = await request.json().catch(() => ({}))
   const taskId = body.task_id
 
-  if (!taskId || !['auto_backup', 'auto_cleanup', 'agent_heartbeat'].includes(taskId)) {
-    return NextResponse.json({ error: 'task_id required: auto_backup, auto_cleanup, or agent_heartbeat' }, { status: 400 })
+  if (!taskId || !['auto_backup', 'auto_cleanup', 'agent_heartbeat', 'office_autopilot'].includes(taskId)) {
+    return NextResponse.json({ error: 'task_id required: auto_backup, auto_cleanup, agent_heartbeat, or office_autopilot' }, { status: 400 })
   }
 
   const result = await triggerTask(taskId)

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getAllGatewaySessions } from '@/lib/sessions'
+import { aliasSessionKey, getAgentDisplayName } from '@/lib/identity-alias'
 import { requireRole } from '@/lib/auth'
 import { logger } from '@/lib/logger'
 
@@ -16,8 +17,10 @@ export async function GET(request: NextRequest) {
       const pct = context > 0 ? Math.round((total / context) * 100) : 0
       return {
         id: s.sessionId || s.key,
-        key: s.key,
+        key: aliasSessionKey(s.key),
+        runtimeKey: s.key,
         agent: s.agent,
+        agentDisplay: getAgentDisplayName(s.agent),
         kind: s.chatType || 'unknown',
         age: formatAge(s.updatedAt),
         model: s.model,

--- a/src/app/api/spawn/route.ts
+++ b/src/app/api/spawn/route.ts
@@ -1,9 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { runClawdbot } from '@/lib/command'
+import { runOpenClaw } from '@/lib/command'
 import { requireRole } from '@/lib/auth'
-import { config } from '@/lib/config'
-import { readdir, readFile, stat } from 'fs/promises'
-import { join } from 'path'
 import { heavyLimiter } from '@/lib/rate-limit'
 import { logger } from '@/lib/logger'
 import { validateBody, spawnAgentSchema } from '@/lib/validation'
@@ -20,156 +17,63 @@ export async function POST(request: NextRequest) {
     if ('error' in result) return result.error
     const { task, model, label, timeoutSeconds } = result.data
 
-    const timeout = timeoutSeconds
-
-    // Generate spawn ID
     const spawnId = `spawn-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
+    const sessionId = label || `mc-spawn-${Date.now()}`
+    const idempotencyKey = spawnId
 
-    // Construct the spawn command
-    // Using OpenClaw's sessions_spawn function via clawdbot CLI
-    const spawnPayload = {
-      task,
-      model,
-      label,
-      runTimeoutSeconds: timeout
-    }
-    const commandArg = `sessions_spawn(${JSON.stringify(spawnPayload)})`
+    logger.info({ spawnId, sessionId, model }, 'Spawning agent via gateway call')
+
+    const message = model ? `[model:${model}] ${task}` : task
+    const params = JSON.stringify({ message, sessionId, idempotencyKey })
+
+    const token = process.env.OPENCLAW_GATEWAY_TOKEN || ''
+
+    // openclaw gateway call agent --token <t> --params <json> --json --timeout <ms>
+    const args = [
+      'gateway', 'call', 'agent',
+      '--token', token,
+      '--params', params,
+      '--json',
+      '--timeout', String(((timeoutSeconds ?? 60) + 10) * 1000)
+    ]
 
     try {
-      // Execute the spawn command
-      const { stdout, stderr } = await runClawdbot(['-c', commandArg], {
-        timeoutMs: 10000
+      const { stdout, stderr } = await runOpenClaw(args, {
+        timeoutMs: ((timeoutSeconds ?? 60) + 15) * 1000,
       })
 
-      // Parse the response to extract session info
-      let sessionInfo = null
-      try {
-        // Look for session information in stdout
-        const sessionMatch = stdout.match(/Session created: (.+)/)
-        if (sessionMatch) {
-          sessionInfo = sessionMatch[1]
-        }
-      } catch (parseError) {
-        logger.error({ err: parseError }, 'Failed to parse session info')
-      }
+      let res: Record<string, unknown> = {}
+      try { res = JSON.parse(stdout) } catch { /* non-json output */ }
 
       return NextResponse.json({
         success: true,
         spawnId,
-        sessionInfo,
-        task,
-        model,
-        label,
-        timeoutSeconds: timeout,
+        sessionInfo: (res?.runId as string) || sessionId,
+        runId: res?.runId,
+        status: res?.status,
+        task, model, label, sessionId,
+        timeoutSeconds,
         createdAt: Date.now(),
         stdout: stdout.trim(),
-        stderr: stderr.trim()
       })
-
     } catch (execError: any) {
-      logger.error({ err: execError }, 'Spawn execution error')
-      
+      logger.error({ err: execError }, 'Gateway spawn failed')
       return NextResponse.json({
         success: false,
         spawnId,
         error: execError.message || 'Failed to spawn agent',
-        task,
-        model,
-        label,
-        timeoutSeconds: timeout,
+        task, model, label, timeoutSeconds,
         createdAt: Date.now()
       }, { status: 500 })
     }
-
-  } catch (error) {
+  } catch (error: any) {
     logger.error({ err: error }, 'Spawn API error')
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    )
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
 }
 
-// Get spawn history
 export async function GET(request: NextRequest) {
   const auth = requireRole(request, 'viewer')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
-
-  try {
-    const { searchParams } = new URL(request.url)
-    const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 200)
-
-    // In a real implementation, you'd store spawn history in a database
-    // For now, we'll try to read recent spawn activity from logs
-    
-    try {
-      if (!config.logsDir) {
-        return NextResponse.json({ history: [] })
-      }
-
-      const files = await readdir(config.logsDir)
-      const logFiles = await Promise.all(
-        files
-          .filter((file) => file.endsWith('.log'))
-          .map(async (file) => {
-            const fullPath = join(config.logsDir, file)
-            const stats = await stat(fullPath)
-            return { file, fullPath, mtime: stats.mtime.getTime() }
-          })
-      )
-
-      const recentLogs = logFiles
-        .sort((a, b) => b.mtime - a.mtime)
-        .slice(0, 5)
-
-      const lines: string[] = []
-
-      for (const log of recentLogs) {
-        const content = await readFile(log.fullPath, 'utf-8')
-        const matched = content
-          .split('\n')
-          .filter((line) => line.includes('sessions_spawn'))
-        lines.push(...matched)
-      }
-
-      const spawnHistory = lines
-        .slice(-limit)
-        .map((line, index) => {
-          try {
-            const timestampMatch = line.match(
-              /(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})/
-            )
-            const modelMatch = line.match(/model[:\s]+"([^"]+)"/)
-            const taskMatch = line.match(/task[:\s]+"([^"]+)"/)
-
-            return {
-              id: `history-${Date.now()}-${index}`,
-              timestamp: timestampMatch
-                ? new Date(timestampMatch[1]).getTime()
-                : Date.now(),
-              model: modelMatch ? modelMatch[1] : 'unknown',
-              task: taskMatch ? taskMatch[1] : 'unknown',
-              status: 'completed',
-              line: line.trim()
-            }
-          } catch (parseError) {
-            return null
-          }
-        })
-        .filter(Boolean)
-
-      return NextResponse.json({ history: spawnHistory })
-
-    } catch (logError) {
-      // If we can't read logs, return empty history
-      return NextResponse.json({ history: [] })
-    }
-
-  } catch (error) {
-    logger.error({ err: error }, 'Spawn history API error')
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    )
-  }
+  return NextResponse.json({ history: [] })
 }

--- a/src/app/api/standup/route.ts
+++ b/src/app/api/standup/route.ts
@@ -50,28 +50,28 @@ export async function POST(request: NextRequest) {
       SELECT id, title, status, created_at, due_date
       FROM tasks
       WHERE assigned_to = ?
-      AND status = 'in_progress'
+      AND status IN ('in-progress', 'in_progress')
       ORDER BY created_at ASC
     `);
     const assignedTasksStmt = db.prepare(`
       SELECT id, title, status, created_at, due_date, priority
       FROM tasks
       WHERE assigned_to = ?
-      AND status = 'assigned'
+      AND status IN ('todo', 'assigned')
       ORDER BY priority DESC, created_at ASC
     `);
     const reviewTasksStmt = db.prepare(`
       SELECT id, title, status, updated_at
       FROM tasks
       WHERE assigned_to = ?
-      AND status IN ('review', 'quality_review')
+      AND status IN ('review', 'quality_review', 'needs-approval', 'needs_approval')
       ORDER BY updated_at ASC
     `);
     const blockedTasksStmt = db.prepare(`
       SELECT id, title, status, priority, created_at, metadata
       FROM tasks
       WHERE assigned_to = ?
-      AND (priority = 'urgent' OR metadata LIKE '%blocked%')
+      AND (status = 'blocked' OR priority = 'urgent' OR metadata LIKE '%blocked%')
       AND status NOT IN ('done')
       ORDER BY priority DESC, created_at ASC
     `);

--- a/src/app/api/tasks/[id]/approval/route.ts
+++ b/src/app/api/tasks/[id]/approval/route.ts
@@ -1,0 +1,144 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getDatabase, db_helpers } from '@/lib/db'
+import { requireRole } from '@/lib/auth'
+import { logger } from '@/lib/logger'
+import { mutationLimiter } from '@/lib/rate-limit'
+import { normalizeTaskStatus } from '@/lib/task-workflow'
+import { eventBus } from '@/lib/event-bus'
+
+interface ApprovalBody {
+  action: 'approve' | 'reject'
+  summary: string
+  rationale?: string
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  try {
+    const db = getDatabase()
+    const resolved = await params
+    const taskId = Number(resolved.id)
+    if (!Number.isFinite(taskId)) {
+      return NextResponse.json({ error: 'Invalid task ID' }, { status: 400 })
+    }
+
+    const approvals = db.prepare(
+      `SELECT id, task_id, action, summary, rationale, actor, metadata, created_at
+       FROM task_approvals
+       WHERE task_id = ?
+       ORDER BY created_at DESC, id DESC`
+    ).all(taskId) as any[]
+
+    const latest = approvals[0] || null
+    const parsed = approvals.map((a) => ({
+      ...a,
+      metadata: a.metadata ? JSON.parse(a.metadata) : null,
+    }))
+
+    return NextResponse.json({ latest: latest ? { ...latest, metadata: latest.metadata ? JSON.parse(latest.metadata) : null } : null, approvals: parsed })
+  } catch (error) {
+    logger.error({ err: error }, 'GET /api/tasks/[id]/approval error')
+    return NextResponse.json({ error: 'Failed to fetch approvals' }, { status: 500 })
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  const rateCheck = mutationLimiter(request)
+  if (rateCheck) return rateCheck
+
+  try {
+    const db = getDatabase()
+    const resolved = await params
+    const taskId = Number(resolved.id)
+    if (!Number.isFinite(taskId)) {
+      return NextResponse.json({ error: 'Invalid task ID' }, { status: 400 })
+    }
+
+    const task = db.prepare('SELECT * FROM tasks WHERE id = ?').get(taskId) as any
+    if (!task) return NextResponse.json({ error: 'Task not found' }, { status: 404 })
+
+    const body = (await request.json()) as ApprovalBody
+    if (!body || (body.action !== 'approve' && body.action !== 'reject')) {
+      return NextResponse.json({ error: 'action must be approve or reject' }, { status: 400 })
+    }
+    if (!body.summary || !String(body.summary).trim()) {
+      return NextResponse.json({ error: 'summary is required' }, { status: 400 })
+    }
+
+    const now = Math.floor(Date.now() / 1000)
+    const actor = auth.user.username
+
+    const insert = db.prepare(`
+      INSERT INTO task_approvals (task_id, action, summary, rationale, actor, metadata, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `)
+
+    const approvalMeta = {
+      taskStatusAtDecision: normalizeTaskStatus(task.status),
+      taskTitle: task.title,
+    }
+
+    const result = insert.run(
+      taskId,
+      body.action,
+      String(body.summary).trim(),
+      body.rationale ? String(body.rationale).trim() : null,
+      actor,
+      JSON.stringify(approvalMeta),
+      now,
+    )
+
+    // One-click behavior
+    const nextStatus = body.action === 'approve'
+      ? (normalizeTaskStatus(task.status) === 'review' ? 'done' : 'todo')
+      : 'blocked'
+
+    db.prepare('UPDATE tasks SET status = ?, updated_at = ? WHERE id = ?').run(nextStatus, now, taskId)
+
+    db_helpers.logActivity(
+      body.action === 'approve' ? 'task_approved' : 'task_rejected',
+      'task',
+      taskId,
+      actor,
+      `${body.action === 'approve' ? 'Approved' : 'Rejected'} task: ${task.title}`,
+      {
+        summary: body.summary,
+        rationale: body.rationale || null,
+        nextStatus,
+      }
+    )
+
+    eventBus.broadcast('task.updated', { id: taskId, status: nextStatus, updated_at: now })
+
+    return NextResponse.json({
+      approval: {
+        id: Number(result.lastInsertRowid),
+        task_id: taskId,
+        action: body.action,
+        summary: body.summary,
+        rationale: body.rationale || null,
+        actor,
+        metadata: approvalMeta,
+        created_at: now,
+      },
+      task: {
+        id: taskId,
+        status: nextStatus,
+      },
+    })
+  } catch (error) {
+    logger.error({ err: error }, 'POST /api/tasks/[id]/approval error')
+    return NextResponse.json({ error: 'Failed to submit approval decision' }, { status: 500 })
+  }
+}

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -1,20 +1,12 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { getDatabase, Task, db_helpers } from '@/lib/db';
-import { eventBus } from '@/lib/event-bus';
-import { getUserFromRequest, requireRole } from '@/lib/auth';
-import { mutationLimiter } from '@/lib/rate-limit';
-import { logger } from '@/lib/logger';
-import { validateBody, updateTaskSchema } from '@/lib/validation';
-
-function hasAegisApproval(db: ReturnType<typeof getDatabase>, taskId: number): boolean {
-  const review = db.prepare(`
-    SELECT status FROM quality_reviews
-    WHERE task_id = ? AND reviewer = 'aegis'
-    ORDER BY created_at DESC
-    LIMIT 1
-  `).get(taskId) as { status?: string } | undefined
-  return review?.status === 'approved'
-}
+import { NextRequest, NextResponse } from 'next/server'
+import { getDatabase, Task, db_helpers } from '@/lib/db'
+import { eventBus } from '@/lib/event-bus'
+import { getUserFromRequest, requireRole } from '@/lib/auth'
+import { mutationLimiter } from '@/lib/rate-limit'
+import { logger } from '@/lib/logger'
+import { validateBody, updateTaskSchema } from '@/lib/validation'
+import { hasApprovedTask } from '@/lib/task-approvals'
+import { normalizeTaskStatus, requiresExternalApproval, shouldRequireApprovalForDone } from '@/lib/task-workflow'
 
 /**
  * GET /api/tasks/[id] - Get a specific task
@@ -23,36 +15,36 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const auth = requireRole(request, 'viewer');
-  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status });
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
 
   try {
-    const db = getDatabase();
-    const resolvedParams = await params;
-    const taskId = parseInt(resolvedParams.id);
+    const db = getDatabase()
+    const resolvedParams = await params
+    const taskId = parseInt(resolvedParams.id)
 
     if (isNaN(taskId)) {
-      return NextResponse.json({ error: 'Invalid task ID' }, { status: 400 });
+      return NextResponse.json({ error: 'Invalid task ID' }, { status: 400 })
     }
-    
-    const stmt = db.prepare('SELECT * FROM tasks WHERE id = ?');
-    const task = stmt.get(taskId) as Task;
-    
+
+    const stmt = db.prepare('SELECT * FROM tasks WHERE id = ?')
+    const task = stmt.get(taskId) as Task
+
     if (!task) {
-      return NextResponse.json({ error: 'Task not found' }, { status: 404 });
+      return NextResponse.json({ error: 'Task not found' }, { status: 404 })
     }
-    
-    // Parse JSON fields
+
     const taskWithParsedData = {
       ...task,
       tags: task.tags ? JSON.parse(task.tags) : [],
-      metadata: task.metadata ? JSON.parse(task.metadata) : {}
-    };
-    
-    return NextResponse.json({ task: taskWithParsedData });
+      metadata: task.metadata ? JSON.parse(task.metadata) : {},
+      status: normalizeTaskStatus(task.status),
+    }
+
+    return NextResponse.json({ task: taskWithParsedData })
   } catch (error) {
-    logger.error({ err: error }, 'GET /api/tasks/[id] error');
-    return NextResponse.json({ error: 'Failed to fetch task' }, { status: 500 });
+    logger.error({ err: error }, 'GET /api/tasks/[id] error')
+    return NextResponse.json({ error: 'Failed to fetch task' }, { status: 500 })
   }
 }
 
@@ -63,31 +55,30 @@ export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const auth = requireRole(request, 'operator');
-  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status });
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
 
-  const rateCheck = mutationLimiter(request);
-  if (rateCheck) return rateCheck;
+  const rateCheck = mutationLimiter(request)
+  if (rateCheck) return rateCheck
 
   try {
-    const db = getDatabase();
-    const resolvedParams = await params;
-    const taskId = parseInt(resolvedParams.id);
-    const validated = await validateBody(request, updateTaskSchema);
-    if ('error' in validated) return validated.error;
-    const body = validated.data;
-    
+    const db = getDatabase()
+    const resolvedParams = await params
+    const taskId = parseInt(resolvedParams.id)
+    const validated = await validateBody(request, updateTaskSchema)
+    if ('error' in validated) return validated.error
+    const body = validated.data
+
     if (isNaN(taskId)) {
-      return NextResponse.json({ error: 'Invalid task ID' }, { status: 400 });
+      return NextResponse.json({ error: 'Invalid task ID' }, { status: 400 })
     }
-    
-    // Get current task for comparison
-    const currentTask = db.prepare('SELECT * FROM tasks WHERE id = ?').get(taskId) as Task;
-    
+
+    const currentTask = db.prepare('SELECT * FROM tasks WHERE id = ?').get(taskId) as Task
+
     if (!currentTask) {
-      return NextResponse.json({ error: 'Task not found' }, { status: 404 });
+      return NextResponse.json({ error: 'Task not found' }, { status: 404 })
     }
-    
+
     const {
       title,
       description,
@@ -98,103 +89,110 @@ export async function PUT(
       estimated_hours,
       actual_hours,
       tags,
-      metadata
-    } = body;
-    
-    const now = Math.floor(Date.now() / 1000);
-    
-    // Build dynamic update query
-    const fieldsToUpdate = [];
-    const updateParams: any[] = [];
-    
+      metadata,
+    } = body
+
+    const now = Math.floor(Date.now() / 1000)
+
+    const fieldsToUpdate = []
+    const updateParams: any[] = []
+
     if (title !== undefined) {
-      fieldsToUpdate.push('title = ?');
-      updateParams.push(title);
+      fieldsToUpdate.push('title = ?')
+      updateParams.push(title)
     }
     if (description !== undefined) {
-      fieldsToUpdate.push('description = ?');
-      updateParams.push(description);
+      fieldsToUpdate.push('description = ?')
+      updateParams.push(description)
     }
     if (status !== undefined) {
-      if (status === 'done' && !hasAegisApproval(db, taskId)) {
+      const parsedMetadata = metadata !== undefined
+        ? metadata
+        : (currentTask.metadata ? JSON.parse(currentTask.metadata) : {})
+      let normalizedNext = normalizeTaskStatus(status)
+
+      if (shouldRequireApprovalForDone(currentTask.status, normalizedNext, parsedMetadata) && !hasApprovedTask(taskId)) {
         return NextResponse.json(
-          { error: 'Aegis approval is required to move task to done.' },
+          { error: 'Approval is required before this task can be moved to done.' },
           { status: 403 }
         )
       }
-      fieldsToUpdate.push('status = ?');
-      updateParams.push(status);
+
+      if (requiresExternalApproval(parsedMetadata) && !hasApprovedTask(taskId) && normalizedNext !== 'done') {
+        normalizedNext = 'needs-approval'
+      }
+
+      fieldsToUpdate.push('status = ?')
+      updateParams.push(normalizedNext)
     }
     if (priority !== undefined) {
-      fieldsToUpdate.push('priority = ?');
-      updateParams.push(priority);
+      fieldsToUpdate.push('priority = ?')
+      updateParams.push(priority)
     }
     if (assigned_to !== undefined) {
-      fieldsToUpdate.push('assigned_to = ?');
-      updateParams.push(assigned_to);
+      fieldsToUpdate.push('assigned_to = ?')
+      updateParams.push(assigned_to)
     }
     if (due_date !== undefined) {
-      fieldsToUpdate.push('due_date = ?');
-      updateParams.push(due_date);
+      fieldsToUpdate.push('due_date = ?')
+      updateParams.push(due_date)
     }
     if (estimated_hours !== undefined) {
-      fieldsToUpdate.push('estimated_hours = ?');
-      updateParams.push(estimated_hours);
+      fieldsToUpdate.push('estimated_hours = ?')
+      updateParams.push(estimated_hours)
     }
     if (actual_hours !== undefined) {
-      fieldsToUpdate.push('actual_hours = ?');
-      updateParams.push(actual_hours);
+      fieldsToUpdate.push('actual_hours = ?')
+      updateParams.push(actual_hours)
     }
     if (tags !== undefined) {
-      fieldsToUpdate.push('tags = ?');
-      updateParams.push(JSON.stringify(tags));
+      fieldsToUpdate.push('tags = ?')
+      updateParams.push(JSON.stringify(tags))
     }
     if (metadata !== undefined) {
-      fieldsToUpdate.push('metadata = ?');
-      updateParams.push(JSON.stringify(metadata));
+      fieldsToUpdate.push('metadata = ?')
+      updateParams.push(JSON.stringify(metadata))
     }
-    
-    fieldsToUpdate.push('updated_at = ?');
-    updateParams.push(now);
-    updateParams.push(taskId);
-    
-    if (fieldsToUpdate.length === 1) { // Only updated_at
-      return NextResponse.json({ error: 'No fields to update' }, { status: 400 });
+
+    fieldsToUpdate.push('updated_at = ?')
+    updateParams.push(now)
+    updateParams.push(taskId)
+
+    if (fieldsToUpdate.length === 1) {
+      return NextResponse.json({ error: 'No fields to update' }, { status: 400 })
     }
-    
+
     const stmt = db.prepare(`
-      UPDATE tasks 
+      UPDATE tasks
       SET ${fieldsToUpdate.join(', ')}
       WHERE id = ?
-    `);
-    
-    stmt.run(...updateParams);
-    
-    // Track changes and log activities
-    const changes: string[] = [];
-    
-    if (status && status !== currentTask.status) {
-      changes.push(`status: ${currentTask.status} → ${status}`);
-      
-      // Create notification for status change if assigned
+    `)
+
+    stmt.run(...updateParams)
+
+    const changes: string[] = []
+
+    if (status && normalizeTaskStatus(status) !== normalizeTaskStatus(currentTask.status)) {
+      const normalized = normalizeTaskStatus(status)
+      changes.push(`status: ${normalizeTaskStatus(currentTask.status)} → ${normalized}`)
+
       if (currentTask.assigned_to) {
         db_helpers.createNotification(
           currentTask.assigned_to,
           'status_change',
           'Task Status Updated',
-          `Task "${currentTask.title}" status changed to ${status}`,
+          `Task "${currentTask.title}" status changed to ${normalized}`,
           'task',
           taskId
-        );
+        )
       }
     }
-    
+
     if (assigned_to !== undefined && assigned_to !== currentTask.assigned_to) {
-      changes.push(`assigned: ${currentTask.assigned_to || 'unassigned'} → ${assigned_to || 'unassigned'}`);
-      
-      // Create notification for new assignee
+      changes.push(`assigned: ${currentTask.assigned_to || 'unassigned'} → ${assigned_to || 'unassigned'}`)
+
       if (assigned_to) {
-        db_helpers.ensureTaskSubscription(taskId, assigned_to);
+        db_helpers.ensureTaskSubscription(taskId, assigned_to)
         db_helpers.createNotification(
           assigned_to,
           'assignment',
@@ -202,19 +200,18 @@ export async function PUT(
           `You have been assigned to task: ${currentTask.title}`,
           'task',
           taskId
-        );
+        )
       }
     }
-    
+
     if (title && title !== currentTask.title) {
-      changes.push('title updated');
+      changes.push('title updated')
     }
-    
+
     if (priority && priority !== currentTask.priority) {
-      changes.push(`priority: ${currentTask.priority} → ${priority}`);
+      changes.push(`priority: ${currentTask.priority} → ${priority}`)
     }
-    
-    // Log activity if there were meaningful changes
+
     if (changes.length > 0) {
       db_helpers.logActivity(
         'task_updated',
@@ -222,34 +219,33 @@ export async function PUT(
         taskId,
         getUserFromRequest(request)?.username || 'system',
         `Task updated: ${changes.join(', ')}`,
-        { 
-          changes: changes,
+        {
+          changes,
           oldValues: {
             title: currentTask.title,
-            status: currentTask.status,
+            status: normalizeTaskStatus(currentTask.status),
             priority: currentTask.priority,
-            assigned_to: currentTask.assigned_to
+            assigned_to: currentTask.assigned_to,
           },
-          newValues: { title, status, priority, assigned_to }
+          newValues: { title, status: status ? normalizeTaskStatus(status) : undefined, priority, assigned_to },
         }
-      );
+      )
     }
-    
-    // Fetch updated task
-    const updatedTask = db.prepare('SELECT * FROM tasks WHERE id = ?').get(taskId) as Task;
+
+    const updatedTask = db.prepare('SELECT * FROM tasks WHERE id = ?').get(taskId) as Task
     const parsedTask = {
       ...updatedTask,
       tags: updatedTask.tags ? JSON.parse(updatedTask.tags) : [],
-      metadata: updatedTask.metadata ? JSON.parse(updatedTask.metadata) : {}
-    };
+      metadata: updatedTask.metadata ? JSON.parse(updatedTask.metadata) : {},
+      status: normalizeTaskStatus(updatedTask.status),
+    }
 
-    // Broadcast to SSE clients
-    eventBus.broadcast('task.updated', parsedTask);
+    eventBus.broadcast('task.updated', parsedTask)
 
-    return NextResponse.json({ task: parsedTask });
+    return NextResponse.json({ task: parsedTask })
   } catch (error) {
-    logger.error({ err: error }, 'PUT /api/tasks/[id] error');
-    return NextResponse.json({ error: 'Failed to update task' }, { status: 500 });
+    logger.error({ err: error }, 'PUT /api/tasks/[id] error')
+    return NextResponse.json({ error: 'Failed to update task' }, { status: 500 })
   }
 }
 
@@ -260,33 +256,54 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const auth = requireRole(request, 'operator');
-  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status });
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
 
-  const rateCheck = mutationLimiter(request);
-  if (rateCheck) return rateCheck;
+  const rateCheck = mutationLimiter(request)
+  if (rateCheck) return rateCheck
 
   try {
-    const db = getDatabase();
-    const resolvedParams = await params;
-    const taskId = parseInt(resolvedParams.id);
-    
+    const db = getDatabase()
+    const resolvedParams = await params
+    const taskId = parseInt(resolvedParams.id)
+
     if (isNaN(taskId)) {
-      return NextResponse.json({ error: 'Invalid task ID' }, { status: 400 });
+      return NextResponse.json({ error: 'Invalid task ID' }, { status: 400 })
     }
-    
-    // Get task before deletion for logging
-    const task = db.prepare('SELECT * FROM tasks WHERE id = ?').get(taskId) as Task;
-    
+
+    const task = db.prepare('SELECT * FROM tasks WHERE id = ?').get(taskId) as Task
+
     if (!task) {
-      return NextResponse.json({ error: 'Task not found' }, { status: 404 });
+      return NextResponse.json({ error: 'Task not found' }, { status: 404 })
     }
-    
-    // Delete task (cascades will handle comments)
-    const stmt = db.prepare('DELETE FROM tasks WHERE id = ?');
-    stmt.run(taskId);
-    
-    // Log deletion
+
+    // If this is an external mirrored task, record a tombstone so sync doesn't recreate it.
+    try {
+      const metadata = task.metadata ? JSON.parse(task.metadata as any) : {}
+      const external = metadata?.external
+      if (external?.source && external?.taskId) {
+        db.prepare(`
+          INSERT INTO external_task_tombstones (source, external_id, deleted_by, reason, created_at)
+          VALUES (?, ?, ?, ?, ?)
+          ON CONFLICT(source, external_id) DO UPDATE SET
+            deleted_by = excluded.deleted_by,
+            reason = excluded.reason,
+            created_at = excluded.created_at
+        `).run(
+          String(external.source),
+          String(external.taskId),
+          getUserFromRequest(request)?.username || 'system',
+          'user_deleted_task',
+          Math.floor(Date.now() / 1000),
+        )
+      }
+    } catch {
+      // best effort only
+    }
+
+    const stmt = db.prepare('DELETE FROM tasks WHERE id = ?')
+    stmt.run(taskId)
+
     db_helpers.logActivity(
       'task_deleted',
       'task',
@@ -295,17 +312,16 @@ export async function DELETE(
       `Deleted task: ${task.title}`,
       {
         title: task.title,
-        status: task.status,
-        assigned_to: task.assigned_to
+        status: normalizeTaskStatus(task.status),
+        assigned_to: task.assigned_to,
       }
-    );
+    )
 
-    // Broadcast to SSE clients
-    eventBus.broadcast('task.deleted', { id: taskId, title: task.title });
+    eventBus.broadcast('task.deleted', { id: taskId, title: task.title })
 
-    return NextResponse.json({ success: true });
+    return NextResponse.json({ success: true })
   } catch (error) {
-    logger.error({ err: error }, 'DELETE /api/tasks/[id] error');
-    return NextResponse.json({ error: 'Failed to delete task' }, { status: 500 });
+    logger.error({ err: error }, 'DELETE /api/tasks/[id] error')
+    return NextResponse.json({ error: 'Failed to delete task' }, { status: 500 })
   }
 }

--- a/src/app/api/tasks/openclaw-comms-sync/route.ts
+++ b/src/app/api/tasks/openclaw-comms-sync/route.ts
@@ -1,0 +1,180 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { mutationLimiter } from '@/lib/rate-limit'
+import { getDatabase } from '@/lib/db'
+import { eventBus } from '@/lib/event-bus'
+import { validateBody } from '@/lib/validation'
+import { z } from 'zod'
+import { readFileSync, existsSync, mkdirSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
+const bodySchema = z.object({
+  sessionKeys: z.array(z.string()).max(200),
+})
+
+type SyncState = Record<string, { offset: number }>
+
+const STATE_PATH = '/root/.openclaw/workspace/research/mission-control/.data/openclaw-comms-sync.json'
+
+function loadState(): SyncState {
+  try {
+    if (!existsSync(STATE_PATH)) {
+      mkdirSync(join(STATE_PATH, '..'), { recursive: true })
+      return {}
+    }
+    return JSON.parse(readFileSync(STATE_PATH, 'utf-8'))
+  } catch {
+    return {}
+  }
+}
+
+function saveState(state: SyncState) {
+  try {
+    mkdirSync(join(STATE_PATH, '..'), { recursive: true })
+    writeFileSync(STATE_PATH, JSON.stringify(state, null, 2))
+  } catch {
+    // ignore
+  }
+}
+
+function parseAgentIdFromSessionKey(sessionKey: string): string | null {
+  const m = sessionKey.match(/^agent:([^:]+):/)
+  return m ? m[1] : null
+}
+
+function parseTaskIdFromSessionKey(sessionKey: string): string | null {
+  const m = sessionKey.match(/^agent:[^:]+:(proj:[^:]+:\d{8}:[a-z0-9-]+)$/i)
+  return m ? m[1] : null
+}
+
+function resolveSessionId(openclawHome: string, agentId: string, sessionKey: string): string | null {
+  try {
+    const mapPath = join(openclawHome, 'agents', agentId, 'sessions', 'sessions.json')
+    if (!existsSync(mapPath)) return null
+    const data = JSON.parse(readFileSync(mapPath, 'utf-8'))
+    const entry = data?.[sessionKey]
+    if (entry?.sessionId) return String(entry.sessionId)
+    return null
+  } catch {
+    return null
+  }
+}
+
+function extractText(content: any): string {
+  if (typeof content === 'string') return content
+  if (Array.isArray(content)) {
+    return content
+      .map((c) => {
+        if (!c) return ''
+        if (typeof c === 'string') return c
+        if (typeof c.text === 'string') return c.text
+        return ''
+      })
+      .join('')
+      .trim()
+  }
+  return ''
+}
+
+export async function POST(request: NextRequest) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  const rateCheck = mutationLimiter(request)
+  if (rateCheck) return rateCheck
+
+  const validated = await validateBody(request, bodySchema)
+  if ('error' in validated) return validated.error
+
+  const openclawHome = process.env.OPENCLAW_HOME || '/root/.openclaw'
+  const db = getDatabase()
+  const state = loadState()
+
+  let inserted = 0
+
+  for (const sessionKey of validated.data.sessionKeys) {
+    const agentId = parseAgentIdFromSessionKey(sessionKey)
+    const taskId = parseTaskIdFromSessionKey(sessionKey)
+    if (!agentId || !taskId) continue
+
+    const sessionId = resolveSessionId(openclawHome, agentId, sessionKey)
+    if (!sessionId) continue
+
+    const jsonlPath = join(openclawHome, 'agents', agentId, 'sessions', `${sessionId}.jsonl`)
+    if (!existsSync(jsonlPath)) continue
+
+    const raw = readFileSync(jsonlPath, 'utf-8')
+    const lines = raw.split('\n')
+    const storedOffset = state[sessionKey]?.offset ?? 0
+    const offset = Math.min(storedOffset, lines.length)
+
+    if (offset >= lines.length) {
+      state[sessionKey] = { offset: lines.length }
+      continue
+    }
+
+    const newLines = lines.slice(offset)
+    for (const line of newLines) {
+      const trimmed = line.trim()
+      if (!trimmed) continue
+      let obj: any
+      try {
+        obj = JSON.parse(trimmed)
+      } catch {
+        continue
+      }
+
+      if (obj?.type !== 'message') continue
+      const msg = obj?.message
+      const role = msg?.role
+      const content = msg?.content
+      const text = extractText(content)
+      if (!text) continue
+
+      const conversation_id = `coord:${taskId}`
+      const from_agent = role === 'assistant' ? agentId : (role || 'user')
+      const to_agent = null
+      const created_at = Math.floor(new Date(obj.timestamp).getTime() / 1000) || Math.floor(Date.now() / 1000)
+
+      // Deduplicate by (conversation_id, from_agent, created_at, content hash)
+      const exists = db
+        .prepare('SELECT id FROM messages WHERE conversation_id = ? AND from_agent = ? AND created_at = ? AND content = ? LIMIT 1')
+        .get(conversation_id, from_agent, created_at, text) as any
+      if (exists) continue
+
+      const stmt = db.prepare(
+        'INSERT INTO messages (conversation_id, from_agent, to_agent, content, message_type, metadata, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
+      )
+      const res = stmt.run(
+        conversation_id,
+        from_agent,
+        to_agent,
+        text,
+        'text',
+        JSON.stringify({ source: 'openclaw', sessionKey }),
+        created_at
+      )
+
+      inserted += 1
+
+      const id = Number(res.lastInsertRowid)
+      eventBus.broadcast('chat.message', {
+        id,
+        conversation_id,
+        from_agent,
+        to_agent,
+        content: text,
+        message_type: 'text',
+        metadata: { source: 'openclaw', sessionKey },
+        read_at: null,
+        created_at,
+      })
+    }
+
+    state[sessionKey] = { offset: lines.length }
+  }
+
+  saveState(state)
+
+  return NextResponse.json({ success: true, inserted })
+}

--- a/src/app/api/tasks/openclaw-sync/route.ts
+++ b/src/app/api/tasks/openclaw-sync/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { mutationLimiter } from '@/lib/rate-limit'
+import { mirrorOpenClawTasksAndComms } from '@/lib/openclaw-mirror'
+import { logger } from '@/lib/logger'
+
+/**
+ * Server-side OpenClaw mirror trigger.
+ * This endpoint does NOT rely on the browser tick stream.
+ * It projects OpenClaw sessions → MC tasks, and mirrors session transcripts → coord threads.
+ */
+export async function POST(request: NextRequest) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  const rateCheck = mutationLimiter(request)
+  if (rateCheck) return rateCheck
+
+  try {
+    const result = mirrorOpenClawTasksAndComms()
+    return NextResponse.json({ success: true, ...result })
+  } catch (err: any) {
+    logger.error({ err }, 'POST /api/tasks/openclaw-sync error')
+    return NextResponse.json({ error: err?.message || 'Mirror failed' }, { status: 500 })
+  }
+}

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -1,93 +1,82 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { getDatabase, Task, db_helpers } from '@/lib/db';
-import { eventBus } from '@/lib/event-bus';
-import { requireRole } from '@/lib/auth';
-import { mutationLimiter } from '@/lib/rate-limit';
-import { logger } from '@/lib/logger';
-import { validateBody, createTaskSchema, bulkUpdateTaskStatusSchema } from '@/lib/validation';
-
-function hasAegisApproval(db: ReturnType<typeof getDatabase>, taskId: number): boolean {
-  const review = db.prepare(`
-    SELECT status FROM quality_reviews
-    WHERE task_id = ? AND reviewer = 'aegis'
-    ORDER BY created_at DESC
-    LIMIT 1
-  `).get(taskId) as { status?: string } | undefined
-  return review?.status === 'approved'
-}
+import { NextRequest, NextResponse } from 'next/server'
+import { getDatabase, Task, db_helpers } from '@/lib/db'
+import { eventBus } from '@/lib/event-bus'
+import { requireRole } from '@/lib/auth'
+import { mutationLimiter } from '@/lib/rate-limit'
+import { logger } from '@/lib/logger'
+import { validateBody, createTaskSchema, bulkUpdateTaskStatusSchema } from '@/lib/validation'
+import { hasApprovedTask } from '@/lib/task-approvals'
+import { normalizeTaskStatus, requiresExternalApproval, shouldRequireApprovalForDone } from '@/lib/task-workflow'
 
 /**
  * GET /api/tasks - List all tasks with optional filtering
  * Query params: status, assigned_to, priority, limit, offset
  */
 export async function GET(request: NextRequest) {
-  const auth = requireRole(request, 'viewer');
-  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status });
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
 
   try {
-    const db = getDatabase();
-    const { searchParams } = new URL(request.url);
+    const db = getDatabase()
+    const { searchParams } = new URL(request.url)
 
-    // Parse query parameters
-    const status = searchParams.get('status');
-    const assigned_to = searchParams.get('assigned_to');
-    const priority = searchParams.get('priority');
-    const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 200);
-    const offset = parseInt(searchParams.get('offset') || '0');
-    
-    // Build dynamic query
-    let query = 'SELECT * FROM tasks WHERE 1=1';
-    const params: any[] = [];
-    
+    const status = searchParams.get('status')
+    const assigned_to = searchParams.get('assigned_to')
+    const priority = searchParams.get('priority')
+    const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 200)
+    const offset = parseInt(searchParams.get('offset') || '0')
+
+    let query = 'SELECT * FROM tasks WHERE 1=1'
+    const params: any[] = []
+
     if (status) {
-      query += ' AND status = ?';
-      params.push(status);
+      query += ' AND status = ?'
+      params.push(normalizeTaskStatus(status))
     }
-    
+
     if (assigned_to) {
-      query += ' AND assigned_to = ?';
-      params.push(assigned_to);
+      query += ' AND assigned_to = ?'
+      params.push(assigned_to)
     }
-    
+
     if (priority) {
-      query += ' AND priority = ?';
-      params.push(priority);
+      query += ' AND priority = ?'
+      params.push(priority)
     }
-    
-    query += ' ORDER BY created_at DESC LIMIT ? OFFSET ?';
-    params.push(limit, offset);
-    
-    const stmt = db.prepare(query);
-    const tasks = stmt.all(...params) as Task[];
-    
-    // Parse JSON fields
-    const tasksWithParsedData = tasks.map(task => ({
+
+    query += ' ORDER BY created_at DESC LIMIT ? OFFSET ?'
+    params.push(limit, offset)
+
+    const stmt = db.prepare(query)
+    const tasks = stmt.all(...params) as Task[]
+
+    const tasksWithParsedData = tasks.map((task) => ({
       ...task,
       tags: task.tags ? JSON.parse(task.tags) : [],
-      metadata: task.metadata ? JSON.parse(task.metadata) : {}
-    }));
-    
-    // Get total count for pagination
-    let countQuery = 'SELECT COUNT(*) as total FROM tasks WHERE 1=1';
-    const countParams: any[] = [];
+      metadata: task.metadata ? JSON.parse(task.metadata) : {},
+      status: normalizeTaskStatus(task.status),
+    }))
+
+    let countQuery = 'SELECT COUNT(*) as total FROM tasks WHERE 1=1'
+    const countParams: any[] = []
     if (status) {
-      countQuery += ' AND status = ?';
-      countParams.push(status);
+      countQuery += ' AND status = ?'
+      countParams.push(normalizeTaskStatus(status))
     }
     if (assigned_to) {
-      countQuery += ' AND assigned_to = ?';
-      countParams.push(assigned_to);
+      countQuery += ' AND assigned_to = ?'
+      countParams.push(assigned_to)
     }
     if (priority) {
-      countQuery += ' AND priority = ?';
-      countParams.push(priority);
+      countQuery += ' AND priority = ?'
+      countParams.push(priority)
     }
-    const countRow = db.prepare(countQuery).get(...countParams) as { total: number };
+    const countRow = db.prepare(countQuery).get(...countParams) as { total: number }
 
-    return NextResponse.json({ tasks: tasksWithParsedData, total: countRow.total, page: Math.floor(offset / limit) + 1, limit });
+    return NextResponse.json({ tasks: tasksWithParsedData, total: countRow.total, page: Math.floor(offset / limit) + 1, limit })
   } catch (error) {
-    logger.error({ err: error }, 'GET /api/tasks error');
-    return NextResponse.json({ error: 'Failed to fetch tasks' }, { status: 500 });
+    logger.error({ err: error }, 'GET /api/tasks error')
+    return NextResponse.json({ error: 'Failed to fetch tasks' }, { status: 500 })
   }
 }
 
@@ -95,17 +84,17 @@ export async function GET(request: NextRequest) {
  * POST /api/tasks - Create a new task
  */
 export async function POST(request: NextRequest) {
-  const auth = requireRole(request, 'operator');
-  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status });
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
 
-  const rateCheck = mutationLimiter(request);
-  if (rateCheck) return rateCheck;
+  const rateCheck = mutationLimiter(request)
+  if (rateCheck) return rateCheck
 
   try {
-    const db = getDatabase();
-    const validated = await validateBody(request, createTaskSchema);
-    if ('error' in validated) return validated.error;
-    const body = validated.data;
+    const db = getDatabase()
+    const validated = await validateBody(request, createTaskSchema)
+    if ('error' in validated) return validated.error
+    const body = validated.data
 
     const user = auth.user
     const {
@@ -118,28 +107,32 @@ export async function POST(request: NextRequest) {
       due_date,
       estimated_hours,
       tags = [],
-      metadata = {}
-    } = body;
-    
-    // Check for duplicate title
-    const existingTask = db.prepare('SELECT id FROM tasks WHERE title = ?').get(title);
-    if (existingTask) {
-      return NextResponse.json({ error: 'Task with this title already exists' }, { status: 409 });
+      metadata = {},
+    } = body
+
+    let normalizedStatus = normalizeTaskStatus(status)
+    if (requiresExternalApproval(metadata) && normalizedStatus !== 'done') {
+      normalizedStatus = 'needs-approval'
     }
-    
-    const now = Math.floor(Date.now() / 1000);
-    
+
+    const existingTask = db.prepare('SELECT id FROM tasks WHERE title = ?').get(title)
+    if (existingTask) {
+      return NextResponse.json({ error: 'Task with this title already exists' }, { status: 409 })
+    }
+
+    const now = Math.floor(Date.now() / 1000)
+
     const stmt = db.prepare(`
       INSERT INTO tasks (
         title, description, status, priority, assigned_to, created_by,
         created_at, updated_at, due_date, estimated_hours, tags, metadata
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `);
-    
+    `)
+
     const dbResult = stmt.run(
       title,
       description,
-      status,
+      normalizedStatus,
       priority,
       assigned_to,
       created_by,
@@ -149,23 +142,21 @@ export async function POST(request: NextRequest) {
       estimated_hours,
       JSON.stringify(tags),
       JSON.stringify(metadata)
-    );
+    )
 
-    const taskId = dbResult.lastInsertRowid as number;
-    
-    // Log activity
+    const taskId = dbResult.lastInsertRowid as number
+
     db_helpers.logActivity('task_created', 'task', taskId, created_by, `Created task: ${title}`, {
       title,
-      status,
+      status: normalizedStatus,
       priority,
-      assigned_to
-    });
+      assigned_to,
+    })
 
     if (created_by) {
       db_helpers.ensureTaskSubscription(taskId, created_by)
     }
 
-    // Create notification if assigned
     if (assigned_to) {
       db_helpers.ensureTaskSubscription(taskId, assigned_to)
       db_helpers.createNotification(
@@ -175,24 +166,23 @@ export async function POST(request: NextRequest) {
         `You have been assigned to task: ${title}`,
         'task',
         taskId
-      );
+      )
     }
-    
-    // Fetch the created task
-    const createdTask = db.prepare('SELECT * FROM tasks WHERE id = ?').get(taskId) as Task;
+
+    const createdTask = db.prepare('SELECT * FROM tasks WHERE id = ?').get(taskId) as Task
     const parsedTask = {
       ...createdTask,
       tags: JSON.parse(createdTask.tags || '[]'),
-      metadata: JSON.parse(createdTask.metadata || '{}')
-    };
+      metadata: JSON.parse(createdTask.metadata || '{}'),
+      status: normalizeTaskStatus(createdTask.status),
+    }
 
-    // Broadcast to SSE clients
-    eventBus.broadcast('task.created', parsedTask);
+    eventBus.broadcast('task.created', parsedTask)
 
-    return NextResponse.json({ task: parsedTask }, { status: 201 });
+    return NextResponse.json({ task: parsedTask }, { status: 201 })
   } catch (error) {
-    logger.error({ err: error }, 'POST /api/tasks error');
-    return NextResponse.json({ error: 'Failed to create task' }, { status: 500 });
+    logger.error({ err: error }, 'POST /api/tasks error')
+    return NextResponse.json({ error: 'Failed to create task' }, { status: 500 })
   }
 }
 
@@ -200,70 +190,72 @@ export async function POST(request: NextRequest) {
  * PUT /api/tasks - Update multiple tasks (for drag-and-drop status changes)
  */
 export async function PUT(request: NextRequest) {
-  const auth = requireRole(request, 'operator');
-  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status });
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
 
-  const rateCheck = mutationLimiter(request);
-  if (rateCheck) return rateCheck;
+  const rateCheck = mutationLimiter(request)
+  if (rateCheck) return rateCheck
 
   try {
-    const db = getDatabase();
-    const validated = await validateBody(request, bulkUpdateTaskStatusSchema);
-    if ('error' in validated) return validated.error;
-    const { tasks } = validated.data;
+    const db = getDatabase()
+    const validated = await validateBody(request, bulkUpdateTaskStatusSchema)
+    if ('error' in validated) return validated.error
+    const { tasks } = validated.data
 
-    const now = Math.floor(Date.now() / 1000);
+    const now = Math.floor(Date.now() / 1000)
 
     const updateStmt = db.prepare(`
       UPDATE tasks
       SET status = ?, updated_at = ?
       WHERE id = ?
-    `);
+    `)
 
     const actor = auth.user.username
 
     const transaction = db.transaction((tasksToUpdate: any[]) => {
       for (const task of tasksToUpdate) {
-        const oldTask = db.prepare('SELECT * FROM tasks WHERE id = ?').get(task.id) as Task;
+        const oldTask = db.prepare('SELECT * FROM tasks WHERE id = ?').get(task.id) as Task
+        if (!oldTask) continue
 
-        if (task.status === 'done' && !hasAegisApproval(db, task.id)) {
-          throw new Error(`Aegis approval required for task ${task.id}`)
+        const normalizedNext = normalizeTaskStatus(task.status)
+        const metadata = oldTask.metadata ? JSON.parse(oldTask.metadata) : {}
+
+        if (shouldRequireApprovalForDone(oldTask.status, normalizedNext, metadata) && !hasApprovedTask(task.id)) {
+          throw new Error(`Approval required before moving task ${task.id} to done`)
         }
 
-        updateStmt.run(task.status, now, task.id);
+        updateStmt.run(normalizedNext, now, task.id)
 
-        // Log status change if different
-        if (oldTask && oldTask.status !== task.status) {
+        if (oldTask.status !== normalizedNext) {
           db_helpers.logActivity(
             'task_updated',
             'task',
             task.id,
             actor,
-            `Task moved from ${oldTask.status} to ${task.status}`,
-            { oldStatus: oldTask.status, newStatus: task.status }
-          );
+            `Task moved from ${normalizeTaskStatus(oldTask.status)} to ${normalizedNext}`,
+            { oldStatus: normalizeTaskStatus(oldTask.status), newStatus: normalizedNext }
+          )
         }
       }
-    });
-    
-    transaction(tasks);
+    })
 
-    // Broadcast status changes to SSE clients
+    transaction(tasks)
+
     for (const task of tasks) {
       eventBus.broadcast('task.status_changed', {
         id: task.id,
-        status: task.status,
+        status: normalizeTaskStatus(task.status),
         updated_at: Math.floor(Date.now() / 1000),
-      });
+      })
     }
 
-    return NextResponse.json({ success: true, updated: tasks.length });
+    return NextResponse.json({ success: true, updated: tasks.length })
   } catch (error) {
-    logger.error({ err: error }, 'PUT /api/tasks error');
+    logger.error({ err: error }, 'PUT /api/tasks error')
     const message = error instanceof Error ? error.message : 'Failed to update tasks'
-    if (message.includes('Aegis approval required')) {
-      return NextResponse.json({ error: message }, { status: 403 });
+    if (message.includes('Approval required')) {
+      return NextResponse.json({ error: message }, { status: 403 })
     }
-    return NextResponse.json({ error: 'Failed to update tasks' }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to update tasks' }, { status: 500 })
   }
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -148,7 +148,7 @@ export default function LoginPage() {
 
           <button
             type="submit"
-            disabled={loading || !username || !password}
+            disabled={loading}
             className="w-full h-10 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-smooth flex items-center justify-center gap-2"
           >
             {loading ? (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,6 +13,7 @@ import { TokenDashboardPanel } from '@/components/panels/token-dashboard-panel'
 import { AgentCostPanel } from '@/components/panels/agent-cost-panel'
 import { SessionDetailsPanel } from '@/components/panels/session-details-panel'
 import { TaskBoardPanel } from '@/components/panels/task-board-panel'
+import { ApprovalInboxPanel } from '@/components/panels/approval-inbox-panel'
 import { ActivityFeedPanel } from '@/components/panels/activity-feed-panel'
 import { AgentSquadPanelPhase3 } from '@/components/panels/agent-squad-panel-phase3'
 import { AgentCommsPanel } from '@/components/panels/agent-comms-panel'
@@ -137,6 +138,8 @@ function ContentRouter({ tab }: { tab: string }) {
       )
     case 'tasks':
       return <TaskBoardPanel />
+    case 'approvals':
+      return <ApprovalInboxPanel />
     case 'agents':
       return (
         <>

--- a/src/components/dashboard/dashboard.tsx
+++ b/src/components/dashboard/dashboard.tsx
@@ -29,13 +29,17 @@ export function Dashboard() {
 
   const [systemStats, setSystemStats] = useState<any>(null)
   const [dbStats, setDbStats] = useState<DbStats | null>(null)
+  const [approvalInbox, setApprovalInbox] = useState<Array<{ id: number; title: string; status: string }>>([])
+  const [autopilotSummary, setAutopilotSummary] = useState<string>('No autopilot runs yet')
   const [isLoading, setIsLoading] = useState(true)
 
   const loadDashboard = useCallback(async () => {
     try {
-      const [dashRes, sessRes] = await Promise.all([
+      const [dashRes, sessRes, approvalsRes, autopilotRes] = await Promise.all([
         fetch('/api/status?action=dashboard'),
         fetch('/api/sessions'),
+        fetch('/api/approvals?limit=5'),
+        fetch('/api/office/autopilot?limit=1'),
       ])
 
       if (dashRes.ok) {
@@ -50,6 +54,21 @@ export function Dashboard() {
         const data = await sessRes.json()
         if (data && !data.error) setSessions(data.sessions || data)
       }
+
+      if (approvalsRes.ok) {
+        const data = await approvalsRes.json()
+        if (data && !data.error) {
+          setApprovalInbox((data.approvals || []).map((a: any) => ({ id: a.id, title: a.title, status: a.status })))
+        }
+      }
+
+      if (autopilotRes.ok) {
+        const data = await autopilotRes.json()
+        if (data && !data.error) {
+          const latest = (data.runs || [])[0]
+          setAutopilotSummary(latest?.summary || 'No autopilot runs yet')
+        }
+      }
     } catch {
       // silent
     } finally {
@@ -61,7 +80,13 @@ export function Dashboard() {
 
   const activeSessions = sessions.filter(s => s.active).length
   const errorCount = logs.filter(l => l.level === 'error').length
-  const runningTasks = dbStats?.tasks.byStatus?.in_progress ?? tasks.filter(t => t.status === 'in_progress').length
+  const runningTasks =
+    (dbStats?.tasks.byStatus?.['in-progress'] ?? 0) +
+    (dbStats?.tasks.byStatus?.in_progress ?? tasks.filter(t => t.status === 'in_progress').length)
+  const blockedTasks =
+    (dbStats?.tasks.byStatus?.blocked ?? 0)
+  const approvalsPending =
+    (dbStats?.tasks.byStatus?.['needs-approval'] ?? 0) + (dbStats?.tasks.byStatus?.needs_approval ?? 0)
   const onlineAgents = dbStats ? (dbStats.agents.total - (dbStats.agents.byStatus?.offline ?? 0)) : agents.filter(a => a.status !== 'offline').length
 
   if (isLoading) {
@@ -88,7 +113,7 @@ export function Dashboard() {
   return (
     <div className="p-5 space-y-5">
       {/* Top Metric Cards */}
-      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+      <div className="grid grid-cols-2 lg:grid-cols-6 gap-3">
         <div className="cursor-pointer" onClick={() => setActiveTab('history')}>
           <MetricCard
             label="Active Sessions"
@@ -109,11 +134,27 @@ export function Dashboard() {
         </div>
         <div className="cursor-pointer" onClick={() => setActiveTab('tasks')}>
           <MetricCard
-            label="Tasks Running"
+            label="In Progress"
             value={runningTasks}
             total={dbStats?.tasks.total ?? tasks.length}
             icon={<TaskIcon />}
             color="purple"
+          />
+        </div>
+        <div className="cursor-pointer" onClick={() => setActiveTab('tasks')}>
+          <MetricCard
+            label="Blocked"
+            value={blockedTasks}
+            icon={<ErrorIcon />}
+            color={blockedTasks > 0 ? 'red' : 'green'}
+          />
+        </div>
+        <div className="cursor-pointer" onClick={() => setActiveTab('approvals')}>
+          <MetricCard
+            label="Needs Approval"
+            value={approvalsPending}
+            icon={<TaskIcon />}
+            color={approvalsPending > 0 ? 'red' : 'green'}
           />
         </div>
         <div className="cursor-pointer" onClick={() => setActiveTab('logs')}>
@@ -123,6 +164,37 @@ export function Dashboard() {
             icon={<ErrorIcon />}
             color={errorCount > 0 ? 'red' : 'green'}
           />
+        </div>
+      </div>
+
+      <div className="grid lg:grid-cols-2 gap-4">
+        <div className="panel cursor-pointer hover:border-primary/30 transition-smooth" onClick={() => setActiveTab('approvals')}>
+          <div className="panel-header">
+            <h3 className="text-sm font-semibold text-foreground">Approval Inbox (Human Gate)</h3>
+            <span className="text-xs text-amber-300">{approvalInbox.length} pending</span>
+          </div>
+          <div className="panel-body space-y-2">
+            {approvalInbox.length === 0 ? (
+              <p className="text-xs text-muted-foreground">No approvals pending.</p>
+            ) : (
+              approvalInbox.slice(0, 4).map((item) => (
+                <div key={item.id} className="flex items-center justify-between text-xs border border-border/60 rounded px-2 py-1">
+                  <span className="text-foreground truncate pr-2">#{item.id} {item.title}</span>
+                  <span className="text-amber-300">{item.status}</span>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        <div className="panel">
+          <div className="panel-header">
+            <h3 className="text-sm font-semibold text-foreground">Office Autopilot</h3>
+            <span className="text-xs text-muted-foreground">Conductor loop</span>
+          </div>
+          <div className="panel-body">
+            <p className="text-xs text-muted-foreground leading-relaxed">{autopilotSummary}</p>
+          </div>
         </div>
       </div>
 
@@ -468,9 +540,16 @@ function formatBytes(bytes: number): string {
 function taskStatusColor(status: string): string {
   switch (status) {
     case 'done': return 'bg-green-500'
+    case 'in-progress':
     case 'in_progress': return 'bg-blue-500'
-    case 'review': case 'quality_review': return 'bg-purple-500'
+    case 'review':
+    case 'quality_review': return 'bg-purple-500'
+    case 'todo':
     case 'assigned': return 'bg-amber-500'
+    case 'blocked': return 'bg-red-500'
+    case 'needs-approval':
+    case 'needs_approval': return 'bg-orange-500'
+    case 'backlog': return 'bg-slate-500'
     case 'inbox': return 'bg-muted-foreground/40'
     default: return 'bg-muted-foreground/30'
   }

--- a/src/components/layout/nav-rail.tsx
+++ b/src/components/layout/nav-rail.tsx
@@ -23,6 +23,7 @@ const navGroups: NavGroup[] = [
       { id: 'overview', label: 'Overview', icon: <OverviewIcon />, priority: true },
       { id: 'agents', label: 'Agents', icon: <AgentsIcon />, priority: true },
       { id: 'tasks', label: 'Tasks', icon: <TasksIcon />, priority: true },
+      { id: 'approvals', label: 'Approvals', icon: <AlertIcon />, priority: true },
       { id: 'sessions', label: 'Sessions', icon: <SessionsIcon />, priority: false },
     ],
   },

--- a/src/components/panels/agent-comms-panel.tsx
+++ b/src/components/panels/agent-comms-panel.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { useSmartPoll } from '@/lib/use-smart-poll'
 import { useMissionControl } from '@/store'
 
-const COORDINATOR_AGENT = (process.env.NEXT_PUBLIC_COORDINATOR_AGENT || 'coordinator').toLowerCase()
+const COORDINATOR_AGENT = (process.env.NEXT_PUBLIC_COORDINATOR_AGENT || 'conductor').toLowerCase()
 
 interface CommsMessage {
   id: number

--- a/src/components/panels/agent-detail-tabs.tsx
+++ b/src/components/panels/agent-detail-tabs.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import { MODEL_CATALOG } from '@/lib/models'
 
 interface Agent {
   id: number
@@ -878,7 +879,7 @@ export function CreateAgentModal({
           template: selectedTemplate || undefined,
           write_to_gateway: formData.write_to_gateway,
           gateway_config: {
-            model: { primary: `anthropic/claude-${formData.model === 'opus' ? 'opus-4-5' : formData.model === 'haiku' ? 'haiku-4-5' : 'sonnet-4-20250514'}` },
+            model: { primary: MODEL_CATALOG.find(m => m.alias === formData.model)?.name ?? formData.model },
             identity: { name: formData.name, theme: formData.role, emoji: formData.emoji },
             sandbox: {
               mode: formData.sandboxMode,

--- a/src/components/panels/agent-squad-panel-phase3.tsx
+++ b/src/components/panels/agent-squad-panel-phase3.tsx
@@ -487,24 +487,50 @@ function AgentDetailModalPhase3({
   const [heartbeatData, setHeartbeatData] = useState<HeartbeatResponse | null>(null)
   const [loadingHeartbeat, setLoadingHeartbeat] = useState(false)
 
-  // Load SOUL templates
+  // Load SOUL templates + latest SOUL content
   useEffect(() => {
-    const loadTemplates = async () => {
+    const loadSoulTabData = async () => {
       try {
-        const response = await fetch(`/api/agents/${agent.name}/soul`, {
-          method: 'PATCH'
-        })
-        if (response.ok) {
-          const data = await response.json()
+        const [templatesRes, soulRes] = await Promise.all([
+          fetch(`/api/agents/${encodeURIComponent(agent.name)}/soul`, { method: 'PATCH' }),
+          fetch(`/api/agents/${encodeURIComponent(agent.name)}/soul`),
+        ])
+
+        if (templatesRes.ok) {
+          const data = await templatesRes.json()
           setSoulTemplates(data.templates || [])
         }
+
+        if (soulRes.ok) {
+          const data = await soulRes.json()
+          setFormData(prev => ({ ...prev, soul_content: data.soul_content || '' }))
+        }
       } catch (error) {
-        console.error('Failed to load SOUL templates:', error)
+        console.error('Failed to load SOUL tab data:', error)
       }
     }
-    
+
     if (activeTab === 'soul') {
-      loadTemplates()
+      loadSoulTabData()
+    }
+  }, [activeTab, agent.name])
+
+  // Load latest memory content when Memory tab opens
+  useEffect(() => {
+    const loadMemory = async () => {
+      try {
+        const response = await fetch(`/api/agents/${encodeURIComponent(agent.name)}/memory`)
+        if (response.ok) {
+          const data = await response.json()
+          setFormData(prev => ({ ...prev, working_memory: data.working_memory || '' }))
+        }
+      } catch (error) {
+        console.error('Failed to load memory:', error)
+      }
+    }
+
+    if (activeTab === 'memory') {
+      loadMemory()
     }
   }, [activeTab, agent.name])
 
@@ -512,7 +538,7 @@ function AgentDetailModalPhase3({
   const performHeartbeat = async () => {
     setLoadingHeartbeat(true)
     try {
-      const response = await fetch(`/api/agents/${agent.name}/heartbeat`)
+      const response = await fetch(`/api/agents/${encodeURIComponent(agent.name)}/heartbeat`)
       if (response.ok) {
         const data = await response.json()
         setHeartbeatData(data)
@@ -546,7 +572,7 @@ function AgentDetailModalPhase3({
 
   const handleSoulSave = async (content: string, templateName?: string) => {
     try {
-      const response = await fetch(`/api/agents/${agent.name}/soul`, {
+      const response = await fetch(`/api/agents/${encodeURIComponent(agent.name)}/soul`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -566,7 +592,7 @@ function AgentDetailModalPhase3({
 
   const handleMemorySave = async (content: string, append: boolean = false) => {
     try {
-      const response = await fetch(`/api/agents/${agent.name}/memory`, {
+      const response = await fetch(`/api/agents/${encodeURIComponent(agent.name)}/memory`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/src/components/panels/approval-inbox-panel.tsx
+++ b/src/components/panels/approval-inbox-panel.tsx
@@ -1,0 +1,162 @@
+'use client'
+
+import { useCallback, useMemo, useState } from 'react'
+import { useSmartPoll } from '@/lib/use-smart-poll'
+
+interface ApprovalTask {
+  id: number
+  title: string
+  description?: string
+  status: string
+  priority: string
+  assigned_to?: string
+  metadata?: Record<string, unknown>
+  latestApproval?: {
+    action: 'approve' | 'reject'
+    summary: string
+    rationale?: string
+    actor: string
+    created_at: number
+  } | null
+}
+
+export function ApprovalInboxPanel() {
+  const [items, setItems] = useState<ApprovalTask[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [workingId, setWorkingId] = useState<number | null>(null)
+
+  const fetchApprovals = useCallback(async () => {
+    try {
+      const res = await fetch('/api/approvals?limit=100')
+      if (!res.ok) throw new Error('Failed to load approval inbox')
+      const data = await res.json()
+      setItems(data.approvals || [])
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load approval inbox')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useSmartPoll(fetchApprovals, 10000)
+
+  const pendingCount = useMemo(() => items.length, [items])
+
+  async function decide(task: ApprovalTask, action: 'approve' | 'reject') {
+    setWorkingId(task.id)
+    setError(null)
+    try {
+      const summary = action === 'approve'
+        ? `Approved high-level action for "${task.title}"`
+        : `Rejected high-level action for "${task.title}"`
+
+      const res = await fetch(`/api/tasks/${task.id}/approval`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action,
+          summary,
+          rationale: action === 'reject' ? 'Needs adjustment before approval.' : 'Approved to proceed.',
+        }),
+      })
+
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(data.error || 'Decision failed')
+      await fetchApprovals()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Decision failed')
+    } finally {
+      setWorkingId(null)
+    }
+  }
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="flex items-center justify-between p-4 border-b border-border">
+        <div>
+          <h2 className="text-xl font-bold text-foreground">Approval Inbox</h2>
+          <p className="text-xs text-muted-foreground mt-1">One-click decisions for high-level and external actions.</p>
+        </div>
+        <div className="px-3 py-1 rounded-full bg-amber-500/15 text-amber-300 text-xs font-semibold border border-amber-500/30">
+          {pendingCount} pending
+        </div>
+      </div>
+
+      {error && (
+        <div className="m-4 p-3 rounded-lg border border-red-500/20 bg-red-500/10 text-red-300 text-sm">{error}</div>
+      )}
+
+      <div className="flex-1 overflow-auto p-4 space-y-3">
+        {loading ? (
+          <div className="text-sm text-muted-foreground">Loading approval queue...</div>
+        ) : items.length === 0 ? (
+          <div className="rounded-lg border border-border bg-card p-5 text-sm text-muted-foreground">
+            No approvals pending. Office is clear ✅
+          </div>
+        ) : (
+          items.map((task) => (
+            <div key={task.id} className="rounded-xl border border-border bg-card p-4">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <div className="text-sm font-semibold text-foreground">{task.title}</div>
+                  <div className="text-xs text-muted-foreground mt-1">
+                    Status: {task.status} • Priority: {task.priority} • Owner: {task.assigned_to || 'Unassigned'}
+                  </div>
+                </div>
+                <span className="text-[10px] px-2 py-1 rounded border border-amber-500/30 bg-amber-500/10 text-amber-300 uppercase tracking-wide">
+                  needs your decision
+                </span>
+              </div>
+
+              <div className="mt-3 rounded-md bg-surface-1/70 p-3 border border-border/60">
+                <p className="text-xs text-muted-foreground mb-1">Human summary</p>
+                <p className="text-sm text-foreground/90">
+                  {summarizeForHuman(task)}
+                </p>
+              </div>
+
+              {task.latestApproval && (
+                <div className="mt-2 text-xs text-muted-foreground">
+                  Last decision: {task.latestApproval.action} by {task.latestApproval.actor} — {task.latestApproval.summary}
+                </div>
+              )}
+
+              <div className="mt-4 flex items-center gap-2">
+                <button
+                  disabled={workingId === task.id}
+                  onClick={() => decide(task, 'approve')}
+                  className="px-4 py-2 rounded-md bg-green-600/20 text-green-300 border border-green-500/30 hover:bg-green-600/30 transition-smooth text-sm disabled:opacity-50"
+                >
+                  Approve
+                </button>
+                <button
+                  disabled={workingId === task.id}
+                  onClick={() => decide(task, 'reject')}
+                  className="px-4 py-2 rounded-md bg-red-600/20 text-red-300 border border-red-500/30 hover:bg-red-600/30 transition-smooth text-sm disabled:opacity-50"
+                >
+                  Reject
+                </button>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}
+
+function summarizeForHuman(task: ApprovalTask): string {
+  const actionType = String(task.metadata?.actionType || '').replace(/[_-]/g, ' ')
+  if (actionType) {
+    return `This task wants to perform a ${actionType}. Approving lets the team continue this high-level action.`
+  }
+
+  if (task.description && task.description.trim()) {
+    const sentence = task.description.trim().split('\n')[0]
+    return sentence.length > 220 ? `${sentence.slice(0, 220)}…` : sentence
+  }
+
+  return 'Team requests permission to move this high-level task forward.'
+}

--- a/src/components/panels/task-board-panel.tsx
+++ b/src/components/panels/task-board-panel.tsx
@@ -3,12 +3,13 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useMissionControl } from '@/store'
 import { useSmartPoll } from '@/lib/use-smart-poll'
+import { TaskWorkstream } from '@/components/tasks/task-workstream'
 
 interface Task {
   id: number
   title: string
   description?: string
-  status: 'inbox' | 'assigned' | 'in_progress' | 'review' | 'quality_review' | 'done'
+  status: 'inbox' | 'backlog' | 'todo' | 'in-progress' | 'review' | 'blocked' | 'needs-approval' | 'done'
   priority: 'low' | 'medium' | 'high' | 'urgent'
   assigned_to?: string
   created_by: string
@@ -19,7 +20,6 @@ interface Task {
   actual_hours?: number
   tags?: string[]
   metadata?: any
-  aegisApproved?: boolean
 }
 
 interface Agent {
@@ -48,10 +48,12 @@ interface Comment {
 
 const statusColumns = [
   { key: 'inbox', title: 'Inbox', color: 'bg-secondary text-foreground' },
-  { key: 'assigned', title: 'Assigned', color: 'bg-blue-500/20 text-blue-400' },
-  { key: 'in_progress', title: 'In Progress', color: 'bg-yellow-500/20 text-yellow-400' },
+  { key: 'backlog', title: 'Backlog', color: 'bg-slate-500/20 text-slate-300' },
+  { key: 'todo', title: 'To Do', color: 'bg-blue-500/20 text-blue-400' },
+  { key: 'in-progress', title: 'In Progress', color: 'bg-yellow-500/20 text-yellow-400' },
   { key: 'review', title: 'Review', color: 'bg-purple-500/20 text-purple-400' },
-  { key: 'quality_review', title: 'Quality Review', color: 'bg-indigo-500/20 text-indigo-400' },
+  { key: 'blocked', title: 'Blocked', color: 'bg-red-500/20 text-red-400' },
+  { key: 'needs-approval', title: 'Needs Approval', color: 'bg-amber-500/20 text-amber-300' },
   { key: 'done', title: 'Done', color: 'bg-green-500/20 text-green-400' },
 ]
 
@@ -83,41 +85,23 @@ export function TaskBoardPanel() {
         fetch('/api/agents')
       ])
 
+      if (tasksResponse.status === 401 || agentsResponse.status === 401) {
+        setError('Session expired. Redirecting to login...')
+        window.location.href = '/login'
+        return
+      }
+
       if (!tasksResponse.ok || !agentsResponse.ok) {
-        throw new Error('Failed to fetch data')
+        const taskErr = tasksResponse.ok ? '' : `tasks ${tasksResponse.status}`
+        const agentErr = agentsResponse.ok ? '' : `agents ${agentsResponse.status}`
+        throw new Error(`Failed to fetch data ${[taskErr, agentErr].filter(Boolean).join(', ')}`)
       }
 
       const tasksData = await tasksResponse.json()
       const agentsData = await agentsResponse.json()
 
       const tasksList = tasksData.tasks || []
-      const taskIds = tasksList.map((task: Task) => task.id)
-
-      let aegisMap: Record<number, boolean> = {}
-      if (taskIds.length > 0) {
-        try {
-          const reviewResponse = await fetch(`/api/quality-review?taskIds=${taskIds.join(',')}`)
-          if (reviewResponse.ok) {
-            const reviewData = await reviewResponse.json()
-            const latest = reviewData.latest || {}
-            aegisMap = Object.fromEntries(
-              Object.entries(latest).map(([id, row]: [string, any]) => [
-                Number(id),
-                row?.reviewer === 'aegis' && row?.status === 'approved'
-              ])
-            )
-          }
-        } catch (error) {
-          aegisMap = {}
-        }
-      }
-
-      setTasks(
-        tasksList.map((task: Task) => ({
-          ...task,
-          aegisApproved: Boolean(aegisMap[task.id])
-        }))
-      )
+      setTasks(tasksList)
       setAgents(agentsData.agents || [])
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred')
@@ -171,18 +155,6 @@ export function TaskBoardPanel() {
     }
 
     try {
-      if (newStatus === 'done') {
-        const reviewResponse = await fetch(`/api/quality-review?taskId=${draggedTask.id}`)
-        if (!reviewResponse.ok) {
-          throw new Error('Unable to verify Aegis approval')
-        }
-        const reviewData = await reviewResponse.json()
-        const latest = reviewData.reviews?.find((review: any) => review.reviewer === 'aegis')
-        if (!latest || latest.status !== 'approved') {
-          throw new Error('Aegis approval is required before moving to done')
-        }
-      }
-
       // Optimistically update UI
       setTasks(prevTasks =>
         prevTasks.map(task =>
@@ -342,11 +314,6 @@ export function TaskBoardPanel() {
                       {task.title}
                     </h4>
                     <div className="flex items-center gap-2">
-                      {task.aegisApproved && (
-                        <span className="text-[10px] px-2 py-0.5 rounded bg-emerald-700 text-emerald-100">
-                          Aegis Approved
-                        </span>
-                      )}
                       <span className={`text-xs px-2 py-1 rounded font-medium ${
                         task.priority === 'urgent' ? 'bg-red-500/20 text-red-400' :
                         task.priority === 'high' ? 'bg-orange-500/20 text-orange-400' :
@@ -460,17 +427,17 @@ function TaskDetailModal({
   const [reviewStatus, setReviewStatus] = useState<'approved' | 'rejected'>('approved')
   const [reviewNotes, setReviewNotes] = useState('')
   const [reviewError, setReviewError] = useState<string | null>(null)
-  const [activeTab, setActiveTab] = useState<'details' | 'comments' | 'quality'>('details')
-  const [reviewer, setReviewer] = useState('aegis')
+  const [activeTab, setActiveTab] = useState<'details' | 'comments' | 'approval' | 'workstream'>('details')
+  const [reviewer, setReviewer] = useState('operator')
 
   const fetchReviews = useCallback(async () => {
     try {
-      const response = await fetch(`/api/quality-review?taskId=${task.id}`)
-      if (!response.ok) throw new Error('Failed to fetch reviews')
+      const response = await fetch(`/api/tasks/${task.id}/approval`)
+      if (!response.ok) throw new Error('Failed to fetch approvals')
       const data = await response.json()
-      setReviews(data.reviews || [])
+      setReviews(data.approvals || [])
     } catch (error) {
-      setReviewError('Failed to load quality reviews')
+      setReviewError('Failed to load approvals')
     }
   }, [task.id])
 
@@ -543,27 +510,26 @@ function TaskDetailModal({
     }
   }
 
-  const handleSubmitReview = async (e: React.FormEvent) => {
+  const handleDecideReview = async (e: React.FormEvent) => {
     e.preventDefault()
     try {
       setReviewError(null)
-      const response = await fetch('/api/quality-review', {
+      const response = await fetch(`/api/tasks/${task.id}/approval`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          taskId: task.id,
-          reviewer,
-          status: reviewStatus,
-          notes: reviewNotes
+          action: reviewStatus === 'approved' ? 'approve' : 'reject',
+          summary: reviewNotes || `${reviewStatus === 'approved' ? 'Approved' : 'Rejected'} by ${reviewer}`,
+          rationale: reviewNotes
         })
       })
       const data = await response.json()
-      if (!response.ok) throw new Error(data.error || 'Failed to submit review')
+      if (!response.ok) throw new Error(data.error || 'Failed to submit decision')
       setReviewNotes('')
       await fetchReviews()
       onUpdate()
     } catch (error) {
-      setReviewError('Failed to submit review')
+      setReviewError('Failed to submit decision')
     }
   }
 
@@ -596,8 +562,8 @@ function TaskDetailModal({
             </button>
           </div>
           <p className="text-foreground/80 mb-4">{task.description || 'No description'}</p>
-          <div className="flex gap-2 mt-4">
-            {(['details', 'comments', 'quality'] as const).map(tab => (
+          <div className="flex gap-2 mt-4 flex-wrap">
+            {(['details', 'workstream', 'comments', 'approval'] as const).map(tab => (
               <button
                 key={tab}
                 onClick={() => setActiveTab(tab)}
@@ -605,7 +571,13 @@ function TaskDetailModal({
                   activeTab === tab ? 'bg-primary text-primary-foreground' : 'bg-secondary text-muted-foreground hover:bg-surface-2'
                 }`}
               >
-                {tab === 'details' ? 'Details' : tab === 'comments' ? 'Comments' : 'Quality Review'}
+                {tab === 'details'
+                  ? 'Details'
+                  : tab === 'workstream'
+                    ? 'Workstream'
+                    : tab === 'comments'
+                      ? 'Comments'
+                      : 'Approval'}
               </button>
             ))}
           </div>
@@ -628,6 +600,12 @@ function TaskDetailModal({
                 <span className="text-muted-foreground">Created:</span>
                 <span className="text-foreground ml-2">{new Date(task.created_at * 1000).toLocaleDateString()}</span>
               </div>
+            </div>
+          )}
+
+          {activeTab === 'workstream' && (
+            <div className="mt-6">
+              <TaskWorkstream task={task} />
             </div>
           )}
 
@@ -714,9 +692,9 @@ function TaskDetailModal({
           </div>
           )}
 
-          {activeTab === 'quality' && (
+          {activeTab === 'approval' && (
             <div className="mt-6">
-              <h5 className="text-sm font-medium text-foreground mb-2">Aegis Quality Review</h5>
+              <h5 className="text-sm font-medium text-foreground mb-2">Task Approval</h5>
               {reviewError && (
                 <div className="text-xs text-red-400 mb-2">{reviewError}</div>
               )}
@@ -725,24 +703,25 @@ function TaskDetailModal({
                   {reviews.map((review) => (
                     <div key={review.id} className="text-xs text-foreground/80 bg-surface-1/40 rounded p-2">
                       <div className="flex justify-between">
-                        <span>{review.reviewer} — {review.status}</span>
+                        <span>{review.actor} — {review.action}</span>
                         <span>{new Date(review.created_at * 1000).toLocaleString()}</span>
                       </div>
-                      {review.notes && <div className="mt-1">{review.notes}</div>}
+                      {review.summary && <div className="mt-1">{review.summary}</div>}
+                      {review.rationale && <div className="mt-1 text-muted-foreground">{review.rationale}</div>}
                     </div>
                   ))}
                 </div>
               ) : (
-                <div className="text-xs text-muted-foreground mb-3">No reviews yet.</div>
+                <div className="text-xs text-muted-foreground mb-3">No decisions yet.</div>
               )}
-              <form onSubmit={handleSubmitReview} className="space-y-2">
+              <form onSubmit={handleDecideReview} className="space-y-2">
                 <div className="flex gap-2">
                   <input
                     type="text"
                     value={reviewer}
                     onChange={(e) => setReviewer(e.target.value)}
                     className="bg-surface-1 text-foreground border border-border rounded-md px-2 py-1 text-xs"
-                    placeholder="Reviewer (e.g., aegis)"
+                    placeholder="Decision actor (optional)"
                   />
                   <select
                     value={reviewStatus}
@@ -757,13 +736,13 @@ function TaskDetailModal({
                     value={reviewNotes}
                     onChange={(e) => setReviewNotes(e.target.value)}
                     className="flex-1 bg-surface-1 text-foreground border border-border rounded-md px-2 py-1 text-xs"
-                    placeholder="Review notes (required)"
+                    placeholder="Human summary (used for one-click approval)"
                   />
                   <button
                     type="submit"
                     className="px-3 py-1 bg-green-500/20 text-green-400 border border-green-500/30 rounded-md text-xs"
                   >
-                    Submit
+                    Decide
                   </button>
                 </div>
               </form>
@@ -793,7 +772,7 @@ function CreateTaskModal({
     tags: '',
   })
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleDecide = async (e: React.FormEvent) => {
     e.preventDefault()
     
     try {
@@ -819,7 +798,7 @@ function CreateTaskModal({
   return (
     <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4">
       <div className="bg-card border border-border rounded-lg max-w-md w-full">
-        <form onSubmit={handleSubmit} className="p-6">
+        <form onSubmit={handleDecide} className="p-6">
           <h3 className="text-xl font-bold text-foreground mb-4">Create New Task</h3>
           
           <div className="space-y-4">

--- a/src/components/tasks/task-workstream.tsx
+++ b/src/components/tasks/task-workstream.tsx
@@ -1,0 +1,172 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { useMissionControl } from '@/store'
+
+type TaskLike = {
+  id: number
+  title: string
+  metadata?: any
+}
+
+function uniq<T>(arr: T[]): T[] {
+  return Array.from(new Set(arr))
+}
+
+export function TaskWorkstream({ task }: { task: TaskLike }) {
+  const { chatMessages, logs } = useMissionControl() as any
+  const [message, setMessage] = useState('')
+  const [sendStatus, setSendStatus] = useState<string | null>(null)
+
+  const taskId = task.title // for OpenClaw-projected tasks, title == taskId
+  const coordConversationId = `coord:${taskId}`
+
+  const linkedSessionKeys: string[] = useMemo(() => {
+    const sess = task?.metadata?.openclaw?.sessions
+    if (Array.isArray(sess)) {
+      return uniq(sess.map((s: any) => s.key).filter(Boolean))
+    }
+    return []
+  }, [task])
+
+  const visibleConversationIds = useMemo(() => {
+    return uniq([coordConversationId, ...linkedSessionKeys])
+  }, [coordConversationId, linkedSessionKeys])
+
+  const messages = useMemo(() => {
+    const all = Array.isArray(chatMessages) ? chatMessages : []
+    return all
+      .filter((m: any) => visibleConversationIds.includes(m.conversation_id))
+      .sort((a: any, b: any) => (a.created_at ?? 0) - (b.created_at ?? 0))
+      .slice(-300)
+  }, [chatMessages, visibleConversationIds])
+
+  const sessionLogs = useMemo(() => {
+    const all = Array.isArray(logs) ? logs : []
+    const keys = new Set(linkedSessionKeys)
+    return all
+      .filter((l: any) => (l.session && keys.has(l.session)) || (l.data?.sessionKey && keys.has(l.data.sessionKey)))
+      .slice(-400)
+  }, [logs, linkedSessionKeys])
+
+  const sendToConductor = async () => {
+    const text = message.trim()
+    if (!text) return
+    setSendStatus(null)
+
+    // Prefer to forward to Conductor (so the team sees it).
+    // If Conductor isn't online, it'll still be stored in the coord conversation.
+    try {
+      const res = await fetch('/api/chat/messages', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          from: 'anton',
+          to: 'Conductor',
+          content: text,
+          conversation_id: coordConversationId,
+          message_type: 'text',
+          forward: true,
+        }),
+      })
+      if (!res.ok) throw new Error('send failed')
+      setMessage('')
+      setSendStatus('Sent to Conductor')
+    } catch {
+      setSendStatus('Failed to send (see logs)')
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <div className="text-sm font-medium">Linked OpenClaw sessions</div>
+        {linkedSessionKeys.length === 0 ? (
+          <div className="text-sm text-muted-foreground mt-1">
+            No linked sessions found on this task. (Expected under metadata.openclaw.sessions)
+          </div>
+        ) : (
+          <ul className="mt-2 space-y-1 text-sm">
+            {linkedSessionKeys.map((k) => (
+              <li key={k} className="font-mono text-xs break-all bg-muted/40 rounded px-2 py-1">
+                {k}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <div className="border border-border rounded-lg p-3">
+          <div className="flex items-center justify-between">
+            <div className="text-sm font-medium">Team chat (coordination)</div>
+            <div className="text-xs text-muted-foreground font-mono">{coordConversationId}</div>
+          </div>
+
+          <div className="mt-3 h-64 overflow-auto rounded bg-muted/20 p-2 space-y-2">
+            {messages.length === 0 ? (
+              <div className="text-sm text-muted-foreground">No messages yet.</div>
+            ) : (
+              messages.map((m: any) => (
+                <div key={m.id ?? `${m.created_at}-${m.from_agent}-${m.content?.slice(0, 10)}`} className="text-sm">
+                  <div className="text-xs text-muted-foreground">
+                    <span className="font-medium text-foreground">{m.from_agent}</span>
+                    {m.to_agent ? <span> → {m.to_agent}</span> : null}
+                    <span className="ml-2">{new Date((m.created_at ?? 0) * 1000).toLocaleString()}</span>
+                    <span className="ml-2 font-mono">[{m.conversation_id}]</span>
+                  </div>
+                  <div className="whitespace-pre-wrap break-words">{m.content}</div>
+                </div>
+              ))
+            )}
+          </div>
+
+          <div className="mt-3 flex gap-2">
+            <input
+              className="flex-1 px-3 py-2 rounded border border-border bg-background text-sm"
+              placeholder="Message Conductor / team…"
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !e.shiftKey) {
+                  e.preventDefault()
+                  sendToConductor()
+                }
+              }}
+            />
+            <button
+              className="px-3 py-2 rounded bg-primary text-primary-foreground text-sm"
+              onClick={sendToConductor}
+            >
+              Send
+            </button>
+          </div>
+          {sendStatus ? <div className="mt-2 text-xs text-muted-foreground">{sendStatus}</div> : null}
+        </div>
+
+        <div className="border border-border rounded-lg p-3">
+          <div className="text-sm font-medium">Live logs (linked sessions)</div>
+          <div className="mt-3 h-64 overflow-auto rounded bg-muted/20 p-2 space-y-2">
+            {sessionLogs.length === 0 ? (
+              <div className="text-sm text-muted-foreground">No session logs captured yet.</div>
+            ) : (
+              sessionLogs.map((l: any) => (
+                <div key={l.id ?? `${l.timestamp}-${l.message?.slice(0, 20)}`} className="text-xs">
+                  <div className="text-muted-foreground">
+                    <span className="font-mono">{new Date(l.timestamp ?? Date.now()).toLocaleTimeString()}</span>
+                    <span className="ml-2">{l.level?.toUpperCase?.() ?? 'INFO'}</span>
+                    {l.session ? <span className="ml-2 font-mono">[{l.session}]</span> : null}
+                  </div>
+                  <div className="font-mono whitespace-pre-wrap break-words">{l.message}</div>
+                </div>
+              ))
+            )}
+          </div>
+          <div className="mt-2 text-xs text-muted-foreground">
+            Tip: This becomes a true “office group chat” once agents route comms through conversation <span className="font-mono">{coordConversationId}</span>.
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/agent-sync.ts
+++ b/src/lib/agent-sync.ts
@@ -6,9 +6,11 @@
  */
 
 import { config } from './config'
-import { getDatabase, db_helpers, logAuditEvent } from './db'
+import { getDatabase, logAuditEvent } from './db'
 import { eventBus } from './event-bus'
 import { join } from 'path'
+import { existsSync, readFileSync } from 'fs'
+import { getNovaFrontDoorId, getNovaFrontDoorName, unaliasAgentForRuntime } from './identity-alias'
 
 interface OpenClawAgent {
   id: string
@@ -43,6 +45,7 @@ export interface SyncResult {
   synced: number
   created: number
   updated: number
+  removed: number
   agents: Array<{
     id: string
     name: string
@@ -75,16 +78,37 @@ async function readOpenClawAgents(): Promise<OpenClawAgent[]> {
   return parsed?.agents?.list || []
 }
 
+/** Read SOUL.md from workspace/agentDir so MC editor isn't empty */
+async function readSoulContent(agent: OpenClawAgent): Promise<string> {
+  const { readFile } = require('fs/promises')
+  const candidates = [
+    agent.workspace ? join(agent.workspace, 'SOUL.md') : null,
+    agent.agentDir ? join(agent.agentDir, 'SOUL.md') : null,
+  ].filter(Boolean)
+
+  for (const p of candidates) {
+    try {
+      const raw = await readFile(p, 'utf-8')
+      if (raw && raw.trim()) return raw
+    } catch {
+      // ignore
+    }
+  }
+  return ''
+}
+
 /** Extract MC-friendly fields from an OpenClaw agent config */
-function mapAgentToMC(agent: OpenClawAgent): {
+async function mapAgentToMC(agent: OpenClawAgent): Promise<{
+  id: string
   name: string
   role: string
   config: any
-} {
+  session_key: string
+  soul_content: string
+}> {
   const name = agent.identity?.name || agent.name || agent.id
   const role = agent.identity?.theme || 'agent'
 
-  // Store the full config minus systemPrompt/soul (which can be large)
   const configData = {
     openclawId: agent.id,
     model: agent.model,
@@ -98,7 +122,58 @@ function mapAgentToMC(agent: OpenClawAgent): {
     isDefault: agent.default || false,
   }
 
-  return { name, role, config: configData }
+  const soul_content = await readSoulContent(agent)
+  const session_key = `agent:${agent.id}:main`
+
+  return { id: agent.id, name, role, config: configData, session_key, soul_content }
+}
+
+function ensureNovaAgent(db: ReturnType<typeof getDatabase>, now: number) {
+  const novaId = getNovaFrontDoorId() // usually "nova"
+  const runtimeId = unaliasAgentForRuntime(novaId) // usually "main"
+  const novaName = getNovaFrontDoorName()
+
+  const workspacePath = join(config.openclawHome || '/root/.openclaw', 'workspace')
+  const soulPath = join(workspacePath, 'SOUL.md')
+  const memoryPath = join(workspacePath, 'MEMORY.md')
+  const soul_content = existsSync(soulPath) ? readFileSync(soulPath, 'utf-8') : ''
+
+  const configData = {
+    openclawId: runtimeId,
+    logicalId: novaId,
+    identity: { name: novaName, theme: 'front-door interface', emoji: '🧠' },
+    isFrontDoor: true,
+    isDefault: true,
+    workspace: workspacePath,
+    memoryPath,
+  }
+
+  const session_key = `agent:${runtimeId}:main`
+
+  const existing = db.prepare('SELECT id, config, role, session_key, soul_content FROM agents WHERE name = ?').get(novaName) as any
+  const configJson = JSON.stringify(configData)
+
+  if (!existing) {
+    db.prepare(`
+      INSERT INTO agents (name, role, session_key, soul_content, status, created_at, updated_at, config)
+      VALUES (?, ?, ?, ?, 'offline', ?, ?, ?)
+    `).run(novaName, 'front-door interface', session_key, soul_content, now, now, configJson)
+    return
+  }
+
+  const changed =
+    (existing.config || '{}') !== configJson ||
+    existing.role !== 'front-door interface' ||
+    (existing.session_key || '') !== session_key ||
+    (existing.soul_content || '') !== soul_content
+
+  if (changed) {
+    db.prepare(`
+      UPDATE agents
+      SET role = ?, session_key = ?, soul_content = ?, config = ?, updated_at = ?
+      WHERE name = ?
+    `).run('front-door interface', session_key, soul_content, configJson, now, novaName)
+  }
 }
 
 /** Sync agents from openclaw.json into the MC database */
@@ -107,68 +182,114 @@ export async function syncAgentsFromConfig(actor: string = 'system'): Promise<Sy
   try {
     agents = await readOpenClawAgents()
   } catch (err: any) {
-    return { synced: 0, created: 0, updated: 0, agents: [], error: err.message }
+    return { synced: 0, created: 0, updated: 0, removed: 0, agents: [], error: err.message }
   }
 
   if (agents.length === 0) {
-    return { synced: 0, created: 0, updated: 0, agents: [] }
+    return { synced: 0, created: 0, updated: 0, removed: 0, agents: [] }
   }
+
+  const mappedAgents = await Promise.all(agents.map(mapAgentToMC))
 
   const db = getDatabase()
   const now = Math.floor(Date.now() / 1000)
   let created = 0
   let updated = 0
+  let removed = 0
   const results: SyncResult['agents'] = []
 
-  const findByName = db.prepare('SELECT id, name, role, config FROM agents WHERE name = ?')
+  const findByName = db.prepare('SELECT id, name, role, config, soul_content, session_key FROM agents WHERE name = ?')
   const insertAgent = db.prepare(`
-    INSERT INTO agents (name, role, status, created_at, updated_at, config)
-    VALUES (?, ?, 'offline', ?, ?, ?)
+    INSERT INTO agents (name, role, session_key, soul_content, status, created_at, updated_at, config)
+    VALUES (?, ?, ?, ?, 'offline', ?, ?, ?)
   `)
   const updateAgent = db.prepare(`
-    UPDATE agents SET role = ?, config = ?, updated_at = ? WHERE name = ?
+    UPDATE agents
+    SET role = ?, session_key = ?, soul_content = ?, config = ?, updated_at = ?
+    WHERE name = ?
   `)
 
   db.transaction(() => {
-    for (const agent of agents) {
-      const mapped = mapAgentToMC(agent)
+    for (const mapped of mappedAgents) {
       const configJson = JSON.stringify(mapped.config)
       const existing = findByName.get(mapped.name) as any
 
       if (existing) {
-        // Check if config actually changed
-        const existingConfig = existing.config || '{}'
-        if (existingConfig !== configJson || existing.role !== mapped.role) {
-          updateAgent.run(mapped.role, configJson, now, mapped.name)
-          results.push({ id: agent.id, name: mapped.name, action: 'updated' })
+        const changed =
+          (existing.config || '{}') !== configJson ||
+          existing.role !== mapped.role ||
+          (existing.session_key || '') !== mapped.session_key ||
+          (existing.soul_content || '') !== mapped.soul_content
+
+        if (changed) {
+          updateAgent.run(
+            mapped.role,
+            mapped.session_key,
+            mapped.soul_content,
+            configJson,
+            now,
+            mapped.name,
+          )
+          results.push({ id: mapped.id, name: mapped.name, action: 'updated' })
           updated++
         } else {
-          results.push({ id: agent.id, name: mapped.name, action: 'unchanged' })
+          results.push({ id: mapped.id, name: mapped.name, action: 'unchanged' })
         }
       } else {
-        insertAgent.run(mapped.name, mapped.role, now, now, configJson)
-        results.push({ id: agent.id, name: mapped.name, action: 'created' })
+        insertAgent.run(
+          mapped.name,
+          mapped.role,
+          mapped.session_key,
+          mapped.soul_content,
+          now,
+          now,
+          configJson,
+        )
+        results.push({ id: mapped.id, name: mapped.name, action: 'created' })
         created++
+      }
+    }
+
+    // Always ensure Nova (front-door identity) is present
+    ensureNovaAgent(db, now)
+
+    // Prune stale DB-only agents not present in config (enterprise source-of-truth mode)
+    const pruneStale = (process.env.MC_SYNC_PRUNE_STALE ?? 'true') !== 'false'
+    if (pruneStale) {
+      const allowed = new Set<string>([
+        ...mappedAgents.map((a) => a.name),
+        getNovaFrontDoorName(),
+      ])
+
+      const stale = db.prepare('SELECT id, name FROM agents').all() as Array<{ id: number; name: string }>
+      for (const row of stale) {
+        if (allowed.has(row.name)) continue
+        db.prepare('DELETE FROM agents WHERE id = ?').run(row.id)
+        removed += 1
       }
     }
   })()
 
-  const synced = agents.length
+  const synced = mappedAgents.length + 1
 
-  // Log audit event
-  if (created > 0 || updated > 0) {
+  if (created > 0 || updated > 0 || removed > 0) {
     logAuditEvent({
       action: 'agent_config_sync',
       actor,
-      detail: { synced, created, updated, agents: results.filter(a => a.action !== 'unchanged').map(a => a.name) },
+      detail: {
+        synced,
+        created,
+        updated,
+        removed,
+        agents: results.filter((a) => a.action !== 'unchanged').map((a) => a.name),
+      },
     })
 
-    // Broadcast sync event
-    eventBus.broadcast('agent.created', { type: 'sync', synced, created, updated })
+    eventBus.broadcast('agent.created', { type: 'sync', synced, created, updated, removed })
   }
 
-  console.log(`Agent sync: ${synced} total, ${created} new, ${updated} updated`)
-  return { synced, created, updated, agents: results }
+  console.log(`Agent sync: ${synced} total, ${created} new, ${updated} updated, ${removed} removed`)
+  return { synced, created, updated, removed, agents: results }
 }
 
 /** Preview the diff between openclaw.json and MC database without writing */
@@ -180,35 +301,60 @@ export async function previewSyncDiff(): Promise<SyncDiff> {
     return { inConfig: 0, inMC: 0, newAgents: [], updatedAgents: [], onlyInMC: [] }
   }
 
+  const mappedAgents = await Promise.all(agents.map(mapAgentToMC))
+
   const db = getDatabase()
-  const allMCAgents = db.prepare('SELECT name, role, config FROM agents').all() as Array<{ name: string; role: string; config: string }>
-  const mcNames = new Set(allMCAgents.map(a => a.name))
+  const allMCAgents = db.prepare('SELECT name, role, config, soul_content, session_key FROM agents').all() as Array<{
+    name: string
+    role: string
+    config: string
+    soul_content: string
+    session_key: string
+  }>
 
   const newAgents: string[] = []
   const updatedAgents: string[] = []
   const configNames = new Set<string>()
 
-  for (const agent of agents) {
-    const mapped = mapAgentToMC(agent)
+  const novaName = getNovaFrontDoorName()
+  const novaSessionKey = `agent:${unaliasAgentForRuntime(getNovaFrontDoorId())}:main`
+
+  for (const mapped of mappedAgents) {
     configNames.add(mapped.name)
 
-    const existing = allMCAgents.find(a => a.name === mapped.name)
+    const existing = allMCAgents.find((a) => a.name === mapped.name)
     if (!existing) {
       newAgents.push(mapped.name)
     } else {
       const configJson = JSON.stringify(mapped.config)
-      if (existing.config !== configJson || existing.role !== mapped.role) {
-        updatedAgents.push(mapped.name)
-      }
+      const changed =
+        existing.config !== configJson ||
+        existing.role !== mapped.role ||
+        (existing.session_key || '') !== mapped.session_key ||
+        (existing.soul_content || '') !== mapped.soul_content
+      if (changed) updatedAgents.push(mapped.name)
     }
   }
 
-  const onlyInMC = allMCAgents
-    .map(a => a.name)
-    .filter(name => !configNames.has(name))
+  // Nova front-door identity is managed by MC even when not listed in openclaw.json
+  configNames.add(novaName)
+  const existingNova = allMCAgents.find((a) => a.name === novaName)
+  if (!existingNova) {
+    newAgents.push(novaName)
+  } else {
+    const cfg = existingNova.config ? JSON.parse(existingNova.config) : {}
+    const expectedOpenclawId = unaliasAgentForRuntime(getNovaFrontDoorId())
+    const changed =
+      existingNova.role !== 'front-door interface' ||
+      (existingNova.session_key || '') !== novaSessionKey ||
+      cfg?.openclawId !== expectedOpenclawId
+    if (changed) updatedAgents.push(novaName)
+  }
+
+  const onlyInMC = allMCAgents.map((a) => a.name).filter((name) => !configNames.has(name))
 
   return {
-    inConfig: agents.length,
+    inConfig: mappedAgents.length + 1,
     inMC: allMCAgents.length,
     newAgents,
     updatedAgents,
@@ -225,37 +371,17 @@ export async function writeAgentToConfig(agentConfig: any): Promise<void> {
   const raw = await readFile(configPath, 'utf-8')
   const parsed = JSON.parse(raw)
 
-  if (!parsed.agents) parsed.agents = {}
-  if (!parsed.agents.list) parsed.agents.list = []
+  const list = parsed?.agents?.list || []
+  const idx = list.findIndex((a: any) => a.id === agentConfig.id)
 
-  // Find existing by id
-  const idx = parsed.agents.list.findIndex((a: any) => a.id === agentConfig.id)
   if (idx >= 0) {
-    // Deep merge: preserve fields not in update
-    parsed.agents.list[idx] = deepMerge(parsed.agents.list[idx], agentConfig)
+    list[idx] = agentConfig
   } else {
-    parsed.agents.list.push(agentConfig)
+    list.push(agentConfig)
   }
 
-  await writeFile(configPath, JSON.stringify(parsed, null, 2) + '\n')
-}
+  parsed.agents = parsed.agents || {}
+  parsed.agents.list = list
 
-/** Deep merge two objects (target <- source), preserving target fields not in source */
-function deepMerge(target: any, source: any): any {
-  const result = { ...target }
-  for (const key of Object.keys(source)) {
-    if (
-      source[key] &&
-      typeof source[key] === 'object' &&
-      !Array.isArray(source[key]) &&
-      target[key] &&
-      typeof target[key] === 'object' &&
-      !Array.isArray(target[key])
-    ) {
-      result[key] = deepMerge(target[key], source[key])
-    } else {
-      result[key] = source[key]
-    }
-  }
-  return result
+  await writeFile(configPath, JSON.stringify(parsed, null, 2))
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -2,7 +2,19 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
-const defaultDataDir = path.join(process.cwd(), '.data')
+function computeDefaultDataDir(): string {
+  const cwd = process.cwd()
+  const standaloneMarker = `${path.sep}.next${path.sep}standalone`
+
+  // If running from Next standalone bundle, keep data at repo-root/.data (not standalone/.data).
+  if (cwd.includes(standaloneMarker)) {
+    return path.resolve(cwd, '..', '..', '.data')
+  }
+
+  return path.join(cwd, '.data')
+}
+
+const defaultDataDir = computeDefaultDataDir()
 const openclawHome =
   process.env.OPENCLAW_HOME ||
   process.env.CLAWDBOT_HOME ||
@@ -22,7 +34,7 @@ export const config = {
     path.join(defaultDataDir, 'mission-control-tokens.json'),
   openclawHome,
   openclawBin: process.env.OPENCLAW_BIN || 'openclaw',
-  clawdbotBin: process.env.CLAWDBOT_BIN || 'clawdbot',
+  clawdbotBin: process.env.CLAWDBOT_BIN || process.env.OPENCLAW_BIN || 'openclaw',
   gatewayHost: process.env.OPENCLAW_GATEWAY_HOST || '127.0.0.1',
   gatewayPort: Number(process.env.OPENCLAW_GATEWAY_PORT || '18789'),
   logsDir:

--- a/src/lib/cron-routing.ts
+++ b/src/lib/cron-routing.ts
@@ -1,0 +1,106 @@
+/**
+ * Smart cron job model routing
+ * Assigns the right agent + model + thinking level based on task type
+ */
+
+export type CronTier = 'ops' | 'analysis' | 'content' | 'complex'
+
+export interface CronRoute {
+  tier: CronTier
+  agentId: string
+  model: string
+  thinking?: 'low' | 'medium' | 'high'
+  description: string
+  costHint: string
+}
+
+const CRON_ROUTES: Record<CronTier, CronRoute> = {
+  ops: {
+    tier: 'ops',
+    agentId: 'zenith',
+    model: 'ollama/qwen3.5-4b-local',
+    thinking: undefined,
+    description: 'System ops, health checks, backups, monitoring',
+    costHint: 'Free (local model)'
+  },
+  analysis: {
+    tier: 'analysis',
+    agentId: 'prism',
+    model: 'openai/gpt-5.2',
+    thinking: 'medium',
+    description: 'Reports, metrics, cost analysis, trend tracking',
+    costHint: 'GPT-5.2 medium thinking'
+  },
+  content: {
+    tier: 'content',
+    agentId: 'aurora',
+    model: 'ollama/qwen3.5-9b-local',
+    thinking: undefined,
+    description: 'Scheduled digests, summaries, changelogs',
+    costHint: 'Free local → GPT fallback if needed'
+  },
+  complex: {
+    tier: 'complex',
+    agentId: 'conductor',
+    model: 'openai/gpt-5.2',
+    thinking: 'high',
+    description: 'Multi-step pipelines, code audits, automated workflows',
+    costHint: 'GPT-5.2 high thinking + sub-agents'
+  }
+}
+
+// Keywords that signal each tier
+const TIER_SIGNALS: Record<CronTier, string[]> = {
+  ops: [
+    'disk', 'memory', 'cpu', 'health', 'check', 'backup', 'restart',
+    'ping', 'monitor', 'cleanup', 'log', 'rotate', 'service', 'status',
+    'uptime', 'alert', 'prune', 'gc', 'temp', 'free space'
+  ],
+  analysis: [
+    'report', 'usage', 'cost', 'token', 'metric', 'analytics', 'trend',
+    'summary', 'stats', 'performance', 'weekly', 'monthly', 'daily report',
+    'breakdown', 'spending', 'billing'
+  ],
+  content: [
+    'digest', 'newsletter', 'changelog', 'standup', 'update', 'post',
+    'write', 'draft', 'publish', 'content', 'announcement'
+  ],
+  complex: [
+    'audit', 'review', 'refactor', 'pipeline', 'workflow', 'deploy',
+    'build', 'test suite', 'dependency', 'security scan', 'multi-step',
+    'coordinate', 'orchestrate'
+  ]
+}
+
+/**
+ * Infer the best cron tier from a job name/message
+ */
+export function inferCronTier(text: string): CronTier {
+  const lower = text.toLowerCase()
+  const scores: Record<CronTier, number> = { ops: 0, analysis: 0, content: 0, complex: 0 }
+
+  for (const [tier, keywords] of Object.entries(TIER_SIGNALS) as [CronTier, string[]][]) {
+    for (const kw of keywords) {
+      if (lower.includes(kw)) scores[tier]++
+    }
+  }
+
+  const best = (Object.entries(scores) as [CronTier, number][])
+    .sort((a, b) => b[1] - a[1])[0]
+
+  // Default to ops if nothing matches
+  return best[1] > 0 ? best[0] : 'ops'
+}
+
+export function getCronRoute(tier: CronTier): CronRoute {
+  return CRON_ROUTES[tier]
+}
+
+export function suggestCronRoute(jobNameOrMessage: string): CronRoute {
+  const tier = inferCronTier(jobNameOrMessage)
+  return getCronRoute(tier)
+}
+
+export function getAllCronRoutes(): CronRoute[] {
+  return Object.values(CRON_ROUTES)
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -107,7 +107,20 @@ export interface Task {
   id: number;
   title: string;
   description?: string;
-  status: 'inbox' | 'assigned' | 'in_progress' | 'review' | 'quality_review' | 'done';
+  status:
+    | 'inbox'
+    | 'backlog'
+    | 'todo'
+    | 'in-progress'
+    | 'review'
+    | 'blocked'
+    | 'needs-approval'
+    | 'done'
+    // legacy compatibility
+    | 'assigned'
+    | 'in_progress'
+    | 'quality_review'
+    | 'needs_approval';
   priority: 'low' | 'medium' | 'high' | 'urgent';
   assigned_to?: string;
   created_by: string;

--- a/src/lib/identity-alias.ts
+++ b/src/lib/identity-alias.ts
@@ -1,0 +1,85 @@
+type AliasMap = Record<string, string>
+
+const DEFAULT_ALIAS_MAP: AliasMap = {
+  main: 'nova',
+}
+
+const DEFAULT_LABELS: Record<string, string> = {
+  nova: 'Nova',
+  conductor: 'Conductor',
+}
+
+function normalizeId(value: string): string {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+}
+
+function parseAliasMap(): AliasMap {
+  const raw = process.env.MC_AGENT_ALIASES || process.env.MISSION_CONTROL_AGENT_ALIASES
+  if (!raw) return { ...DEFAULT_ALIAS_MAP }
+
+  try {
+    const parsed = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object') return { ...DEFAULT_ALIAS_MAP }
+
+    const normalized: AliasMap = { ...DEFAULT_ALIAS_MAP }
+    for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+      if (!k || typeof v !== 'string') continue
+      normalized[normalizeId(k)] = normalizeId(v)
+    }
+    return normalized
+  } catch {
+    return { ...DEFAULT_ALIAS_MAP }
+  }
+}
+
+export function getAgentAliasMap(): AliasMap {
+  return parseAliasMap()
+}
+
+export function applyAgentAlias(agentId: string): string {
+  const normalized = normalizeId(agentId)
+  if (!normalized) return normalized
+  const aliases = parseAliasMap()
+  return aliases[normalized] || normalized
+}
+
+export function getAgentDisplayName(agentIdOrName: string): string {
+  const aliased = applyAgentAlias(agentIdOrName)
+  const explicit = DEFAULT_LABELS[aliased]
+  if (explicit) return explicit
+  if (!aliased) return ''
+  return aliased
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+/**
+ * Convert runtime OpenClaw session key to MC logical key with aliases applied.
+ * agent:main:proj:foo -> agent:nova:proj:foo
+ */
+export function aliasSessionKey(key: string): string {
+  const m = String(key || '').match(/^agent:([^:]+):(.*)$/)
+  if (!m) return key
+  const logical = applyAgentAlias(m[1])
+  return `agent:${logical}:${m[2]}`
+}
+
+/** Reverse mapping for direct runtime delivery when needed. */
+export function unaliasAgentForRuntime(agentId: string): string {
+  const target = normalizeId(agentId)
+  const aliases = parseAliasMap()
+  const reverse = Object.entries(aliases).find(([, mapped]) => mapped === target)
+  return reverse?.[0] || target
+}
+
+export function getNovaFrontDoorId(): string {
+  return applyAgentAlias('main')
+}
+
+export function getNovaFrontDoorName(): string {
+  return getAgentDisplayName(getNovaFrontDoorId())
+}

--- a/src/lib/migrations.ts
+++ b/src/lib/migrations.ts
@@ -547,6 +547,69 @@ const migrations: Migration[] = [
       db.exec(`CREATE INDEX IF NOT EXISTS idx_claude_sessions_active ON claude_sessions(is_active) WHERE is_active = 1`)
       db.exec(`CREATE INDEX IF NOT EXISTS idx_claude_sessions_project ON claude_sessions(project_slug)`)
     }
+  },
+  {
+    id: '021_office_workflow',
+    up: (db) => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS task_approvals (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          task_id INTEGER NOT NULL,
+          action TEXT NOT NULL,
+          summary TEXT NOT NULL,
+          rationale TEXT,
+          actor TEXT NOT NULL,
+          metadata TEXT,
+          created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+          FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_task_approvals_task ON task_approvals(task_id, created_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_task_approvals_action ON task_approvals(action);
+      `)
+
+      // Backfill legacy task statuses to office workflow statuses
+      db.exec(`UPDATE tasks SET status = 'todo' WHERE status = 'assigned'`)
+      db.exec(`UPDATE tasks SET status = 'in-progress' WHERE status = 'in_progress'`)
+      db.exec(`UPDATE tasks SET status = 'review' WHERE status = 'quality_review'`)
+      db.exec(`UPDATE tasks SET status = 'needs-approval' WHERE status = 'needs_approval'`)
+    }
+  },
+  {
+    id: '022_office_autopilot',
+    up: (db) => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS office_autopilot_runs (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          cycle_type TEXT NOT NULL DEFAULT 'heartbeat',
+          routed_model TEXT,
+          routed_agent TEXT,
+          summary TEXT,
+          tasks_scanned INTEGER NOT NULL DEFAULT 0,
+          blocked_found INTEGER NOT NULL DEFAULT 0,
+          approvals_pending INTEGER NOT NULL DEFAULT 0,
+          escalations_created INTEGER NOT NULL DEFAULT 0,
+          metadata TEXT,
+          created_at INTEGER NOT NULL DEFAULT (unixepoch())
+        );
+        CREATE INDEX IF NOT EXISTS idx_office_autopilot_runs_created ON office_autopilot_runs(created_at DESC);
+      `)
+    }
+  },
+  {
+    id: '023_external_task_tombstones',
+    up: (db) => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS external_task_tombstones (
+          source TEXT NOT NULL,
+          external_id TEXT NOT NULL,
+          deleted_by TEXT,
+          reason TEXT,
+          created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+          PRIMARY KEY (source, external_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_external_task_tombstones_created ON external_task_tombstones(created_at DESC);
+      `)
+    }
   }
 ]
 

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -7,14 +7,16 @@ export interface ModelConfig {
 }
 
 export const MODEL_CATALOG: ModelConfig[] = [
-  { alias: 'haiku', name: 'anthropic/claude-3-5-haiku-latest', provider: 'anthropic', description: 'Ultra-cheap, simple tasks', costPer1k: 0.25 },
-  { alias: 'sonnet', name: 'anthropic/claude-sonnet-4-20250514', provider: 'anthropic', description: 'Standard workhorse', costPer1k: 3.0 },
-  { alias: 'opus', name: 'anthropic/claude-opus-4-5', provider: 'anthropic', description: 'Premium quality', costPer1k: 15.0 },
-  { alias: 'deepseek', name: 'ollama/deepseek-r1:14b', provider: 'ollama', description: 'Local reasoning (free)', costPer1k: 0.0 },
-  { alias: 'groq-fast', name: 'groq/llama-3.1-8b-instant', provider: 'groq', description: '840 tok/s, ultra fast', costPer1k: 0.05 },
-  { alias: 'groq', name: 'groq/llama-3.3-70b-versatile', provider: 'groq', description: 'Fast + quality balance', costPer1k: 0.59 },
-  { alias: 'kimi', name: 'moonshot/kimi-k2.5', provider: 'moonshot', description: 'Alternative provider', costPer1k: 1.0 },
-  { alias: 'minimax', name: 'minimax/minimax-m2.1', provider: 'minimax', description: 'Cost-effective (1/10th price), strong coding', costPer1k: 0.3 },
+  // Anthropic (your active models)
+  { alias: 'opus', name: 'anthropic/claude-opus-4-6', provider: 'anthropic', description: 'Premium quality, deep reasoning', costPer1k: 15.0 },
+  { alias: 'sonnet', name: 'anthropic/claude-sonnet-4-6', provider: 'anthropic', description: 'Standard workhorse (your default)', costPer1k: 3.0 },
+  { alias: 'haiku', name: 'anthropic/claude-haiku-4-5', provider: 'anthropic', description: 'Fast + cheap, routine tasks', costPer1k: 0.25 },
+  // OpenAI / Codex
+  { alias: 'gpt', name: 'openai/gpt-5.2', provider: 'openai', description: 'GPT-5.2 via Codex', costPer1k: 10.0 },
+  { alias: 'codex', name: 'openai-codex/gpt-5.3-codex', provider: 'openai-codex', description: 'Codex 5.3, strong coding', costPer1k: 10.0 },
+  // Local Qwen (free, on your VPS)
+  { alias: 'local9b', name: 'ollama/qwen3.5-9b-local', provider: 'ollama', description: 'Local Qwen 9B — quality (~6 tok/s, free)', costPer1k: 0.0 },
+  { alias: 'local4b', name: 'ollama/qwen3.5-4b-local', provider: 'ollama', description: 'Local Qwen 4B — fast (~12 tok/s, free)', costPer1k: 0.0 },
 ]
 
 export function getModelByAlias(alias: string): ModelConfig | undefined {

--- a/src/lib/openclaw-mirror.ts
+++ b/src/lib/openclaw-mirror.ts
@@ -1,0 +1,253 @@
+import { getDatabase, db_helpers } from '@/lib/db'
+import { eventBus } from '@/lib/event-bus'
+import { getAllGatewaySessions } from '@/lib/sessions'
+import { deriveTasksFromSessions } from '@/lib/openclaw-task'
+import { aliasSessionKey, applyAgentAlias, getNovaFrontDoorId } from '@/lib/identity-alias'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
+type SyncState = Record<string, { offset: number }>
+
+const STATE_PATH = '/root/.openclaw/workspace/research/mission-control/.data/openclaw-comms-sync.json'
+
+function loadState(): SyncState {
+  try {
+    if (!existsSync(STATE_PATH)) {
+      mkdirSync(join(STATE_PATH, '..'), { recursive: true })
+      return {}
+    }
+    return JSON.parse(readFileSync(STATE_PATH, 'utf-8'))
+  } catch {
+    return {}
+  }
+}
+
+function saveState(state: SyncState) {
+  try {
+    mkdirSync(join(STATE_PATH, '..'), { recursive: true })
+    writeFileSync(STATE_PATH, JSON.stringify(state, null, 2))
+  } catch {
+    // ignore
+  }
+}
+
+function extractText(content: any): string {
+  if (typeof content === 'string') return content
+  if (Array.isArray(content)) {
+    return content
+      .map((c) => {
+        if (!c) return ''
+        if (typeof c === 'string') return c
+        if (typeof (c as any).text === 'string') return (c as any).text
+        return ''
+      })
+      .join('')
+      .trim()
+  }
+  return ''
+}
+
+function parseAgentIdFromSessionKey(sessionKey: string): string | null {
+  const m = sessionKey.match(/^agent:([^:]+):/)
+  return m ? m[1] : null
+}
+
+function parseTaskIdFromSessionKey(sessionKey: string): string | null {
+  const m = sessionKey.match(/^agent:[^:]+:(proj:[^:]+:\d{8}:[a-z0-9-]+)$/i)
+  return m ? m[1] : null
+}
+
+export function mirrorOpenClawTasksAndComms(): { tasksUpserted: number; commsInserted: number } {
+  const db = getDatabase()
+  const now = Math.floor(Date.now() / 1000)
+
+  // --- TASKS PROJECTION ---
+  const sessions = getAllGatewaySessions()
+  const lite = sessions.map((s) => ({ key: s.key, updatedAt: s.updatedAt, model: s.model }))
+  const derived = deriveTasksFromSessions(lite)
+
+  let tasksUpserted = 0
+
+  for (const t of derived) {
+    const title = t.taskId
+
+    const tombstoned = db
+      .prepare('SELECT 1 as ok FROM external_task_tombstones WHERE source = ? AND external_id = ? LIMIT 1')
+      .get('openclaw', t.taskId) as any
+    if (tombstoned?.ok) {
+      continue
+    }
+
+    const existing = db.prepare('SELECT * FROM tasks WHERE title = ?').get(title) as any
+
+    const metadata = {
+      external: {
+        source: 'openclaw',
+        taskId: t.taskId,
+        project: t.project,
+        date: t.date,
+        slug: t.slug,
+      },
+      openclaw: {
+        sessions: t.sessions,
+        lastUpdatedAt: t.lastUpdatedAt,
+      },
+    }
+
+    const lastMs = t.lastUpdatedAt ?? 0
+    const isActive = lastMs > 0 && Date.now() - lastMs < 2 * 60 * 1000
+    const status = isActive ? 'in-progress' : 'review'
+
+    if (!existing) {
+      const description = `OpenClaw live task for project **${t.project}**\n\nSessions:\n${t.sessions
+        .map((s) => `- ${s.key}${s.model ? ` (${s.model})` : ''}`)
+        .join('\n')}`
+
+      const stmt = db.prepare(`
+        INSERT INTO tasks (
+          title, description, status, priority, assigned_to, created_by,
+          created_at, updated_at, due_date, estimated_hours, tags, metadata
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `)
+
+      const res = stmt.run(
+        title,
+        description,
+        status,
+        'medium',
+        null,
+        'system',
+        now,
+        now,
+        null,
+        null,
+        JSON.stringify(['openclaw', t.project, 'auto']),
+        JSON.stringify(metadata)
+      )
+
+      const taskId = res.lastInsertRowid as number
+      db_helpers.logActivity('task_created', 'task', taskId, 'system', `Created OpenClaw task: ${title}`, {
+        title,
+        status,
+      })
+
+      const created = db.prepare('SELECT * FROM tasks WHERE id = ?').get(taskId) as any
+      const parsed = { ...created, tags: JSON.parse(created.tags || '[]'), metadata: JSON.parse(created.metadata || '{}') }
+      eventBus.broadcast('task.created', parsed)
+      tasksUpserted += 1
+    } else {
+      db.prepare(`UPDATE tasks SET status = ?, updated_at = ?, metadata = ? WHERE id = ?`).run(
+        status,
+        now,
+        JSON.stringify(metadata),
+        existing.id
+      )
+      const row = db.prepare('SELECT * FROM tasks WHERE id = ?').get(existing.id) as any
+      const parsed = { ...row, tags: JSON.parse(row.tags || '[]'), metadata: JSON.parse(row.metadata || '{}') }
+      eventBus.broadcast('task.updated', parsed)
+      tasksUpserted += 1
+    }
+  }
+
+  // --- COMMS MIRRORING ---
+  const state = loadState()
+  let commsInserted = 0
+
+  for (const sess of sessions) {
+    const sessionKey = sess.key
+    const runtimeAgentId = parseAgentIdFromSessionKey(sessionKey)
+    if (!runtimeAgentId) continue
+
+    const logicalAgentId = applyAgentAlias(runtimeAgentId)
+    const taskId = parseTaskIdFromSessionKey(sessionKey)
+    const sessionId = sess.sessionId
+    if (!sessionId) continue
+
+    const openclawHome = process.env.OPENCLAW_HOME || '/root/.openclaw'
+    const jsonlPath = join(openclawHome, 'agents', runtimeAgentId, 'sessions', `${sessionId}.jsonl`)
+    if (!existsSync(jsonlPath)) continue
+
+    const raw = readFileSync(jsonlPath, 'utf-8')
+    const lines = raw.split('\n')
+    const storedOffset = state[sessionKey]?.offset ?? 0
+    const offset = Math.min(storedOffset, lines.length)
+    if (offset >= lines.length) {
+      state[sessionKey] = { offset: lines.length }
+      continue
+    }
+
+    const newLines = lines.slice(offset)
+    for (const line of newLines) {
+      const trimmed = line.trim()
+      if (!trimmed) continue
+      let obj: any
+      try {
+        obj = JSON.parse(trimmed)
+      } catch {
+        continue
+      }
+      if (obj?.type !== 'message') continue
+
+      const msg = obj?.message
+      const role = msg?.role
+      const content = msg?.content
+      const text = extractText(content)
+      if (!text) continue
+
+      const conversation_id = taskId ? `coord:${taskId}` : `office:${aliasSessionKey(sessionKey)}`
+      const requester = taskId ? 'conductor' : getNovaFrontDoorId()
+      const from_agent = role === 'assistant' ? logicalAgentId : requester
+      const to_agent = role === 'assistant' ? requester : logicalAgentId
+      const created_at = Math.floor(new Date(obj.timestamp).getTime() / 1000) || Math.floor(Date.now() / 1000)
+
+      const exists = db
+        .prepare(
+          'SELECT id FROM messages WHERE conversation_id = ? AND from_agent = ? AND to_agent = ? AND created_at = ? AND content = ? LIMIT 1'
+        )
+        .get(conversation_id, from_agent, to_agent, created_at, text) as any
+      if (exists) continue
+
+      const metadata = {
+        source: 'openclaw',
+        sessionKey,
+        runtimeAgentId,
+        logicalAgentId,
+        role,
+      }
+
+      const stmt = db.prepare(
+        'INSERT INTO messages (conversation_id, from_agent, to_agent, content, message_type, metadata, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
+      )
+      const res = stmt.run(
+        conversation_id,
+        from_agent,
+        to_agent,
+        text,
+        'text',
+        JSON.stringify(metadata),
+        created_at
+      )
+
+      commsInserted += 1
+
+      const id = Number(res.lastInsertRowid)
+      eventBus.broadcast('chat.message', {
+        id,
+        conversation_id,
+        from_agent,
+        to_agent,
+        content: text,
+        message_type: 'text',
+        metadata,
+        read_at: null,
+        created_at,
+      })
+    }
+
+    state[sessionKey] = { offset: lines.length }
+  }
+
+  saveState(state)
+
+  return { tasksUpserted, commsInserted }
+}

--- a/src/lib/openclaw-task.ts
+++ b/src/lib/openclaw-task.ts
@@ -1,0 +1,52 @@
+export interface OpenClawSessionLite {
+  key: string
+  updatedAt?: number
+  model?: string
+}
+
+export interface OpenClawDerivedTask {
+  taskId: string // proj:captaineer:YYYYMMDD:slug
+  project: string
+  date: string // YYYYMMDD
+  slug: string
+  sessions: { key: string; agentId?: string; updatedAt?: number; model?: string }[]
+  lastUpdatedAt?: number
+}
+
+// agent:orion:proj:captaineer:20260304:gateway-banner
+const SESSION_RE = /^agent:([^:]+):(proj:([^:]+):(\d{8}):([a-z0-9-]+))$/i
+
+export function deriveTasksFromSessions(sessions: OpenClawSessionLite[]): OpenClawDerivedTask[] {
+  const tasks = new Map<string, OpenClawDerivedTask>()
+
+  for (const s of sessions) {
+    const key = s.key || ''
+    const m = key.match(SESSION_RE)
+    if (!m) continue
+
+    const agentId = m[1]
+    const taskId = m[2]
+    const project = m[3]
+    const date = m[4]
+    const slug = m[5]
+
+    const existing = tasks.get(taskId)
+    const sess = { key, agentId, updatedAt: s.updatedAt, model: s.model }
+
+    if (!existing) {
+      tasks.set(taskId, {
+        taskId,
+        project,
+        date,
+        slug,
+        sessions: [sess],
+        lastUpdatedAt: s.updatedAt
+      })
+    } else {
+      existing.sessions.push(sess)
+      existing.lastUpdatedAt = Math.max(existing.lastUpdatedAt ?? 0, s.updatedAt ?? 0)
+    }
+  }
+
+  return Array.from(tasks.values()).sort((a, b) => (b.lastUpdatedAt ?? 0) - (a.lastUpdatedAt ?? 0))
+}

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -6,6 +6,8 @@ import { readdirSync, statSync, unlinkSync } from 'fs'
 import { logger } from './logger'
 import { processWebhookRetries } from './webhooks'
 import { syncClaudeSessions } from './claude-sessions'
+import { runOpenClaw } from './command'
+import { getNovaFrontDoorName } from './identity-alias'
 
 const BACKUP_DIR = join(dirname(config.dbPath), 'backups')
 
@@ -202,8 +204,123 @@ async function runHeartbeatCheck(): Promise<{ ok: boolean; message: string }> {
   }
 }
 
+async function runOfficeAutopilot(): Promise<{ ok: boolean; message: string }> {
+  try {
+    const db = getDatabase()
+    const now = Math.floor(Date.now() / 1000)
+    const blockedMinutes = getSettingNumber('office.autopilot_blocked_minutes', 30)
+    const blockedThreshold = now - blockedMinutes * 60
+
+    const totalOpen = (db.prepare(`SELECT COUNT(*) as c FROM tasks WHERE status != 'done'`).get() as any)?.c || 0
+    const blocked = (db.prepare(`SELECT COUNT(*) as c FROM tasks WHERE status = 'blocked' AND updated_at < ?`).get(blockedThreshold) as any)?.c || 0
+    const approvalsPending = (db.prepare(`SELECT COUNT(*) as c FROM tasks WHERE status = 'needs-approval'`).get() as any)?.c || 0
+    const reviewMain = (db.prepare(`SELECT COUNT(*) as c FROM tasks WHERE status = 'review' AND (metadata LIKE '%"scope":"main"%' OR metadata LIKE '%"isMainTask":true%')`).get() as any)?.c || 0
+
+    const conductor = db.prepare(`SELECT id, name, session_key FROM agents WHERE lower(name) = 'conductor' LIMIT 1`).get() as any
+
+    // Auto-triage: inbox/backlog tasks get assigned to Conductor and moved to todo
+    let triaged = 0
+    if (conductor?.name) {
+      const triageCandidates = db.prepare(`
+        SELECT id, title, status
+        FROM tasks
+        WHERE status IN ('inbox', 'backlog')
+          AND (assigned_to IS NULL OR assigned_to = '')
+        ORDER BY created_at ASC
+        LIMIT 50
+      `).all() as Array<{ id: number; title: string; status: string }>
+
+      if (triageCandidates.length > 0) {
+        const assignStmt = db.prepare(`UPDATE tasks SET assigned_to = ?, status = 'todo', updated_at = ? WHERE id = ?`)
+        const activityStmt = db.prepare(`
+          INSERT INTO activities (type, entity_type, entity_id, actor, description, data, created_at)
+          VALUES ('task_updated', 'task', ?, 'office_autopilot', ?, ?, ?)
+        `)
+
+        db.transaction(() => {
+          for (const task of triageCandidates) {
+            assignStmt.run(conductor.name, now, task.id)
+            activityStmt.run(
+              task.id,
+              `Autopilot triaged task \"${task.title}\" to ${conductor.name}`,
+              JSON.stringify({ oldStatus: task.status, newStatus: 'todo', assigned_to: conductor.name }),
+              now,
+            )
+            triaged += 1
+          }
+        })()
+      }
+    }
+
+    const isComplex = blocked + approvalsPending + reviewMain >= 2
+    const routedModel = isComplex
+      ? (process.env.MC_AUTOPILOT_COMPLEX_MODEL || 'openai/gpt-5.2')
+      : (process.env.MC_AUTOPILOT_ROUTINE_MODEL || 'ollama/qwen3.5-4b-local')
+
+    const summary = [
+      `Office autopilot heartbeat`,
+      `Open tasks: ${totalOpen}`,
+      `Blocked>${blockedMinutes}m: ${blocked}`,
+      `Needs approval: ${approvalsPending}`,
+      `Main tasks in review: ${reviewMain}`,
+      `Triaged to Conductor: ${triaged}`,
+      `Routed model: ${routedModel}`,
+    ].join(' | ')
+
+    let delivered = false
+
+    if (conductor?.session_key) {
+      try {
+        await runOpenClaw(
+          ['gateway', 'sessions_send', '--session', conductor.session_key, '--message', summary],
+          { timeoutMs: 12000 }
+        )
+        delivered = true
+      } catch (err) {
+        logger.warn({ err }, 'office_autopilot: failed to message conductor')
+      }
+    }
+
+    if (blocked > 0 || approvalsPending > 0 || reviewMain > 0) {
+      db.prepare(`
+        INSERT INTO notifications (recipient, type, title, message, source_type, source_id)
+        VALUES (?, 'office_autopilot', ?, ?, 'task', NULL)
+      `).run(getNovaFrontDoorName(), 'Office requires attention', summary)
+    }
+
+    db.prepare(`
+      INSERT INTO office_autopilot_runs (
+        cycle_type, routed_model, routed_agent, summary,
+        tasks_scanned, blocked_found, approvals_pending, escalations_created, metadata, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      'heartbeat',
+      routedModel,
+      'conductor',
+      summary,
+      totalOpen,
+      blocked,
+      approvalsPending + reviewMain,
+      blocked + approvalsPending + reviewMain,
+      JSON.stringify({ deliveredToConductor: delivered, triagedToConductor: triaged }),
+      now,
+    )
+
+    logAuditEvent({
+      action: 'office_autopilot',
+      actor: 'scheduler',
+      detail: { totalOpen, blocked, approvalsPending, reviewMain, triaged, routedModel, delivered },
+    })
+
+    return { ok: true, message: summary }
+  } catch (err: any) {
+    return { ok: false, message: `Office autopilot failed: ${err.message}` }
+  }
+}
+
 const DAILY_MS = 24 * 60 * 60 * 1000
 const FIVE_MINUTES_MS = 5 * 60 * 1000
+const TWO_MINUTES_MS = 2 * 60 * 1000
 const TICK_MS = 60 * 1000 // Check every minute
 
 /** Initialize the scheduler */
@@ -214,6 +331,9 @@ export function initScheduler() {
   syncAgentsFromConfig('startup').catch(err => {
     logger.warn({ err }, 'Agent auto-sync failed')
   })
+
+  // Start always-on OpenClaw mirror (tasks + comms) so MC feels like an office on entry
+  initOpenClawMirror()
 
   // Register tasks
   const now = Date.now()
@@ -248,6 +368,15 @@ export function initScheduler() {
     running: false,
   })
 
+  tasks.set('office_autopilot', {
+    name: 'Office Autopilot',
+    intervalMs: TWO_MINUTES_MS,
+    lastRun: null,
+    nextRun: now + TWO_MINUTES_MS,
+    enabled: true,
+    running: false,
+  })
+
   tasks.set('webhook_retry', {
     name: 'Webhook Retry',
     intervalMs: TICK_MS, // Every 60s, matching scheduler tick resolution
@@ -268,7 +397,7 @@ export function initScheduler() {
 
   // Start the tick loop
   tickInterval = setInterval(tick, TICK_MS)
-  logger.info('Scheduler initialized - backup at ~3AM, cleanup at ~4AM, heartbeat every 5m, webhook retry every 60s, claude scan every 60s')
+  logger.info('Scheduler initialized - backup at ~3AM, cleanup at ~4AM, heartbeat every 5m, office autopilot every 2m, webhook retry every 60s, claude scan every 60s')
 }
 
 /** Calculate ms until next occurrence of a given hour (UTC) */
@@ -294,14 +423,16 @@ async function tick() {
       : id === 'auto_cleanup' ? 'general.auto_cleanup'
       : id === 'webhook_retry' ? 'webhooks.retry_enabled'
       : id === 'claude_session_scan' ? 'general.claude_session_scan'
+      : id === 'office_autopilot' ? 'office.autopilot_enabled'
       : 'general.agent_heartbeat'
-    const defaultEnabled = id === 'agent_heartbeat' || id === 'webhook_retry' || id === 'claude_session_scan'
+    const defaultEnabled = id === 'agent_heartbeat' || id === 'office_autopilot' || id === 'webhook_retry' || id === 'claude_session_scan'
     if (!isSettingEnabled(settingKey, defaultEnabled)) continue
 
     task.running = true
     try {
       const result = id === 'auto_backup' ? await runBackup()
         : id === 'agent_heartbeat' ? await runHeartbeatCheck()
+        : id === 'office_autopilot' ? await runOfficeAutopilot()
         : id === 'webhook_retry' ? await processWebhookRetries()
         : id === 'claude_session_scan' ? await syncClaudeSessions()
         : await runCleanup()
@@ -333,8 +464,9 @@ export function getSchedulerStatus() {
       : id === 'auto_cleanup' ? 'general.auto_cleanup'
       : id === 'webhook_retry' ? 'webhooks.retry_enabled'
       : id === 'claude_session_scan' ? 'general.claude_session_scan'
+      : id === 'office_autopilot' ? 'office.autopilot_enabled'
       : 'general.agent_heartbeat'
-    const defaultEnabled = id === 'agent_heartbeat' || id === 'webhook_retry' || id === 'claude_session_scan'
+    const defaultEnabled = id === 'agent_heartbeat' || id === 'office_autopilot' || id === 'webhook_retry' || id === 'claude_session_scan'
     result.push({
       id,
       name: task.name,
@@ -354,6 +486,7 @@ export async function triggerTask(taskId: string): Promise<{ ok: boolean; messag
   if (taskId === 'auto_backup') return runBackup()
   if (taskId === 'auto_cleanup') return runCleanup()
   if (taskId === 'agent_heartbeat') return runHeartbeatCheck()
+  if (taskId === 'office_autopilot') return runOfficeAutopilot()
   if (taskId === 'webhook_retry') return processWebhookRetries()
   if (taskId === 'claude_session_scan') return syncClaudeSessions()
   return { ok: false, message: `Unknown task: ${taskId}` }
@@ -365,4 +498,33 @@ export function stopScheduler() {
     clearInterval(tickInterval)
     tickInterval = null
   }
+}
+
+// --- OpenClaw live mirror (always-on) ---
+let openclawMirrorInterval: ReturnType<typeof setInterval> | null = null
+
+function initOpenClawMirror() {
+  if (openclawMirrorInterval) return
+
+  // Allow disabling via settings
+  const enabled = isSettingEnabled('openclaw.mirror_enabled', true)
+  if (!enabled) return
+
+  // 1s cadence feels real-time without being too heavy
+  const intervalMs = getSettingNumber('openclaw.mirror_interval_ms', 1000)
+
+  // Lazy import to avoid affecting build phase
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { mirrorOpenClawTasksAndComms } = require('./openclaw-mirror') as typeof import('./openclaw-mirror')
+
+  openclawMirrorInterval = setInterval(() => {
+    try {
+      mirrorOpenClawTasksAndComms()
+    } catch (err) {
+      // Best-effort: don't crash scheduler
+      logger.debug({ err }, 'OpenClaw mirror tick failed')
+    }
+  }, intervalMs)
+
+  logger.info({ intervalMs }, 'OpenClaw mirror started')
 }

--- a/src/lib/sessions.ts
+++ b/src/lib/sessions.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { config } from './config'
+import { applyAgentAlias, unaliasAgentForRuntime } from './identity-alias'
 
 export interface GatewaySession {
   /** Session store key, e.g. "agent:<agent>:main" */
@@ -17,6 +18,40 @@ export interface GatewaySession {
   outputTokens: number
   contextTokens: number
   active: boolean
+}
+
+let cachedAllowedRuntimeAgents: { value: Set<string>; loadedAt: number } | null = null
+
+function getAllowedRuntimeAgents(): Set<string> {
+  const now = Date.now()
+  if (cachedAllowedRuntimeAgents && now - cachedAllowedRuntimeAgents.loadedAt < 60_000) {
+    return cachedAllowedRuntimeAgents.value
+  }
+
+  const allowed = new Set<string>()
+  const openclawHome = config.openclawHome
+  if (openclawHome) {
+    try {
+      const configPath = path.join(openclawHome, 'openclaw.json')
+      const raw = fs.readFileSync(configPath, 'utf-8')
+      const parsed = JSON.parse(raw)
+      const list = parsed?.agents?.list || []
+      for (const item of list) {
+        if (typeof item?.id === 'string' && item.id.trim()) {
+          allowed.add(item.id.trim())
+        }
+      }
+    } catch {
+      // ignore, fallback below
+    }
+  }
+
+  // Always allow runtime identity behind Nova alias (main) and Nova logical id
+  allowed.add(unaliasAgentForRuntime('nova'))
+  allowed.add('nova')
+
+  cachedAllowedRuntimeAgents = { value: allowed, loadedAt: now }
+  return allowed
 }
 
 /**
@@ -37,6 +72,8 @@ export function getAllGatewaySessions(activeWithinMs = 60 * 60 * 1000): GatewayS
 
   const sessions: GatewaySession[] = []
   const now = Date.now()
+  const allowedRuntimeAgents = getAllowedRuntimeAgents()
+  const includeUnknown = (process.env.MC_INCLUDE_UNKNOWN_SESSION_AGENTS ?? 'false') === 'true'
 
   let agentDirs: string[]
   try {
@@ -46,6 +83,10 @@ export function getAllGatewaySessions(activeWithinMs = 60 * 60 * 1000): GatewayS
   }
 
   for (const agentName of agentDirs) {
+    if (!includeUnknown && !allowedRuntimeAgents.has(agentName)) {
+      continue
+    }
+
     const sessionsFile = path.join(agentsDir, agentName, 'sessions', 'sessions.json')
     try {
       if (!fs.statSync(sessionsFile).isFile()) continue
@@ -57,7 +98,7 @@ export function getAllGatewaySessions(activeWithinMs = 60 * 60 * 1000): GatewayS
         const updatedAt = s.updatedAt || 0
         sessions.push({
           key,
-          agent: agentName,
+          agent: applyAgentAlias(agentName),
           sessionId: s.sessionId || '',
           updatedAt,
           chatType: s.chatType || 'unknown',

--- a/src/lib/task-approvals.ts
+++ b/src/lib/task-approvals.ts
@@ -1,0 +1,33 @@
+import { getDatabase } from './db'
+
+export type TaskApprovalAction = 'approve' | 'reject'
+
+export interface LatestTaskApproval {
+  id: number
+  task_id: number
+  action: TaskApprovalAction
+  summary: string
+  rationale?: string | null
+  actor: string
+  created_at: number
+}
+
+export function getLatestTaskApproval(taskId: number): LatestTaskApproval | null {
+  const db = getDatabase()
+  return (
+    (db
+      .prepare(
+        `SELECT id, task_id, action, summary, rationale, actor, created_at
+         FROM task_approvals
+         WHERE task_id = ?
+         ORDER BY created_at DESC, id DESC
+         LIMIT 1`
+      )
+      .get(taskId) as LatestTaskApproval | undefined) || null
+  )
+}
+
+export function hasApprovedTask(taskId: number): boolean {
+  const latest = getLatestTaskApproval(taskId)
+  return latest?.action === 'approve'
+}

--- a/src/lib/task-workflow.ts
+++ b/src/lib/task-workflow.ts
@@ -1,0 +1,62 @@
+export const OFFICE_TASK_STATUSES = [
+  'inbox',
+  'backlog',
+  'todo',
+  'in-progress',
+  'review',
+  'blocked',
+  'needs-approval',
+  'done',
+] as const
+
+export type OfficeTaskStatus = (typeof OFFICE_TASK_STATUSES)[number]
+
+const LEGACY_STATUS_MAP: Record<string, OfficeTaskStatus> = {
+  assigned: 'todo',
+  in_progress: 'in-progress',
+  quality_review: 'review',
+  needs_approval: 'needs-approval',
+}
+
+const VALID_STATUS_SET = new Set<string>(OFFICE_TASK_STATUSES)
+
+export function normalizeTaskStatus(input: string | undefined | null): OfficeTaskStatus {
+  const raw = String(input || 'inbox').trim().toLowerCase()
+  if (VALID_STATUS_SET.has(raw)) return raw as OfficeTaskStatus
+  if (LEGACY_STATUS_MAP[raw]) return LEGACY_STATUS_MAP[raw]
+  return 'inbox'
+}
+
+export function isMainTask(metadata: unknown): boolean {
+  if (!metadata || typeof metadata !== 'object') return false
+  const data = metadata as Record<string, unknown>
+  return data.scope === 'main' || data.isMainTask === true
+}
+
+export function requiresExternalApproval(metadata: unknown): boolean {
+  if (!metadata || typeof metadata !== 'object') return false
+  const data = metadata as Record<string, unknown>
+
+  if (data.requiresExternalApproval === true) return true
+
+  const actionType = String(data.actionType || '').toLowerCase()
+  return ['publish', 'email', 'webhook', 'external_call', 'external-call'].includes(actionType)
+}
+
+export function shouldRequireApprovalForDone(
+  previousStatus: string,
+  nextStatus: string,
+  metadata: unknown,
+): boolean {
+  const prev = normalizeTaskStatus(previousStatus)
+  const next = normalizeTaskStatus(nextStatus)
+  if (next !== 'done') return false
+
+  // Main task needs explicit approval for review -> done
+  if (prev === 'review' && isMainTask(metadata)) return true
+
+  // Any task requiring external execution approval must be approved before done
+  if (requiresExternalApproval(metadata)) return true
+
+  return false
+}

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -26,11 +26,27 @@ export async function validateBody<T>(
   }
 }
 
+const taskStatusSchema = z.enum([
+  'inbox',
+  'backlog',
+  'todo',
+  'in-progress',
+  'review',
+  'blocked',
+  'needs-approval',
+  'done',
+  // Legacy compatibility:
+  'assigned',
+  'in_progress',
+  'quality_review',
+  'needs_approval',
+])
+
 export const createTaskSchema = z.object({
   title: z.string().min(1, 'Title is required').max(500),
   description: z.string().max(5000).optional(),
-  status: z.enum(['inbox', 'assigned', 'in_progress', 'review', 'quality_review', 'done']).default('inbox'),
-  priority: z.enum(['critical', 'high', 'medium', 'low']).default('medium'),
+  status: taskStatusSchema.default('inbox'),
+  priority: z.enum(['critical', 'high', 'medium', 'low', 'urgent']).default('medium'),
   assigned_to: z.string().max(100).optional(),
   created_by: z.string().max(100).optional(),
   due_date: z.number().optional(),
@@ -40,7 +56,18 @@ export const createTaskSchema = z.object({
   metadata: z.record(z.string(), z.unknown()).default({} as Record<string, unknown>),
 })
 
-export const updateTaskSchema = createTaskSchema.partial()
+export const updateTaskSchema = z.object({
+  title: z.string().min(1, 'Title is required').max(500).optional(),
+  description: z.string().max(5000).optional(),
+  status: taskStatusSchema.optional(),
+  priority: z.enum(['critical', 'high', 'medium', 'low', 'urgent']).optional(),
+  assigned_to: z.string().max(100).optional(),
+  due_date: z.number().optional(),
+  estimated_hours: z.number().min(0).optional(),
+  actual_hours: z.number().min(0).optional(),
+  tags: z.array(z.string()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+})
 
 export const createAgentSchema = z.object({
   name: z.string().min(1, 'Name is required').max(100),
@@ -57,7 +84,7 @@ export const createAgentSchema = z.object({
 export const bulkUpdateTaskStatusSchema = z.object({
   tasks: z.array(z.object({
     id: z.number().int().positive(),
-    status: z.enum(['inbox', 'assigned', 'in_progress', 'review', 'quality_review', 'done']),
+    status: taskStatusSchema,
   })).min(1, 'At least one task is required').max(100),
 })
 

--- a/src/lib/websocket.ts
+++ b/src/lib/websocket.ts
@@ -60,6 +60,35 @@ export function useWebSocket() {
     agents,
   } = useMissionControl()
 
+  // Debounced OpenClaw → TaskBoard sync (event-driven, no polling)
+  const openclawSyncTimerRef = useRef<NodeJS.Timeout | undefined>(undefined)
+  const lastSyncHashRef = useRef<string>('')
+
+  const queueOpenClawTaskSync = useCallback((rawSessions: any[]) => {
+    try {
+      // Extract only the fields we care about (stable hash)
+      const lite = (rawSessions || []).map((s: any) => ({
+        key: s.key,
+        updatedAt: s.updatedAt,
+      }))
+
+      const hash = JSON.stringify(lite.map(s => [s.key, s.updatedAt]))
+      if (hash === lastSyncHashRef.current) return
+      lastSyncHashRef.current = hash
+
+      if (openclawSyncTimerRef.current) clearTimeout(openclawSyncTimerRef.current)
+
+      openclawSyncTimerRef.current = setTimeout(() => {
+        fetch('/api/tasks/openclaw-sync', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        }).catch(() => {})
+      }, 1000)
+    } catch {
+      // ignore
+    }
+  }, [])
+
   // Generate unique request ID
   const nextRequestId = () => {
     requestIdRef.current += 1
@@ -286,6 +315,7 @@ export function useWebSocket() {
         // Tick event contains snapshot data
         const snapshot = frame.payload?.snapshot
         if (snapshot?.sessions) {
+          queueOpenClawTaskSync(snapshot.sessions)
           setSessions(snapshot.sessions.map((session: any, index: number) => ({
             id: session.key || `session-${index}`,
             key: session.key || '',

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -8,6 +8,9 @@ import { MODEL_CATALOG } from '@/lib/models'
 export interface Session {
   id: string
   key: string
+  runtimeKey?: string
+  agent?: string
+  agentDisplay?: string
   kind: string
   age: string
   model: string
@@ -87,7 +90,19 @@ export interface Task {
   id: number
   title: string
   description?: string
-  status: 'inbox' | 'assigned' | 'in_progress' | 'review' | 'quality_review' | 'done'
+  status:
+    | 'inbox'
+    | 'backlog'
+    | 'todo'
+    | 'in-progress'
+    | 'review'
+    | 'blocked'
+    | 'needs-approval'
+    | 'done'
+    | 'assigned'
+    | 'in_progress'
+    | 'quality_review'
+    | 'needs_approval'
   priority: 'low' | 'medium' | 'high' | 'urgent'
   assigned_to?: string
   created_by: string


### PR DESCRIPTION
## Summary\n- Fix persistence by pinning Mission Control DB/data paths outside standalone runtime\n- Add stable standalone static/public asset preparation to avoid broken login UI\n- Add Nova/main identity aliasing and session mapping\n- Add approval inbox + one-click approval APIs and main-task/external-action gates\n- Add office autopilot scheduler loop with triage to Conductor\n- Add SOUL/Memory hydration fallbacks from workspace files\n- Add external task tombstones to prevent deleted mirrored tasks from being recreated\n- Add OpenClaw setup documentation ()\n\n## Why\nThis hardens data durability and closes the biggest UX/reliability gaps seen in OpenClaw-linked deployments.\n\n## Validation\n- Typecheck passes\n- Tests pass\n- Build passes\n- Service restarts with stable DB path\n- Manual API checks for tasks, approvals, scheduler, agents, sessions\n