### PR TITLE
fix(docker): resolve compose validation error for pids_limit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,12 +21,12 @@ services:
       - NET_BIND_SERVICE
     security_opt:
       - no-new-privileges:true
-    pids_limit: 256
     deploy:
       resources:
         limits:
           memory: 512M
           cpus: '1.0'
+          pids: 256
     networks:
       - mc-net
     restart: unless-stopped


### PR DESCRIPTION
### What this PR does
Fixes the V2.0+ Docker Compose validation error:
`services.mission-control: can't set distinct values on 'pids_limit' and 'deploy.resources.limits.pids': invalid compose project`

Fixes #285

### Cause
The existing `docker-compose.yml` in `main` (post v2.0) has `pids_limit` at the service root level while also using a `deploy.resources` block. This triggers validation failures in modern Compose engines.

As per the [Docker Compose Deploy Specification](https://docs.docker.com/reference/compose-file/deploy/#pids), this property needs to be unified under the deployment limits block to ensure compatibility.

### Changes
Moved `pids_limit: 256` into `deploy.resources.limits.pids: 256`.