### PR TITLE
[Bug] Add missing Agent Squad Phase 3 translations

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1824,6 +1824,21 @@
     "loadingSkillContent": "جارٍ تحميل SKILL.md...",
     "noContent": "لا يوجد محتوى."
   },
+  "agentSquadPhase3": {
+    "title": "Agent Squad",
+    "activeHeartbeats": "{count} active heartbeats",
+    "live": "Live",
+    "manual": "Manual",
+    "syncing": "Syncing...",
+    "syncConfig": "Sync Config",
+    "syncLocal": "Sync Local",
+    "addAgent": "Add Agent",
+    "refresh": "Refresh",
+    "noAgents": "No agents registered",
+    "noAgentsHint": "Sync from config or create your first agent to get started.",
+    "wake": "Wake",
+    "spawn": "Spawn"
+  },
   "orchestration": {
     "tabCommand": "الأوامر",
     "tabWorkflows": "سير العمل",

--- a/messages/de.json
+++ b/messages/de.json
@@ -1824,6 +1824,21 @@
     "loadingSkillContent": "SKILL.md wird geladen...",
     "noContent": "Kein Inhalt."
   },
+  "agentSquadPhase3": {
+    "title": "Agent Squad",
+    "activeHeartbeats": "{count} active heartbeats",
+    "live": "Live",
+    "manual": "Manual",
+    "syncing": "Syncing...",
+    "syncConfig": "Sync Config",
+    "syncLocal": "Sync Local",
+    "addAgent": "Add Agent",
+    "refresh": "Refresh",
+    "noAgents": "No agents registered",
+    "noAgentsHint": "Sync from config or create your first agent to get started.",
+    "wake": "Wake",
+    "spawn": "Spawn"
+  },
   "orchestration": {
     "tabCommand": "Befehl",
     "tabWorkflows": "Workflows",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1824,6 +1824,21 @@
     "loadingSkillContent": "Loading SKILL.md...",
     "noContent": "No content."
   },
+  "agentSquadPhase3": {
+    "title": "Agent Squad",
+    "activeHeartbeats": "{count} active heartbeats",
+    "live": "Live",
+    "manual": "Manual",
+    "syncing": "Syncing...",
+    "syncConfig": "Sync Config",
+    "syncLocal": "Sync Local",
+    "addAgent": "Add Agent",
+    "refresh": "Refresh",
+    "noAgents": "No agents registered",
+    "noAgentsHint": "Sync from config or create your first agent to get started.",
+    "wake": "Wake",
+    "spawn": "Spawn"
+  },
   "orchestration": {
     "tabCommand": "Command",
     "tabWorkflows": "Workflows",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1824,6 +1824,21 @@
     "loadingSkillContent": "Cargando SKILL.md...",
     "noContent": "Sin contenido."
   },
+  "agentSquadPhase3": {
+    "title": "Agent Squad",
+    "activeHeartbeats": "{count} active heartbeats",
+    "live": "Live",
+    "manual": "Manual",
+    "syncing": "Syncing...",
+    "syncConfig": "Sync Config",
+    "syncLocal": "Sync Local",
+    "addAgent": "Add Agent",
+    "refresh": "Refresh",
+    "noAgents": "No agents registered",
+    "noAgentsHint": "Sync from config or create your first agent to get started.",
+    "wake": "Wake",
+    "spawn": "Spawn"
+  },
   "orchestration": {
     "tabCommand": "Comando",
     "tabWorkflows": "Flujos de trabajo",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1824,6 +1824,21 @@
     "loadingSkillContent": "Chargement du SKILL.md...",
     "noContent": "Aucun contenu."
   },
+  "agentSquadPhase3": {
+    "title": "Agent Squad",
+    "activeHeartbeats": "{count} active heartbeats",
+    "live": "Live",
+    "manual": "Manual",
+    "syncing": "Syncing...",
+    "syncConfig": "Sync Config",
+    "syncLocal": "Sync Local",
+    "addAgent": "Add Agent",
+    "refresh": "Refresh",
+    "noAgents": "No agents registered",
+    "noAgentsHint": "Sync from config or create your first agent to get started.",
+    "wake": "Wake",
+    "spawn": "Spawn"
+  },
   "orchestration": {
     "tabCommand": "Commande",
     "tabWorkflows": "Flux de travail",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1824,6 +1824,21 @@
     "loadingSkillContent": "SKILL.md を読み込み中...",
     "noContent": "コンテンツがありません。"
   },
