### PR TITLE
fix: stop forcing dangerouslyDisableDeviceAuth + fix exec security value

### DIFF
--- a/src/app/api/security-scan/fix/route.ts
+++ b/src/app/api/security-scan/fix/route.ts
@@ -272,10 +272,10 @@ export async function POST(request: NextRequest) {
       if (shouldFix('exec_restricted')) {
         if (!ocConfig.tools) ocConfig.tools = {}
         if (!ocConfig.tools.exec) ocConfig.tools.exec = {}
-        if (ocConfig.tools.exec.security !== 'sandbox' && ocConfig.tools.exec.security !== 'deny') {
-          ocConfig.tools.exec.security = 'sandbox'
+        if (ocConfig.tools.exec.security !== 'allowlist' && ocConfig.tools.exec.security !== 'deny') {
+          ocConfig.tools.exec.security = 'allowlist'
           configChanged = true
-          results.push({ id: 'exec_restricted', name: 'Exec tool restriction', fixed: true, detail: 'Set exec security to "sandbox"', fixSafety: FIX_SAFETY['exec_restricted'] })
+          results.push({ id: 'exec_restricted', name: 'Exec tool restriction', fixed: true, detail: 'Set exec security to "allowlist"', fixSafety: FIX_SAFETY['exec_restricted'] })
         }
       }
 

--- a/src/lib/gateway-runtime.ts
+++ b/src/lib/gateway-runtime.ts
@@ -44,19 +44,16 @@ export function registerMcAsDashboard(mcUrl: string): { registered: boolean; alr
     const origin = new URL(mcUrl).origin
     const origins: string[] = parsed.gateway.controlUi.allowedOrigins || []
     const alreadyInOrigins = origins.includes(origin)
-    const deviceAuthAlreadyDisabled = parsed.gateway.controlUi.dangerouslyDisableDeviceAuth === true
 
-    if (alreadyInOrigins && deviceAuthAlreadyDisabled) {
+    if (alreadyInOrigins) {
       return { registered: false, alreadySet: true }
     }
 
-    // Add MC origin to allowedOrigins and disable device auth
-    // (MC authenticates via gateway token — device pairing is unnecessary)
-    if (!alreadyInOrigins) {
-      origins.push(origin)
-      parsed.gateway.controlUi.allowedOrigins = origins
-    }
-    parsed.gateway.controlUi.dangerouslyDisableDeviceAuth = true
+    // Add MC origin to allowedOrigins only — do NOT touch dangerouslyDisableDeviceAuth.
+    // MC authenticates via gateway token, but forcing device auth off is a security
+    // downgrade that the operator should control, not Mission Control.
+    origins.push(origin)
+    parsed.gateway.controlUi.allowedOrigins = origins
 
     fs.writeFileSync(configPath, JSON.stringify(parsed, null, 2) + '\n')
     logger.info({ origin }, 'Registered MC origin in gateway config')

--- a/src/lib/security-scan.ts
+++ b/src/lib/security-scan.ts
@@ -362,9 +362,9 @@ function scanOpenClaw(): Category {
   checks.push({
     id: 'exec_restricted',
     name: 'Exec tool restricted',
-    status: execSecurity === 'deny' ? 'pass' : execSecurity === 'sandbox' ? 'pass' : 'warn',
+    status: execSecurity === 'deny' ? 'pass' : execSecurity === 'allowlist' ? 'pass' : 'warn',
     detail: `Exec security: ${execSecurity || 'default'}`,
-    fix: execSecurity !== 'deny' && execSecurity !== 'sandbox' ? 'Set tools.exec.security to "deny" or "sandbox"' : '',
+    fix: execSecurity !== 'deny' && execSecurity !== 'allowlist' ? 'Set tools.exec.security to "deny" or "allowlist"' : '',
     severity: 'high',
   })
 


### PR DESCRIPTION
## Summary

- **#357** — MC origin registration no longer forces `dangerouslyDisableDeviceAuth = true`. It now only adds the MC origin to `gateway.controlUi.allowedOrigins`, leaving device auth under operator control.
- **#356** — Security scan and auto-fix now use `allowlist` instead of `sandbox` for `tools.exec.security`. Current OpenClaw only accepts `deny`, `allowlist`, `full` — the old `sandbox` value was invalid and broke configs.

## Test plan

- [x] All 694 unit tests pass
- [x] Typecheck clean

Closes #357, closes #356