### PR TITLE
docs(changelog): add [Unreleased] section tracking pending fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to Mission Control are documented in this file.
 
+<!-- Maintainer note: add entries under [Unreleased] as PRs merge; bump to a version when releasing. -->
+
+## [Unreleased]
+
+### Fixed
+- SQLite `SQLITE_BUSY` contention — added `busy_timeout` pragma and guarded build-phase eager DB initialisation (#337)
+- Skill registry path traversal and SSRF — extended `SECURITY_RULES` with directory traversal patterns and private-IP/metadata URL detection (#338, #336)
+
+### Tests
+- Vitest coverage threshold enforcement — added coverage for pure utility modules to satisfy the 60% global threshold; threshold now passes in CI (#339)
+
+---
+
 ## [2.0.1] - 2026-03-13
 
 ### Fixed


### PR DESCRIPTION
## Summary

Adds an `[Unreleased]` section to the CHANGELOG to track changes merged or in-flight that haven't been versioned yet.

## Changes documented

- SQLite `SQLITE_BUSY` fix (busy_timeout + build-phase guard) — #337
- Skill registry path traversal + SSRF security rules — #338, #336
- Vitest 60% coverage threshold fix — #339

## Why

The CHANGELOG had no mechanism to track unreleased work. Contributors and users checking the changelog would see nothing between the last release (v2.0.1) and the current state of `main`. This adds the standard `[Unreleased]` heading pattern (keep-a-changelog convention) so future maintainers can incrementally document changes before cutting a release.

## Checklist
- [x] No code changes — docs only
- [x] Follows keep-a-changelog conventions
- [x] PR descriptions included for referenced fixes