### PR TITLE
fix: cron panel crash on missing schedule + doctor parser false positive

### DIFF
--- a/src/components/panels/cron-management-panel.tsx
+++ b/src/components/panels/cron-management-panel.tsx
@@ -526,6 +526,7 @@ export function CronManagementPanel() {
   )
 
   const filteredJobs = cronJobs
+    .filter((job) => typeof job.schedule === 'string' && job.schedule.length > 0)
     .filter((job) => {
       const query = searchQuery.trim().toLowerCase()
       const matchesQuery =
@@ -563,7 +564,7 @@ export function CronManagementPanel() {
         case 'name':
           return dir * a.name.localeCompare(b.name)
         case 'schedule':
-          return dir * a.schedule.localeCompare(b.schedule)
+          return dir * (a.schedule || '').localeCompare(b.schedule || '')
         case 'lastRun':
           return dir * ((a.lastRun || 0) - (b.lastRun || 0))
         case 'nextRun':

--- a/src/lib/__tests__/openclaw-doctor.test.ts
+++ b/src/lib/__tests__/openclaw-doctor.test.ts
@@ -119,4 +119,31 @@ Run "openclaw doctor --fix" to apply changes.
     expect(result.category).toBe('general')
     expect(result.canFix).toBe(false)
   })
+
+  it('treats positive security lines as healthy, not warnings (#331)', () => {
+    const result = parseOpenClawDoctorOutput(`
+? Security
+- No channel security warnings detected.
+- Run: openclaw security audit --deep
+`, 0)
+
+    expect(result.healthy).toBe(true)
+    expect(result.level).toBe('healthy')
+    expect(result.issues).toEqual([])
+  })
+
+  it('still detects real security warnings alongside positive lines', () => {
+    const result = parseOpenClawDoctorOutput(`
+? Security
+- Channel "public" has no auth configured.
+- No channel security warnings detected.
+- Run: openclaw security audit --deep
+`, 0)
+
+    expect(result.healthy).toBe(false)
+    expect(result.level).toBe('warning')
+    expect(result.issues).toEqual([
+      'Channel "public" has no auth configured.',
+    ])
+  })
 })

--- a/src/lib/openclaw-doctor.ts
+++ b/src/lib/openclaw-doctor.ts
@@ -24,6 +24,13 @@ function isSessionAgingLine(line: string): boolean {
   return /^agent:[\w:-]+ \(\d+[mh] ago\)$/i.test(line)
 }
 
+function isPositiveOrInstructionalLine(line: string): boolean {
+  return /^no .* warnings? detected/i.test(line) ||
+    /^no issues/i.test(line) ||
+    /^run:\s/i.test(line) ||
+    /^all .* (healthy|ok|valid|passed)/i.test(line)
+}
+
 function isDecorativeLine(line: string): boolean {
   return /^[▄█▀░\s]+$/.test(line) || /openclaw doctor/i.test(line) || /🦞\s*openclaw\s*🦞/i.test(line)
 }
@@ -130,10 +137,12 @@ export function parseOpenClawDoctorOutput(
   const issues = lines
     .filter(line => /^[-*]\s+/.test(line))
     .map(line => line.replace(/^[-*]\s+/, '').trim())
-    .filter(line => !isSessionAgingLine(line) && !isStateDirectoryListLine(line))
+    .filter(line => !isSessionAgingLine(line) && !isStateDirectoryListLine(line) && !isPositiveOrInstructionalLine(line))
 
-  const mentionsWarnings = /\bwarning|warnings|problem|problems|invalid config|fix\b/i.test(raw)
-  const mentionsHealthy = /\bok\b|\bhealthy\b|\bno issues\b|\bvalid\b/i.test(raw)
+  // Strip positive/negated phrases before checking for warning keywords
+  const rawForWarningCheck = raw.replace(/\bno\s+\w+\s+(?:security\s+)?warnings?\s+detected\b/gi, '')
+  const mentionsWarnings = /\bwarning|warnings|problem|problems|invalid config|fix\b/i.test(rawForWarningCheck)
+  const mentionsHealthy = /\bok\b|\bhealthy\b|\bno issues\b|\bno\b.*\bwarnings?\s+detected\b|\bvalid\b/i.test(raw)
 
   let level: OpenClawDoctorLevel = 'healthy'
   if (exitCode !== 0 || /invalid config|failed|error/i.test(raw)) {


### PR DESCRIPTION
## Summary

Fixes two open bugs:

**#342 — Cron page crashes when a job is missing `schedule`**
- Filters out malformed cron jobs (missing/empty `schedule` field) before any `.toLowerCase()` or `.localeCompare()` calls
- Adds defensive guard in sort comparator

**#331 — Doctor parser treats positive security line as warning**
- Excludes positive/instructional lines like "No channel security warnings detected" and "Run: ..." from the issues list
- Strips negated warning phrases from raw text before keyword detection, so "No channel security warnings detected" doesn't trigger warning level
- Adds `mentionsHealthy` match for "no ... warnings detected" pattern

## Test plan

- [x] TypeScript typecheck passes
- [x] 661 unit tests pass (2 new tests for doctor parser)
- [x] New test: positive-only security output → healthy
- [x] New test: real warning + positive line → only real warning in issues

Closes #342, closes #331