### PR TITLE
fix: enable vertical scrolling on tasks board columns

### DIFF
--- a/src/components/panels/task-board-panel.tsx
+++ b/src/components/panels/task-board-panel.tsx
@@ -773,13 +773,13 @@ export function TaskBoardPanel() {
       )}
 
       {/* Kanban Board */}
-      <div className="flex-1 flex gap-4 p-4 overflow-x-auto" role="region" aria-label={t('taskBoard')}>
+      <div className="flex-1 min-h-0 flex gap-4 p-4 overflow-x-auto" role="region" aria-label={t('taskBoard')}>
         {statusColumns.map(column => (
           <div
             key={column.key}
             role="region"
             aria-label={t('columnAriaLabel', { title: column.title, count: tasksByStatus[column.key]?.length || 0 })}
-            className="flex-1 min-w-80 bg-surface-0 border border-border/60 rounded-xl flex flex-col transition-colors duration-200 [&.drag-over]:border-primary/40 [&.drag-over]:bg-primary/[0.02]"
+            className="flex-1 min-w-80 min-h-0 bg-surface-0 border border-border/60 rounded-xl flex flex-col transition-colors duration-200 [&.drag-over]:border-primary/40 [&.drag-over]:bg-primary/[0.02]"
             onDragEnter={(e) => handleDragEnter(e, column.key)}
             onDragLeave={handleDragLeave}
             onDragOver={handleDragOver}


### PR DESCRIPTION
## Summary
- Add `min-h-0` to the kanban board flex container and its column children so that `overflow-y-auto` on column bodies actually triggers
- Without this, flexbox `min-height: auto` (the default) causes containers to grow unbounded instead of constraining height and enabling scroll

Fixes #376

## Test plan
- [ ] Open /tasks with enough tasks to overflow the viewport vertically
- [ ] Verify each column scrolls independently when content overflows
- [ ] Verify horizontal scrolling of columns still works on narrow viewports