### PR TITLE
fix: add workspace skill root to skill-sync.ts (#410)

### DIFF
--- a/src/lib/skill-sync.ts
+++ b/src/lib/skill-sync.ts
@@ -1,7 +1,7 @@
 /**
  * Skill Sync — Bidirectional disk ↔ DB synchronization for agent skills.
  *
- * Scans 4 skill roots for directories containing SKILL.md, hashes content,
+ * Scans 5 skill roots for directories containing SKILL.md, hashes content,
  * and upserts into the `skills` DB table.  UI edits write through to disk
  * and update the content hash so the next sync cycle skips them.
  *
@@ -66,6 +66,7 @@ function getSkillRoots(): Array<{ source: string; path: string }> {
     { source: 'project-agents', path: process.env.MC_SKILLS_PROJECT_AGENTS_DIR || join(cwd, '.agents', 'skills') },
     { source: 'project-codex', path: process.env.MC_SKILLS_PROJECT_CODEX_DIR || join(cwd, '.codex', 'skills') },
     { source: 'openclaw', path: process.env.MC_SKILLS_OPENCLAW_DIR || join(openclawState, 'skills') },
+    { source: 'workspace', path: process.env.MC_SKILLS_WORKSPACE_DIR || join(process.env.OPENCLAW_WORKSPACE_DIR || process.env.MISSION_CONTROL_WORKSPACE_DIR || join(openclawState, 'workspace'), 'skills') },
   ]
 }
 
@@ -126,7 +127,7 @@ export async function syncSkillsFromDisk(): Promise<{ ok: boolean; message: stri
     }
 
     // Fetch current DB rows (only local sources, not registry-installed via slug)
-    const localSources = ['user-agents', 'user-codex', 'project-agents', 'project-codex', 'openclaw']
+    const localSources = ['user-agents', 'user-codex', 'project-agents', 'project-codex', 'openclaw', 'workspace']
     const dbRows = db.prepare(
       `SELECT * FROM skills WHERE source IN (${localSources.map(() => '?').join(',')})`
     ).all(...localSources) as SkillRow[]


### PR DESCRIPTION
## Summary

- **Adds \`workspace\` root to \`getSkillRoots()\`** (\`src/lib/skill-sync.ts\`): mirrors the root added to \`route.ts\` in #408; the scheduler now discovers and syncs skills from \`~/.openclaw/workspace/skills\` (or \`MC_SKILLS_WORKSPACE_DIR\` / \`OPENCLAW_WORKSPACE_DIR\` overrides)
- **Adds \`'workspace'\` to \`localSources\`** (\`syncSkillsFromDisk()\`): the DB query that checks for existing rows before upsert now includes the workspace source, preventing spurious re-inserts on every sync cycle
- **Updates doc comment** from "Scans 4 skill roots" to "Scans 5 skill roots"

Closes #410

## Test plan

- [x] Verified locally: placed skills with \`SKILL.md\` in \`~/.openclaw/workspace/skills/\`, triggered scheduler via \`POST /api/scheduler\` with \`task_id=skill_sync\` — skills appeared in DB and Skills Hub showed correct count (10 workspace skills)
- [x] Confirmed \`~/.openclaw/workspace/skills\` card updates from **0 → 10** after sync
- [ ] \`pnpm typecheck\` — no errors
- [ ] \`pnpm test\` — all pass
- [ ] \`pnpm lint\` — no new warnings