+  "agentSquadPhase3": {
+    "title": "Agent Squad",
+    "activeHeartbeats": "{count} active heartbeats",
+    "live": "Live",
+    "manual": "Manual",
+    "syncing": "Syncing...",
+    "syncConfig": "Sync Config",
+    "syncLocal": "Sync Local",
+    "addAgent": "Add Agent",
+    "refresh": "Refresh",
+    "noAgents": "No agents registered",
+    "noAgentsHint": "Sync from config or create your first agent to get started.",
+    "wake": "Wake",
+    "spawn": "Spawn"
+  },
   "orchestration": {
     "tabCommand": "コマンド",
     "tabWorkflows": "ワークフロー",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1824,6 +1824,21 @@
     "loadingSkillContent": "SKILL.md 로드 중...",
     "noContent": "내용 없음."
   },
+  "agentSquadPhase3": {
+    "title": "Agent Squad",
+    "activeHeartbeats": "{count} active heartbeats",
+    "live": "Live",
+    "manual": "Manual",
+    "syncing": "Syncing...",
+    "syncConfig": "Sync Config",
+    "syncLocal": "Sync Local",
+    "addAgent": "Add Agent",
+    "refresh": "Refresh",
+    "noAgents": "No agents registered",
+    "noAgentsHint": "Sync from config or create your first agent to get started.",
+    "wake": "Wake",
+    "spawn": "Spawn"
+  },
   "orchestration": {
     "tabCommand": "명령",
     "tabWorkflows": "워크플로",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1824,6 +1824,21 @@
     "loadingSkillContent": "Carregando SKILL.md...",
     "noContent": "Sem conteúdo."
   },
+  "agentSquadPhase3": {
+    "title": "Agent Squad",
+    "activeHeartbeats": "{count} active heartbeats",
+    "live": "Live",
+    "manual": "Manual",
+    "syncing": "Syncing...",
+    "syncConfig": "Sync Config",
+    "syncLocal": "Sync Local",
+    "addAgent": "Add Agent",
+    "refresh": "Refresh",
+    "noAgents": "No agents registered",
+    "noAgentsHint": "Sync from config or create your first agent to get started.",
+    "wake": "Wake",
+    "spawn": "Spawn"
+  },
   "orchestration": {
     "tabCommand": "Comando",
     "tabWorkflows": "Fluxos de trabalho",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -1824,6 +1824,21 @@
     "loadingSkillContent": "Загрузка SKILL.md...",
     "noContent": "Нет содержимого."
   },
+  "agentSquadPhase3": {
+    "title": "Agent Squad",
+    "activeHeartbeats": "{count} active heartbeats",
+    "live": "Live",
+    "manual": "Manual",
+    "syncing": "Syncing...",
+    "syncConfig": "Sync Config",
+    "syncLocal": "Sync Local",
+    "addAgent": "Add Agent",
+    "refresh": "Refresh",
+    "noAgents": "No agents registered",
+    "noAgentsHint": "Sync from config or create your first agent to get started.",
+    "wake": "Wake",
+    "spawn": "Spawn"
+  },
   "orchestration": {
     "tabCommand": "Команда",
     "tabWorkflows": "Рабочие процессы",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -694,6 +694,21 @@
     "loadingSkillContent": "加载 SKILL.md...",
     "noContent": "无内容。"
   },
+  "agentSquadPhase3": {
+    "title": "Agent Squad",
+    "activeHeartbeats": "{count} active heartbeats",
+    "live": "Live",
+    "manual": "Manual",
+    "syncing": "Syncing...",
+    "syncConfig": "Sync Config",
+    "syncLocal": "Sync Local",
+    "addAgent": "Add Agent",
+    "refresh": "Refresh",
+    "noAgents": "No agents registered",
+    "noAgentsHint": "Sync from config or create your first agent to get started.",
+    "wake": "Wake",
+    "spawn": "Spawn"
+  },
   "orchestration": {
     "tabCommand": "命令",
     "tabWorkflows": "工作流",


### PR DESCRIPTION
## Summary
- add the missing `agentSquadPhase3` translation namespace
- restore human-readable labels in the Agent Squad Phase 3 panel
- prevent raw i18n keys from showing up in the title and action buttons

## Notes
This uses the same English strings across locale files as a fallback so the panel stops rendering raw keys immediately.

Closes #360
