### PR TITLE
feat: add awaiting_owner task status detection

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -593,6 +593,7 @@
     "columnAriaLabel": "عمود {title}، {count} مهمة",
     "colInbox": "البريد الوارد",
     "colAssigned": "مُخصّص",
+    "colAwaitingOwner": "بانتظار المالك",
     "colInProgress": "قيد التنفيذ",
     "colReview": "المراجعة",
     "colQualityReview": "مراجعة الجودة",

--- a/messages/de.json
+++ b/messages/de.json
@@ -593,6 +593,7 @@
     "columnAriaLabel": "Spalte {title}, {count} Aufgaben",
     "colInbox": "Posteingang",
     "colAssigned": "Zugewiesen",
+    "colAwaitingOwner": "Wartet auf Besitzer",
     "colInProgress": "In Bearbeitung",
     "colReview": "Überprüfung",
     "colQualityReview": "Qualitätsprüfung",

--- a/messages/en.json
+++ b/messages/en.json
@@ -742,6 +742,7 @@
     "columnAriaLabel": "{title} column, {count} tasks",
     "colInbox": "Inbox",
     "colAssigned": "Assigned",
+    "colAwaitingOwner": "Awaiting Owner",
     "colInProgress": "In Progress",
     "colReview": "Review",
     "colQualityReview": "Quality Review",

--- a/messages/es.json
+++ b/messages/es.json
@@ -593,6 +593,7 @@
     "columnAriaLabel": "Columna {title}, {count} tareas",
     "colInbox": "Bandeja de entrada",
     "colAssigned": "Asignado",
+    "colAwaitingOwner": "Esperando al propietario",
     "colInProgress": "En progreso",
     "colReview": "Revisión",
     "colQualityReview": "Revisión de calidad",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -593,6 +593,7 @@
     "columnAriaLabel": "Colonne {title}, {count} tâches",
     "colInbox": "Boîte de réception",
     "colAssigned": "Assigné",
+    "colAwaitingOwner": "En attente du propriétaire",
     "colInProgress": "En cours",
     "colReview": "Révision",
     "colQualityReview": "Révision qualité",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -593,6 +593,7 @@
     "columnAriaLabel": "{title}列、{count}件のタスク",
     "colInbox": "受信トレイ",
     "colAssigned": "割り当て済み",
+    "colAwaitingOwner": "オーナー待ち",
     "colInProgress": "進行中",
     "colReview": "レビュー",
     "colQualityReview": "品質レビュー",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -593,6 +593,7 @@
     "columnAriaLabel": "{title} 열, {count}개 작업",
     "colInbox": "받은 편지함",
     "colAssigned": "할당됨",
+    "colAwaitingOwner": "소유자 대기 중",
     "colInProgress": "진행 중",
     "colReview": "검토",
     "colQualityReview": "품질 검토",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -593,6 +593,7 @@
     "columnAriaLabel": "Coluna {title}, {count} tarefas",
     "colInbox": "Caixa de entrada",
     "colAssigned": "Atribuído",
+    "colAwaitingOwner": "Aguardando proprietário",
     "colInProgress": "Em andamento",
     "colReview": "Revisão",
     "colQualityReview": "Revisão de qualidade",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -593,6 +593,7 @@
     "columnAriaLabel": "Колонка {title}, {count} задач",
     "colInbox": "Входящие",
     "colAssigned": "Назначено",
+    "colAwaitingOwner": "Ожидает владельца",
     "colInProgress": "В работе",
     "colReview": "На проверке",
     "colQualityReview": "Контроль качества",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -831,6 +831,7 @@
     "columnAriaLabel": "{title} 列，{count} 个任务",
     "colInbox": "收件箱",
     "colAssigned": "已分配",
+    "colAwaitingOwner": "等待所有者",
     "colInProgress": "进行中",
     "colReview": "审查",
     "colQualityReview": "质量审查",

