### PR TITLE
RF-117: add deterministic task repo target metadata routing

### DIFF
--- a/src/app/api/agents/[id]/heartbeat/route.ts
+++ b/src/app/api/agents/[id]/heartbeat/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDatabase, db_helpers } from '@/lib/db';
 import { requireRole } from '@/lib/auth';
 import { logger } from '@/lib/logger';
+import { resolveTaskImplementationTarget } from '@/lib/task-routing';
 
 /**
  * GET /api/agents/[id]/heartbeat - Agent heartbeat check
@@ -79,8 +80,8 @@ export async function GET(
       AND status IN ('assigned', 'in_progress')
       ORDER BY priority DESC, created_at ASC
       LIMIT 10
-    `).all(agent.name, workspaceId);
-    
+    `).all(agent.name, workspaceId) as any[];
+
     if (assignedTasks.length > 0) {
       workItems.push({
         type: 'assigned_tasks',
@@ -90,7 +91,8 @@ export async function GET(
           title: t.title,
           status: t.status,
           priority: t.priority,
-          due_date: t.due_date
+          due_date: t.due_date,
+          ...resolveTaskImplementationTarget(t),
         }))
       });
     }

--- a/src/lib/__tests__/task-routing.test.ts
+++ b/src/lib/__tests__/task-routing.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { resolveTaskImplementationTarget } from '@/lib/task-routing'
+
+describe('resolveTaskImplementationTarget', () => {
+  it('returns explicit implementation target metadata when present', () => {
+    const result = resolveTaskImplementationTarget({
+      metadata: {
+        implementation_repo: 'torreypjones/cloudstack-razor',
+        code_location: '/apps/api',
+      },
+    })
+
+    expect(result).toEqual({
+      implementation_repo: 'torreypjones/cloudstack-razor',
+      code_location: '/apps/api',
+    })
+  })
+
+  it('supports legacy metadata keys for backward compatibility', () => {
+    const result = resolveTaskImplementationTarget({
+      metadata: {
+        github_repo: 'torreypjones/cloudstack-razor',
+        path: '/packages/core',
+      },
+    })
+
+    expect(result).toEqual({
+      implementation_repo: 'torreypjones/cloudstack-razor',
+      code_location: '/packages/core',
+    })
+  })
+
+  it('returns empty object for missing metadata', () => {
+    expect(resolveTaskImplementationTarget({ metadata: null })).toEqual({})
+  })
+})

--- a/src/lib/__tests__/validation.test.ts
+++ b/src/lib/__tests__/validation.test.ts
@@ -55,10 +55,31 @@ describe('createTaskSchema', () => {
     expect(result.success).toBe(true)
   })
 
+  it('accepts implementation target metadata fields', () => {
+    const result = createTaskSchema.safeParse({
+      title: 'Route this task',
+      metadata: {
+        implementation_repo: 'torreypjones/cloudstack-razor',
+        code_location: '/apps/api',
+      },
+    })
+    expect(result.success).toBe(true)
+  })
+
   it('rejects invalid feedback_rating', () => {
     const result = createTaskSchema.safeParse({
       title: 'Invalid rating test',
       feedback_rating: 6,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects non-string implementation target metadata fields', () => {
+    const result = createTaskSchema.safeParse({
+      title: 'Bad metadata',
+      metadata: {
+        implementation_repo: 123,
+      },
     })
     expect(result.success).toBe(false)
   })

--- a/src/lib/task-routing.ts
+++ b/src/lib/task-routing.ts
@@ -1,0 +1,60 @@
+export type TaskMetadata = Record<string, unknown>
+
+export interface TaskLike {
+  metadata?: string | TaskMetadata | null
+}
+
+export interface TaskImplementationTarget {
+  implementation_repo?: string
+  code_location?: string
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function parseMetadata(metadata: TaskLike['metadata']): TaskMetadata {
+  if (!metadata) return {}
+
+  if (typeof metadata === 'string') {
+    try {
+      const parsed = JSON.parse(metadata) as unknown
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as TaskMetadata
+      }
+      return {}
+    } catch {
+      return {}
+    }
+  }
+
+  if (typeof metadata === 'object' && !Array.isArray(metadata)) {
+    return metadata
+  }
+
+  return {}
+}
+
+export function resolveTaskImplementationTarget(task: TaskLike): TaskImplementationTarget {
+  const metadata = parseMetadata(task.metadata)
+
+  const implementationRepoCandidates = [
+    metadata.implementation_repo,
+    metadata.implementationRepo,
+    metadata.github_repo,
+  ]
+
+  const codeLocationCandidates = [
+    metadata.code_location,
+    metadata.codeLocation,
+    metadata.path,
+  ]
+
+  const implementation_repo = implementationRepoCandidates.find(isNonEmptyString)
+  const code_location = codeLocationCandidates.find(isNonEmptyString)
+
+  return {
+    ...(implementation_repo ? { implementation_repo } : {}),
+    ...(code_location ? { code_location } : {}),
+  }
+}

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -26,6 +26,11 @@ export async function validateBody<T>(
   }
 }
 
+const taskMetadataSchema = z.object({
+  implementation_repo: z.string().min(1, 'implementation_repo cannot be empty').max(200).optional(),
+  code_location: z.string().min(1, 'code_location cannot be empty').max(500).optional(),
+}).catchall(z.unknown())
+
 export const createTaskSchema = z.object({
   title: z.string().min(1, 'Title is required').max(500),
   description: z.string().max(5000).optional(),
@@ -44,7 +49,7 @@ export const createTaskSchema = z.object({
   retry_count: z.number().int().min(0).optional(),
   completed_at: z.number().optional(),
   tags: z.array(z.string()).default([] as string[]),
-  metadata: z.record(z.string(), z.unknown()).default({} as Record<string, unknown>),
+  metadata: taskMetadataSchema.default({} as Record<string, unknown>),
 })
 
 export const updateTaskSchema = createTaskSchema.partial()


### PR DESCRIPTION
## Summary
- validate explicit implementation target metadata on task create/update (`implementation_repo`, `code_location`)
- add `resolveTaskImplementationTarget` helper with backward-compatible legacy key fallback (`github_repo`, `path`)
- include resolved implementation target fields in heartbeat assigned task payloads for deterministic work-loop repo routing
- add unit tests for validation and routing resolution behavior

## Test Evidence
- npm run test
- npm run lint
- npm run typecheck

## Label
Attempted to include `--label owner:jack` per workflow requirement, but repository label permissions/availability prevented applying it from this account.
