### PR TITLE
feat: Mission Control prioritisation + agent queues

### DIFF
--- a/scripts/seed-current-tasks.js
+++ b/scripts/seed-current-tasks.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+const API = 'http://127.0.0.1:3200'
+const KEY = 'mc-api-henry-2026-key'
+
+const tasks = [
+  // Propel (project_id: 3)
+  { title: 'Fix PR #6 merge conflict + PR #3 conflicts', project_id: 3, assigned_to: 'forge', priority: 'high', urgency: 5, due_date: Math.floor(Date.now()/1000), status: 'assigned' },
+  { title: 'Propel website launch checklist', project_id: 3, assigned_to: 'henry', priority: 'high', urgency: 4, due_date: Math.floor(new Date('2026-03-15').getTime()/1000), status: 'assigned' },
+  { title: 'Outreach email templates ready for warmup', project_id: 3, assigned_to: 'quill', priority: 'medium', urgency: 3, due_date: Math.floor(new Date('2026-03-22').getTime()/1000), status: 'assigned' },
+  { title: 'Ace outreach engine setup', project_id: 3, assigned_to: 'ace', priority: 'high', urgency: 4, due_date: Math.floor(new Date('2026-03-22').getTime()/1000), status: 'assigned' },
+  
+  // JWF (project_id: 4)
+  { title: 'PR #51 hero contrast fix', project_id: 4, assigned_to: 'forge', priority: 'medium', urgency: 3, due_date: Math.floor(new Date('2026-03-10').getTime()/1000), status: 'assigned' },
+  { title: 'Visual QA on Warm Editorial redesign', project_id: 4, assigned_to: 'scout', priority: 'medium', urgency: 3, due_date: Math.floor(new Date('2026-03-12').getTime()/1000), status: 'assigned' },
+  
+  // Conewise/TM Planner (project_id: 1)
+  { title: 'Fix map rendering (Leaflet swap)', project_id: 1, assigned_to: 'forge', priority: 'high', urgency: 5, due_date: Math.floor(Date.now()/1000), status: 'in_progress' },
+  { title: 'Phase 2 polygon drawing + plan generation', project_id: 1, assigned_to: 'forge', priority: 'high', urgency: 4, due_date: Math.floor(new Date('2026-03-15').getTime()/1000), status: 'assigned' },
+  { title: 'Conewise name + domain decision', project_id: 1, assigned_to: 'henry', priority: 'low', urgency: 2, status: 'inbox' },
+  
+  // Atlas (project_id: 2)
+  { title: 'Gemini review + merge PRs #40 #41 #42', project_id: 2, assigned_to: 'henry', priority: 'high', urgency: 3, due_date: Math.floor(Date.now()/1000), status: 'assigned' },
+  { title: 'Ongoing Atlas backlog improvements', project_id: 2, assigned_to: 'forge', priority: 'low', urgency: 2, status: 'inbox' },
+  
+  // DeliverReel (project_id: 6)
+  { title: 'Convex setup (no Convex yet)', project_id: 6, assigned_to: 'forge', priority: 'high', urgency: 5, due_date: Math.floor(new Date('2026-03-25').getTime()/1000), status: 'assigned' },
+  { title: 'Stripe webhooks test', project_id: 6, assigned_to: 'scout', priority: 'high', urgency: 4, due_date: Math.floor(new Date('2026-03-25').getTime()/1000), status: 'assigned' },
+  { title: 'Launch plan + PH prep (DeliverReel)', project_id: 6, assigned_to: 'quill', priority: 'high', urgency: 4, due_date: Math.floor(new Date('2026-03-28').getTime()/1000), status: 'assigned' },
+  
+  // Tempo (project_id: 1 — use General since no Tempo project)
+  { title: 'Stripe integration test (Tempo)', project_id: 1, assigned_to: 'scout', priority: 'high', urgency: 4, due_date: Math.floor(new Date('2026-03-25').getTime()/1000), status: 'assigned' },
+  { title: 'Launch plan + PH prep (Tempo)', project_id: 1, assigned_to: 'quill', priority: 'high', urgency: 4, due_date: Math.floor(new Date('2026-03-28').getTime()/1000), status: 'assigned' },
+  
+  // Harbour/QuickSite (project_id: 7)
+  { title: 'Autonomous website builder spec', project_id: 7, assigned_to: 'sage', priority: 'high', urgency: 3, due_date: Math.floor(new Date('2026-03-10').getTime()/1000), status: 'assigned' },
+  { title: 'Build demo quality website example', project_id: 7, assigned_to: 'forge', priority: 'high', urgency: 4, due_date: Math.floor(new Date('2026-03-14').getTime()/1000), status: 'assigned' },
+  { title: 'GMB + social content scraper', project_id: 7, assigned_to: 'forge', priority: 'medium', urgency: 3, due_date: Math.floor(new Date('2026-03-21').getTime()/1000), status: 'assigned' },
+]
+
+async function seed() {
+  for (const task of tasks) {
+    try {
+      const res = await fetch(`${API}/api/tasks`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-api-key': KEY },
+        body: JSON.stringify(task),
+      })
+      const data = await res.json()
+      if (res.ok) {
+        console.log(`✅ Created: ${task.title} (id: ${data.task?.id || data.id})`)
+      } else {
+        console.log(`❌ Failed: ${task.title} — ${data.error}`)
+      }
+    } catch (err) {
+      console.log(`❌ Error: ${task.title} — ${err.message}`)
+    }
+  }
+}
+
+seed()

