### PR TITLE
feat: add projects management panel and CRUD test coverage

### DIFF
--- a/src/app/[[...panel]]/page.tsx
+++ b/src/app/[[...panel]]/page.tsx
@@ -30,6 +30,7 @@ import { IntegrationsPanel } from '@/components/panels/integrations-panel'
 import { AlertRulesPanel } from '@/components/panels/alert-rules-panel'
 import { MultiGatewayPanel } from '@/components/panels/multi-gateway-panel'
 import { SuperAdminPanel } from '@/components/panels/super-admin-panel'
+import { ProjectsPanel } from '@/components/panels/projects-panel'
 import { OfficePanel } from '@/components/panels/office-panel'
 import { GitHubSyncPanel } from '@/components/panels/github-sync-panel'
 import { ChatPanel } from '@/components/chat/chat-panel'
@@ -270,6 +271,8 @@ function ContentRouter({ tab }: { tab: string }) {
       return <SuperAdminPanel />
     case 'workspaces':
       return <SuperAdminPanel />
+    case 'projects':
+      return <ProjectsPanel />
     default:
       return <Dashboard />
   }

--- a/src/components/layout/nav-rail.tsx
+++ b/src/components/layout/nav-rail.tsx
@@ -58,6 +58,7 @@ const navGroups: NavGroup[] = [
       { id: 'users', label: 'Users', icon: <UsersIcon />, priority: false },
       { id: 'audit', label: 'Audit', icon: <AuditIcon />, priority: false },
       { id: 'history', label: 'History', icon: <HistoryIcon />, priority: false },
+      { id: 'projects', label: 'Projects', icon: <ProjectsIcon />, priority: false },
       { id: 'gateways', label: 'Gateways', icon: <GatewaysIcon />, priority: false },
       { id: 'gateway-config', label: 'Config', icon: <GatewayConfigIcon />, priority: false, requiresGateway: true },
       { id: 'integrations', label: 'Integrations', icon: <IntegrationsIcon />, priority: false },
@@ -437,6 +438,15 @@ function TasksIcon() {
     <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
       <rect x="2" y="1" width="12" height="14" rx="1.5" />
       <path d="M5 5h6M5 8h6M5 11h3" />
+    </svg>
+  )
+}
+
+function ProjectsIcon() {
+  return (
+    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M1.5 4.5A1.5 1.5 0 0 1 3 3h3l1.2 1.5H13A1.5 1.5 0 0 1 14.5 6v6.5A1.5 1.5 0 0 1 13 14H3a1.5 1.5 0 0 1-1.5-1.5V4.5z" />
+      <path d="M5 8h6M5 10.5h4" />
     </svg>
   )
 }

