### PR TITLE
fix(docker): resolve compose validation error for pids_limit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,12 +21,12 @@ services:
       - NET_BIND_SERVICE
     security_opt:
       - no-new-privileges:true
-    pids_limit: 256
     deploy:
       resources:
         limits:
           memory: 512M
           cpus: '1.0'
+          pids: 256
     networks:
       - mc-net
     restart: unless-stopped


### PR DESCRIPTION
### What this PR does
Fixes the Docker Compose validation error:
`services.mission-control: can't set distinct values on 'pids_limit' and 'deploy.resources.limits.pids': invalid compose project`

Fixes #281

### Cause
In modern Docker Compose (v2 engine), setting `pids_limit` at the service root level while also using a `deploy.resources` block triggers validation conflicts. 

As per the [Docker Compose Deploy Specification](https://docs.docker.com/reference/compose-file/deploy/#pids), the property should be moved into the deployment limits block to maintain cross-engine compatibility and avoid collision.

### Changes
Moved `pids_limit: 256` into `deploy.resources.limits.pids: 256` in `docker-compose.yml`.