### PR TITLE
[Bug] Keep MC origin registration from forcing device auth off

### DIFF
--- a/src/lib/gateway-runtime.ts
+++ b/src/lib/gateway-runtime.ts
@@ -44,19 +44,16 @@ export function registerMcAsDashboard(mcUrl: string): { registered: boolean; alr
     const origin = new URL(mcUrl).origin
     const origins: string[] = parsed.gateway.controlUi.allowedOrigins || []
     const alreadyInOrigins = origins.includes(origin)
-    const deviceAuthAlreadyDisabled = parsed.gateway.controlUi.dangerouslyDisableDeviceAuth === true
 
-    if (alreadyInOrigins && deviceAuthAlreadyDisabled) {
+    if (alreadyInOrigins) {
       return { registered: false, alreadySet: true }
     }
 
-    // Add MC origin to allowedOrigins and disable device auth
-    // (MC authenticates via gateway token — device pairing is unnecessary)
+    // Add MC origin to allowedOrigins only. Keep the device auth policy unchanged.
     if (!alreadyInOrigins) {
       origins.push(origin)
       parsed.gateway.controlUi.allowedOrigins = origins
     }
-    parsed.gateway.controlUi.dangerouslyDisableDeviceAuth = true
 
     fs.writeFileSync(configPath, JSON.stringify(parsed, null, 2) + '\n')
     logger.info({ origin }, 'Registered MC origin in gateway config')


### PR DESCRIPTION
## Summary
- stop egisterMcAsDashboard() from flipping gateway.controlUi.dangerouslyDisableDeviceAuth to 	rue
- keep auto-registration limited to llowedOrigins
- preserve the operator's existing Control UI device-auth policy

## Why
Mission Control currently mutates the OpenClaw gateway config during MC origin registration and forces dangerouslyDisableDeviceAuth=true. That silently weakens the security posture and also causes false-negative remediation attempts in the security scan.

Closes #357