### PR TITLE
fix: fetch notifications immediately when recipient changes

### DIFF
--- a/src/components/panels/notifications-panel.tsx
+++ b/src/components/panels/notifications-panel.tsx
@@ -48,8 +48,9 @@ export function NotificationsPanel() {
   useEffect(() => {
     if (recipient) {
       window.localStorage.setItem('mc.notifications.recipient', recipient)
+      fetchNotifications()
     }
-  }, [recipient])
+  }, [recipient, fetchNotifications])
 
   useSmartPoll(fetchNotifications, 30000, { enabled: !!recipient, pauseWhenSseConnected: true })
 


### PR DESCRIPTION
## Summary
- The Notifications panel never fetches when the user types a recipient name
- `useSmartPoll` fires once on mount with empty recipient (returns early), then waits 30s — or never polls again if SSE is connected (`pauseWhenSseConnected: true`)
- Result: user types an agent name, nothing happens, panel stays empty

## Fix
Added `fetchNotifications()` call to the existing recipient `useEffect`, so notifications load immediately when the recipient value changes.

## Test plan
- [ ] Navigate to Notifications panel
- [ ] Type an agent name (e.g. "saski") in the recipient field
- [ ] Notifications should load immediately (not after 30s or never)
- [ ] Changing the recipient to a different name should fetch that agent's notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)