### PR TITLE
fix(onboarding): use POST for gateway health check in wizard

### DIFF
--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -523,7 +523,7 @@ function StepGatewayLink({ isGateway, registration, onNext, onBack }: {
   const testConnection = async () => {
     setTesting(true)
     try {
-      const res = await fetch('/api/gateways/health')
+      const res = await fetch('/api/gateways/health', { method: 'POST' })
       setHealthOk(res.ok)
     } catch {
       setHealthOk(false)


### PR DESCRIPTION
## Summary
- The "Test Connection" button in the onboarding wizard (`StepGatewayLink`) calls `/api/gateways/health` with GET, but the route only exports `POST` — resulting in HTTP 405 and "Gateway unreachable" shown to the user even when the gateway is online.
- One-line fix: add `{ method: 'POST' }` to the fetch call.

Related: #332 #333

## Test plan
- [ ] Open onboarding wizard on a fresh or existing MC install with a gateway configured
- [ ] Click "Test Connection" on the Gateway Link step
- [ ] Should show "Gateway reachable" instead of "Gateway unreachable"