### PR TITLE
fix: use CSPRNG for password generation in install.ps1

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -68,7 +68,10 @@ function Test-Command { param([string]$Name) $null -ne (Get-Command $Name -Error
 function Get-RandomPassword {
     param([int]$Length = 24)
     $chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
-    -join (1..$Length | ForEach-Object { $chars[(Get-Random -Maximum $chars.Length)] })
+    $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+    $bytes = New-Object byte[] $Length
+    $rng.GetBytes($bytes)
+    -join ($bytes | ForEach-Object { $chars[$_ % $chars.Length] })
 }
 
 function Get-RandomHex {


### PR DESCRIPTION
## Summary

- Replaces `Get-Random` (backed by `System.Random`, clock-seeded) with `RandomNumberGenerator` in `Get-RandomPassword`
- Matches the CSPRNG already used by `Get-RandomHex` in the same file
- Prevents predictable password generation if an attacker knows the approximate installer run time

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (710/710)
- [ ] Verify `install.ps1` still generates valid passwords on Windows