### PR TITLE
fix: show all agents in command select, disable those without active session (#321)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1829,6 +1829,8 @@
     "tabPipelines": "Pipelines",
     "tabFleet": "Fleet",
     "selectAgent": "Select agent...",
+    "noAgentsRegistered": "No agents registered",
+    "noSessionSuffix": "no session",
     "commandPlaceholder": "Send command or message to agent...",
     "send": "Send",
     "noTemplates": "No workflow templates yet",

--- a/src/components/panels/orchestration-bar.tsx
+++ b/src/components/panels/orchestration-bar.tsx
@@ -268,9 +268,12 @@ export function OrchestrationBar() {
               className="h-9 px-2 rounded-md bg-secondary border border-border text-sm text-foreground min-w-[140px]"
             >
               <option value="">{t('selectAgent')}</option>
-              {agents.filter(a => a.session_key).map(a => (
-                <option key={a.name} value={a.name}>
-                  {a.name} ({a.status})
+              {agents.length === 0 && (
+                <option value="" disabled>{t('noAgentsRegistered')}</option>
+              )}
+              {agents.map(a => (
+                <option key={a.name} value={a.name} disabled={!a.session_key} title={!a.session_key ? 'Agent has no active session' : undefined}>
+                  {a.name} ({a.status}){!a.session_key ? ` — ${t('noSessionSuffix')}` : ''}
                 </option>
               ))}
             </select>


### PR DESCRIPTION
## Summary

Fixes #321 — Agent select menu appears empty in the Agent panel.

## Root Cause

In `orchestration-bar.tsx`, the agent select dropdown was filtered to only show agents that have a `session_key` set:

```tsx
{agents.filter(a => a.session_key).map(a => (
  <option key={a.name} value={a.name}>...</option>
))}
```

If agents are registered in the database but none currently have an active session (e.g. agents are offline, or running in a standalone mode), the dropdown appears completely empty — giving the impression that no agents exist at all.

## Fix

- **Show all registered agents** in the dropdown instead of filtering them out
- Agents **without a session_key** are shown as **disabled** with a `— no session` suffix and a `title` tooltip explaining they can't currently receive messages
- When the agents array is truly empty, a `No agents registered` placeholder option is shown
- Added i18n keys `noAgentsRegistered` and `noSessionSuffix` to `messages/en.json`
- The send button remains correctly disabled when no selectable agent is chosen

## Before / After

| Before | After |
|--------|-------|
| Dropdown empty when agents exist but have no active session | All registered agents visible; inactive ones shown as disabled with explanation |

## Testing

Tested with agents registered but no active sessions — all agents now appear in the dropdown, with offline agents clearly indicated.