--- a/src/components/panels/projects-panel.tsx
+++ b/src/components/panels/projects-panel.tsx
@@ -1,0 +1,307 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+interface Project {
+  id: number
+  workspace_id: number
+  name: string
+  slug: string
+  description: string | null
+  ticket_prefix: string
+  ticket_counter: number
+  status: 'active' | 'archived'
+  created_at: number
+  updated_at: number
+}
+
+interface Draft {
+  name: string
+  description: string
+  ticket_prefix: string
+}
+
+function toDraft(project: Project): Draft {
+  return {
+    name: project.name,
+    description: project.description || '',
+    ticket_prefix: project.ticket_prefix,
+  }
+}
+
+export function ProjectsPanel() {
+  const [projects, setProjects] = useState<Project[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+
+  const [form, setForm] = useState({
+    name: '',
+    ticket_prefix: '',
+    description: '',
+  })
+
+  const [editingId, setEditingId] = useState<number | null>(null)
+  const [draft, setDraft] = useState<Draft | null>(null)
+
+  const activeCount = useMemo(() => projects.filter((p) => p.status === 'active').length, [projects])
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true)
+      const response = await fetch('/api/projects?includeArchived=1')
+      const data = await response.json()
+      if (!response.ok) throw new Error(data.error || 'Failed to load projects')
+      setProjects(data.projects || [])
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load projects')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const createProject = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!form.name.trim()) return
+    try {
+      setSaving(true)
+      const response = await fetch('/api/projects', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: form.name,
+          ticket_prefix: form.ticket_prefix,
+          description: form.description,
+        }),
+      })
+      const data = await response.json()
+      if (!response.ok) throw new Error(data.error || 'Failed to create project')
+      setForm({ name: '', ticket_prefix: '', description: '' })
+      await load()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create project')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const beginEdit = (project: Project) => {
+    setEditingId(project.id)
+    setDraft(toDraft(project))
+  }
+
+  const cancelEdit = () => {
+    setEditingId(null)
+    setDraft(null)
+  }
+
+  const saveEdit = async (projectId: number) => {
+    if (!draft) return
+    try {
+      setSaving(true)
+      const response = await fetch(`/api/projects/${projectId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: draft.name,
+          description: draft.description,
+          ticket_prefix: draft.ticket_prefix,
+        }),
+      })
+      const data = await response.json()
+      if (!response.ok) throw new Error(data.error || 'Failed to update project')
+      cancelEdit()
+      await load()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update project')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const toggleStatus = async (project: Project) => {
+    try {
+      const response = await fetch(`/api/projects/${project.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: project.status === 'active' ? 'archived' : 'active' }),
+      })
+      const data = await response.json()
+      if (!response.ok) throw new Error(data.error || 'Failed to update project status')
+      await load()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update project status')
+    }
+  }
+
+  const deleteProject = async (project: Project) => {
+    if (!confirm(`Delete project "${project.name}"? Existing tasks will be moved to General.`)) return
+    try {
+      const response = await fetch(`/api/projects/${project.id}?mode=delete`, { method: 'DELETE' })
+      const data = await response.json()
+      if (!response.ok) throw new Error(data.error || 'Failed to delete project')
+      if (editingId === project.id) cancelEdit()
+      await load()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete project')
+    }
+  }
+
+  return (
+    <div className="p-4 md:p-6 max-w-5xl mx-auto space-y-5">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-foreground">Projects</h2>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Manage projects and ticket prefixes used for task references.
+          </p>
+        </div>
+        <div className="text-xs text-muted-foreground">
+          {activeCount} active / {projects.length} total
+        </div>
+      </div>
+
+      {error && (
+        <div className="bg-red-500/10 border border-red-500/30 text-red-400 text-sm rounded-lg p-3">{error}</div>
+      )}
+
+      <div className="bg-card border border-border rounded-lg p-4">
+        <h3 className="text-sm font-semibold text-foreground mb-3">Create Project</h3>
+        <form onSubmit={createProject} className="grid grid-cols-1 md:grid-cols-4 gap-3">
+          <input
+            type="text"
+            value={form.name}
+            onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
+            placeholder="Project name"
+            className="md:col-span-2 bg-surface-1 text-foreground border border-border rounded-md px-3 py-2 text-sm"
+            required
+          />
+          <input
+            type="text"
+            value={form.ticket_prefix}
+            onChange={(e) => setForm((prev) => ({ ...prev, ticket_prefix: e.target.value }))}
+            placeholder="Ticket prefix (e.g. API)"
+            className="bg-surface-1 text-foreground border border-border rounded-md px-3 py-2 text-sm"
+          />
+          <button
+            type="submit"
+            disabled={saving}
+            className="bg-primary text-primary-foreground rounded-md px-3 py-2 text-sm font-medium hover:bg-primary/90 disabled:opacity-50"
+          >
+            {saving ? 'Saving...' : 'Add Project'}
+          </button>
+          <input
+            type="text"
+            value={form.description}
+            onChange={(e) => setForm((prev) => ({ ...prev, description: e.target.value }))}
+            placeholder="Description (optional)"
+            className="md:col-span-4 bg-surface-1 text-foreground border border-border rounded-md px-3 py-2 text-sm"
+          />
+        </form>
+      </div>
+
+      <div className="bg-card border border-border rounded-lg p-4">
+        <h3 className="text-sm font-semibold text-foreground mb-3">Existing Projects</h3>
+
+        {loading ? (
+          <div className="text-sm text-muted-foreground">Loading projects...</div>
+        ) : projects.length === 0 ? (
+          <div className="text-sm text-muted-foreground">No projects found.</div>
+        ) : (
+          <div className="space-y-3">
+            {projects.map((project) => {
+              const isGeneral = project.slug === 'general'
+              const isEditing = editingId === project.id && draft !== null
+
+              return (
+                <div key={project.id} className="border border-border rounded-md p-3">
+                  {isEditing ? (
+                    <div className="grid grid-cols-1 md:grid-cols-4 gap-2">
+                      <input
+                        type="text"
+                        value={draft.name}
+                        onChange={(e) => setDraft((prev) => (prev ? { ...prev, name: e.target.value } : prev))}
+                        className="md:col-span-2 bg-surface-1 text-foreground border border-border rounded-md px-3 py-2 text-sm"
+                      />
+                      <input
+                        type="text"
+                        value={draft.ticket_prefix}
+                        onChange={(e) => setDraft((prev) => (prev ? { ...prev, ticket_prefix: e.target.value } : prev))}
+                        className="bg-surface-1 text-foreground border border-border rounded-md px-3 py-2 text-sm"
+                      />
+                      <div className="flex gap-2">
+                        <button
+                          onClick={() => saveEdit(project.id)}
+                          disabled={saving}
+                          className="flex-1 bg-primary text-primary-foreground rounded-md px-3 py-2 text-xs font-medium hover:bg-primary/90 disabled:opacity-50"
+                        >
+                          Save
+                        </button>
+                        <button
+                          onClick={cancelEdit}
+                          className="flex-1 bg-secondary text-muted-foreground rounded-md px-3 py-2 text-xs font-medium hover:bg-surface-2"
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                      <input
+                        type="text"
+                        value={draft.description}
+                        onChange={(e) => setDraft((prev) => (prev ? { ...prev, description: e.target.value } : prev))}
+                        className="md:col-span-4 bg-surface-1 text-foreground border border-border rounded-md px-3 py-2 text-sm"
+                        placeholder="Description"
+                      />
+                    </div>
+                  ) : (
+                    <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+                      <div>
+                        <div className="text-sm font-medium text-foreground">{project.name}</div>
+                        <div className="text-xs text-muted-foreground mt-0.5">
+                          {project.ticket_prefix} · {project.slug} · {project.status} · {project.ticket_counter} tickets
+                        </div>
+                        {project.description && (
+                          <div className="text-xs text-muted-foreground mt-1">{project.description}</div>
+                        )}
+                      </div>
+
+                      <div className="flex flex-wrap gap-2">
+                        <button
+                          onClick={() => beginEdit(project)}
+                          className="px-3 py-1.5 text-xs rounded border border-border text-foreground hover:bg-secondary"
+                        >
+                          Edit
+                        </button>
+
+                        {!isGeneral && (
+                          <>
+                            <button
+                              onClick={() => toggleStatus(project)}
+                              className="px-3 py-1.5 text-xs rounded border border-border text-foreground hover:bg-secondary"
+                            >
+                              {project.status === 'active' ? 'Archive' : 'Activate'}
+                            </button>
+                            <button
+                              onClick={() => deleteProject(project)}
+                              className="px-3 py-1.5 text-xs rounded border border-red-500/30 text-red-400 hover:bg-red-500/10"
+                            >
+                              Delete
+                            </button>
+                          </>
+                        )}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/tests/projects-crud.spec.ts
+++ b/tests/projects-crud.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from '@playwright/test'
+import { API_KEY_HEADER } from './helpers'
+
+function uid() {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+}
+
+test.describe('Projects CRUD', () => {
+  const cleanup: number[] = []
+
+  test.afterEach(async ({ request }) => {
+    for (const id of cleanup.splice(0)) {
+      await request.delete(`/api/projects/${id}?mode=delete`, { headers: API_KEY_HEADER }).catch(() => {})
+    }
+  })
+
+  test('create, update ticket prefix, archive, and delete project', async ({ request }) => {
+    const base = uid().toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 6)
+
+    const createRes = await request.post('/api/projects', {
+      headers: API_KEY_HEADER,
+      data: {
+        name: `E2E Project ${uid()}`,
+        ticket_prefix: `${base}A`,
+        description: 'created by e2e',
+      },
+    })
+    expect(createRes.status()).toBe(201)
+    const createBody = await createRes.json()
+    const id = createBody.project?.id as number
+    cleanup.push(id)
+    expect(createBody.project.ticket_prefix).toBe(`${base}A`)
+
+    const patchRes = await request.patch(`/api/projects/${id}`, {
+      headers: API_KEY_HEADER,
+      data: {
+        ticket_prefix: `${base}B`,
+        description: 'updated by e2e',
+      },
+    })
+    expect(patchRes.status()).toBe(200)
+    const patchBody = await patchRes.json()
+    expect(patchBody.project.ticket_prefix).toBe(`${base}B`)
+
+    const archiveRes = await request.patch(`/api/projects/${id}`, {
+      headers: API_KEY_HEADER,
+      data: { status: 'archived' },
+    })
+    expect(archiveRes.status()).toBe(200)
+    const archiveBody = await archiveRes.json()
+    expect(archiveBody.project.status).toBe('archived')
+
+    const listRes = await request.get('/api/projects?includeArchived=1', { headers: API_KEY_HEADER })
+    expect(listRes.status()).toBe(200)
+    const listBody = await listRes.json()
+    expect(listBody.projects.some((p: any) => p.id === id && p.ticket_prefix === `${base}B`)).toBe(true)
+
+    const deleteRes = await request.delete(`/api/projects/${id}?mode=delete`, { headers: API_KEY_HEADER })
+    expect(deleteRes.status()).toBe(200)
+    const deleteBody = await deleteRes.json()
+    expect(deleteBody.success).toBe(true)
+
+    const getDeleted = await request.get(`/api/projects/${id}`, { headers: API_KEY_HEADER })
+    expect(getDeleted.status()).toBe(404)
+
+    cleanup.length = 0
+  })
+
+  test('rejects duplicate ticket prefix in the same workspace', async ({ request }) => {
+    const base = uid().toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 6)
+    const prefix = `${base}X`
+
+    const firstRes = await request.post('/api/projects', {
+      headers: API_KEY_HEADER,
+      data: {
+        name: `E2E Dup One ${uid()}`,
+        ticket_prefix: prefix,
+      },
+    })
+    expect(firstRes.status()).toBe(201)
+    const firstBody = await firstRes.json()
+    cleanup.push(firstBody.project.id)
+
+    const secondRes = await request.post('/api/projects', {
+      headers: API_KEY_HEADER,
+      data: {
+        name: `E2E Dup Two ${uid()}`,
+        ticket_prefix: prefix,
+      },
+    })
+    expect(secondRes.status()).toBe(409)
+  })
+})


### PR DESCRIPTION
## Summary
- add a dedicated projects panel for managing project metadata
- wire the panel into the main router and nav rail
- support create/edit/archive/activate/delete project actions from UI
- add e2e coverage for project lifecycle and duplicate ticket-prefix rejection

## Why
Issue #228 requested a first-class way to manage projects and ticket prefixes from Mission Control without using direct API calls.

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm test:e2e (204 passed)

Closes #228