### PR TITLE
[Bug] Treat allowlist exec security as hardened

### DIFF
--- a/src/lib/security-scan.ts
+++ b/src/lib/security-scan.ts
@@ -362,9 +362,9 @@ function scanOpenClaw(): Category {
   checks.push({
     id: 'exec_restricted',
     name: 'Exec tool restricted',
-    status: execSecurity === 'deny' ? 'pass' : execSecurity === 'sandbox' ? 'pass' : 'warn',
+    status: execSecurity === 'deny' || execSecurity === 'allowlist' ? 'pass' : 'warn',
     detail: `Exec security: ${execSecurity || 'default'}`,
-    fix: execSecurity !== 'deny' && execSecurity !== 'sandbox' ? 'Set tools.exec.security to "deny" or "sandbox"' : '',
+    fix: execSecurity !== 'deny' && execSecurity !== 'allowlist' ? 'Set tools.exec.security to "deny" or "allowlist"' : '',
     severity: 'high',
   })
 


### PR DESCRIPTION
## Summary
- treat `tools.exec.security = "allowlist"` as a passing restricted mode
- stop recommending the unsupported `sandbox` value
- align the scan guidance with the currently accepted OpenClaw config values

## Why
The OpenClaw security scan currently warns on `allowlist` and suggests `sandbox`, but `sandbox` is not accepted by the current OpenClaw config schema. That leaves operators with a false warning and a remediation hint that can break the gateway config.

Closes #356
