### PR TITLE
fix: docker compose pids location + clear stale update banner

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,12 +30,12 @@ services:
       - NET_BIND_SERVICE
     security_opt:
       - no-new-privileges:true
-    pids_limit: 256
     deploy:
       resources:
         limits:
           memory: 512M
           cpus: '1.0'
+          pids: 256
     networks:
       - mc-net
     restart: unless-stopped

--- a/src/app/[[...panel]]/page.tsx
+++ b/src/app/[[...panel]]/page.tsx
@@ -254,6 +254,8 @@ export default function Home() {
             releaseNotes: data.releaseNotes,
             updateCommand: data.updateCommand,
           })
+        } else {
+          setOpenclawUpdate(null)
         }
       })
       .catch(() => {})

--- a/src/lib/__tests__/docker-compose-schema.test.ts
+++ b/src/lib/__tests__/docker-compose-schema.test.ts
@@ -12,13 +12,13 @@ const ROOT = resolve(__dirname, '../../..')
 describe('docker-compose.yml schema', () => {
   const content = readFileSync(resolve(ROOT, 'docker-compose.yml'), 'utf-8')
 
-  it('uses service-level pids_limit instead of deploy.resources.limits.pids', () => {
-    // pids_limit should be at service level (not nested inside deploy)
-    expect(content).toContain('pids_limit:')
+  it('uses deploy.resources.limits.pids (not service-level pids_limit)', () => {
+    // pids limit must be inside deploy.resources.limits for Compose v5+ compatibility.
+    // Service-level pids_limit causes "can't set distinct values" errors on some versions.
+    expect(content).not.toContain('pids_limit:')
 
-    // Should NOT have pids inside deploy.resources.limits
     const deployBlock = content.match(/deploy:[\s\S]*?(?=\n\s{4}\w|\nvolumes:|\nnetworks:)/)?.[0] ?? ''
-    expect(deployBlock).not.toContain('pids:')
+    expect(deployBlock).toContain('pids:')
   })
 
   it('still has memory and cpus in deploy.resources.limits', () => {


### PR DESCRIPTION
## Summary

- **#353** — Move `pids_limit` from service-level to `deploy.resources.limits.pids`. Compose v5+ normalizes both into the same internal field, causing "can't set distinct values" errors on some versions.
- **#351** — Add `else { setOpenclawUpdate(null) }` when `/api/openclaw/version` returns `updateAvailable: false`. Previously the banner persisted after a successful update because only the `true` path was handled.

## Test plan

- [x] `docker compose config` validates cleanly
- [x] All 694 unit tests pass
- [x] Typecheck clean
- [x] Docker compose schema test updated to match new pids location

Closes #353, closes #351