### PR TITLE
fix: allow gateway WebSocket path override for reverse proxies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,8 @@ OPENCLAW_HOME=
 # Gateway connection (used by frontend WebSocket)
 OPENCLAW_GATEWAY_HOST=127.0.0.1
 OPENCLAW_GATEWAY_PORT=18789
+# Optional: path used by front-end reverse proxies (e.g., /api/gateway/ws)
+OPENCLAW_GATEWAY_PATH=
 # Optional: token used by server-side gateway calls
 OPENCLAW_GATEWAY_TOKEN=
 # Tools profile used when Mission Control spawns sessions via sessions_spawn.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Running AI agents at scale means juggling sessions, tasks, costs, and reliabilit
 - **Quality gates** — Built-in review system that blocks task completion without sign-off
 - **Multi-gateway** — Connect to multiple agent gateways simultaneously (OpenClaw, and more coming soon)
 
+If your gateway is routed through a reverse proxy, configure the optional WebSocket path (e.g., `/api/gateway/ws`) when adding it so Mission Control connects over the proxy port instead of requiring direct access to 18789.
+
 ## Quick Start
 
 > **Requires [pnpm](https://pnpm.io/installation)** — Mission Control uses pnpm for dependency management. Install it with `npm install -g pnpm` or `corepack enable`.
@@ -380,6 +382,7 @@ See [`.env.example`](.env.example) for the complete list. Key variables:
 | `OPENCLAW_HOME` | No | Legacy alias for state dir (fallback if `OPENCLAW_STATE_DIR` unset) |
 | `OPENCLAW_GATEWAY_HOST` | No | Gateway host (default: `127.0.0.1`) |
 | `OPENCLAW_GATEWAY_PORT` | No | Gateway WebSocket port (default: `18789`) |
+| `OPENCLAW_GATEWAY_PATH` | No | Optional WebSocket path for reverse proxies (e.g., `/api/gateway/ws`) |
 | `OPENCLAW_GATEWAY_TOKEN` | No | Server-side gateway auth token |
 | `OPENCLAW_TOOLS_PROFILE` | No | Tools profile for `sessions_spawn` (recommended: `coding`) |
 | `NEXT_PUBLIC_GATEWAY_TOKEN` | No | Browser-side gateway auth token (must use `NEXT_PUBLIC_` prefix) |

--- a/src/app/api/gateways/connect/route.ts
+++ b/src/app/api/gateways/connect/route.ts
@@ -8,6 +8,7 @@ interface GatewayEntry {
   host: string
   port: number
   token: string
+  path: string
 }
 
 function ensureTable(db: ReturnType<typeof getDatabase>) {
@@ -62,6 +63,7 @@ export async function POST(request: NextRequest) {
     host: gateway.host,
     port: gateway.port,
     browserProtocol: request.nextUrl.protocol,
+    path: gateway.path,
   })
 
   const envToken = (process.env.NEXT_PUBLIC_GATEWAY_TOKEN || process.env.NEXT_PUBLIC_WS_TOKEN || '').trim()

--- a/src/app/api/gateways/route.ts
+++ b/src/app/api/gateways/route.ts
@@ -7,6 +7,7 @@ interface GatewayEntry {
   name: string
   host: string
   port: number
+  path: string
   token: string
   is_primary: number
   status: string
@@ -25,6 +26,7 @@ function ensureTable(db: ReturnType<typeof getDatabase>) {
       name TEXT NOT NULL UNIQUE,
       host TEXT NOT NULL DEFAULT '127.0.0.1',
       port INTEGER NOT NULL DEFAULT 18789,
+      path TEXT NOT NULL DEFAULT '',
       token TEXT NOT NULL DEFAULT '',
       is_primary INTEGER NOT NULL DEFAULT 0,
       status TEXT NOT NULL DEFAULT 'unknown',
@@ -36,6 +38,14 @@ function ensureTable(db: ReturnType<typeof getDatabase>) {
       updated_at INTEGER NOT NULL DEFAULT (unixepoch())
     )
   `)
+
+  try {
+    db.exec("ALTER TABLE gateways ADD COLUMN path TEXT NOT NULL DEFAULT ''")
+  } catch (err: any) {
+    if (!String(err?.message).toLowerCase().includes('duplicate column name')) {
+      throw err
+    }
+  }
 }
 
 /**
@@ -55,14 +65,19 @@ export async function GET(request: NextRequest) {
     const name = String(process.env.MC_DEFAULT_GATEWAY_NAME || 'primary')
     const host = String(process.env.OPENCLAW_GATEWAY_HOST || '127.0.0.1')
     const mainPort = parseInt(process.env.OPENCLAW_GATEWAY_PORT || process.env.GATEWAY_PORT || process.env.NEXT_PUBLIC_GATEWAY_PORT || '18789')
+    const mainPath =
+      process.env.OPENCLAW_GATEWAY_PATH ||
+      process.env.GATEWAY_PATH ||
+      process.env.NEXT_PUBLIC_GATEWAY_PATH ||
+      ''
     const mainToken =
       process.env.OPENCLAW_GATEWAY_TOKEN ||
       process.env.GATEWAY_TOKEN ||
       ''
 
     db.prepare(`
-      INSERT INTO gateways (name, host, port, token, is_primary) VALUES (?, ?, ?, ?, 1)
-    `).run(name, host, mainPort, mainToken)
+      INSERT INTO gateways (name, host, port, path, token, is_primary) VALUES (?, ?, ?, ?, ?, 1)
+    `).run(name, host, mainPort, mainPath, mainToken)
 
     const seeded = db.prepare('SELECT * FROM gateways ORDER BY is_primary DESC, name ASC').all() as GatewayEntry[]
     return NextResponse.json({ gateways: redactTokens(seeded) })
@@ -82,11 +97,13 @@ export async function POST(request: NextRequest) {
   ensureTable(db)
   const body = await request.json()
 
-  const { name, host, port, token, is_primary } = body
+  const { name, host, port, token, is_primary, path } = body
 
   if (!name || !host || !port) {
     return NextResponse.json({ error: 'name, host, and port are required' }, { status: 400 })
   }
+
+  const normalizedPath = typeof path === 'string' ? path.trim() : ''
 
   try {
     // If marking as primary, unset other primaries
@@ -95,8 +112,8 @@ export async function POST(request: NextRequest) {
     }
 
     const result = db.prepare(`
-      INSERT INTO gateways (name, host, port, token, is_primary) VALUES (?, ?, ?, ?, ?)
-    `).run(name, host, port, token || '', is_primary ? 1 : 0)
+      INSERT INTO gateways (name, host, port, path, token, is_primary) VALUES (?, ?, ?, ?, ?, ?)
+    `).run(name, host, port, normalizedPath, token || '', is_primary ? 1 : 0)
 
     try {
       db.prepare('INSERT INTO audit_log (action, actor, detail) VALUES (?, ?, ?)').run(
@@ -136,7 +153,7 @@ export async function PUT(request: NextRequest) {
     db.prepare('UPDATE gateways SET is_primary = 0').run()
   }
 
-  const allowed = ['name', 'host', 'port', 'token', 'is_primary', 'status', 'last_seen', 'latency', 'sessions_count', 'agents_count']
+  const allowed = ['name', 'host', 'port', 'path', 'token', 'is_primary', 'status', 'last_seen', 'latency', 'sessions_count', 'agents_count']
   const sets: string[] = []
   const values: any[] = []
 

--- a/src/components/panels/multi-gateway-panel.tsx
+++ b/src/components/panels/multi-gateway-panel.tsx
@@ -10,6 +10,7 @@ interface Gateway {
   name: string
   host: string
   port: number
+  path: string
   token_set: boolean
   is_primary: number
   status: string
@@ -107,6 +108,7 @@ export function MultiGatewayPanel() {
         host: gw.host,
         port: gw.port,
         browserProtocol: window.location.protocol,
+        path: gw.path,
       }))
       const token = String(payload?.token || '')
       connect(wsUrl, token)
@@ -330,6 +332,11 @@ function GatewayCard({ gateway, health, isProbing, isCurrentlyConnected, onSetPr
           </div>
           <div className="flex items-center gap-4 mt-1.5 text-xs text-muted-foreground">
             <span className="font-mono">{gateway.host}:{gateway.port}</span>
+            {gateway.path && (
+              <span>
+                Path: <span className="font-mono">{gateway.path}</span>
+              </span>
+            )}
             <span>Token: {gateway.token_set ? 'Set' : 'None'}</span>
             {gateway.latency != null && <span>Latency: {gateway.latency}ms</span>}
             <span>Last: {lastSeen}</span>
@@ -390,7 +397,7 @@ function GatewayCard({ gateway, health, isProbing, isCurrentlyConnected, onSetPr
 }
 
 function AddGatewayForm({ onAdded, onCancel }: { onAdded: () => void; onCancel: () => void }) {
-  const [form, setForm] = useState({ name: '', host: '127.0.0.1', port: '18789', token: '' })
+  const [form, setForm] = useState({ name: '', host: '127.0.0.1', port: '18789', token: '', path: '' })
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
 
@@ -407,6 +414,7 @@ function AddGatewayForm({ onAdded, onCancel }: { onAdded: () => void; onCancel: 
           name: form.name,
           host: form.host,
           port: parseInt(form.port),
+          path: form.path,
           token: form.token,
           is_primary: false,
         }),
@@ -467,6 +475,16 @@ function AddGatewayForm({ onAdded, onCancel }: { onAdded: () => void; onCancel: 
             value={form.token}
             onChange={e => setForm({ ...form, token: e.target.value })}
             placeholder="Optional"
+            className="w-full h-8 px-2.5 rounded-md bg-secondary border border-border text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+          />
+        </div>
+        <div className="md:col-span-4">
+          <label className="block text-2xs text-muted-foreground mb-1">Path (optional)</label>
+          <input
+            type="text"
+            value={form.path}
+            onChange={e => setForm({ ...form, path: e.target.value })}
+            placeholder="e.g., /api/gateway/ws"
             className="w-full h-8 px-2.5 rounded-md bg-secondary border border-border text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
           />
         </div>

--- a/src/lib/__tests__/gateway-url.test.ts
+++ b/src/lib/__tests__/gateway-url.test.ts
@@ -41,4 +41,29 @@ describe('buildGatewayWebSocketUrl', () => {
       browserProtocol: 'https:',
     })).toBe('wss://bill.tail8b4599.ts.net:4443')
   })
+
+  it('appends a configured websocket path when provided explicitly', () => {
+    expect(buildGatewayWebSocketUrl({
+      host: 'cb.example.net',
+      port: 18789,
+      browserProtocol: 'https:',
+      path: '/api/gateway/ws',
+    })).toBe('wss://cb.example.net/api/gateway/ws')
+  })
+
+  it('uses the host path when no explicit path is provided', () => {
+    expect(buildGatewayWebSocketUrl({
+      host: 'cb.example.net/api/gateway/ws',
+      port: 18789,
+      browserProtocol: 'https:',
+    })).toBe('wss://cb.example.net/api/gateway/ws')
+  })
+
+  it('preserves a websocket path when a ws:// URL is supplied', () => {
+    expect(buildGatewayWebSocketUrl({
+      host: 'ws://gateway.example.com/api/gateway/ws?foo=bar',
+      port: 18789,
+      browserProtocol: 'http:',
+    })).toBe('ws://gateway.example.com/api/gateway/ws')
+  })
 })

--- a/src/lib/gateway-url.ts
+++ b/src/lib/gateway-url.ts
@@ -1,11 +1,63 @@
+function normalizeGatewayPath(value?: string): string {
+  if (!value) return ''
+  const trimmed = value.trim()
+  if (!trimmed) return ''
+  const withLeadingSlash = trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+  const withoutTrailing = withLeadingSlash.replace(/\/+$/, '')
+  return withoutTrailing === '/' ? '' : withoutTrailing
+}
+
+function stripPathFromHost(host: string): { host: string; path: string } {
+  const [hostPart, ...rest] = host.split('/')
+  const sanitizedHost = (hostPart || '').trim()
+  const path = rest.length ? normalizeGatewayPath('/' + rest.join('/')) : ''
+  return { host: sanitizedHost, path }
+}
+
+function stripPortForLocalCheck(host: string): string {
+  if (!host) return ''
+  const lower = host.toLowerCase()
+  if (lower.startsWith('[')) {
+    const closing = lower.indexOf(']')
+    if (closing > -1) return lower.slice(1, closing)
+    return lower
+  }
+  const colonIndex = lower.lastIndexOf(':')
+  if (colonIndex > -1 && lower.indexOf(':') === colonIndex) {
+    const portCandidate = lower.slice(colonIndex + 1)
+    if (/^\d+$/.test(portCandidate)) {
+      return lower.slice(0, colonIndex)
+    }
+  }
+  return lower
+}
+
 function isLocalHost(host: string): boolean {
-  const normalized = host.toLowerCase()
+  const normalized = stripPortForLocalCheck(host)
   return (
     normalized === 'localhost' ||
+    normalized.endsWith('.local') ||
     normalized === '127.0.0.1' ||
     normalized === '::1' ||
-    normalized.endsWith('.local')
+    normalized === '[::1]'
   )
+}
+
+function formatHostForUrl(host: string): string {
+  if (!host) return host
+  const trimmed = host.trim()
+  if (trimmed.startsWith('[') && trimmed.endsWith(']')) return trimmed
+  const colonCount = (trimmed.match(/:/g) || []).length
+  if (colonCount > 1 && !trimmed.startsWith('[')) {
+    return `[${trimmed}]`
+  }
+  return trimmed
+}
+
+function appendPath(baseUrl: string, path: string): string {
+  const trimmedBase = baseUrl.replace(/\/$/, '')
+  if (!path) return trimmedBase
+  return `${trimmedBase}${path}`
 }
 
 function normalizeProtocol(protocol: string): 'ws:' | 'wss:' {
@@ -17,13 +69,16 @@ export function buildGatewayWebSocketUrl(input: {
   host: string
   port: number
   browserProtocol?: string
+  path?: string
 }): string {
   const rawHost = String(input.host || '').trim()
   const port = Number(input.port)
   const browserProtocol = input.browserProtocol === 'https:' ? 'https:' : 'http:'
+  const explicitPath = normalizeGatewayPath(input.path)
 
   if (!rawHost) {
-    return `${browserProtocol === 'https:' ? 'wss' : 'ws'}://127.0.0.1:${port || 18789}`
+    const base = `${browserProtocol === 'https:' ? 'wss' : 'ws'}://127.0.0.1:${port || 18789}`
+    return appendPath(base, explicitPath)
   }
 
   const prefixed =
@@ -31,30 +86,35 @@ export function buildGatewayWebSocketUrl(input: {
     rawHost.startsWith('wss://') ||
     rawHost.startsWith('http://') ||
     rawHost.startsWith('https://')
-      ? rawHost
-      : null
 
   if (prefixed) {
     try {
-      const parsed = new URL(prefixed)
-      parsed.protocol = normalizeProtocol(parsed.protocol)
-      // Users often paste dashboard/session URLs; websocket connect should target gateway root.
-      parsed.pathname = '/'
+      const parsed = new URL(rawHost)
+      const scheme = parsed.protocol
+      const isWebSocketScheme = scheme === 'ws:' || scheme === 'wss:'
+      parsed.protocol = normalizeProtocol(scheme)
       parsed.search = ''
       parsed.hash = ''
-      return parsed.toString().replace(/\/$/, '')
+      const hostPath = isWebSocketScheme ? normalizeGatewayPath(parsed.pathname) : ''
+      parsed.pathname = '/'
+      const base = parsed.toString()
+      const finalPath = explicitPath || hostPath
+      return appendPath(base, finalPath)
     } catch {
-      return prefixed
+      return appendPath(rawHost, explicitPath)
     }
   }
 
+  const { host: hostOnly, path: inferredPath } = stripPathFromHost(rawHost)
+  const resolvedHost = hostOnly || '127.0.0.1'
+  const compiledPath = explicitPath || inferredPath
   const wsProtocol = browserProtocol === 'https:' ? 'wss' : 'ws'
   const shouldOmitPort =
     wsProtocol === 'wss' &&
-    !isLocalHost(rawHost) &&
+    !isLocalHost(resolvedHost) &&
     port === 18789
-
-  return shouldOmitPort
-    ? `${wsProtocol}://${rawHost}`
-    : `${wsProtocol}://${rawHost}:${port || 18789}`
+  const portSegment = shouldOmitPort ? '' : `:${port || 18789}`
+  const formattedHost = formatHostForUrl(resolvedHost)
+  const base = `${wsProtocol}://${formattedHost}${portSegment}`
+  return appendPath(base, compiledPath)
 }

--- a/tests/gateway-connect.spec.ts
+++ b/tests/gateway-connect.spec.ts
@@ -19,8 +19,9 @@ test.describe('Gateway Connect API', () => {
       headers: API_KEY_HEADER,
       data: {
         name: `e2e-gw-${Date.now()}`,
-        host: 'https://example.tailnet.ts.net:4443/sessions',
+        host: 'https://example.tailnet.ts.net:4443',
         port: 18789,
+        path: '/api/gateway/ws',
         token: 'gw-token-123',
       },
     })
@@ -36,7 +37,7 @@ test.describe('Gateway Connect API', () => {
     expect(connectRes.status()).toBe(200)
     const connectBody = await connectRes.json()
 
-    expect(connectBody.ws_url).toBe('wss://example.tailnet.ts.net:4443')
+    expect(connectBody.ws_url).toBe('wss://example.tailnet.ts.net:4443/api/gateway/ws')
     expect(connectBody.token).toBe('gw-token-123')
     expect(connectBody.token_set).toBe(true)
   })
@@ -47,5 +48,32 @@ test.describe('Gateway Connect API', () => {
       data: { id: 999999 },
     })
     expect(res.status()).toBe(404)
+  })
+
+  test('drops https path when no override path is configured', async ({ request }) => {
+    const createRes = await request.post('/api/gateways', {
+      headers: API_KEY_HEADER,
+      data: {
+        name: `e2e-gw-path-${Date.now()}`,
+        host: 'https://example.tailnet.ts.net:4443/sessions',
+        port: 18789,
+        token: 'gw-token-456',
+      },
+    })
+    expect(createRes.status()).toBe(201)
+    const createBody = await createRes.json()
+    const gatewayId = createBody.gateway?.id as number
+    cleanup.push(gatewayId)
+
+    const connectRes = await request.post('/api/gateways/connect', {
+      headers: API_KEY_HEADER,
+      data: { id: gatewayId },
+    })
+    expect(connectRes.status()).toBe(200)
+    const connectBody = await connectRes.json()
+
+    expect(connectBody.ws_url).toBe('wss://example.tailnet.ts.net:4443')
+    expect(connectBody.token).toBe('gw-token-456')
+    expect(connectBody.token_set).toBe(true)
   })
 })


### PR DESCRIPTION
Fixes #270

When deploying Mission Control on a VPS, the gateway connection shows "offline" because WebSocket ports (18789, 18790) are blocked by VPS firewalls. The browser tries to connect to `ws://public-ip:18790/ws` but fails.

This PR adds an optional `path` field to gateway configuration, allowing users to specify a WebSocket path when using reverse proxies (e.g., `/api/gateway/ws`). This enables WebSocket connections over standard HTTP ports (80/443) through the proxy instead of requiring direct port access.

## Changes

- Added `path` field to gateways table schema (with backwards-compatible migration)
- Updated `buildGatewayWebSocketUrl()` to accept and append custom paths
- Added path handling in API routes and seeding logic
- Updated UI to show path input field when adding gateways
- Added tests for path override behavior
- Updated environment variable documentation

## Testing

- Added unit tests for path appending and preservation behavior
- Updated Playwright tests for gateway connection with path
- Verified existing tests pass

## Usage

Users can now add gateways with a path (e.g., `/api/gateway/ws`) when the gateway is behind a reverse proxy. The WebSocket URL is constructed as `wss://host:port/path`.

Fixes #270