### PR TITLE
fix(docker): allow check-node-version.mjs in .dockerignore for local builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ node_modules
 .github
 ops
 scripts
+!scripts/check-node-version.mjs


### PR DESCRIPTION
## Description
Fixes #282

Building the Docker image locally currently fails because the `scripts` directory is ignored in `.dockerignore`, but the `build` command in `package.json` requires `scripts/check-node-version.mjs` to run the node version verification.

This PR adds an exclusion (`!scripts/check-node-version.mjs`) to `.dockerignore` so that only the necessary version-check script is included during the Docker build context, without pulling in other unrelated operational scripts.

## Changes
- Updated `.dockerignore` to include `!scripts/check-node-version.mjs`.