### PR TITLE
fix: mobile responsiveness for dashboard overview

### DIFF
--- a/src/components/dashboard/dashboard.tsx
+++ b/src/components/dashboard/dashboard.tsx
@@ -276,7 +276,7 @@ export function Dashboard() {
                 : 'Gateway-first health, session routing, queue pressure, and incident response signals.'}
             </p>
           </div>
-          <div className="grid grid-cols-2 gap-2 min-w-[280px]">
+          <div className="grid grid-cols-2 gap-2 w-full lg:w-auto lg:min-w-[280px]">
             <SignalPill label="Mode" value={isLocal ? 'Local' : 'Gateway'} tone="info" />
             <SignalPill label="Events" value={`${mergedRecentLogs.length} stream`} tone={recentErrorLogs > 0 ? 'warning' : 'success'} />
             <SignalPill label="Queue" value={String(backlogCount)} tone={backlogCount > 10 ? 'warning' : 'info'} />

--- a/src/components/dashboard/widget-grid.tsx
+++ b/src/components/dashboard/widget-grid.tsx
@@ -32,10 +32,10 @@ const WIDGET_COMPONENTS: Record<string, React.ComponentType<{ data: DashboardDat
 
 // Map widget defaultSize to CSS grid column spans
 const SIZE_CLASSES: Record<string, string> = {
-  sm: 'xl:col-span-6',
-  md: 'xl:col-span-4',
-  lg: 'xl:col-span-8',
-  full: 'xl:col-span-12',
+  sm: 'md:col-span-6 xl:col-span-6',
+  md: 'md:col-span-6 xl:col-span-4',
+  lg: 'md:col-span-12 xl:col-span-8',
+  full: 'col-span-full',
 }
 
 export function WidgetGrid({ data }: { data: DashboardData }) {
@@ -153,7 +153,7 @@ export function WidgetGrid({ data }: { data: DashboardData }) {
     const flushRow = () => {
       if (rowWidgets.length === 0) return
       elements.push(
-        <section key={`row-${elements.length}`} className="grid xl:grid-cols-12 gap-4">
+        <section key={`row-${elements.length}`} className="grid md:grid-cols-12 gap-4">
           {rowWidgets.map(({ id, size }) => renderWidget(id, SIZE_CLASSES[size] || 'xl:col-span-4'))}
         </section>
       )

--- a/src/components/dashboard/widget-primitives.tsx
+++ b/src/components/dashboard/widget-primitives.tsx
@@ -110,7 +110,7 @@ export function MetricCard({ label, value, total, subtitle, icon, color }: {
         <div className="w-5 h-5 opacity-60">{icon}</div>
       </div>
       <div className="flex items-baseline gap-1">
-        <span className="text-2xl font-bold font-mono-tight">{value}</span>
+        <span className="text-xl sm:text-2xl font-bold font-mono-tight">{value}</span>
         {total != null && <span className="text-xs opacity-50 font-mono-tight">/ {total}</span>}
       </div>
       {subtitle && <div className="text-2xs opacity-50 font-mono-tight mt-0.5">{subtitle}</div>}

--- a/src/components/dashboard/widgets/gateway-health-widget.tsx
+++ b/src/components/dashboard/widgets/gateway-health-widget.tsx
@@ -8,7 +8,7 @@ export function GatewayHealthWidget({ data }: { data: DashboardData }) {
   return (
     <div className="panel">
       <div className="panel-header"><h3 className="text-sm font-semibold">Gateway Health + Golden Signals</h3></div>
-      <div className="panel-body space-y-3">
+      <div className="panel-body space-y-3 overflow-y-auto max-h-[60vh] md:max-h-none">
         <HealthRow label="Gateway" value={connection.isConnected ? 'Connected' : 'Disconnected'} status={gatewayHealthStatus} />
         <HealthRow label="Traffic (sessions)" value={`${sessions.length}`} status={sessions.length > 0 ? 'good' : 'warn'} />
         <HealthRow label="Errors (24h)" value={`${errorCount}`} status={errorCount > 0 ? 'warn' : 'good'} />

--- a/src/components/dashboard/widgets/metric-cards-widget.tsx
+++ b/src/components/dashboard/widgets/metric-cards-widget.tsx
@@ -45,7 +45,7 @@ export function MetricCardsWidget({ data }: { data: DashboardData }) {
 
   if (isLocal) {
     return (
-      <section className="grid grid-cols-2 xl:grid-cols-6 gap-3">
+      <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-3">
         <MetricCard
           label="Claude"
           value={isClaudeLoading ? '...' : claudeActive}
@@ -96,7 +96,7 @@ export function MetricCardsWidget({ data }: { data: DashboardData }) {
   }
 
   return (
-    <section className="grid grid-cols-2 xl:grid-cols-5 gap-3">
+    <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-3">
       <MetricCard label="Gateway" value={connection.isConnected ? 'Online' : 'Offline'} subtitle="transport status" icon={<GatewayIcon />} color={connection.isConnected ? 'green' : 'red'} />
       <MetricCard label="Sessions" value={activeSessions} total={sessions.length} subtitle="active / total" icon={<SessionIcon />} color="blue" />
       <MetricCard label="Agent Capacity" value={onlineAgents} subtitle={`${dbStats?.agents.total ?? agents.length} total`} icon={<AgentIcon />} color="green" />

--- a/src/components/dashboard/widgets/runtime-health-widget.tsx
+++ b/src/components/dashboard/widgets/runtime-health-widget.tsx
@@ -8,7 +8,7 @@ export function RuntimeHealthWidget({ data }: { data: DashboardData }) {
   return (
     <div className="panel">
       <div className="panel-header"><h3 className="text-sm font-semibold">Local Runtime Health</h3></div>
-      <div className="panel-body space-y-3">
+      <div className="panel-body space-y-3 overflow-y-auto max-h-[60vh] md:max-h-none">
         <HealthRow label="Local OS" value={localOsStatus.value} status={localOsStatus.status} />
         <HealthRow label="Claude Runtime" value={claudeHealth.value} status={claudeHealth.status} />
         <HealthRow label="Codex Runtime" value={codexHealth.value} status={codexHealth.status} />

--- a/src/components/layout/header-bar.tsx
+++ b/src/components/layout/header-bar.tsx
@@ -470,7 +470,7 @@ function ModeBadge({
 
   if (isLocal) {
     return (
-      <div className="flex items-center gap-1.5 px-2 py-1 rounded-md text-2xs bg-void-cyan/10 border border-void-cyan/25">
+      <div className="flex items-center gap-1.5 px-3 py-2.5 min-h-[44px] rounded-md text-2xs bg-void-cyan/10 border border-void-cyan/25">
         <span className="w-1.5 h-1.5 rounded-full bg-void-cyan" />
         <span className="font-medium text-void-cyan">{th('local')}</span>
       </div>
@@ -512,7 +512,7 @@ function ModeBadge({
     >
       <button
         onClick={!isConnected ? onReconnect : undefined}
-        className={`flex items-center gap-1.5 px-2 py-1 rounded-md text-2xs border ${borderClass} ${
+        className={`flex items-center gap-1.5 px-3 py-2.5 min-h-[44px] rounded-md text-2xs border ${borderClass} ${
           !isConnected ? 'cursor-pointer hover:brightness-125' : 'cursor-default'
         } transition-all`}
       >


### PR DESCRIPTION
## Summary

Fixes several mobile layout issues on the Overview dashboard that cause broken grids, cut-off content, and cramped tap targets on small screens (<640px).

## Changes

**Metric cards grid** — stacked to single column on mobile, 2-col at `sm`, 3-col at `lg`, full grid at `xl`. Previously the last card sat alone on a row due to fixed `grid-cols-2`.

**Widget grid breakpoints** — switched from `xl:grid-cols-12` to `md:grid-cols-12` with corresponding `md:col-span-*` classes so the multi-column layout activates at tablet width, not just extra-large screens.

**Gateway Health / Runtime Health widgets** — added `overflow-y-auto max-h-[60vh] md:max-h-none` to panel bodies so content doesn't get silently clipped on small viewports.

**GW badge tap target** — increased from `px-2 py-1` to `px-3 py-2.5 min-h-[44px]` to meet the 44px minimum touch target size (both gateway and local mode badges).

**Signal pills grid** — removed `min-w-[280px]` which caused horizontal overflow on mobile; replaced with `w-full lg:w-auto lg:min-w-[280px]`.

**Metric card font** — `text-2xl` → `text-xl sm:text-2xl` for consistent rendering across viewport sizes.

## Testing

- `npm run build` passes with zero errors
- All changes use Tailwind responsive classes only — no custom CSS added