### PR TITLE
fix: websocket reverse-proxy fallback + release/docs hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ pnpm dev                    # http://localhost:3000/setup
 docker compose up           # auto-generates credentials, persists across restarts
 ```
 
+### Prebuilt Images
+
+The project publishes multi-arch images to GHCR on main and version tags.
+
+```bash
+docker pull ghcr.io/builderz-labs/mission-control:latest
+docker run --rm -p 3000:3000 ghcr.io/builderz-labs/mission-control:latest
+```
+
+Docker Hub publishing is optional and may depend on org package visibility/secrets. If `docker.io/builderz-labs/mission-control` is unavailable, use GHCR.
+
 For production hardening (read-only filesystem, capability dropping, HSTS, network isolation):
 
 ```bash
@@ -115,6 +126,7 @@ For the full walkthrough, see the **[Quickstart Guide](docs/quickstart.md)**.
 | [CLI Integration](docs/cli-integration.md) | Connect Claude Code, Codex, or any CLI tool directly |
 | [Deployment](docs/deployment.md) | Production deployment, reverse proxy, VPS setup |
 | [Security Hardening](docs/SECURITY-HARDENING.md) | Docker hardening, CSP, network isolation |
+| [Release Process](RELEASE.md) | SemVer policy, branch strategy, tag/release checklist |
 | [API Reference](openapi.json) | OpenAPI 3.1 spec — 101 REST endpoints with Scalar UI at `/api-docs` |
 
 ### Gateway Optional Mode

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,51 @@
+# Release Process
+
+This repository uses Semantic Versioning (SemVer): `MAJOR.MINOR.PATCH`.
+
+- MAJOR: breaking API/behavior changes
+- MINOR: backward-compatible features
+- PATCH: backward-compatible fixes
+
+## Branch Strategy
+
+- `main` is the integration branch and must stay green.
+- PRs merge into `main` after passing quality gates.
+- Official releases are cut from `main` and tagged `vX.Y.Z`.
+- Hotfixes also merge via PR into `main`, then receive a PATCH tag.
+
+We intentionally keep a trunk-based workflow (no long-lived `develop` branch) to reduce merge drift.
+
+## Required Gates Before Release
+
+1. CI quality gate passes (lint/typecheck/tests/build)
+2. Security-sensitive changes reviewed
+3. API contract parity checks pass
+4. Release notes/changelog summary prepared
+
+## Tagging and Publishing
+
+Create an annotated tag from `main`:
+
+```bash
+git checkout main
+git pull --ff-only origin main
+git tag -a vX.Y.Z -m "release: vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+On push to `v*.*.*`, GitHub Actions publishes container images and release artifacts.
+
+## Compatibility and Deprecation
+
+- Any route removal or contract-breaking change must be documented in PR notes and release notes.
+- Keep deprecation windows when practical (aliases/shims) before full removal.
+- Include migration guidance for env vars, config paths, and API consumers.
+
+## Release Checklist
+
+- [ ] Version decision (major/minor/patch) agreed
+- [ ] `main` green and up to date
+- [ ] Breaking changes called out (if any)
+- [ ] Upgrade notes written
+- [ ] Tag `vX.Y.Z` created and pushed
+- [ ] Container image availability verified (`ghcr.io/builderz-labs/mission-control`)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -285,6 +285,8 @@ Then point UI to:
 NEXT_PUBLIC_GATEWAY_URL=wss://your-domain.com/gateway-ws
 ```
 
+Mission Control now retries common reverse-proxy websocket paths (`/gateway-ws`, `/gw`) automatically when root-path handshake fails, but setting `NEXT_PUBLIC_GATEWAY_URL` is still recommended for deterministic production behavior.
+
 ## Next Steps
 
 Once deployed, set up your agents and orchestration:

--- a/src/lib/__tests__/gateway-url.test.ts
+++ b/src/lib/__tests__/gateway-url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildGatewayWebSocketUrl } from '@/lib/gateway-url'
+import { buildGatewayPathFallbackUrls, buildGatewayWebSocketUrl } from '@/lib/gateway-url'
 
 describe('buildGatewayWebSocketUrl', () => {
   it('builds ws URL with host and port for local dev', () => {
@@ -96,5 +96,25 @@ describe('buildGatewayWebSocketUrl', () => {
       port: 9090,
       browserProtocol: 'http:',
     })).toBe('ws://gateway.example.com:9090')
+  })
+})
+
+describe('buildGatewayPathFallbackUrls', () => {
+  it('suggests common proxy websocket paths for root URLs', () => {
+    expect(buildGatewayPathFallbackUrls('wss://gateway.example.com')).toEqual([
+      'wss://gateway.example.com/gateway-ws',
+      'wss://gateway.example.com/gw',
+    ])
+  })
+
+  it('keeps token query params when generating fallbacks', () => {
+    expect(buildGatewayPathFallbackUrls('wss://gateway.example.com?token=abc')).toEqual([
+      'wss://gateway.example.com/gateway-ws?token=abc',
+      'wss://gateway.example.com/gw?token=abc',
+    ])
+  })
+
+  it('returns no fallbacks when URL already has a non-root path', () => {
+    expect(buildGatewayPathFallbackUrls('wss://gateway.example.com/gateway-ws')).toEqual([])
   })
 })

--- a/src/lib/gateway-url.ts
+++ b/src/lib/gateway-url.ts
@@ -37,6 +37,36 @@ function formatWebSocketUrl(parsed: URL): string {
   return parsed.toString().replace(/\/$/, '').replace('/?', '?')
 }
 
