### PR TITLE
fix: don't penalize security score for missing OpenClaw

### DIFF
--- a/src/lib/security-scan.ts
+++ b/src/lib/security-scan.ts
@@ -265,13 +265,16 @@ function scanOpenClaw(): Category {
   const configPath = config.openclawConfigPath
 
   if (!configPath || !existsSync(configPath)) {
+    const gatewayOptional = process.env.NEXT_PUBLIC_GATEWAY_OPTIONAL === 'true'
     checks.push({
       id: 'config_found',
       name: 'OpenClaw config found',
-      status: 'warn',
-      detail: 'openclaw.json not found — OpenClaw checks skipped',
-      fix: 'Set OPENCLAW_HOME or OPENCLAW_CONFIG_PATH in .env',
-      severity: 'medium',
+      status: gatewayOptional ? 'pass' : 'warn',
+      detail: gatewayOptional
+        ? 'OpenClaw not configured (standalone mode — gateway optional)'
+        : 'openclaw.json not found — OpenClaw checks skipped',
+      fix: gatewayOptional ? '' : 'Set OPENCLAW_HOME or OPENCLAW_CONFIG_PATH in .env',
+      severity: 'low',
     })
     return scoreCategory(checks)
   }


### PR DESCRIPTION
## Summary

- In standalone/Docker mode (`NEXT_PUBLIC_GATEWAY_OPTIONAL=true`), the OpenClaw security check now passes instead of warning — no more 0% dragging down the score
- In normal mode without OpenClaw, severity lowered from `medium` to `low` (weight 1 instead of 2) since a missing OpenClaw is a deployment choice, not a security vulnerability

## Test plan

- [x] `pnpm test` — 878 tests pass
- [ ] Run in Docker with `NEXT_PUBLIC_GATEWAY_OPTIONAL=true` — OpenClaw category should show 100%
- [ ] Run locally without OpenClaw — OpenClaw category shows warning but minimal score impact