### PR TITLE
fix: session cookie SameSite + skip static assets in proxy

### DIFF
--- a/src/lib/session-cookie.ts
+++ b/src/lib/session-cookie.ts
@@ -40,7 +40,7 @@ export function getMcSessionCookieOptions(input: { maxAgeSeconds: number; isSecu
   return {
     httpOnly: true,
     secure,
-    sameSite: 'strict',
+    sameSite: 'lax',
     maxAge: input.maxAgeSeconds,
     path: '/',
   }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -131,6 +131,13 @@ function extractApiKeyFromRequest(request: NextRequest): string {
 }
 
 export function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl
+
+  // Skip static assets — let Next.js serve them directly
+  if (pathname.startsWith('/_next/static') || pathname.startsWith('/_next/image') || pathname === '/favicon.ico' || pathname.startsWith('/brand/')) {
+    return NextResponse.next()
+  }
+
   // Network access control.
   // In production: default-deny unless explicitly allowed.
   // In dev/test: allow all hosts unless overridden.
@@ -152,8 +159,6 @@ export function proxy(request: NextRequest) {
   if (!isAllowedHost) {
     return addSecurityHeaders(new NextResponse('Forbidden', { status: 403 }), request)
   }
-
-  const { pathname } = request.nextUrl
 
   // CSRF Origin validation for mutating requests
   const method = request.method.toUpperCase()


### PR DESCRIPTION
## Summary
- Change session cookie `SameSite` from `strict` to `lax` — mobile browsers behind reverse proxy tunnels (Cloudflare, ngrok, etc.) treat navigation as cross-site, blocking strict cookies after login redirect.
- Add early return in `proxy()` for static asset paths (`_next/static`, `_next/image`, `favicon.ico`, `brand/`) so they bypass auth checks and are served directly by Next.js.

## Test plan
- [ ] Login via reverse proxy tunnel on mobile browser
- [ ] Verify CSS/JS loads correctly on login page (no unstyled page)
- [ ] Verify static assets don't redirect to /login

🤖 Generated with [Claude Code](https://claude.com/claude-code)