### PR TITLE
fix(gateway): use /health instead of /api/health for health probes

### DIFF
--- a/src/app/api/channels/route.ts
+++ b/src/app/api/channels/route.ts
@@ -186,7 +186,7 @@ async function isGatewayReachable(): Promise<boolean> {
   try {
     const controller = new AbortController()
     const timeout = setTimeout(() => controller.abort(), 2000)
-    const res = await fetch(`${gatewayInternalUrl}/api/health`, {
+    const res = await fetch(`${gatewayInternalUrl}/health`, {
       headers: gatewayHeaders(),
       signal: controller.signal,
     })

--- a/src/app/api/gateways/health/route.ts
+++ b/src/app/api/gateways/health/route.ts
@@ -144,7 +144,7 @@ function buildGatewayProbeUrl(host: string, port: number): string | null {
       if (!parsed.port && Number.isFinite(port) && port > 0) {
         parsed.port = String(port)
       }
-      parsed.pathname = parsed.pathname.replace(/\/+$/, '') + '/api/health'
+      parsed.pathname = parsed.pathname.replace(/\/+$/, '') + '/health'
       return parsed.toString()
     } catch {
       return null
@@ -152,7 +152,7 @@ function buildGatewayProbeUrl(host: string, port: number): string | null {
   }
 
   if (!Number.isFinite(port) || port <= 0) return null
-  return `http://${rawHost}:${port}/api/health`
+  return `http://${rawHost}:${port}/health`
 }
 
 /**


### PR DESCRIPTION
## Summary

The gateway health probe in `buildGatewayProbeUrl()` hardcodes `/api/health` as the probe endpoint, but the OpenClaw gateway serves its health check on `/health`. This causes the server-side health probe to always return HTTP 404, marking gateways as offline/error in the dashboard even when they are healthy and responsive.

### Changes

- **`src/app/api/gateways/health/route.ts`**: Changed `buildGatewayProbeUrl()` to use `/health` instead of `/api/health` (both the URL-parsed and template-literal paths)
- **`src/app/api/channels/route.ts`**: Changed `isGatewayReachable()` to use `/health` instead of `/api/health`

### Reproduction

1. Install Mission Control with a standard OpenClaw gateway
2. Navigate to the dashboard
3. Gateway Health widget shows "Disconnected" / "error" with HTTP 404
4. `curl http://127.0.0.1:18789/api/health` → 404
5. `curl http://127.0.0.1:18789/health` → 200 `{"ok":true,"status":"live"}`

### After fix

Gateway Health widget correctly shows "Connected" / "online" with latency.