--- a/src/app/api/agents/[name]/queue/route.ts
+++ b/src/app/api/agents/[name]/queue/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getDatabase } from '@/lib/db'
+import { requireRole } from '@/lib/auth'
+import { computePriorityScore } from '@/lib/priority'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ name: string }> }
+) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  const { name } = await params
+  const db = getDatabase()
+  const workspaceId = auth.user.workspace_id
+
+  const tasks = db.prepare(`
+    SELECT t.*, p.name as project_name, p.ticket_prefix as project_prefix
+    FROM tasks t
+    LEFT JOIN projects p ON p.id = t.project_id AND p.workspace_id = t.workspace_id
+    WHERE t.assigned_to = ? AND t.workspace_id = ? AND t.status IN ('assigned', 'in_progress')
+    ORDER BY t.created_at DESC
+  `).all(name, workspaceId) as any[]
+
+  const queue = tasks.map(t => ({
+    id: t.id,
+    title: t.title,
+    description: t.description,
+    status: t.status,
+    priority: t.priority,
+    urgency: t.urgency ?? 3,
+    due_date: t.due_date,
+    priority_score: computePriorityScore(t.urgency ?? 3, t.due_date),
+    project: t.project_name ?? 'General',
+  })).sort((a, b) => b.priority_score - a.priority_score)
+
+  return NextResponse.json({ agent: name, queue })
+}

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -130,6 +130,7 @@ export async function PUT(
       feedback_notes,
       retry_count,
       completed_at,
+      urgency,
       tags,
       metadata
     } = body;
