### PR TITLE
fix: render markdown in task comments

### DIFF
--- a/src/components/panels/task-board-panel.tsx
+++ b/src/components/panels/task-board-panel.tsx
@@ -1385,7 +1385,7 @@ function TaskDetailModal({
           </div>
           <span>{new Date(comment.created_at * 1000).toLocaleString()}</span>
         </div>
-        <div className="text-sm text-foreground/90 mt-1 whitespace-pre-wrap">{text}</div>
+        <div className="text-sm text-foreground/90 mt-1 prose prose-invert prose-sm max-w-none"><MarkdownRenderer content={text} /></div>
         {comment.replies && comment.replies.length > 0 && (
           <div className="mt-3 space-y-3">
             {comment.replies.map(reply => renderComment(reply, depth + 1))}


### PR DESCRIPTION
## Problem

Task comments were rendered as plain text with `whitespace-pre-wrap` despite `MarkdownRenderer` already being imported in the file and used for task descriptions and other sections.

Agent resolutions often contain markdown — tables, code blocks, headers, bullet lists. Without markdown rendering these appeared as raw symbols and were hard to read.

## Solution

Hook `MarkdownRenderer` into the `renderComment` function, consistent with how task descriptions are already rendered elsewhere in the same component.

```diff
- <div className="text-sm text-foreground/90 mt-1 whitespace-pre-wrap">{text}</div>
+ <div className="text-sm text-foreground/90 mt-1 prose prose-invert prose-sm max-w-none"><MarkdownRenderer content={text} /></div>
```

## Notes

- `MarkdownRenderer` was already imported at line 14 and used for task descriptions (line 1050) and the task detail view (line 1447) — just not wired up for comments
- No new dependencies introduced
- One line change