+export function buildGatewayPathFallbackUrls(rawUrl: string): string[] {
+  const trimmed = String(rawUrl || '').trim()
+  if (!trimmed) return []
+
+  let parsed: URL
+  try {
+    parsed = new URL(trimmed)
+  } catch {
+    return []
+  }
+
+  const normalizedPath = (parsed.pathname || '/').replace(/\/+$/, '') || '/'
+  if (normalizedPath !== '/') return []
+
+  const fallbacks = ['/gateway-ws', '/gw']
+  const seen = new Set<string>([formatWebSocketUrl(parsed)])
+  const urls: string[] = []
+
+  for (const path of fallbacks) {
+    parsed.pathname = path
+    const candidate = formatWebSocketUrl(parsed)
+    if (!seen.has(candidate)) {
+      seen.add(candidate)
+      urls.push(candidate)
+    }
+  }
+
+  return urls
+}
+
 export function buildGatewayWebSocketUrl(input: {
   host: string
   port: number

--- a/src/lib/websocket.ts
+++ b/src/lib/websocket.ts
@@ -3,7 +3,7 @@
 import { useCallback, useEffect } from 'react'
 import { useMissionControl } from '@/store'
 import { normalizeModel } from '@/lib/utils'
-import { buildGatewayWebSocketUrl } from '@/lib/gateway-url'
+import { buildGatewayPathFallbackUrls, buildGatewayWebSocketUrl } from '@/lib/gateway-url'
 import {
   getOrCreateDeviceIdentity,
   signPayload,
@@ -71,6 +71,7 @@ const gatewaySupportsPingRef: { current: boolean } = { current: true }
 const lastSeqRef: { current: number | null } = { current: null }
 const tokenOnlyFallbackRef: { current: boolean } = { current: false }
 const tokenOnlyFallbackTriedRef: { current: boolean } = { current: false }
+const wsPathFallbackTriedRef: { current: Set<string> } = { current: new Set() }
 
 export function useWebSocket() {
   const maxReconnectAttempts = 10
@@ -688,6 +689,9 @@ export function useWebSocket() {
     authTokenRef.current = token || urlToken || ''
 
     const normalizedUrl = normalizeWebSocketUrl(url)
+    if (reconnectUrl.current !== normalizedUrl) {
+      wsPathFallbackTriedRef.current.clear()
+    }
     reconnectUrl.current = normalizedUrl
     handshakeCompleteRef.current = false
     manualDisconnectRef.current = false
@@ -733,6 +737,30 @@ export function useWebSocket() {
 
         // Skip auto-reconnect if this was a manual disconnect
         if (manualDisconnectRef.current) return
+
+        // If the initial handshake never completed and the URL is root-only,
+        // try common reverse-proxy websocket paths before exponential backoff.
+        if (!handshakeCompleteRef.current) {
+          const fallback = buildGatewayPathFallbackUrls(normalizedUrl).find(
+            (candidate) => !wsPathFallbackTriedRef.current.has(candidate),
+          )
+          if (fallback) {
+            wsPathFallbackTriedRef.current.add(fallback)
+            reconnectUrl.current = fallback
+            addLog({
+              id: `gateway-path-fallback-${Date.now()}`,
+              timestamp: Date.now(),
+              level: 'warn',
+              source: 'websocket',
+              message: `Handshake failed on root path. Retrying WebSocket via ${new URL(fallback).pathname}.`,
+            })
+            reconnectTimeoutRef.current = setTimeout(() => {
+              connectRef.current(fallback, authTokenRef.current)
+            }, 250)
+            return
+          }
+        }
+
         // Skip auto-reconnect for non-retryable handshake failures
         if (nonRetryableErrorRef.current) {
           setConnection({ reconnectAttempts: 0 })
@@ -803,6 +831,7 @@ export function useWebSocket() {
     // Signal manual disconnect before closing so onclose skips auto-reconnect
     manualDisconnectRef.current = true
     reconnectAttemptsRef.current = 0
+    wsPathFallbackTriedRef.current.clear()
 
     if (reconnectTimeoutRef.current) {
       clearTimeout(reconnectTimeoutRef.current)


### PR DESCRIPTION
## Summary
This PR addresses open triage items by shipping a concrete fix for gateway websocket failures behind reverse proxies and adding maintainer-ready release/image docs.

### 1) WebSocket reliability behind reverse proxy (#485)
- Adds `buildGatewayPathFallbackUrls()` in `src/lib/gateway-url.ts`
- When initial root-path WS handshake fails, client retries common proxy paths (`/gateway-ws`, `/gw`) before standard exponential backoff
- Preserves query params (including token auth) in fallback URLs
- Clears fallback state on manual disconnect/new URL
- Adds focused tests in `src/lib/__tests__/gateway-url.test.ts`

### 2) Release process standardization (#479)
- Adds `RELEASE.md` documenting SemVer policy, trunk-based branching model, required gates, tagging flow, and release checklist
- Links release process from README docs index

### 3) Public image guidance (#475)
- Adds README "Prebuilt Images" section for GHCR pull/run
- Documents GHCR as canonical fallback if Docker Hub visibility is unavailable
- Adds deployment note clarifying explicit `NEXT_PUBLIC_GATEWAY_URL` is still recommended

## Validation
- `pnpm test` ✅ (69 files, 878 tests)
- `pnpm test:e2e` ✅ (510 tests)

## Notes
- This PR intentionally focuses on maintainable, low-risk changes directly tied to open issues.
- For #467, there is still insufficient reproduction data to implement a reliable fix in code.

Fixes #485
Closes #479
Refs #475