### PR TITLE
feat(gateway-auth): enhance authentication configuration and credenti…

### DIFF
--- a/src/lib/gateway-runtime.ts
+++ b/src/lib/gateway-runtime.ts
@@ -5,7 +5,9 @@ import { logger } from '@/lib/logger'
 interface OpenClawGatewayConfig {
   gateway?: {
     auth?: {
+      mode?: 'token' | 'password'
       token?: string
+      password?: string
     }
     port?: number
     controlUi?: {
@@ -65,13 +67,26 @@ export function registerMcAsDashboard(mcUrl: string): { registered: boolean; alr
   }
 }
 
+/**
+ * Returns the gateway auth credential (token or password) for Bearer/WS auth.
+ * Env overrides: OPENCLAW_GATEWAY_TOKEN, GATEWAY_TOKEN, OPENCLAW_GATEWAY_PASSWORD, GATEWAY_PASSWORD.
+ * From config: uses gateway.auth.token when mode is "token", gateway.auth.password when mode is "password".
+ */
 export function getDetectedGatewayToken(): string {
   const envToken = (process.env.OPENCLAW_GATEWAY_TOKEN || process.env.GATEWAY_TOKEN || '').trim()
   if (envToken) return envToken
+  
+  const envPassword = (process.env.OPENCLAW_GATEWAY_PASSWORD || process.env.GATEWAY_PASSWORD || '').trim()
+  if (envPassword) return envPassword
 
   const parsed = readOpenClawConfig()
-  const cfgToken = String(parsed?.gateway?.auth?.token || '').trim()
-  return cfgToken
+  const auth = parsed?.gateway?.auth
+  const mode = auth?.mode === 'password' ? 'password' : 'token'
+  const credential =
+    mode === 'password'
+      ? String(auth?.password ?? '').trim()
+      : String(auth?.token ?? '').trim()
+  return credential
 }
 
 export function getDetectedGatewayPort(): number | null {

--- a/src/lib/security-scan.ts
+++ b/src/lib/security-scan.ts
@@ -306,12 +306,15 @@ function scanOpenClaw(): Category {
   } catch { /* skip */ }
 
   const gwAuth = ocConfig?.gateway?.auth
+  const tokenOk = gwAuth?.mode === 'token' && (gwAuth?.token ?? '').trim().length > 0
+  const passwordOk = gwAuth?.mode === 'password' && (gwAuth?.password ?? '').trim().length > 0
+  const authOk = tokenOk || passwordOk
   checks.push({
     id: 'gateway_auth',
     name: 'Gateway authentication',
-    status: gwAuth?.mode === 'token' && gwAuth?.token ? 'pass' : 'fail',
-    detail: gwAuth?.mode === 'token' ? 'Token auth enabled' : `Auth mode: ${gwAuth?.mode || 'none'}`,
-    fix: gwAuth?.mode !== 'token' ? 'Set gateway.auth.mode to "token" with a strong random token' : '',
+    status: authOk ? 'pass' : 'fail',
+    detail: tokenOk ? 'Token auth enabled' : passwordOk ? 'Password auth enabled' : `Auth mode: ${gwAuth?.mode || 'none'} (credential required)`,
+    fix: !authOk ? 'Set gateway.auth.mode to "token" with gateway.auth.token, or "password" with gateway.auth.password' : '',
     severity: 'critical',
   })
 


### PR DESCRIPTION
# Summary

- Added support for specifying authentication mode ('token' or 'password') in the gateway configuration.
- Updated `getDetectedGatewayToken` function to return the appropriate credential based on the selected mode.
- Improved security scan checks for gateway authentication, ensuring both token and password modes are validated correctly.


# Risk Level
Low 
