### PR TITLE
fix(csp): allow inline styles to unblock Office panel and React rendering

### DIFF
--- a/src/lib/csp.ts
+++ b/src/lib/csp.ts
@@ -7,7 +7,7 @@ export function buildMissionControlCsp(input: { nonce: string; googleEnabled: bo
     `object-src 'none'`,
     `frame-ancestors 'none'`,
     `script-src 'self' 'nonce-${nonce}' 'strict-dynamic' blob:${googleEnabled ? ' https://accounts.google.com' : ''}`,
-    `style-src 'self' 'nonce-${nonce}'`,
+    `style-src 'self' 'unsafe-inline'`,
     `connect-src 'self' ws: wss: http://127.0.0.1:* http://localhost:* https://cdn.jsdelivr.net`,
     `img-src 'self' data: blob:${googleEnabled ? ' https://*.googleusercontent.com https://lh3.googleusercontent.com' : ''}`,
     `font-src 'self' data:`,


### PR DESCRIPTION
## Summary
- The `style-src` CSP directive currently uses `'self' 'nonce-...'`, which blocks all inline `style` attributes
- This breaks the **Office panel** completely — agents, rooms, desks, glow effects, and positioning all use inline styles and are silently blocked
- It also affects Radix UI, Recharts, reactflow, and other libraries that set inline styles at runtime
- The browser console floods with dozens of CSP violation errors on every page load

## Fix
Changed `style-src 'self' 'nonce-${nonce}'` to `style-src 'self' 'unsafe-inline'`.

Inline `style` **attributes** (e.g. `<div style="...">`) cannot carry a nonce — only `<style>` tags can. Since React and its ecosystem use runtime inline style attributes extensively, `'unsafe-inline'` is the standard approach. This does not affect script-src (which remains nonce-protected).

## Test plan
- [ ] Open `/office` — agents should appear at desks with colored glow effects and room layouts
- [ ] Open any page — browser console should be free of `style-src` CSP violations
- [ ] Verify script-src still uses nonce protection (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)