### PR TITLE
fix: prefer explicit public gateway websocket url

### DIFF
--- a/src/app/api/gateways/connect/route.ts
+++ b/src/app/api/gateways/connect/route.ts
@@ -174,9 +174,14 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Gateway not found' }, { status: 404 })
   }
 
+  // Prefer an explicitly configured browser WebSocket URL when provided.
+  // This is required for reverse-proxy setups where the browser-facing gateway
+  // lives on a different host/path than the server-side localhost gateway.
+  const explicitBrowserWsUrl = String(process.env.NEXT_PUBLIC_GATEWAY_URL || '').trim()
+
   // When gateway host is localhost but the browser is remote (e.g. Tailscale),
   // resolve the correct browser-accessible WebSocket URL.
-  const remoteUrl = resolveRemoteGatewayUrl(gateway, request)
+  const remoteUrl = explicitBrowserWsUrl || resolveRemoteGatewayUrl(gateway, request)
   const ws_url = remoteUrl || buildGatewayWebSocketUrl({
     host: gateway.host,
     port: gateway.port,


### PR DESCRIPTION
## Summary
- prefer `NEXT_PUBLIC_GATEWAY_URL` when resolving the browser-facing gateway websocket URL
- keep the existing auto-resolution fallback when no explicit public websocket URL is configured

## Problem
Mission Control can be deployed with a split gateway setup:

- **server-side** gateway access stays on localhost (for example `127.0.0.1:18789`)
- **browser-side** gateway access goes through a reverse-proxied public websocket URL (for example `wss://claw.example.com/gateway-ws`)

In that setup, `/api/gateways/connect` currently rewrites the browser websocket target based on the localhost primary gateway entry. That can break remote browser connectivity even when `NEXT_PUBLIC_GATEWAY_URL` is explicitly configured.

## Fix
If `NEXT_PUBLIC_GATEWAY_URL` is set, use that first for the browser websocket URL.

If it is not set, keep the current behavior and fall back to:
- `resolveRemoteGatewayUrl(...)`
- then `buildGatewayWebSocketUrl(...)`

## Why this helps
This makes reverse-proxy/public-gateway setups work without breaking the existing localhost/Tailscale-style auto-resolution path.

## Tested
Tested with:

- Mission Control served remotely over HTTPS
- OpenClaw Gateway available to Mission Control server-side on localhost
- browser websocket exposed separately via reverse proxy path (`/gateway-ws`)

After this change, remote Mission Control was able to connect successfully when `NEXT_PUBLIC_GATEWAY_URL` was respected.