### PR TITLE
docs: add screenshot drift prevention guide and CI workflow

### DIFF
--- a/.github/workflows/screenshot-drift.yml
+++ b/.github/workflows/screenshot-drift.yml
@@ -1,0 +1,98 @@
+name: Screenshot Drift Check
+
+on:
+  pull_request:
+    paths:
+      - "src/app/**"
+      - "src/components/**"
+      - "public/**"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  flag-drift:
+    name: Flag potential screenshot drift
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for UI changes
+        id: ui_changed
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              per_page: 100,
+            });
+
+            const uiPaths = files
+              .map(f => f.filename)
+              .filter(f =>
+                f.startsWith('src/app/') ||
+                f.startsWith('src/components/') ||
+                f.startsWith('public/')
+              );
+
+            core.setOutput('count', uiPaths.length);
+            core.setOutput('paths', uiPaths.slice(0, 10).join('\n'));
+
+      - name: Add label if UI changed
+        if: steps.ui_changed.outputs.count > 0
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Ensure the label exists
+            try {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'screenshot-drift',
+                color: 'f9d71c',
+                description: 'UI changed — README screenshots may need updating',
+              });
+            } catch (_) { /* label already exists */ }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['screenshot-drift'],
+            });
+
+      - name: Post checklist comment
+        if: steps.ui_changed.outputs.count > 0
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const paths = `${{ steps.ui_changed.outputs.paths }}`;
+            const body = [
+              '## 📸 Screenshot Drift Check',
+              '',
+              'This PR modifies UI source files. Please verify whether the README screenshots need refreshing:',
+              '',
+              '- [ ] `docs/mission-control-overview.png` — main dashboard',
+              '- [ ] `docs/mission-control-agents.png` — agents panel',
+              '- [ ] `docs/mission-control-memory-graph.png` — memory graph',
+              '',
+              '<details><summary>Changed UI files</summary>',
+              '',
+              '```',
+              paths,
+              '```',
+              '',
+              '</details>',
+              '',
+              'See [`docs/SCREENSHOT-GUIDE.md`](docs/SCREENSHOT-GUIDE.md) for instructions on capturing and optimising screenshots.',
+              '',
+              '_This comment is posted automatically and can be dismissed if no visual changes occurred._',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });

--- a/docs/SCREENSHOT-GUIDE.md
+++ b/docs/SCREENSHOT-GUIDE.md
@@ -1,0 +1,88 @@
+# Screenshot Guide
+
+This document explains how to capture and update the README screenshots so they stay in sync with the UI.
+
+## Screenshots in the README
+
+| File | Section | Description |
+|------|---------|-------------|
+| `docs/mission-control-overview.png` | Dashboard Overview | Main dashboard view |
+| `docs/mission-control-agents.png` | Agents Panel | Active agents list |
+| `docs/mission-control-memory-graph.png` | Memory Graph | Agent memory graph |
+
+## When to Refresh
+
+Screenshots should be updated when:
+
+- A new page, panel, or major UI component is added
+- An existing page layout changes noticeably
+- The color scheme or branding updates
+- A GitHub Actions `screenshot-drift` label is applied to a PR (see [automation](#automation))
+
+## How to Take New Screenshots
+
+### Prerequisites
+
+- Mission Control running locally (`pnpm dev` or Docker)
+- Browser with at least 1440×900 viewport recommended
+
+### Steps
+
+1. **Start the app** (with some sample data for a realistic view):
+
+   ```bash
+   pnpm dev
+   # or
+   docker compose up
+   ```
+
+2. **Seed sample data** (optional but recommended for non-empty screenshots):
+
+   ```bash
+   pnpm seed   # if a seed script exists, otherwise populate via UI
+   ```
+
+3. **Navigate to each page** and take a screenshot:
+
+   | Screenshot | URL | Notes |
+   |-----------|-----|-------|
+   | `mission-control-overview.png` | `/` | Main dashboard, full page |
+   | `mission-control-agents.png` | `/agents` | Agents panel open |
+   | `mission-control-memory-graph.png` | `/memory` | Memory graph with nodes |
+
+4. **Crop and optimise** to reduce file size:
+
+   ```bash
+   # macOS
+   pngcrush -reduce -brute input.png output.png
+
+   # Linux
+   optipng -o5 input.png
+   # or
+   pngquant --quality=80-95 --output output.png input.png
+   ```
+
+5. **Replace the files** under `docs/` and commit:
+
+   ```bash
+   cp ~/Downloads/dashboard.png docs/mission-control-overview.png
+   git add docs/
+   git commit -m "docs: refresh README screenshots"
+   ```
+
+## Automation
+
+The repository has a GitHub Actions workflow (`.github/workflows/screenshot-drift.yml`) that:
+
+- Detects changes to files under `src/app/`, `src/components/`, and `public/`
+- Adds a `screenshot-drift` label to the PR as a reminder
+- Posts a checklist comment listing which screenshots may need updating
+
+This does **not** auto-capture screenshots — it just flags the PR so a human can decide whether the change is visually significant enough to warrant a refresh.
+
+## Tips
+
+- Use a consistent browser zoom level (100%) and window size
+- Hide bookmarks bar and dev tools before capturing
+- Light mode and dark mode screenshots can coexist — add a `*-dark.png` variant if useful
+- Prefer PNG for UI screenshots (lossless); JPEG for photos/illustrations


### PR DESCRIPTION
## Summary

README screenshots drift as the UI evolves. The last refresh was on 2026-03-11, since then significant UI changes landed (first-time setup wizard, health history timeline, onboarding enhancements).

## Changes

- **`docs/SCREENSHOT-GUIDE.md`** — step-by-step guide for capturing, optimising, and committing fresh screenshots, including a table of which file maps to which URL
- **`.github/workflows/screenshot-drift.yml`** — lightweight CI workflow that:
  - Triggers on PRs touching `src/app/`, `src/components/`, or `public/`
  - Applies a `screenshot-drift` label as a visual reminder
  - Posts a checklist comment listing all three screenshots so reviewers can tick off what they verified

## Why

Screenshots are a first impression for open-source contributors. Stale screenshots erode trust and make the project look unmaintained. This automation doesn't require running a browser in CI — it just nudges the right humans at the right time.

## Testing

Workflow triggers on UI-touching PRs only; harmless on docs/config PRs.