### PR TITLE
fix(tasks): use --expect-final for agent dispatch and Aegis review

### DIFF
--- a/src/lib/task-dispatch.ts
+++ b/src/lib/task-dispatch.ts
@@ -215,22 +215,18 @@ export async function runAegisReviews(): Promise<{ ok: boolean; message: string 
         idempotencyKey: `aegis-review-${task.id}-${Date.now()}`,
         deliver: false,
       }
-      const invokeResult = await runOpenClaw(
-        ['gateway', 'call', 'agent', '--timeout', '10000', '--params', JSON.stringify(invokeParams), '--json'],
-        { timeoutMs: 12_000 }
-      )
-      const acceptedPayload = parseGatewayJson(invokeResult.stdout)
-        ?? parseGatewayJson(String((invokeResult as any)?.stderr || ''))
-      const runId = acceptedPayload?.runId
-      if (!runId) throw new Error('Gateway did not return a runId for Aegis review')
-
-      const waitResult = await runOpenClaw(
-        ['gateway', 'call', 'agent.wait', '--timeout', '120000', '--params', JSON.stringify({ runId, timeoutMs: 115_000 }), '--json'],
+      // Use --expect-final to block until the agent completes and returns the full
+      // response payload (payloads[0].text). The two-step agent → agent.wait pattern
+      // only returns lifecycle metadata (runId/status/timestamps) and never includes
+      // the agent's actual text, so Aegis could never parse a verdict.
+      const finalResult = await runOpenClaw(
+        ['gateway', 'call', 'agent', '--expect-final', '--timeout', '120000', '--params', JSON.stringify(invokeParams), '--json'],
         { timeoutMs: 125_000 }
       )
-      const waitPayload = parseGatewayJson(waitResult.stdout)
+      const finalPayload = parseGatewayJson(finalResult.stdout)
+        ?? parseGatewayJson(String((finalResult as any)?.stderr || ''))
       const agentResponse = parseAgentResponse(
-        waitPayload?.result ? JSON.stringify(waitPayload.result) : waitResult.stdout
+        finalPayload?.result ? JSON.stringify(finalPayload.result) : finalResult.stdout
       )
       if (!agentResponse.text) {
         throw new Error('Aegis review returned empty response')
@@ -382,28 +378,21 @@ export async function dispatchAssignedTasks(): Promise<{ ok: boolean; message: s
         idempotencyKey: `task-dispatch-${task.id}-${Date.now()}`,
         deliver: false,
       }
-      const invokeResult = await runOpenClaw(
-        ['gateway', 'call', 'agent', '--timeout', '10000', '--params', JSON.stringify(invokeParams), '--json'],
-        { timeoutMs: 12_000 }
-      )
-      const acceptedPayload = parseGatewayJson(invokeResult.stdout)
-        ?? parseGatewayJson(String((invokeResult as any)?.stderr || ''))
-      const runId = acceptedPayload?.runId
-      if (!runId) throw new Error('Gateway did not return a runId for task dispatch')
-
-      // Step 2: Wait for completion
-      const waitResult = await runOpenClaw(
-        ['gateway', 'call', 'agent.wait', '--timeout', '120000', '--params', JSON.stringify({ runId, timeoutMs: 115_000 }), '--json'],
+      // Use --expect-final to block until the agent completes and returns the full
+      // response payload (result.payloads[0].text). The two-step agent → agent.wait
+      // pattern only returns lifecycle metadata and never includes the agent's text.
+      const finalResult = await runOpenClaw(
+        ['gateway', 'call', 'agent', '--expect-final', '--timeout', '120000', '--params', JSON.stringify(invokeParams), '--json'],
         { timeoutMs: 125_000 }
       )
-      const waitPayload = parseGatewayJson(waitResult.stdout)
+      const finalPayload = parseGatewayJson(finalResult.stdout)
+        ?? parseGatewayJson(String((finalResult as any)?.stderr || ''))
 
       const agentResponse = parseAgentResponse(
-        waitPayload?.result ? JSON.stringify(waitPayload.result) : waitResult.stdout
+        finalPayload?.result ? JSON.stringify(finalPayload.result) : finalResult.stdout
       )
-      // Capture sessionId from the wait payload if not in the parsed response
-      if (!agentResponse.sessionId && waitPayload?.sessionId) {
-        agentResponse.sessionId = waitPayload.sessionId
+      if (!agentResponse.sessionId && finalPayload?.result?.meta?.agentMeta?.sessionId) {
+        agentResponse.sessionId = finalPayload.result.meta.agentMeta.sessionId
       }
 
       if (!agentResponse.text) {


### PR DESCRIPTION
## Problem

The `dispatchAssignedTasks` and `runAegisReviews` functions use a two-step pattern:
1. `openclaw gateway call agent` → receives `{ runId, status: "accepted" }`
2. `openclaw gateway call agent.wait` → receives `{ runId, status, startedAt, endedAt }`

The `agent.wait` RPC is designed for **lifecycle tracking only**. Looking at the gateway source, `readTerminalSnapshotFromDedupeEntry` explicitly returns only `{ status, startedAt, endedAt, error }` — the agent's response text (`result.payloads[0].text`) is intentionally stripped.

The agent's actual text is only returned via the `--expect-final` flag on the initial `agent` call, which keeps the connection open and receives a second response frame once the run completes: `{ runId, status: "ok", summary: "completed", result: { payloads: [...] } }`.

**Effect without this fix:**
- `resolution` is stored as raw wait metadata JSON (`{"runId":"...","status":"ok",...}`) instead of the agent's response
- Aegis receives this JSON as the text to parse, finds no `VERDICT:` token, defaults to `rejected`
- Tasks permanently cycle between `quality_review` → `in_progress` → `review` → `quality_review` and never complete

## Fix

Replace the two-call pattern with a single `--expect-final` call in both `dispatchAssignedTasks` and `runAegisReviews`. Also improve sessionId extraction to use the `agentMeta` path from the final payload structure.

## Testing

Verified against a live OpenClaw gateway (19 agents). With this fix:
- Task dispatch correctly captures agent response text in `resolution`
- Aegis correctly parses `VERDICT: APPROVED` / `VERDICT: REJECTED` from the resolution
- Tasks flow through the complete pipeline to `done`