@@ -213,6 +214,10 @@ export async function PUT(
     if (assigned_to !== undefined) {
       fieldsToUpdate.push('assigned_to = ?');
       updateParams.push(assigned_to);
+    }
+    if (urgency !== undefined) {
+      fieldsToUpdate.push('urgency = ?');
+      updateParams.push(urgency);
     }
     if (due_date !== undefined) {
       fieldsToUpdate.push('due_date = ?');

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -7,6 +7,7 @@ import { logger } from '@/lib/logger';
 import { validateBody, createTaskSchema, bulkUpdateTaskStatusSchema } from '@/lib/validation';
 import { resolveMentionRecipients } from '@/lib/mentions';
 import { normalizeTaskCreateStatus } from '@/lib/task-status';
+import { computePriorityScore } from '@/lib/priority';
 
 function formatTicketRef(prefix?: string | null, num?: number | null): string | undefined {
   if (!prefix || typeof num !== 'number' || !Number.isFinite(num) || num <= 0) return undefined
@@ -109,11 +110,21 @@ export async function GET(request: NextRequest) {
     query += ' ORDER BY t.created_at DESC LIMIT ? OFFSET ?';
     params.push(limit, offset);
     
+    const sortParam = searchParams.get('sort');
+
     const stmt = db.prepare(query);
     const tasks = stmt.all(...params) as Task[];
     
     // Parse JSON fields
-    const tasksWithParsedData = tasks.map(mapTaskRow);
+    let tasksWithParsedData = tasks.map(mapTaskRow);
+
+    // When sort=priority, compute priority_score and sort
+    if (sortParam === 'priority') {
+      tasksWithParsedData = tasksWithParsedData.map(t => ({
+        ...t,
+        priority_score: computePriorityScore((t as any).urgency ?? 3, t.due_date ?? null),
+      })).sort((a, b) => (b as any).priority_score - (a as any).priority_score)
+    }
     
     // Get total count for pagination
     let countQuery = 'SELECT COUNT(*) as total FROM tasks WHERE workspace_id = ?';
@@ -180,7 +191,8 @@ export async function POST(request: NextRequest) {
       retry_count = 0,
       completed_at,
       tags = [],
-      metadata = {}
+      metadata = {},
+      urgency = 3,
     } = body;
     const normalizedStatus = normalizeTaskCreateStatus(status, assigned_to)
     
@@ -216,11 +228,11 @@ export async function POST(request: NextRequest) {
 
       const insertStmt = db.prepare(`
         INSERT INTO tasks (
-          title, description, status, priority, project_id, project_ticket_no, assigned_to, created_by,
+          title, description, status, priority, urgency, project_id, project_ticket_no, assigned_to, created_by,
           created_at, updated_at, due_date, estimated_hours, actual_hours,
           outcome, error_message, resolution, feedback_rating, feedback_notes, retry_count, completed_at,
           tags, metadata, workspace_id
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `)
 
       const dbResult = insertStmt.run(
@@ -228,6 +240,7 @@ export async function POST(request: NextRequest) {
         description,
         normalizedStatus,
         priority,
+        urgency,
         resolvedProjectId,
         row.ticket_counter,
         assigned_to,

--- a/src/app/api/tasks/stale/route.ts
+++ b/src/app/api/tasks/stale/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getDatabase } from '@/lib/db'
+import { requireRole } from '@/lib/auth'
+
+export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  const db = getDatabase()
+  const workspaceId = auth.user.workspace_id
+  const now = Math.floor(Date.now() / 1000)
+
+  const tasks = db.prepare(`
+    SELECT t.id, t.title, t.assigned_to, t.updated_at, t.status,
+           p.name as project_name
+    FROM tasks t
+    LEFT JOIN projects p ON p.id = t.project_id AND p.workspace_id = t.workspace_id
+    WHERE t.workspace_id = ?
+      AND (
+        (t.status = 'in_progress' AND t.updated_at < ?)
+        OR (t.status = 'assigned' AND t.updated_at < ?)
+      )
+    ORDER BY t.updated_at ASC
+  `).all(workspaceId, now - 7200, now - 14400) as any[]
+
+  const staleTasks = tasks.map(t => ({
+    id: t.id,
+    title: t.title,
+    assigned_to: t.assigned_to,
+    updated_at: t.updated_at,
+    status: t.status,
+    project: t.project_name ?? 'General',
+    hours_stale: Math.round((now - t.updated_at) / 3600 * 10) / 10,
+  }))
+
+  return NextResponse.json({ stale_tasks: staleTasks, count: staleTasks.length })
+}

--- a/src/components/panels/task-board-panel.tsx
+++ b/src/components/panels/task-board-panel.tsx
@@ -21,6 +21,8 @@ interface Task {
   status: 'inbox' | 'assigned' | 'in_progress' | 'review' | 'quality_review' | 'done'
   priority: 'low' | 'medium' | 'high' | 'critical' | 'urgent'
   assigned_to?: string
+  urgency?: number
+  priority_score?: number
   created_by: string
   created_at: number
   updated_at: number
@@ -265,6 +267,8 @@ export function TaskBoardPanel() {
   const [agents, setAgents] = useState<Agent[]>([])
   const [projects, setProjects] = useState<Project[]>([])
   const [projectFilter, setProjectFilter] = useState<string>('all')
+  const [assigneeFilter, setAssigneeFilter] = useState<string>('all')
+  const [staleTasks, setStaleTasks] = useState<{id: number; title: string; assigned_to: string; status: string; hours_stale: number}[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [aegisMap, setAegisMap] = useState<Record<number, boolean>>({})
@@ -304,15 +308,20 @@ export function TaskBoardPanel() {
       setError(null)
 
       const tasksQuery = new URLSearchParams()
+      tasksQuery.set('sort', 'priority')
       if (projectFilter !== 'all') {
         tasksQuery.set('project_id', projectFilter)
       }
-      const tasksUrl = tasksQuery.toString() ? `/api/tasks?${tasksQuery.toString()}` : '/api/tasks'
+      if (assigneeFilter !== 'all') {
+        tasksQuery.set('assigned_to', assigneeFilter)
+      }
+      const tasksUrl = `/api/tasks?${tasksQuery.toString()}`
 
-      const [tasksResponse, agentsResponse, projectsResponse] = await Promise.all([
+      const [tasksResponse, agentsResponse, projectsResponse, staleResponse] = await Promise.all([
         fetch(tasksUrl),
         fetch('/api/agents'),
-        fetch('/api/projects')
+        fetch('/api/projects'),
+        fetch('/api/tasks/stale'),
       ])
 
       if (!tasksResponse.ok || !agentsResponse.ok || !projectsResponse.ok) {
@@ -322,6 +331,8 @@ export function TaskBoardPanel() {
       const tasksData = await tasksResponse.json()
       const agentsData = await agentsResponse.json()
       const projectsData = await projectsResponse.json()
+      const staleData = staleResponse.ok ? await staleResponse.json() : { stale_tasks: [] }
+      setStaleTasks(staleData.stale_tasks || [])
 
       const tasksList = tasksData.tasks || []
       const taskIds = tasksList.map((task: Task) => task.id)
@@ -354,7 +365,7 @@ export function TaskBoardPanel() {
     } finally {
       setLoading(false)
     }
-  }, [projectFilter, storeSetTasks])
+  }, [projectFilter, assigneeFilter, storeSetTasks])
 
   useEffect(() => {
     fetchData()
@@ -538,6 +549,18 @@ export function TaskBoardPanel() {
               </option>
             ))}
           </select>
+          <select
+            value={assigneeFilter}
+            onChange={(e) => setAssigneeFilter(e.target.value)}
+            className="h-9 px-3 bg-surface-1 text-foreground border border-border rounded-md text-sm"
+          >
+            <option value="all">All Agents</option>
+            {agents.map((agent) => (
+              <option key={agent.name} value={agent.name}>
+                {agent.name}
+              </option>
+            ))}
+          </select>
         </div>
         <div className="flex gap-2">
           <button
@@ -572,6 +595,26 @@ export function TaskBoardPanel() {
           >
             ×
           </button>
+        </div>
+      )}
+
+      {/* Stale Tasks Warning */}
+      {staleTasks.length > 0 && (
+        <div className="mx-4 mt-3 p-3 bg-amber-500/10 border border-amber-500/30 rounded-lg">
+          <div className="flex items-center gap-2 mb-2">
+            <span className="text-amber-400 font-semibold text-sm">⚠ Stale Tasks ({staleTasks.length})</span>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {staleTasks.slice(0, 6).map(st => (
+              <div key={st.id} className="text-xs bg-amber-500/10 border border-amber-500/20 rounded px-2 py-1">
+                <span className="text-foreground font-medium">{st.title}</span>
+                <span className="text-muted-foreground ml-1">({st.assigned_to || 'unassigned'} · {st.hours_stale}h ago)</span>
+              </div>
+            ))}
+            {staleTasks.length > 6 && (
+              <span className="text-xs text-amber-400">+{staleTasks.length - 6} more</span>
+            )}
+          </div>
         </div>
       )}
 
@@ -617,15 +660,25 @@ export function TaskBoardPanel() {
                       updateTaskUrl(task.id)
                     }
                   }}
-                  className={`bg-surface-1 rounded-lg p-3 cursor-pointer hover:bg-surface-2 transition-smooth border-l-4 ${priorityColors[task.priority]} ${
+                  className={`bg-surface-1 rounded-lg p-3 cursor-pointer hover:bg-surface-2 transition-smooth border-l-4 ${
+                    task.due_date && task.due_date * 1000 < Date.now() ? 'border-red-500' : priorityColors[task.priority]
+                  } ${
                     draggedTask?.id === task.id ? 'opacity-50' : ''
                   }`}
                 >
                   <div className="flex justify-between items-start mb-2">
-                    <h4 className="text-foreground font-medium text-sm leading-tight">
-                      {task.title}
-                    </h4>
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-1.5 min-w-0">
+                      <span className="flex-shrink-0">{
+                        task.priority === 'critical' || (task.urgency && task.urgency >= 5) ? '🔴' :
+                        task.priority === 'high' ? '🟠' :
+                        task.priority === 'medium' ? '🟡' :
+                        '🟢'
+                      }</span>
+                      <h4 className="text-foreground font-medium text-sm leading-tight truncate">
+                        {task.title}
+                      </h4>
+                    </div>
+                    <div className="flex items-center gap-2 flex-shrink-0">
                       {task.ticket_ref && (
                         <span className="text-[10px] px-2 py-0.5 rounded bg-primary/20 text-primary">
                           {task.ticket_ref}
@@ -646,6 +699,9 @@ export function TaskBoardPanel() {
                       </span>
                     </div>
                   </div>
+                  {typeof task.priority_score === 'number' && (
+                    <div className="text-[10px] text-muted-foreground/60 mb-1">Score: {task.priority_score}</div>
+                  )}
                   
                   {task.description && (
                     <div className="mb-2 line-clamp-3 overflow-hidden">
@@ -699,9 +755,11 @@ export function TaskBoardPanel() {
                   {task.due_date && (
                     <div className="mt-2 text-xs">
                       <span className={`${
-                        task.due_date * 1000 < Date.now() ? 'text-red-400' : 'text-yellow-400'
+                        task.due_date * 1000 < Date.now() ? 'text-red-400 font-semibold' :
+                        (task.due_date * 1000 - Date.now()) < 3 * 86400 * 1000 ? 'text-amber-400' :
+                        'text-muted-foreground'
                       }`}>
-                        Due: {formatTaskTimestamp(task.due_date)}
+                        {task.due_date * 1000 < Date.now() ? '⚠ Overdue — ' : 'Due: '}{formatTaskTimestamp(task.due_date)}
                       </span>
                     </div>
                   )}

--- a/src/lib/migrations.ts
+++ b/src/lib/migrations.ts
@@ -830,6 +830,15 @@ const migrations: Migration[] = [
       db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_api_keys_expires_at ON agent_api_keys(expires_at)`)
       db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_api_keys_revoked_at ON agent_api_keys(revoked_at)`)
     }
+  },
+  {
+    id: '028_add_urgency',
+    up: (db) => {
+      const cols = db.prepare("PRAGMA table_info(tasks)").all() as {name:string}[]
+      if (!cols.find(c => c.name === 'urgency')) {
+        db.exec('ALTER TABLE tasks ADD COLUMN urgency INTEGER NOT NULL DEFAULT 3')
+      }
+    }
   }
 ]
 

--- a/src/lib/priority.ts
+++ b/src/lib/priority.ts
@@ -1,0 +1,8 @@
+export function computePriorityScore(urgency: number, dueDate: number | null): number {
+  const now = Math.floor(Date.now() / 1000)
+  const urgencyScore = urgency * 20
+  if (!dueDate) return urgencyScore
+  const daysUntilDue = (dueDate - now) / 86400
+  if (daysUntilDue < 0) return urgencyScore + 100 // overdue
+  return urgencyScore + Math.max(0, 30 - daysUntilDue) * 2
+}

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -33,6 +33,7 @@ export const createTaskSchema = z.object({
   priority: z.enum(['critical', 'high', 'medium', 'low']).default('medium'),
   project_id: z.number().int().positive().optional(),
   assigned_to: z.string().max(100).optional(),
+  urgency: z.number().int().min(1).max(5).default(3),
   due_date: z.number().optional(),
   estimated_hours: z.number().min(0).optional(),
   actual_hours: z.number().min(0).optional(),


### PR DESCRIPTION
5 stories: priority scoring, kanban redesign, agent queue API, stale task monitor, bulk task seed.

## Changes

### US-001: Priority score + smart sort
- New `urgency` column (1-5) on tasks via migration 028
- `computePriorityScore()` helper in `src/lib/priority.ts`
- GET `/api/tasks?sort=priority` sorts by computed priority score
- POST/PUT accept `urgency` field

### US-002: Kanban board redesign
- Priority dots (🔴🟠🟡🟢) on task cards
- Overdue tasks get red left border + warning text
- Due date colour coding (red/amber/gray)
- Priority score display on cards
- Assignee filter dropdown alongside project filter
- Fetches with `sort=priority` by default

### US-003: Agent queue API
- `GET /api/agents/[name]/queue` returns prioritised task queue for an agent

### US-004: Stale task monitor
- `GET /api/tasks/stale` returns tasks stuck in progress (>2h) or assigned (>4h)
- Warning banner on task board showing stale tasks

### US-005: Bulk task seed
- `scripts/seed-current-tasks.js` — 19 tasks across all active projects