### PR TITLE
fix(csp): allow inline styles for Office panel and UI components

### DIFF
--- a/src/lib/csp.ts
+++ b/src/lib/csp.ts
@@ -7,7 +7,7 @@ export function buildMissionControlCsp(input: { nonce: string; googleEnabled: bo
     `object-src 'none'`,
     `frame-ancestors 'none'`,
     `script-src 'self' 'nonce-${nonce}' 'strict-dynamic' blob:${googleEnabled ? ' https://accounts.google.com' : ''}`,
-    `style-src 'self' 'nonce-${nonce}'`,
+    `style-src 'self' 'unsafe-inline'`,
     `connect-src 'self' ws: wss: http://127.0.0.1:* http://localhost:* https://cdn.jsdelivr.net`,
     `img-src 'self' data: blob:${googleEnabled ? ' https://*.googleusercontent.com https://lh3.googleusercontent.com' : ''}`,
     `font-src 'self' data:`,


### PR DESCRIPTION
## Summary
- Change `style-src` CSP directive from `'self' 'nonce-...'` to `'self' 'unsafe-inline'`

## Problem
The current `style-src` policy only allows nonce-based styles, which blocks all inline `style` attributes. This breaks:
- **Office panel** — agent positioning, desk layout, glow effects are all inline styles
- **Radix UI** primitives — dropdown menus, tooltips, popovers use inline positioning
- **Framer Motion** — animation transforms applied as inline styles
- **next/image** — applies inline width/height styles

The browser console fills with dozens of `Applying inline style violates CSP` errors, and the Office page renders without any visual layout.

## Fix
Replace `'nonce-${nonce}'` with `'unsafe-inline'` for `style-src`. Unlike scripts, inline styles pose minimal XSS risk, and nonce-tagging every style attribute is not practical with third-party UI libraries.

## Test plan
- [ ] Open `/office` — agents should render at correct desk positions with glow effects
- [ ] Open any page with dropdowns/tooltips — Radix popovers render correctly
- [ ] No `style-src` CSP violations in browser console