--- a/src/components/panels/task-board-panel.tsx
+++ b/src/components/panels/task-board-panel.tsx
@@ -22,7 +22,7 @@ interface Task {
   id: number
   title: string
   description?: string
-  status: 'inbox' | 'assigned' | 'in_progress' | 'review' | 'quality_review' | 'done'
+  status: 'inbox' | 'assigned' | 'in_progress' | 'review' | 'quality_review' | 'done' | 'awaiting_owner'
   priority: 'low' | 'medium' | 'high' | 'critical' | 'urgent'
   assigned_to?: string
   created_by: string
@@ -89,11 +89,26 @@ interface MentionOption {
 const STATUS_COLUMN_KEYS = [
   { key: 'inbox', titleKey: 'colInbox', color: 'bg-secondary text-foreground' },
   { key: 'assigned', titleKey: 'colAssigned', color: 'bg-blue-500/20 text-blue-400' },
+  { key: 'awaiting_owner', titleKey: 'colAwaitingOwner', color: 'bg-orange-500/20 text-orange-400' },
   { key: 'in_progress', titleKey: 'colInProgress', color: 'bg-yellow-500/20 text-yellow-400' },
   { key: 'review', titleKey: 'colReview', color: 'bg-purple-500/20 text-purple-400' },
   { key: 'quality_review', titleKey: 'colQualityReview', color: 'bg-indigo-500/20 text-indigo-400' },
   { key: 'done', titleKey: 'colDone', color: 'bg-green-500/20 text-green-400' },
 ]
+
+const AWAITING_OWNER_KEYWORDS = [
+  'waiting for', 'waiting on', 'needs human', 'manual action',
+  'account creation', 'browser login', 'approval needed',
+  'owner action', 'human required', 'blocked on owner',
+  'awaiting owner', 'awaiting human', 'needs owner',
+]
+
+function detectAwaitingOwner(task: Task): boolean {
+  if (task.status === 'awaiting_owner') return true
+  if (task.status !== 'assigned' && task.status !== 'in_progress') return false
+  const text = `${task.title} ${task.description || ''}`.toLowerCase()
+  return AWAITING_OWNER_KEYWORDS.some(kw => text.includes(kw))
+}
 
 /** Build a human-readable label for a session key like "agent:nefes:telegram-group-123" */
 function formatSessionLabel(s: { key: string; channel?: string; kind?: string; label?: string }): string {
@@ -484,9 +499,12 @@ export function TaskBoardPanel() {
   // Poll as SSE fallback — pauses when SSE is delivering events
   useSmartPoll(fetchData, 30000, { pauseWhenSseConnected: true })
 
-  // Group tasks by status
+  // Group tasks by status, overriding for awaiting_owner detection
   const tasksByStatus = statusColumns.reduce((acc, column) => {
-    acc[column.key] = tasks.filter(task => task.status === column.key)
+    acc[column.key] = tasks.filter(task => {
+      const effectiveStatus = detectAwaitingOwner(task) ? 'awaiting_owner' : task.status
+      return effectiveStatus === column.key
+    })
     return acc
   }, {} as Record<string, Task[]>)
 
@@ -964,6 +982,11 @@ export function TaskBoardPanel() {
                           {task.aegisApproved && (
                             <span className="text-[10px] px-1.5 py-0.5 rounded bg-emerald-500/15 text-emerald-400 border border-emerald-500/20">
                               Aegis
+                            </span>
+                          )}
+                          {detectAwaitingOwner(task) && (
+                            <span className="text-[10px] px-1.5 py-0.5 rounded bg-orange-500/20 text-orange-400 border border-orange-500/30 font-mono">
+                              {t('colAwaitingOwner')}
                             </span>
                           )}
                         </div>
@@ -1766,6 +1789,7 @@ function ClaudeCodeTasksSection() {
     s === 'completed' ? 'text-green-400' :
     s === 'in_progress' ? 'text-blue-400' :
     s === 'blocked' ? 'text-red-400' :
+    s === 'awaiting_owner' ? 'text-orange-400' :
     'text-muted-foreground'
 
   return (

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -100,7 +100,7 @@ export interface Task {
   id: number
   title: string
   description?: string
-  status: 'inbox' | 'assigned' | 'in_progress' | 'review' | 'quality_review' | 'done'
+  status: 'inbox' | 'assigned' | 'in_progress' | 'review' | 'quality_review' | 'done' | 'awaiting_owner'
   priority: 'low' | 'medium' | 'high' | 'critical' | 'urgent'
   project_id?: number
   project_ticket_no?: number


### PR DESCRIPTION
# Summary
- Add `awaiting_owner` status to the Task type and Zustand store
- Add new column to task board between "Assigned" and "In Progress" with orange styling
- Keyword-based detection: tasks with descriptions containing phrases like "waiting for", "needs human", "approval needed" are automatically placed in the Awaiting Owner column
- i18n keys added for all supported languages

Supersedes #397 (cherry-picked scope: awaiting_owner status only, not the other 9 features from that kitchen-sink PR).

# Risk Level
Low — additive column, keyword detection only applies to assigned/in_progress tasks.

# Tests
- `pnpm typecheck` — passes
- `pnpm test` — 710/710 passing

# Contribution Checklist
- [x] Lint/typecheck/build passing
- [x] No DB migration needed (status is client-side detection)

# Notes
The `awaiting_owner` status works in two ways: (1) tasks explicitly set to this status by the API, and (2) keyword detection on assigned/in_progress tasks that match common phrases indicating human action needed.