### PR TITLE
fix: detect Claude Code auth via ~/.claude.json OAuth account

### DIFF
--- a/src/lib/agent-runtimes.ts
+++ b/src/lib/agent-runtimes.ts
@@ -176,17 +176,62 @@ function detectClaude(): RuntimeStatus {
   const meta = RUNTIME_META.claude
   const { installed, version } = detectBinary(['claude'])
 
-  // Check authentication: ~/.claude/ directory with credentials
+  // Detect Claude Code authentication. Claude supports two auth modes:
+  //
+  // 1. claude.ai subscription (OAuth): stores account info in ~/.claude.json
+  //    under the `oauthAccount` key. No credential file is written inside
+  //    ~/.claude/ — the managed key lives in memory/keychain.
+  //
+  // 2. Anthropic Console (API key): may store a `claudeAiOauth` token in
+  //    ~/.claude/.credentials.json (created by older versions) or simply
+  //    rely on the ANTHROPIC_API_KEY env var.
+  //
+  // Strategy: check ~/.claude.json first (most common), then
+  // ~/.claude/.credentials.json, then fall back to `claude auth status --json`.
   let authenticated = false
   if (installed) {
     try {
       const homedir = require('node:os').homedir()
       const path = require('node:path')
-      authenticated = existsSync(path.join(homedir, '.claude', 'credentials.json'))
-        || existsSync(path.join(homedir, '.claude', '.credentials'))
-        || existsSync(path.join(homedir, '.claude', 'settings.json'))
+      const fs = require('node:fs')
+
+      // Primary: ~/.claude.json (claude.ai subscription login)
+      const claudeJsonPath = path.join(homedir, '.claude.json')
+      if (existsSync(claudeJsonPath)) {
+        const parsed = JSON.parse(fs.readFileSync(claudeJsonPath, 'utf8'))
+        if (parsed.oauthAccount?.emailAddress) {
+          authenticated = true
+        }
+      }
+
+      // Secondary: ~/.claude/.credentials.json (API key / older OAuth flow)
+      if (!authenticated) {
+        const credPath = path.join(homedir, '.claude', '.credentials.json')
+        if (existsSync(credPath)) {
+          const parsed = JSON.parse(fs.readFileSync(credPath, 'utf8'))
+          authenticated = !!(parsed.claudeAiOauth?.accessToken || parsed.apiKey)
+        }
+      }
     } catch {
-      // ignore
+      // ignore parse errors
+    }
+
+    // Fallback: run `claude auth status --json` (covers env-var API key auth
+    // and any future auth mechanisms that don't write a file)
+    if (!authenticated) {
+      try {
+        const { spawnSync } = require('node:child_process')
+        const result = spawnSync('claude', ['auth', 'status', '--json'], {
+          stdio: 'pipe',
+          timeout: 5000,
+        })
+        if (result.status === 0) {
+          const json = JSON.parse(result.stdout?.toString() || '{}')
+          authenticated = json.loggedIn === true
+        }
+      } catch {
+        // ignore — binary may not support --json flag in older versions
+      }
     }
   }
 


### PR DESCRIPTION
## Problem

Mission Control always showed Claude Code as **unauthenticated** — displaying the warning _"Run 'claude login' after install to authenticate"_ — even when the user was fully logged in via `claude.ai` subscription.

### Root Cause

The previous detection logic in `detectClaude()` checked for credential files inside `~/.claude/`:

```ts
authenticated = existsSync(path.join(homedir, '.claude', 'credentials.json'))
  || existsSync(path.join(homedir, '.claude', '.credentials'))
  || existsSync(path.join(homedir, '.claude', 'settings.json'))
```

**None of these files are created by `claude.ai` subscription login.**

When a user runs `claude login` (the default OAuth flow), Claude Code:
- Stores account info in **`~/.claude.json`** under the `oauthAccount` key
- Keeps the actual access token in the OS keychain / memory (`/login managed key`)
- Does **not** write any file inside `~/.claude/`

This means every claude.ai subscriber would see a false-positive unauthenticated warning.

## Fix

Replaced the file-existence checks with a three-tier detection strategy:

### Tier 1 — `~/.claude.json` (Primary)
Covers all **claude.ai subscription** logins (most common). Reads the file and checks for `oauthAccount.emailAddress`.

```ts
const parsed = JSON.parse(fs.readFileSync('~/.claude.json', 'utf8'))
authenticated = !!(parsed.oauthAccount?.emailAddress)
```

### Tier 2 — `~/.claude/.credentials.json` (Secondary)
Covers **Anthropic Console / API key** users and older OAuth installs. Checks for `claudeAiOauth.accessToken` or `apiKey`.

### Tier 3 — `claude auth status --json` (Fallback)
Covers **`ANTHROPIC_API_KEY` env-var** auth and any future authentication mechanisms that don't write a file. Spawns the binary and parses the JSON output.

## Testing

Verified on a machine with `claude.ai` subscription login:
```
$ claude auth status --json
{
  "loggedIn": true,
  "authMethod": "claude.ai",
  "apiKeySource": "/login managed key",
  "email": "user@example.com"
}
```

Before fix: `authenticated: false` ❌  
After fix:  `authenticated: true` ✅

## Files Changed

- `src/lib/agent-runtimes.ts` — updated `detectClaude()` with multi-tier auth detection and inline documentation explaining each auth mode

## Auth Modes Reference

| Login method | Credential location | Previously detected? | Now detected? |
|---|---|---|---|
| `claude login` (claude.ai OAuth) | `~/.claude.json` → `oauthAccount` | ❌ No | ✅ Yes (Tier 1) |
| `claude login --console` (API key OAuth) | `~/.claude/.credentials.json` | ❌ No | ✅ Yes (Tier 2) |
| `ANTHROPIC_API_KEY` env var | n/a (env only) | ❌ No | ✅ Yes (Tier 3) |
