### PR TITLE
feat: add dedicated Aegis agent support for quality reviews

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,13 @@ NEXT_PUBLIC_GOOGLE_CLIENT_ID=
 MC_COORDINATOR_AGENT=coordinator
 NEXT_PUBLIC_COORDINATOR_AGENT=coordinator
 
+# === Aegis Quality Review ===
+# Dedicated agent ID for Aegis quality reviews (optional)
+# When set, all quality reviews use this agent instead of the task's assigned agent
+# This eliminates self-review bias by using a dedicated reviewer agent
+# Example: MC_AEGIS_AGENT_ID=aegis
+# MC_AEGIS_AGENT_ID=
+
 # === 1Password Integration (optional) ===
 # Vault name for 1Password CLI pulls (used by Integrations panel)
 OP_VAULT_NAME=default

--- a/docs/aegis-dedicated-agent.md
+++ b/docs/aegis-dedicated-agent.md
@@ -1,0 +1,90 @@
+# Aegis Dedicated Quality Review Agent
+
+## Overview
+
+Aegis is Mission Control's automated quality review system. When an agent completes a task, Aegis reviews the output before the task can be marked as "done".
+
+## Self-Review Problem
+
+By default, Aegis uses the **same agent** that completed the task to perform the review. This creates a self-review bias where an agent evaluates its own work.
+
+## Solution: Dedicated Aegis Agent
+
+Set `MC_AEGIS_AGENT_ID` to use a dedicated agent for all quality reviews:
+
+```bash
+# .env
+MC_AEGIS_AGENT_ID=aegis
+```
+
+### Step 1: Create Aegis Agent in openclaw.json
+
+```json
+{
+  "agents": {
+    "list": [
+      {
+        "id": "aegis",
+        "name": "Aegis Quality Reviewer",
+        "default": false,
+        "model": {
+          "primary": "claude-sonnet-4-20250514",
+          "fallbacks": ["claude-3-5-sonnet-20241022"]
+        },
+        "identity": {
+          "name": "Aegis",
+          "theme": "quality-assurance",
+          "emoji": "🧪"
+        },
+        "tools": {
+          "allow": ["read", "web_search", "github"]
+        },
+        "sandbox": {
+          "mode": "restrict"
+        }
+      }
+    ]
+  }
+}
+```
+
+### Step 2: Configure Mission Control
+
+```bash
+# .env
+MC_AEGIS_AGENT_ID=aegis
+```
+
+## How It Works
+
+1. Agent completes task → status moves to `review`
+2. Aegis scheduler picks up task
+3. **If `MC_AEGIS_AGENT_ID` is set:** Uses dedicated Aegis agent
+4. **If not set:** Uses task's assigned agent (legacy behavior)
+5. Aegis evaluates resolution against task requirements
+6. `VERDICT: APPROVED` → status → `done`
+7. `VERDICT: REJECTED` → status → `in_progress` with feedback
+
+## Benefits
+
+- **Eliminates self-review bias:** Different agent reviews the work
+- **Consistent quality standards:** Same reviewer for all tasks
+- **Configurable model:** Use stronger/smarter model for reviews
+- **Optional:** Works without configuration (backward compatible)
+
+## Environment Variable
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `MC_AEGIS_AGENT_ID` | No | Agent ID to use for Aegis quality reviews. Defaults to task's assigned agent. |
+
+## Example Configuration
+
+```bash
+# Use dedicated aegis agent with stronger model
+MC_AEGIS_AGENT_ID=aegis
+```
+
+## Backward Compatibility
+
+If `MC_AEGIS_AGENT_ID` is not set, the system behaves exactly as before (uses the task's assigned agent for review).

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -78,6 +78,10 @@ export const config = {
   clawdbotBin: process.env.CLAWDBOT_BIN || 'clawdbot',
   gatewayHost: process.env.OPENCLAW_GATEWAY_HOST || '127.0.0.1',
   gatewayPort: clampInt(Number(process.env.OPENCLAW_GATEWAY_PORT || '18789'), 1, 65535, 18789),
+  // Dedicated Aegis agent for quality reviews (optional)
+  // When set, all Aegis quality reviews use this agent instead of the task's assigned agent
+  // This eliminates self-review bias by using a dedicated reviewer agent
+  aegisAgentId: process.env.MC_AEGIS_AGENT_ID || null,
   logsDir:
     process.env.OPENCLAW_LOG_DIR ||
     (openclawStateDir ? path.join(openclawStateDir, 'logs') : ''),

--- a/src/lib/task-dispatch.ts
+++ b/src/lib/task-dispatch.ts
@@ -2,6 +2,7 @@ import { getDatabase, db_helpers } from './db'
 import { runOpenClaw } from './command'
 import { eventBus } from './event-bus'
 import { logger } from './logger'
+import { config } from './config'
 
 interface DispatchableTask {
   id: number
@@ -114,6 +115,12 @@ interface ReviewableTask {
 }
 
 function resolveGatewayAgentIdForReview(task: ReviewableTask): string {
+  // Priority 1: Use dedicated Aegis agent if configured (eliminates self-review bias)
+  if (config.aegisAgentId) {
+    return config.aegisAgentId
+  }
+
+  // Priority 2: Fallback to task's assigned agent (legacy behavior)
   if (task.agent_config) {
     try {
       const cfg = JSON.parse(task.agent_config)


### PR DESCRIPTION
## Summary

Adds support for a dedicated Aegis quality review agent to eliminate self-review bias.

## Problem

Currently, Aegis uses the **same agent** that completed a task to perform the quality review. This creates self-review bias where an agent evaluates its own work.

## Solution

Add `MC_AEGIS_AGENT_ID` environment variable to configure a dedicated agent for all quality reviews.

## Changes

- **config.ts**: Add `aegisAgentId` config option (reads from `MC_AEGIS_AGENT_ID` env var)
- **task-dispatch.ts**: Update `resolveGatewayAgentIdForReview()` to prioritize dedicated Aegis agent
- **.env.example**: Document new configuration option
- **docs/aegis-dedicated-agent.md**: Full documentation for the feature

## Usage

1. Create an Aegis agent in `openclaw.json`:

```json
{
  "agents": {
    "list": [
      {
        "id": "aegis",
        "name": "Aegis Quality Reviewer",
        "model": { "primary": "claude-sonnet-4-20250514" },
        "identity": { "name": "Aegis", "theme": "quality-assurance", "emoji": "🧪" }
      }
    ]
  }
}
```

2. Set environment variable:

```bash
MC_AEGIS_AGENT_ID=aegis
```

## Benefits

- **Eliminates self-review bias**: Different agent reviews the work
- **Consistent quality standards**: Same reviewer for all tasks  
- **Configurable model**: Use stronger/smarter model for reviews
- **Backward compatible**: Works without configuration (falls back to legacy behavior)

## Testing

- [ ] Unit tests pass
- [ ] Manual testing with dedicated Aegis agent
- [ ] Manual testing without config (backward compat)

## Backward Compatibility

✅ If `MC_AEGIS_AGENT_ID` is not set, the system behaves exactly as before (uses task's assigned agent for review).