### PR TITLE
feat: trading ops, backtesting, and agent bridge panels

### DIFF
--- a/src/app/[[...panel]]/page.tsx
+++ b/src/app/[[...panel]]/page.tsx
@@ -3,6 +3,7 @@
 import { createElement, useEffect, useMemo, useState } from 'react'
 import { usePathname, useRouter } from 'next/navigation'
 import { OpsStrip } from '@/components/layout/ops-strip'
+import { NavRail } from '@/components/layout/nav-rail'
 import { BridgePage } from '@/components/pages/bridge-page'
 import { LabPage } from '@/components/pages/lab-page'
 import { OpenClawPage } from '@/components/pages/openclaw-page'
@@ -38,6 +39,14 @@ import { NodesPanel } from '@/components/panels/nodes-panel'
 import { ExecApprovalPanel } from '@/components/panels/exec-approval-panel'
 import { SystemMonitorPanel } from '@/components/panels/system-monitor-panel'
 import { ChatPagePanel } from '@/components/panels/chat-page-panel'
+import { AgentTable } from '@/components/panels/agent-table'
+import { AgentDetailPanel } from '@/components/panels/agent-detail-panel'
+import { HaltButton } from '@/components/ui/halt-button'
+import { DeployGate } from '@/components/modals/deploy-gate'
+import type { DeployAssessment } from '@/components/modals/deploy-gate'
+import { BacktestResultsPanel } from '@/components/panels/backtest-results-panel'
+import { ChatBridgePanel } from '@/components/panels/chat-bridge-panel'
+import { useAgentStatus } from '@/lib/hooks/use-agent-status'
 import { ChatPanel } from '@/components/chat/chat-panel'
 import { getPluginPanel } from '@/lib/plugins'
 import { shouldRedirectDashboardToHttps } from '@/lib/browser-security'
@@ -386,33 +395,39 @@ export default function Home() {
   }
 
   return (
-    <div className="flex flex-col h-screen bg-background overflow-hidden">
+    <div className="flex h-screen bg-background overflow-hidden">
       <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:top-2 focus:left-2 focus:px-4 focus:py-2 focus:bg-primary focus:text-primary-foreground focus:rounded-md focus:text-sm focus:font-medium">
         {tc('skipToMainContent')}
       </a>
 
-      {/* Top: Ops Strip (replaces HeaderBar + NavRail) */}
-      {!showOnboarding && (
-        <>
-          <OpsStrip />
-          <LocalModeBanner />
-          <UpdateBanner />
-          <OpenClawUpdateBanner />
-          <OpenClawDoctorBanner />
-        </>
-      )}
+      {/* Sidebar */}
+      {!showOnboarding && <NavRail />}
 
       {/* Main content area */}
-      <main
-        id="main-content"
-        className={`flex-1 overflow-hidden ${showOnboarding ? 'pointer-events-none select-none blur-[2px] opacity-30' : ''}`}
-        role="main"
-        aria-hidden={showOnboarding}
-      >
-        <ErrorBoundary key={activeTab}>
-          <ContentRouter tab={activeTab} />
-        </ErrorBoundary>
-      </main>
+      <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
+        {/* Top: Ops Strip */}
+        {!showOnboarding && (
+          <>
+            <OpsStrip />
+            <LocalModeBanner />
+            <UpdateBanner />
+            <OpenClawUpdateBanner />
+            <OpenClawDoctorBanner />
+          </>
+        )}
+
+        {/* Main content */}
+        <main
+          id="main-content"
+          className={`flex-1 overflow-hidden ${showOnboarding ? 'pointer-events-none select-none blur-[2px] opacity-30' : ''}`}
+          role="main"
+          aria-hidden={showOnboarding}
+        >
+          <ErrorBoundary key={activeTab}>
+            <ContentRouter tab={activeTab} />
+          </ErrorBoundary>
+        </main>
+      </div>
 
       {/* Chat panel overlay */}
       {!showOnboarding && <ChatPanel />}
@@ -439,10 +454,15 @@ const ESSENTIAL_PANELS = new Set([
 
 function ContentRouter({ tab }: { tab: string }) {
   const tp = useTranslations('page')
-  const { dashboardMode, interfaceMode, setInterfaceMode } = useMissionControl()
+  const { dashboardMode, interfaceMode, setInterfaceMode, agents, bootComplete } = useMissionControl()
   const navigateToPanel = useNavigateToPanel()
   const isLocal = dashboardMode === 'local'
   const panelName = tab.replace(/-/g, ' ')
+  const [selectedAgentForDetail, setSelectedAgentForDetail] = useState<import('@/store').Agent | null>(null)
+  const [deployGateOpen, setDeployGateOpen] = useState(false)
+  const [deployAssessment, setDeployAssessment] = useState<DeployAssessment | null>(null)
+  const [deployAssessing, setDeployAssessing] = useState(false)
+  useAgentStatus({ pollInterval: 15000, enabled: bootComplete })
 
   // Guard: show nudge for non-essential panels in essential mode
   if (interfaceMode === 'essential' && !ESSENTIAL_PANELS.has(tab)) {
@@ -488,9 +508,33 @@ function ContentRouter({ tab }: { tab: string }) {
         <>
           <OrchestrationBar />
           {isLocal && <LocalAgentsDocPanel />}
-          <AgentSquadPanelPhase3 />
+          <div className="p-4">
+            <div className="flex items-center justify-between mb-3">
+              <h2 className="text-sm font-medium text-[var(--text-primary)]">Fleet</h2>
+              <HaltButton onHalted={() => {}} />
+            </div>
+            <AgentTable
+              agents={agents}
+              onSelectAgent={(agent) => setSelectedAgentForDetail(agent)}
+            />
+          </div>
+          <AgentDetailPanel
+            agent={selectedAgentForDetail}
+            onClose={() => setSelectedAgentForDetail(null)}
+          />
+          <DeployGate
+            isOpen={deployGateOpen}
+            onClose={() => { setDeployGateOpen(false); setDeployAssessment(null) }}
+            onDeploy={() => { setDeployGateOpen(false); setDeployAssessment(null) }}
+            assessment={deployAssessment}
+            isLoading={deployAssessing}
+          />
         </>
       )
+    case 'backtests':
+      return <BacktestResultsPanel className="p-4" />
+    case 'bridge':
+      return <ChatBridgePanel className="p-4" />
     case 'notifications':
       return <NotificationsPanel />
     case 'standup':

--- a/src/app/api/agents/[id]/control/route.ts
+++ b/src/app/api/agents/[id]/control/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getDatabase, db_helpers, logAuditEvent } from '@/lib/db'
+import { requireRole } from '@/lib/auth'
+import { logger } from '@/lib/logger'
+import type { Agent } from '@/lib/db'
+
+type AgentAction = 'start' | 'stop' | 'restart'
+
+const VALID_ACTIONS: AgentAction[] = ['start', 'stop', 'restart']
+
+const ACTION_STATUS_MAP: Record<AgentAction, Agent['status']> = {
+  start: 'idle',
+  stop: 'offline',
+  restart: 'idle',
+}
+
+/**
+ * POST /api/agents/[id]/control - Start, stop, or restart an agent
+ *
+ * Body: { action: 'start' | 'stop' | 'restart' }
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  try {
+    const { id } = await params
+    const workspaceId = auth.user.workspace_id ?? 1
+
+    let body: unknown
+    try {
+      body = await request.json()
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+    }
+
+    if (typeof body !== 'object' || body === null) {
+      return NextResponse.json({ error: 'Request body must be an object' }, { status: 400 })
+    }
+
+    const { action } = body as Record<string, unknown>
+
+    if (typeof action !== 'string' || !(VALID_ACTIONS as string[]).includes(action)) {
+      return NextResponse.json(
+        { error: `Invalid action. Must be one of: ${VALID_ACTIONS.join(', ')}` },
+        { status: 400 }
+      )
+    }
+
+    const validatedAction = action as AgentAction
+
+    const db = getDatabase()
+    const agent: Agent | undefined = isNaN(Number(id))
+      ? (db.prepare('SELECT * FROM agents WHERE name = ? AND workspace_id = ?').get(id, workspaceId) as Agent | undefined)
+      : (db.prepare('SELECT * FROM agents WHERE id = ? AND workspace_id = ?').get(Number(id), workspaceId) as Agent | undefined)
+
+    if (!agent) {
+      return NextResponse.json({ error: 'Agent not found' }, { status: 404 })
+    }
+
+    const newStatus = ACTION_STATUS_MAP[validatedAction]
+    const activityLabel = validatedAction.charAt(0).toUpperCase() + validatedAction.slice(1)
+
+    db_helpers.updateAgentStatus(agent.name, newStatus, `Manual ${activityLabel}`, workspaceId)
+
+    const ipAddress =
+      request.headers.get('x-forwarded-for') ||
+      request.headers.get('x-real-ip') ||
+      'unknown'
+
+    logAuditEvent({
+      action: `agent_${validatedAction}`,
+      actor: auth.user.username,
+      actor_id: auth.user.id,
+      target_type: 'agent',
+      target_id: agent.id,
+      detail: { agent_name: agent.name, action: validatedAction, new_status: newStatus },
+      ip_address: ipAddress,
+    })
+
+    const updatedAgent: Agent = {
+      ...agent,
+      status: newStatus,
+      last_seen: Math.floor(Date.now() / 1000),
+    }
+
+    return NextResponse.json({ success: true, agent: updatedAgent, action: validatedAction })
+  } catch (error) {
+    logger.error({ err: error }, 'POST /api/agents/[id]/control error')
+    return NextResponse.json({ error: 'Failed to control agent' }, { status: 500 })
+  }
+}

--- a/src/app/api/agents/halt/route.ts
+++ b/src/app/api/agents/halt/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getDatabase } from '@/lib/db'
+import { requireRole } from '@/lib/auth'
+import { logger } from '@/lib/logger'
+
+/**
+ * POST /api/agents/halt - Emergency circuit breaker: set ALL agents to offline
+ */
+export async function POST(request: NextRequest) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  try {
+    const db = getDatabase()
+    const now = Math.floor(Date.now() / 1000)
+    const workspaceId = auth.user.workspace_id ?? 1
+
+    // Set all non-offline agents to offline and record the timestamp
+    const result = db
+      .prepare(
+        `UPDATE agents
+         SET status = 'offline', last_seen = ?, updated_at = ?
+         WHERE workspace_id = ? AND status != 'offline'`
+      )
+      .run(now, now, workspaceId)
+
+    return NextResponse.json({
+      success: true,
+      halted_count: result.changes,
+      timestamp: now,
+    })
+  } catch (err) {
+    logger.error({ err }, 'POST /api/agents/halt error')
+    return NextResponse.json(
+      {
+        error: 'Failed to halt agents',
+        detail: err instanceof Error ? err.message : 'Unknown error',
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/agents/status/route.ts
+++ b/src/app/api/agents/status/route.ts
@@ -1,0 +1,126 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getDatabase } from '@/lib/db'
+import { requireRole } from '@/lib/auth'
+import { logger } from '@/lib/logger'
+
+interface AgentRow {
+  id: number
+  name: string
+  role: string
+  status: string
+  last_seen: number | null
+  last_activity: string | null
+  config: string | null
+}
+
+interface TaskStatRow {
+  assigned_to: string
+  active: number | null
+  done: number | null
+}
+
+/**
+ * GET /api/agents/status - Aggregated agent status summary for the dashboard
+ * Query params: status, subsystem
+ */
+export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  try {
+    const db = getDatabase()
+    const { searchParams } = new URL(request.url)
+    const workspaceId = auth.user.workspace_id ?? 1
+
+    const statusFilter = searchParams.get('status')
+    const subsystemFilter = searchParams.get('subsystem')
+
+    const agents = db
+      .prepare(
+        `SELECT id, name, role, status, last_seen, last_activity, config
+         FROM agents
+         WHERE workspace_id = ? AND hidden = 0
+         ORDER BY
+           CASE status
+             WHEN 'error'   THEN 0
+             WHEN 'busy'    THEN 1
+             WHEN 'idle'    THEN 2
+             WHEN 'offline' THEN 3
+             ELSE 4
+           END,
+           name ASC`
+      )
+      .all(workspaceId) as AgentRow[]
+
+    // Fetch task counts for all agents in one query (avoids N+1)
+    const taskStatsByAgent = new Map<string, { active: number; done: number }>()
+
+    if (agents.length > 0) {
+      const taskRows = db
+        .prepare(
+          `SELECT
+             assigned_to,
+             SUM(CASE WHEN status IN ('assigned', 'in_progress') THEN 1 ELSE 0 END) as active,
+             SUM(CASE WHEN status = 'done' THEN 1 ELSE 0 END) as done
+           FROM tasks
+           WHERE workspace_id = ?
+           GROUP BY assigned_to`
+        )
+        .all(workspaceId) as TaskStatRow[]
+
+      for (const row of taskRows) {
+        taskStatsByAgent.set(row.assigned_to, {
+          active: row.active ?? 0,
+          done: row.done ?? 0,
+        })
+      }
+    }
+
+    // Build agent list with optional filters applied
+    const mappedAgents = agents
+      .map((agent) => {
+        const parsedConfig: Record<string, unknown> = agent.config
+          ? (JSON.parse(agent.config) as Record<string, unknown>)
+          : {}
+        const subsystem =
+          typeof parsedConfig.subsystem === 'string' ? parsedConfig.subsystem : 'mission-control'
+        const taskStats = taskStatsByAgent.get(agent.name) ?? { active: 0, done: 0 }
+
+        // Determine whether a recent error exists (status is 'error')
+        const error_recent = agent.status === 'error'
+
+        return {
+          id: agent.id,
+          name: agent.name,
+          role: agent.role,
+          status: agent.status,
+          last_seen: agent.last_seen,
+          last_activity: agent.last_activity,
+          subsystem,
+          task_count_active: taskStats.active,
+          task_count_done: taskStats.done,
+          error_recent,
+        }
+      })
+      .filter((agent) => {
+        if (statusFilter && agent.status !== statusFilter) return false
+        if (subsystemFilter && agent.subsystem !== subsystemFilter) return false
+        return true
+      })
+
+    // Build summary counts — 'busy' maps to 'running'
+    const summary = {
+      total: mappedAgents.length,
+      running: mappedAgents.filter((a) => a.status === 'running' || a.status === 'busy').length,
+      idle: mappedAgents.filter((a) => a.status === 'idle').length,
+      offline: mappedAgents.filter((a) => a.status === 'offline').length,
+      error: mappedAgents.filter((a) => a.status === 'error').length,
+      last_updated: Math.floor(Date.now() / 1000),
+    }
+
+    return NextResponse.json({ summary, agents: mappedAgents })
+  } catch (error) {
+    logger.error({ err: error }, 'GET /api/agents/status error')
+    return NextResponse.json({ error: 'Failed to fetch agent status' }, { status: 500 })
+  }
+}

--- a/src/app/api/backtest/route.ts
+++ b/src/app/api/backtest/route.ts
@@ -1,0 +1,180 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getDatabase } from '@/lib/db'
+import { requireRole } from '@/lib/auth'
+
+interface BacktestRow {
+  id: number
+  strategy: string
+  exchange: string
+  symbol: string
+  timeframe: string
+  status: string
+  metrics: string
+  cost_breakdown: string
+  created_at: number
+  completed_at: number | null
+  error: string | null
+}
+
+interface BacktestResult extends Omit<BacktestRow, 'metrics' | 'cost_breakdown'> {
+  metrics: Record<string, unknown>
+  cost_breakdown: Record<string, unknown>
+}
+
+interface JobEntry {
+  id: number | bigint
+  strategy: string
+  symbol: string
+}
+
+function ensureBacktestTable(): void {
+  const db = getDatabase()
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS backtest_results (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      strategy TEXT NOT NULL,
+      exchange TEXT DEFAULT 'hyperliquid',
+      symbol TEXT DEFAULT 'BTC',
+      timeframe TEXT DEFAULT '15m',
+      status TEXT DEFAULT 'queued',
+      metrics TEXT DEFAULT '{}',
+      cost_breakdown TEXT DEFAULT '{}',
+      created_at INTEGER NOT NULL,
+      completed_at INTEGER,
+      error TEXT
+    )
+  `)
+}
+
+function parseRow(row: BacktestRow): BacktestResult {
+  return {
+    ...row,
+    metrics: JSON.parse(row.metrics || '{}') as Record<string, unknown>,
+    cost_breakdown: JSON.parse(row.cost_breakdown || '{}') as Record<string, unknown>,
+  }
+}
+
+/**
+ * GET /api/backtest - List backtest results
+ * Query params:
+ *   strategy  - filter by strategy name
+ *   limit     - max rows to return (default 50)
+ */
+export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  try {
+    ensureBacktestTable()
+    const db = getDatabase()
+
+    const url = new URL(request.url)
+    const strategy = url.searchParams.get('strategy')
+    const limitParam = url.searchParams.get('limit')
+    const limit = Math.max(1, Math.min(500, parseInt(limitParam || '50', 10) || 50))
+
+    let rows: BacktestRow[]
+    if (strategy) {
+      rows = db
+        .prepare(
+          'SELECT * FROM backtest_results WHERE strategy = ? ORDER BY created_at DESC LIMIT ?'
+        )
+        .all(strategy, limit) as BacktestRow[]
+    } else {
+      rows = db
+        .prepare('SELECT * FROM backtest_results ORDER BY created_at DESC LIMIT ?')
+        .all(limit) as BacktestRow[]
+    }
+
+    const results: BacktestResult[] = rows.map(parseRow)
+
+    return NextResponse.json({ results })
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to fetch backtest results' }, { status: 500 })
+  }
+}
+
+/**
+ * POST /api/backtest - Trigger a backtest run
+ * Body: {
+ *   action: 'run_all' | 'run_single'
+ *   strategy?: string      (required for run_single)
+ *   exchange?: string      (default: 'hyperliquid')
+ *   symbol?: string        (default: 'BTC')
+ *   timeframe?: string     (default: '15m')
+ * }
+ */
+export async function POST(request: NextRequest) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  let body: Record<string, unknown>
+  try {
+    body = (await request.json()) as Record<string, unknown>
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const action = body?.action
+  if (action !== 'run_all' && action !== 'run_single') {
+    return NextResponse.json(
+      { error: 'action must be run_all or run_single' },
+      { status: 400 }
+    )
+  }
+
+  try {
+    ensureBacktestTable()
+    const db = getDatabase()
+    const now = Date.now()
+
+    if (action === 'run_all') {
+      const strategies = ['momentum', 'mean_reversion', 'rbi_v1', 'breakout', 'grid']
+      const symbols = ['BTC', 'ETH', 'SOL']
+      const exchange = typeof body.exchange === 'string' ? body.exchange : 'hyperliquid'
+
+      const insert = db.prepare(
+        'INSERT INTO backtest_results (strategy, exchange, symbol, timeframe, status, created_at) VALUES (?, ?, ?, ?, ?, ?)'
+      )
+
+      const jobs: JobEntry[] = []
+      const insertMany = db.transaction(() => {
+        for (const strat of strategies) {
+          for (const sym of symbols) {
+            const result = insert.run(strat, exchange, sym, '15m', 'queued', now)
+            jobs.push({ id: result.lastInsertRowid, strategy: strat, symbol: sym })
+          }
+        }
+      })
+      insertMany()
+
+      return NextResponse.json({ success: true, jobs, status: 'queued', job_count: jobs.length })
+    }
+
+    // action === 'run_single'
+    if (!body.strategy || typeof body.strategy !== 'string') {
+      return NextResponse.json({ error: 'strategy is required for run_single' }, { status: 400 })
+    }
+
+    const result = db
+      .prepare(
+        'INSERT INTO backtest_results (strategy, exchange, symbol, timeframe, status, created_at) VALUES (?, ?, ?, ?, ?, ?)'
+      )
+      .run(
+        body.strategy,
+        typeof body.exchange === 'string' ? body.exchange : 'hyperliquid',
+        typeof body.symbol === 'string' ? body.symbol : 'BTC',
+        typeof body.timeframe === 'string' ? body.timeframe : '15m',
+        'queued',
+        now
+      )
+
+    return NextResponse.json({
+      success: true,
+      job_id: result.lastInsertRowid,
+      status: 'queued',
+    })
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to queue backtest job' }, { status: 500 })
+  }
+}

--- a/src/app/api/config/trading/route.ts
+++ b/src/app/api/config/trading/route.ts
@@ -1,0 +1,154 @@
+import { NextRequest, NextResponse } from 'next/server'
+import fs from 'node:fs'
+import path from 'node:path'
+
+interface TransactionCostEntry {
+  maker_fee: number
+  taker_fee: number
+  slippage_bps: number
+  funding_rate_per_8h?: number
+}
+
+interface TradingConfig {
+  default_exchange: string
+  symbols: string[]
+  trade_mode: 'paper' | 'live'
+  max_position_usd: number
+  max_total_exposure_usd: number
+  min_balance_usd: number
+  max_drawdown_pct: number
+  default_leverage: number
+  kill_switch_drawdown_pct: number
+  swarm_enabled: boolean
+  require_swarm_confidence_pct: number
+  swarm_vote_timeout_sec: number
+  require_risk_approval: boolean
+  sleep_between_checks_sec: number
+  balance_history_max_entries: number
+  cash_percentage: number
+  data_timeframe: string
+  daysback_for_data: number
+  transaction_costs: Record<string, TransactionCostEntry>
+}
+
+function getConfigPath(): string {
+  return path.resolve(process.cwd(), '..', 'agent-zero', 'agents', 'trader', 'trading_config.json')
+}
+
+/**
+ * Deep merge two objects. Arrays are replaced (not concatenated).
+ * Non-object values in `updates` always overwrite `base`.
+ */
+function deepMerge(base: Record<string, unknown>, updates: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...base }
+
+  for (const key of Object.keys(updates)) {
+    const baseVal = base[key]
+    const updateVal = updates[key]
+
+    if (
+      updateVal !== null &&
+      typeof updateVal === 'object' &&
+      !Array.isArray(updateVal) &&
+      baseVal !== null &&
+      typeof baseVal === 'object' &&
+      !Array.isArray(baseVal)
+    ) {
+      result[key] = deepMerge(
+        baseVal as Record<string, unknown>,
+        updateVal as Record<string, unknown>,
+      )
+    } else {
+      result[key] = updateVal
+    }
+  }
+
+  return result
+}
+
+/**
+ * GET /api/config/trading
+ * Returns the current trading configuration.
+ */
+export async function GET(_request: NextRequest) {
+  const configPath = getConfigPath()
+
+  try {
+    const raw = fs.readFileSync(configPath, 'utf-8')
+    const config = JSON.parse(raw) as TradingConfig
+    return NextResponse.json({ config })
+  } catch (err: unknown) {
+    const nodeErr = err as NodeJS.ErrnoException
+    if (nodeErr.code === 'ENOENT') {
+      return NextResponse.json(
+        { error: 'Trading config file not found', path: configPath },
+        { status: 404 },
+      )
+    }
+    const message = nodeErr instanceof Error ? nodeErr.message : 'Unknown error'
+    return NextResponse.json(
+      { error: `Failed to read trading config: ${message}` },
+      { status: 500 },
+    )
+  }
+}
+
+/**
+ * PUT /api/config/trading
+ * Deep-merges the request body into the existing config and writes it back.
+ * Arrays in the request body replace their counterparts (not appended).
+ */
+export async function PUT(request: NextRequest) {
+  const configPath = getConfigPath()
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON in request body' }, { status: 400 })
+  }
+
+  if (body === null || typeof body !== 'object' || Array.isArray(body)) {
+    return NextResponse.json(
+      { error: 'Request body must be a JSON object' },
+      { status: 400 },
+    )
+  }
+
+  let existing: TradingConfig
+  try {
+    const raw = fs.readFileSync(configPath, 'utf-8')
+    existing = JSON.parse(raw) as TradingConfig
+  } catch (err: unknown) {
+    const nodeErr = err as NodeJS.ErrnoException
+    if (nodeErr.code === 'ENOENT') {
+      return NextResponse.json(
+        { error: 'Trading config file not found', path: configPath },
+        { status: 404 },
+      )
+    }
+    const message = nodeErr instanceof Error ? nodeErr.message : 'Unknown error'
+    return NextResponse.json(
+      { error: `Failed to read trading config: ${message}` },
+      { status: 500 },
+    )
+  }
+
+  const merged = deepMerge(
+    existing as unknown as Record<string, unknown>,
+    body as Record<string, unknown>,
+  ) as unknown as TradingConfig
+
+  try {
+    fs.writeFileSync(configPath, JSON.stringify(merged, null, 2) + '\n', 'utf-8')
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Unknown error'
+    return NextResponse.json(
+      { error: `Failed to write trading config: ${message}` },
+      { status: 500 },
+    )
+  }
+
+  const updated_at = Date.now()
+  return NextResponse.json({ config: merged, updated_at })
+}

--- a/src/app/api/deploy/assess/route.ts
+++ b/src/app/api/deploy/assess/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { assessDeployment, DEFAULT_FEE_SCHEDULES } from '@/lib/transaction-costs'
+
+/**
+ * POST /api/deploy/assess
+ *
+ * Evaluates whether a trading agent deployment is profitable after transaction costs.
+ *
+ * Body:
+ *   agent_name            - Name of the trading agent
+ *   strategy              - Strategy identifier (e.g. "momentum", "mean_reversion")
+ *   exchange              - Exchange identifier (hyperliquid | coinbase | interactive_brokers)
+ *   symbol                - Trading symbol (e.g. "BTC-USD")
+ *   position_size_usd     - Position size in USD
+ *   expected_return_pct   - Expected gross return as a percentage (e.g. 2.5 for 2.5%)
+ *   holding_period_hours  - (optional) Holding period in hours for funding cost estimation
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return NextResponse.json({ error: 'Request body must be a JSON object' }, { status: 400 })
+  }
+
+  const {
+    agent_name,
+    strategy,
+    exchange,
+    symbol,
+    position_size_usd,
+    expected_return_pct,
+    holding_period_hours,
+  } = body as Record<string, unknown>
+
+  // --- Input validation ---
+  const errors: string[] = []
+
+  if (typeof agent_name !== 'string' || agent_name.trim() === '') {
+    errors.push('agent_name must be a non-empty string')
+  }
+  if (typeof strategy !== 'string' || strategy.trim() === '') {
+    errors.push('strategy must be a non-empty string')
+  }
+  if (typeof exchange !== 'string' || exchange.trim() === '') {
+    errors.push('exchange must be a non-empty string')
+  } else if (!DEFAULT_FEE_SCHEDULES[exchange.toLowerCase()]) {
+    const valid = Object.keys(DEFAULT_FEE_SCHEDULES).join(', ')
+    errors.push(`exchange must be one of: ${valid}`)
+  }
+  if (typeof symbol !== 'string' || symbol.trim() === '') {
+    errors.push('symbol must be a non-empty string')
+  }
+  if (typeof position_size_usd !== 'number' || position_size_usd <= 0) {
+    errors.push('position_size_usd must be a positive number')
+  }
+  if (typeof expected_return_pct !== 'number') {
+    errors.push('expected_return_pct must be a number')
+  }
+  if (
+    holding_period_hours !== undefined &&
+    (typeof holding_period_hours !== 'number' || holding_period_hours < 0)
+  ) {
+    errors.push('holding_period_hours must be a non-negative number')
+  }
+
+  if (errors.length > 0) {
+    return NextResponse.json({ error: 'Validation failed', details: errors }, { status: 400 })
+  }
+
+  const assessment = assessDeployment({
+    agent_name: (agent_name as string).trim(),
+    strategy: (strategy as string).trim(),
+    exchange: (exchange as string).trim(),
+    symbol: (symbol as string).trim(),
+    position_size_usd: position_size_usd as number,
+    expected_return_pct: expected_return_pct as number,
+    holding_period_hours:
+      typeof holding_period_hours === 'number' ? holding_period_hours : undefined,
+  })
+
+  return NextResponse.json(assessment)
+}

--- a/src/app/api/events/ingest/route.ts
+++ b/src/app/api/events/ingest/route.ts
@@ -1,0 +1,246 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { eventBus } from '@/lib/event-bus'
+import { db_helpers } from '@/lib/db'
+import { logger } from '@/lib/logger'
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+interface IngestEvent {
+  type: string
+  agent_name: string
+  timestamp?: number
+  subsystem?: string
+  [key: string]: unknown
+}
+
+interface IngestBody {
+  events?: IngestEvent[]
+  type?: string
+  agent_name?: string
+  timestamp?: number
+  subsystem?: string
+  [key: string]: unknown
+}
+
+/**
+ * Validate API key from request headers.
+ * Returns true if auth passes (key matches or no key is configured = dev mode).
+ */
+function isAuthorized(request: NextRequest): boolean {
+  const configuredKey = process.env.MC_API_KEY
+  if (!configuredKey) {
+    // Dev mode: no key configured, allow all requests
+    return true
+  }
+
+  const authHeader = request.headers.get('authorization')
+  if (authHeader?.startsWith('Bearer ')) {
+    const key = authHeader.slice(7)
+    return key === configuredKey
+  }
+
+  const xApiKey = request.headers.get('x-api-key')
+  if (xApiKey) {
+    return xApiKey === configuredKey
+  }
+
+  return false
+}
+
+/**
+ * Validate a single event object.
+ * Returns an error string if invalid, undefined if valid.
+ */
+function validateEvent(event: unknown): string | undefined {
+  if (!event || typeof event !== 'object') {
+    return 'Event must be an object'
+  }
+  const e = event as Record<string, unknown>
+
+  if (typeof e.type !== 'string' || !e.type.startsWith('agent.')) {
+    return 'Event type must be a string starting with "agent."'
+  }
+  if (typeof e.agent_name !== 'string' || e.agent_name.trim() === '') {
+    return 'agent_name must be a non-empty string'
+  }
+
+  return undefined
+}
+
+/**
+ * Process a single valid event: broadcast and perform side effects.
+ */
+function processEvent(event: IngestEvent): void {
+  const { type, agent_name } = event
+
+  // Broadcast via eventBus — cast needed because agent.* types are not in the static EventType union
+  eventBus.broadcast(type as Parameters<typeof eventBus.broadcast>[0], event)
+
+  try {
+    switch (type) {
+      case 'agent.heartbeat': {
+        const status = event.status as string | undefined
+        if (status) {
+          db_helpers.updateAgentStatus(agent_name, status as Parameters<typeof db_helpers.updateAgentStatus>[1])
+        }
+        break
+      }
+
+      case 'agent.status_changed': {
+        const newStatus = event.new_status as string | undefined
+        if (newStatus) {
+          db_helpers.updateAgentStatus(agent_name, newStatus as Parameters<typeof db_helpers.updateAgentStatus>[1])
+        }
+        break
+      }
+
+      case 'agent.trade_opened': {
+        const symbol = (event.symbol as string | undefined) ?? 'unknown'
+        db_helpers.logActivity(
+          type,
+          'agent',
+          0,
+          agent_name,
+          `${agent_name} opened trade: ${symbol}`,
+          event,
+        )
+        break
+      }
+
+      case 'agent.trade_closed': {
+        const symbol = (event.symbol as string | undefined) ?? 'unknown'
+        db_helpers.logActivity(
+          type,
+          'agent',
+          0,
+          agent_name,
+          `${agent_name} closed trade: ${symbol}`,
+          event,
+        )
+        break
+      }
+
+      case 'agent.trade_error': {
+        const reason = (event.reason as string | undefined) ?? 'unknown error'
+        db_helpers.logActivity(
+          type,
+          'agent',
+          0,
+          agent_name,
+          `${agent_name} trade error: ${reason}`,
+          event,
+        )
+        break
+      }
+
+      case 'agent.risk_alert': {
+        const severity = event.severity as string | undefined
+        const message = (event.message as string | undefined) ?? 'Risk alert'
+        db_helpers.logActivity(
+          type,
+          'agent',
+          0,
+          agent_name,
+          `${agent_name} risk alert (${severity ?? 'unknown'}): ${message}`,
+          event,
+        )
+        if (severity === 'critical') {
+          db_helpers.createNotification(
+            'admin',
+            'risk_alert',
+            'Critical Risk Alert',
+            `Agent ${agent_name}: ${message}`,
+            'agent',
+            0,
+          )
+        }
+        break
+      }
+
+      case 'agent.log': {
+        const level = event.level as string | undefined
+        if (level === 'error') {
+          const message = (event.message as string | undefined) ?? 'Agent error'
+          db_helpers.logActivity(
+            type,
+            'agent',
+            0,
+            agent_name,
+            `${agent_name} error: ${message}`,
+            event,
+          )
+        }
+        break
+      }
+
+      default:
+        // No additional side effects for other agent.* types
+        break
+    }
+  } catch (err) {
+    logger.error({ err, type, agent_name }, 'Event side-effect failed')
+    // Don't rethrow — broadcast already succeeded; side effects are best-effort
+  }
+}
+
+/**
+ * POST /api/events/ingest
+ *
+ * Accepts events from Python trading agents and routes them through the event bus.
+ * Supports single-event and batch (events array) payloads.
+ *
+ * Authentication:
+ *   - Bearer token via Authorization header, or x-api-key header
+ *   - Compared against MC_API_KEY env var
+ *   - If MC_API_KEY is unset, all requests are allowed (dev mode)
+ */
+export async function POST(request: NextRequest) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let body: IngestBody
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  // --- Batch mode ---
+  if (Array.isArray(body.events)) {
+    const errors: Array<{ index: number; error: string }> = []
+    let processed = 0
+
+    for (let i = 0; i < body.events.length; i++) {
+      const raw = body.events[i]
+      const validationError = validateEvent(raw)
+      if (validationError) {
+        errors.push({ index: i, error: validationError })
+        continue
+      }
+      processEvent(raw as IngestEvent)
+      processed++
+    }
+
+    return NextResponse.json({ success: true, processed, errors })
+  }
+
+  // --- Single event mode ---
+  const validationError = validateEvent(body)
+  if (validationError) {
+    return NextResponse.json({ error: validationError }, { status: 400 })
+  }
+
+  const event: IngestEvent = {
+    type: body.type as string,
+    agent_name: body.agent_name as string,
+    ...(body.timestamp !== undefined && { timestamp: body.timestamp }),
+    ...(body.subsystem !== undefined && { subsystem: body.subsystem }),
+    ...body,
+  }
+
+  processEvent(event)
+
+  return NextResponse.json({ success: true, event_type: event.type })
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,56 +4,116 @@
 
 @layer base {
   :root {
-    color-scheme: light;
+    color-scheme: dark;
 
-    /* Operator's Desk palette */
-    --background: oklch(0.92 0.025 75);
-    --foreground: oklch(0.22 0.04 50);
-    --card: oklch(0.95 0.01 80);
-    --card-foreground: oklch(0.22 0.04 50);
-    --popover: oklch(0.97 0.01 80);
-    --popover-foreground: oklch(0.22 0.04 50);
-    --primary: oklch(0.60 0.14 40);
-    --primary-foreground: oklch(0.95 0.01 90);
-    --secondary: oklch(0.88 0.04 70);
-    --secondary-foreground: oklch(0.22 0.04 50);
-    --muted: oklch(0.90 0.02 80);
-    --muted-foreground: oklch(0.50 0.02 60);
-    --accent: oklch(0.60 0.14 40);
-    --accent-foreground: oklch(0.95 0.01 90);
-    --destructive: oklch(0.65 0.16 45);
-    --destructive-foreground: oklch(1 0 0);
-    --border: oklch(0.83 0.03 70);
-    --input: oklch(0.88 0.03 75);
-    --ring: oklch(0.60 0.14 40);
+    /* Page backgrounds */
+    --bg: #0f1117;
+    --surface: #1a1d27;
+    --surface-hover: #22252f;
+    --border: #2a2d3a;
+
+    /* Text hierarchy */
+    --text-primary: #e4e4e7;
+    --text-secondary: #a1a1aa;
+    --text-muted: #71717a;
+    --text-dim: #52525b;
+
+    /* Semantic colors */
+    --green: #22c55e;
+    --red: #ef4444;
+    --amber: #f59e0b;
+    --blue: #3b82f6;
+
+    /* Mapped to existing variable names for compatibility */
+    --background: #0f1117;
+    --foreground: #e4e4e7;
+    --card: #1a1d27;
+    --card-foreground: #e4e4e7;
+    --popover: #1a1d27;
+    --popover-foreground: #e4e4e7;
+    --primary: #3b82f6;
+    --primary-foreground: #ffffff;
+    --secondary: #22252f;
+    --secondary-foreground: #e4e4e7;
+    --destructive: #ef4444;
+    --destructive-foreground: #ffffff;
+    --muted: #22252f;
+    --muted-foreground: #71717a;
+    --accent: #22252f;
+    --accent-foreground: #e4e4e7;
+    --input: #2a2d3a;
+    --ring: #3b82f6;
     --radius: 0.375rem;
 
-    /* Semantic status — sage/amber/warm, no red */
-    --success: oklch(0.60 0.12 155);
-    --success-foreground: oklch(1 0 0);
-    --warning: oklch(0.70 0.14 55);
-    --warning-foreground: oklch(0.15 0.04 50);
-    --info: oklch(0.55 0.10 200);
-    --info-foreground: oklch(1 0 0);
+    /* Semantic status */
+    --success: #22c55e;
+    --success-foreground: #ffffff;
+    --warning: #f59e0b;
+    --warning-foreground: #18181b;
+    --info: #3b82f6;
+    --info-foreground: #ffffff;
 
     /* Surface hierarchy */
-    --surface-0: oklch(1 0 0);
-    --surface-1: oklch(0.97 0.01 85);
-    --surface-2: oklch(0.95 0.01 80);
-    --surface-3: oklch(0.92 0.02 75);
-
-    /* Legacy void-* colors mapped to warm palette */
-    --void-cyan: oklch(0.55 0.10 200);
-    --void-mint: oklch(0.60 0.12 155);
-    --void-amber: oklch(0.70 0.14 55);
-    --void-violet: oklch(0.55 0.10 300);
-    --void-crimson: oklch(0.60 0.14 40);
+    --surface-0: #0f1117;
+    --surface-1: #1a1d27;
+    --surface-2: #22252f;
+    --surface-3: #2a2d3a;
 
     /* Agent status dot colors */
-    --status-online: oklch(0.60 0.12 155);
-    --status-busy: oklch(0.70 0.14 55);
-    --status-idle: oklch(0.65 0.03 70);
-    --status-offline: oklch(0.65 0.03 70);
+    --status-online: #22c55e;
+    --status-busy: #f59e0b;
+    --status-idle: #71717a;
+    --status-offline: #71717a;
+  }
+}
+
+@layer base {
+  .light {
+    color-scheme: light;
+    --bg: #fafafa;
+    --surface: #ffffff;
+    --surface-hover: #f4f4f5;
+    --border: #e4e4e7;
+    --text-primary: #18181b;
+    --text-secondary: #52525b;
+    --text-muted: #a1a1aa;
+    --text-dim: #d4d4d8;
+
+    --background: #fafafa;
+    --foreground: #18181b;
+    --card: #ffffff;
+    --card-foreground: #18181b;
+    --popover: #ffffff;
+    --popover-foreground: #18181b;
+    --primary: #3b82f6;
+    --primary-foreground: #ffffff;
+    --secondary: #f4f4f5;
+    --secondary-foreground: #18181b;
+    --destructive: #ef4444;
+    --destructive-foreground: #ffffff;
+    --muted: #f4f4f5;
+    --muted-foreground: #a1a1aa;
+    --accent: #f4f4f5;
+    --accent-foreground: #18181b;
+    --input: #e4e4e7;
+    --ring: #3b82f6;
+
+    --success: #22c55e;
+    --success-foreground: #ffffff;
+    --warning: #f59e0b;
+    --warning-foreground: #18181b;
+    --info: #3b82f6;
+    --info-foreground: #ffffff;
+
+    --surface-0: #fafafa;
+    --surface-1: #ffffff;
+    --surface-2: #f4f4f5;
+    --surface-3: #e4e4e7;
+
+    --status-online: #22c55e;
+    --status-busy: #f59e0b;
+    --status-idle: #a1a1aa;
+    --status-offline: #a1a1aa;
   }
 }
 
@@ -62,7 +122,7 @@
     @apply border-border;
   }
 
-  html { color-scheme: light; }
+  html { color-scheme: dark; }
 
   body {
     @apply bg-background text-foreground;
@@ -105,30 +165,30 @@
   .surface-2 { background: var(--surface-2); }
   .surface-3 { background: var(--surface-3); }
 
-  /* Status badges — warm palette, no red */
+  /* Status badges */
   .badge-success {
     @apply border;
-    background: oklch(0.60 0.12 155 / 0.12);
-    color: oklch(0.45 0.10 155);
-    border-color: oklch(0.60 0.12 155 / 0.25);
+    background: rgba(34, 197, 94, 0.1);
+    color: #22c55e;
+    border-color: rgba(34, 197, 94, 0.2);
   }
   .badge-warning {
     @apply border;
-    background: oklch(0.70 0.14 55 / 0.12);
-    color: oklch(0.50 0.12 55);
-    border-color: oklch(0.70 0.14 55 / 0.25);
+    background: rgba(245, 158, 11, 0.1);
+    color: #f59e0b;
+    border-color: rgba(245, 158, 11, 0.2);
   }
   .badge-error {
     @apply border;
-    background: oklch(0.65 0.16 45 / 0.12);
-    color: oklch(0.50 0.14 45);
-    border-color: oklch(0.65 0.16 45 / 0.25);
+    background: rgba(239, 68, 68, 0.1);
+    color: #ef4444;
+    border-color: rgba(239, 68, 68, 0.2);
   }
   .badge-info {
     @apply border;
-    background: oklch(0.55 0.10 200 / 0.12);
-    color: oklch(0.40 0.10 200);
-    border-color: oklch(0.55 0.10 200 / 0.25);
+    background: rgba(59, 130, 246, 0.1);
+    color: #3b82f6;
+    border-color: rgba(59, 130, 246, 0.2);
   }
   .badge-neutral {
     @apply bg-muted text-muted-foreground border border-border;
@@ -140,13 +200,12 @@
   }
 
   /* Typography */
-  .font-heading { font-family: var(--font-heading), Georgia, serif; }
+  .font-heading { font-family: var(--font-sans), system-ui, sans-serif; font-weight: 600; }
   .font-mono { font-family: var(--font-mono), monospace; }
 
-  /* Operator's Desk panel */
+  /* Desk panel */
   .desk-panel {
-    @apply bg-card border border-border rounded-2xl;
-    box-shadow: 0 14px 30px oklch(0.22 0.04 50 / 0.06), inset 0 1px 0 oklch(1 0 0 / 0.65);
+    @apply bg-card border border-border rounded-lg;
   }
 
   /* Desk tabs */
@@ -156,11 +215,6 @@
   .desk-tab-active {
     @apply bg-primary text-primary-foreground border-primary;
   }
-
-  /* Card accent borders */
-  .desk-card-accent-terracotta { border-left: 4px solid oklch(0.60 0.14 40); }
-  .desk-card-accent-sage { border-left: 4px solid oklch(0.60 0.12 155); }
-  .desk-card-accent-kraft { border-left: 4px solid oklch(0.70 0.06 75); }
 
   /* Generic panel */
   .panel {
@@ -175,13 +229,13 @@
 
   /* Mono/code font */
   .font-mono-tight {
-    font-family: 'JetBrains Mono', 'SF Mono', 'Fira Code', 'Cascadia Code', ui-monospace, monospace;
+    font-family: var(--font-mono), ui-monospace, monospace;
     font-variant-numeric: tabular-nums;
   }
 
   /* Digital clock styling */
   .digital-clock {
-    font-family: 'JetBrains Mono', 'SF Mono', ui-monospace, monospace;
+    font-family: var(--font-mono), ui-monospace, monospace;
     font-weight: 600;
     letter-spacing: 0.04em;
     font-variant-numeric: tabular-nums;
@@ -201,7 +255,7 @@
     background: linear-gradient(
       90deg,
       var(--muted) 0%,
-      oklch(0.50 0.02 60 / 0.1) 50%,
+      rgba(113, 113, 122, 0.1) 50%,
       var(--muted) 100%
     );
     background-size: 200% 100%;
@@ -219,11 +273,6 @@
   @keyframes commandPaletteIn {
     from { transform: translateY(-8px) scale(0.98); opacity: 0; }
     to { transform: translateY(0) scale(1); opacity: 1; }
-  }
-
-  /* Legacy glow effect (mapped to info color) */
-  .glow-cyan {
-    box-shadow: 0 0 8px oklch(0.55 0.10 200 / 0.3);
   }
 
   /* Slide-in for panels */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from 'next'
-import { Fraunces, DM_Sans, IBM_Plex_Mono } from 'next/font/google'
+import { Geist, Geist_Mono } from 'next/font/google'
 import { headers } from 'next/headers'
 import { ThemeProvider } from 'next-themes'
 import { NextIntlClientProvider } from 'next-intl'
@@ -8,9 +8,8 @@ import { THEME_IDS } from '@/lib/themes'
 import { ThemeBackground } from '@/components/ui/theme-background'
 import './globals.css'
 
-const fraunces = Fraunces({ subsets: ['latin'], variable: '--font-heading', display: 'swap', weight: 'variable', axes: ['opsz'] })
-const dmSans = DM_Sans({ subsets: ['latin'], variable: '--font-sans', display: 'swap', weight: 'variable' })
-const ibmPlexMono = IBM_Plex_Mono({ subsets: ['latin'], variable: '--font-mono', display: 'swap', weight: ['400', '500'] })
+const geist = Geist({ subsets: ['latin'], variable: '--font-sans', display: 'swap', weight: ['400', '500', '600'] })
+const geistMono = Geist_Mono({ subsets: ['latin'], variable: '--font-mono', display: 'swap', weight: ['400', '500'] })
 
 function resolveMetadataBase(): URL {
   const candidates = [
@@ -90,15 +89,15 @@ export default async function RootLayout({
             Content is a static string literal — no user input, no XSS vector. */}
         <script
           dangerouslySetInnerHTML={{
-            __html: `(function(){try{var t=localStorage.getItem('theme')||'void';var light=['light','paper'];if(light.indexOf(t)===-1)document.documentElement.classList.add('dark')}catch(e){}})()`,
+            __html: `(function(){try{var t=localStorage.getItem('theme')||'dark';if(t==='light'){}else{document.documentElement.classList.add('dark')}}catch(e){document.documentElement.classList.add('dark')}})()`,
           }}
         />
       </head>
-      <body className={`${fraunces.variable} ${dmSans.variable} ${ibmPlexMono.variable} font-sans antialiased`} suppressHydrationWarning>
+      <body className={`${geist.variable} ${geistMono.variable} font-sans antialiased`} suppressHydrationWarning>
         <NextIntlClientProvider messages={messages}>
           <ThemeProvider
             attribute="class"
-            defaultTheme="light"
+            defaultTheme="dark"
             themes={THEME_IDS}
             enableSystem={false}
             disableTransitionOnChange

--- a/src/components/layout/nav-rail.tsx
+++ b/src/components/layout/nav-rail.tsx
@@ -236,13 +236,13 @@ export function NavRail() {
       <nav
         role="navigation"
         aria-label="Main navigation"
-        className={`hidden md:flex flex-col bg-gradient-to-b from-card to-background border-r border-border shrink-0 transition-all duration-200 ease-in-out ${
-          sidebarExpanded ? 'w-[220px]' : 'w-14'
+        className={`hidden md:flex flex-col bg-[var(--surface)] border-r border-border shrink-0 transition-all duration-200 ease-in-out ${
+          sidebarExpanded ? 'w-[240px]' : 'w-14'
         }`}
       >
         {/* Header: Logo + toggle */}
         <div className={`flex items-center shrink-0 ${sidebarExpanded ? 'px-3 py-3 gap-2.5' : 'flex-col py-3 gap-2'}`}>
-          <div className="w-9 h-9 rounded-lg overflow-hidden bg-background border border-border/50 flex items-center justify-center shrink-0 hover:border-void-cyan/40 hover:glow-cyan transition-smooth">
+          <div className="w-9 h-9 rounded-lg overflow-hidden bg-background border border-border/50 flex items-center justify-center shrink-0 hover:border-[#3b82f6]/40 transition-smooth">
             <Image
               src="/brand/mc-logo-128.png"
               alt="Mission Control logo"
@@ -432,11 +432,11 @@ export function NavRail() {
               href="https://builderz.dev"
               target="_blank"
               rel="noopener noreferrer"
-              className="block rounded-lg border border-void-cyan/20 bg-gradient-to-br from-void-cyan/5 to-transparent hover:from-void-cyan/10 hover:border-void-cyan/40 transition-all duration-200 p-2 group"
+              className="block rounded-lg border border-[#3b82f6]/20 bg-gradient-to-br from-[#3b82f6]/5 to-transparent hover:from-[#3b82f6]/10 hover:border-[#3b82f6]/40 transition-all duration-200 p-2 group"
             >
               <div className="flex items-center gap-1.5 mb-0.5">
-                <span className="text-2xs font-bold text-foreground group-hover:text-void-cyan transition-colors">builderz</span>
-                <span className="text-[9px] px-1 py-px rounded bg-void-cyan/15 text-void-cyan">.dev</span>
+                <span className="text-2xs font-bold text-foreground group-hover:text-[#3b82f6] transition-colors">builderz</span>
+                <span className="text-[9px] px-1 py-px rounded bg-[#3b82f6]/15 text-[#3b82f6]">.dev</span>
               </div>
               <p className="text-[10px] text-muted-foreground/70 leading-snug">AI-native dev shop · Solana experts.</p>
             </a>
@@ -493,12 +493,12 @@ function NavButton({ item, active, expanded, onClick, onPrefetch, nested }: {
           nested ? 'py-1' : 'py-1.5'
         } ${
           active
-            ? 'bg-primary/15 text-primary hover:bg-primary/20'
+            ? 'bg-[var(--surface-hover)] text-[var(--text-primary)] hover:bg-[var(--surface-hover)]'
             : ''
         }`}
       >
         {active && (
-          <span className="absolute left-0 w-0.5 h-5 bg-void-cyan rounded-r glow-cyan" />
+          <span className="absolute right-0 top-1/2 -translate-y-1/2 w-0.5 h-4 bg-[#3b82f6] rounded-l" />
         )}
         <div className={`shrink-0 ${nested ? 'w-4 h-4' : 'w-5 h-5'}`}>{item.icon}</div>
         <span className={`truncate ${nested ? 'text-xs' : 'text-sm'}`}>{item.label}</span>
@@ -528,7 +528,7 @@ function NavButton({ item, active, expanded, onClick, onPrefetch, nested }: {
       </span>
       {/* Active indicator */}
       {active && (
-        <span className="absolute left-0 w-0.5 h-5 bg-primary rounded-r" />
+        <span className="absolute right-0 top-1/2 -translate-y-1/2 w-0.5 h-4 bg-[#3b82f6] rounded-l" />
       )}
     </Button>
   )
@@ -825,7 +825,7 @@ function ContextSwitcher({ currentUser, isAdmin, isLocal, isConnected, tenants, 
   const projectName = activeProject?.name
   const contextLine = projectName ? `${tenantName} / ${projectName}` : tenantName
   const connectionLabel = isLocal ? tcs('localMode') : isConnected ? tcs('connected') : tcs('disconnected')
-  const connectionDotClass = isLocal ? 'bg-void-cyan' : isConnected ? 'bg-green-500' : 'bg-red-500'
+  const connectionDotClass = isLocal ? 'bg-[#3b82f6]' : isConnected ? 'bg-green-500' : 'bg-red-500'
 
   return (
     <div className={`shrink-0 relative ${expanded ? 'px-3 pb-3' : 'flex flex-col items-center pb-3'}`}>
@@ -936,11 +936,11 @@ function ContextSwitcher({ currentUser, isAdmin, isLocal, isConnected, tenants, 
                   }}
                   className={`flex items-center gap-1 px-2 py-1 text-[11px] font-medium transition-colors ${
                     interfaceMode === 'essential'
-                      ? 'bg-void-amber/15 text-void-amber'
+                      ? 'bg-[#f59e0b]/15 text-[#f59e0b]'
                       : 'text-muted-foreground/60 hover:text-muted-foreground'
                   }`}
                 >
-                  <span className={`w-1.5 h-1.5 rounded-full ${interfaceMode === 'essential' ? 'bg-void-amber' : 'bg-muted-foreground/30'}`} />
+                  <span className={`w-1.5 h-1.5 rounded-full ${interfaceMode === 'essential' ? 'bg-[#f59e0b]' : 'bg-muted-foreground/30'}`} />
                   {tcs('essential')}
                 </button>
                 <button
@@ -951,11 +951,11 @@ function ContextSwitcher({ currentUser, isAdmin, isLocal, isConnected, tenants, 
                   }}
                   className={`flex items-center gap-1 px-2 py-1 text-[11px] font-medium transition-colors border-l border-border ${
                     interfaceMode === 'full'
-                      ? 'bg-void-cyan/15 text-void-cyan'
+                      ? 'bg-[#3b82f6]/15 text-[#3b82f6]'
                       : 'text-muted-foreground/60 hover:text-muted-foreground'
                   }`}
                 >
-                  <span className={`w-1.5 h-1.5 rounded-full ${interfaceMode === 'full' ? 'bg-void-cyan' : 'bg-muted-foreground/30'}`} />
+                  <span className={`w-1.5 h-1.5 rounded-full ${interfaceMode === 'full' ? 'bg-[#3b82f6]' : 'bg-muted-foreground/30'}`} />
                   {tcs('full')}
                 </button>
               </div>
@@ -1000,7 +1000,7 @@ function ContextSwitcher({ currentUser, isAdmin, isLocal, isConnected, tenants, 
                     label={defaultOrgName}
                     initial={defaultOrgName[0]?.toUpperCase() || 'D'}
                     active={!activeTenant}
-                    colorClass="bg-void-cyan/20 text-void-cyan"
+                    colorClass="bg-[#3b82f6]/20 text-[#3b82f6]"
                     onClick={() => { onSwitchTenant(null); setOpen(false) }}
                     isActiveOrg={!activeTenant}
                     projects={projects}

--- a/src/components/modals/deploy-gate.tsx
+++ b/src/components/modals/deploy-gate.tsx
@@ -1,0 +1,334 @@
+'use client'
+
+export interface DeployAssessment {
+  verdict: 'profitable' | 'marginal' | 'losing'
+  strategy_info: {
+    agent_name: string
+    strategy: string
+    exchange: string
+    symbol: string
+    position_size_usd: number
+  }
+  cost_breakdown: {
+    entry_fee: number
+    exit_fee: number
+    slippage: number
+    funding: number
+    total_cost: number
+    total_cost_pct: number
+  }
+  expected_return_usd: number
+  net_return_usd: number
+  net_return_pct: number
+  risk_checks: {
+    within_position_limit: boolean
+    within_exposure_limit: boolean
+    kill_switch_ok: boolean
+  }
+}
+
+interface DeployGateProps {
+  isOpen: boolean
+  onClose: () => void
+  onDeploy: () => void
+  assessment: DeployAssessment | null
+  isLoading?: boolean
+}
+
+const VERDICT_COLOR: Record<DeployAssessment['verdict'], string> = {
+  profitable: '#22c55e',
+  marginal: '#f59e0b',
+  losing: '#ef4444',
+}
+
+const VERDICT_BG: Record<DeployAssessment['verdict'], string> = {
+  profitable: 'rgba(34,197,94,0.10)',
+  marginal: 'rgba(245,158,11,0.10)',
+  losing: 'rgba(239,68,68,0.10)',
+}
+
+function formatUsd(value: number): string {
+  return `$${Math.abs(value).toFixed(2)}`
+}
+
+function formatPct(value: number): string {
+  return `${value >= 0 ? '+' : '-'}${Math.abs(value).toFixed(2)}%`
+}
+
+function CostRow({
+  label,
+  value,
+  isBold,
+}: {
+  label: string
+  value: string
+  isBold?: boolean
+}) {
+  return (
+    <div className="flex justify-between py-0.5">
+      <span
+        className="text-xs"
+        style={{ color: 'var(--text-muted)', fontWeight: isBold ? 500 : 400 }}
+      >
+        {label}
+      </span>
+      <span
+        className="text-xs font-mono"
+        style={{ color: 'var(--text-secondary)', fontWeight: isBold ? 500 : 400 }}
+      >
+        {value}
+      </span>
+    </div>
+  )
+}
+
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between py-0.5">
+      <span className="text-xs" style={{ color: 'var(--text-muted)' }}>
+        {label}
+      </span>
+      <span className="text-xs font-mono" style={{ color: 'var(--text-secondary)' }}>
+        {value}
+      </span>
+    </div>
+  )
+}
+
+function RiskDot({ pass, label }: { pass: boolean; label: string }) {
+  return (
+    <div className="flex items-center gap-1">
+      <span
+        style={{
+          display: 'inline-block',
+          width: 6,
+          height: 6,
+          borderRadius: 9999,
+          backgroundColor: pass ? '#22c55e' : '#ef4444',
+          flexShrink: 0,
+        }}
+      />
+      <span className="text-xs" style={{ color: 'var(--text-muted)' }}>
+        {label}
+      </span>
+    </div>
+  )
+}
+
+export function DeployGate({
+  isOpen,
+  onClose,
+  onDeploy,
+  assessment,
+  isLoading = false,
+}: DeployGateProps) {
+  if (!isOpen) return null
+
+  const verdictColor = assessment ? VERDICT_COLOR[assessment.verdict] : '#71717a'
+  const verdictBg = assessment ? VERDICT_BG[assessment.verdict] : 'transparent'
+
+  const allRiskChecksPass = assessment
+    ? assessment.risk_checks.within_position_limit &&
+      assessment.risk_checks.within_exposure_limit &&
+      assessment.risk_checks.kill_switch_ok
+    : true
+
+  const deployLabel =
+    assessment?.verdict === 'losing' ? 'Deploy Anyway' : 'Deploy'
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{ backgroundColor: 'rgba(0,0,0,0.60)' }}
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Deploy Gate"
+    >
+      <div
+        className="w-full p-6"
+        style={{
+          maxWidth: 520,
+          backgroundColor: 'var(--surface)',
+          border: '1px solid var(--border)',
+          borderRadius: 8,
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Loading state */}
+        {isLoading && (
+          <div className="flex items-center justify-center py-8">
+            <span
+              className="text-sm animate-pulse"
+              style={{ color: 'var(--text-muted)' }}
+            >
+              Assessing deployment...
+            </span>
+          </div>
+        )}
+
+        {/* Content */}
+        {!isLoading && assessment && (
+          <>
+            {/* Section 1: Strategy Info */}
+            <div className="mb-4">
+              <div
+                className="text-sm font-medium mb-3"
+                style={{ color: 'var(--text-primary)' }}
+              >
+                Deploy Gate
+              </div>
+              <InfoRow label="Agent" value={assessment.strategy_info.agent_name} />
+              <InfoRow label="Strategy" value={assessment.strategy_info.strategy} />
+              <InfoRow label="Exchange" value={assessment.strategy_info.exchange} />
+              <InfoRow label="Symbol" value={assessment.strategy_info.symbol} />
+              <InfoRow
+                label="Position Size"
+                value={`$${assessment.strategy_info.position_size_usd.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}
+              />
+            </div>
+
+            {/* Section 2: Cost Breakdown */}
+            <div
+              className="pt-4 mb-4"
+              style={{ borderTop: '1px solid var(--border)' }}
+            >
+              <div
+                className="text-xs mb-2"
+                style={{ color: 'var(--text-muted)' }}
+              >
+                Transaction Costs
+              </div>
+              <CostRow label="Entry Fee" value={formatUsd(assessment.cost_breakdown.entry_fee)} />
+              <CostRow label="Exit Fee" value={formatUsd(assessment.cost_breakdown.exit_fee)} />
+              <CostRow label="Slippage" value={formatUsd(assessment.cost_breakdown.slippage)} />
+              <CostRow label="Funding" value={formatUsd(assessment.cost_breakdown.funding)} />
+              <CostRow
+                label="Total"
+                value={`${formatUsd(assessment.cost_breakdown.total_cost)} (${assessment.cost_breakdown.total_cost_pct.toFixed(2)}%)`}
+                isBold
+              />
+            </div>
+
+            {/* Section 3: Verdict Bar */}
+            <div
+              className="pt-4 mb-4"
+              style={{ borderTop: '1px solid var(--border)' }}
+            >
+              <div
+                className="rounded px-3 py-3"
+                style={{ backgroundColor: verdictBg, borderRadius: 6 }}
+              >
+                <div className="flex items-center justify-between mb-2">
+                  <span
+                    className="text-xs font-medium"
+                    style={{ color: verdictColor, textTransform: 'capitalize' }}
+                  >
+                    {assessment.verdict}
+                  </span>
+                  <div className="flex items-center gap-3">
+                    <span
+                      className="text-xs font-mono"
+                      style={{
+                        color:
+                          assessment.net_return_usd >= 0 ? '#22c55e' : '#ef4444',
+                      }}
+                    >
+                      {assessment.net_return_usd >= 0 ? '+' : '-'}
+                      {formatUsd(assessment.net_return_usd)}
+                    </span>
+                    <span
+                      className="text-xs font-mono"
+                      style={{
+                        color:
+                          assessment.net_return_pct >= 0 ? '#22c55e' : '#ef4444',
+                      }}
+                    >
+                      {formatPct(assessment.net_return_pct)}
+                    </span>
+                  </div>
+                </div>
+                <div className="flex items-center gap-4">
+                  <RiskDot
+                    pass={assessment.risk_checks.within_position_limit}
+                    label="Position limit"
+                  />
+                  <RiskDot
+                    pass={assessment.risk_checks.within_exposure_limit}
+                    label="Exposure limit"
+                  />
+                  <RiskDot
+                    pass={assessment.risk_checks.kill_switch_ok}
+                    label="Kill switch"
+                  />
+                </div>
+              </div>
+            </div>
+
+            {/* Action bar */}
+            <div>
+              {!allRiskChecksPass && (
+                <div
+                  className="text-xs mb-2"
+                  style={{ color: '#f59e0b' }}
+                >
+                  One or more risk checks failed. Review before deploying.
+                </div>
+              )}
+              <div className="flex items-center justify-between">
+                <button
+                  type="button"
+                  className="text-sm px-3 py-1.5"
+                  style={{
+                    color: 'var(--text-muted)',
+                    background: 'transparent',
+                    border: 'none',
+                    cursor: 'pointer',
+                    borderRadius: 4,
+                  }}
+                  onMouseEnter={(e) => {
+                    ;(e.currentTarget as HTMLButtonElement).style.color =
+                      'var(--text-secondary)'
+                  }}
+                  onMouseLeave={(e) => {
+                    ;(e.currentTarget as HTMLButtonElement).style.color =
+                      'var(--text-muted)'
+                  }}
+                  onClick={onClose}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  className="text-sm px-4 py-2 font-medium"
+                  style={{
+                    backgroundColor:
+                      assessment.verdict === 'losing'
+                        ? 'rgba(239,68,68,0.70)'
+                        : verdictColor,
+                    color: '#ffffff',
+                    border: 'none',
+                    borderRadius: 4,
+                    cursor: 'pointer',
+                  }}
+                  onClick={onDeploy}
+                >
+                  {deployLabel}
+                </button>
+              </div>
+            </div>
+          </>
+        )}
+
+        {/* Empty / null assessment while not loading */}
+        {!isLoading && !assessment && (
+          <div className="flex items-center justify-center py-8">
+            <span className="text-sm" style={{ color: 'var(--text-muted)' }}>
+              No assessment available.
+            </span>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/panels/agent-detail-panel.tsx
+++ b/src/components/panels/agent-detail-panel.tsx
@@ -1,0 +1,172 @@
+'use client'
+
+import { Agent } from '@/store/index'
+import { StatusBadge } from '@/components/ui/status-badge'
+import { getAgentIdentity, getFreshnessLabel } from '@/lib/agent-identity'
+
+interface AgentDetailPanelProps {
+  agent: Agent | null
+  onClose: () => void
+  className?: string
+}
+
+function mapAgentStatus(status: Agent['status']): 'running' | 'idle' | 'busy' | 'crashed' | 'offline' {
+  switch (status) {
+    case 'busy': return 'busy'
+    case 'error': return 'crashed'
+    case 'idle': return 'idle'
+    case 'offline': return 'offline'
+    default: return 'offline'
+  }
+}
+
+export function AgentDetailPanel({ agent, onClose, className = '' }: AgentDetailPanelProps) {
+  if (!agent) return null
+
+  const identity = getAgentIdentity(agent.name)
+  const mappedStatus = mapAgentStatus(agent.status)
+
+  const isOpen = agent !== null
+
+  return (
+    <>
+      {/* Backdrop overlay */}
+      <div
+        className="fixed inset-0 bg-black/50 z-40"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Slide-out panel */}
+      <div
+        className={`fixed right-0 top-0 h-full w-[400px] z-50 flex flex-col bg-[var(--surface)] border-l border-[var(--border)] ${className}`}
+        style={{
+          transform: isOpen ? 'translateX(0)' : 'translateX(100%)',
+          transition: 'transform 200ms ease-out',
+        }}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Agent detail: ${agent.name}`}
+      >
+        {/* Header bar — sticky top */}
+        <div className="sticky top-0 z-10 bg-[var(--surface)] border-b border-[var(--border)] px-4 py-3 flex-shrink-0">
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0 flex-1">
+              <h2 className="font-mono text-lg text-[var(--text-primary)] truncate leading-tight">
+                {agent.name}
+              </h2>
+              <div className="mt-1">
+                <StatusBadge status={mappedStatus} />
+              </div>
+              <p className="text-xs text-[var(--text-muted)] mt-1 truncate">
+                {identity.roleTitle}
+              </p>
+            </div>
+            <button
+              onClick={onClose}
+              className="flex-shrink-0 w-7 h-7 flex items-center justify-center text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-hover)] rounded transition-colors duration-150"
+              aria-label="Close panel"
+            >
+              <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+                <path d="M1 1l12 12M13 1L1 13" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        {/* Scrollable body */}
+        <div className="flex-1 overflow-y-auto">
+          {/* Overview section */}
+          <div className="px-4 py-4 border-b border-[var(--border)]">
+            <p className="text-sm text-[var(--text-secondary)] leading-relaxed">
+              {identity.oneLiner}
+            </p>
+            <div className="mt-3 flex items-center gap-2 flex-wrap">
+              <span className="inline-flex items-center px-2 py-0.5 text-xs bg-[var(--surface)] border border-[var(--border)] rounded text-[var(--text-secondary)]">
+                {identity.tier}
+              </span>
+              <span className="font-mono text-xs text-[var(--text-muted)]">
+                {identity.runtime || 'Unknown'}
+              </span>
+            </div>
+          </div>
+
+          {/* Stats grid */}
+          <div className="px-4 py-4 border-b border-[var(--border)]">
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <p className="text-xs text-[var(--text-muted)] uppercase tracking-wider mb-1">
+                  Last Seen
+                </p>
+                <p className="font-mono text-sm text-[var(--text-primary)]">
+                  {getFreshnessLabel(agent.last_seen)}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs text-[var(--text-muted)] uppercase tracking-wider mb-1">
+                  Tasks Active
+                </p>
+                <p className="font-mono text-sm text-[var(--text-primary)]">
+                  {agent.taskStats?.in_progress ?? 0}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs text-[var(--text-muted)] uppercase tracking-wider mb-1">
+                  Tasks Done
+                </p>
+                <p className="font-mono text-sm text-[var(--text-primary)]">
+                  {agent.taskStats?.done ?? 0}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs text-[var(--text-muted)] uppercase tracking-wider mb-1">
+                  Total Tasks
+                </p>
+                <p className="font-mono text-sm text-[var(--text-primary)]">
+                  {agent.taskStats?.total ?? 0}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Capabilities section — only if capabilities exist */}
+          {identity.capabilities.length > 0 && (
+            <div className="px-4 py-4 border-b border-[var(--border)]">
+              <p className="text-xs text-[var(--text-muted)] uppercase tracking-wider mb-2">
+                Capabilities
+              </p>
+              <div className="inline-flex flex-wrap gap-1">
+                {identity.capabilities.map((cap) => (
+                  <span
+                    key={cap}
+                    className="px-2 py-0.5 text-xs font-mono bg-[var(--surface)] border border-[var(--border)] rounded text-[var(--text-secondary)]"
+                  >
+                    {cap}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Actions section */}
+          <div className="px-4 py-4">
+            {identity.quickAction && (
+              <button
+                className="w-full px-3 py-2 rounded-md text-sm bg-[#3b82f6]/10 text-[#3b82f6] border border-[#3b82f6]/20 hover:bg-[#3b82f6]/20 transition-colors duration-150 text-left"
+              >
+                {identity.quickAction}
+              </button>
+            )}
+            <button
+              className="mt-2 w-full px-3 py-2 rounded-md text-sm text-[var(--text-secondary)] border border-[var(--border)] hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)] transition-colors duration-150 text-left"
+            >
+              View in Chat
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default AgentDetailPanel

--- a/src/components/panels/agent-table.tsx
+++ b/src/components/panels/agent-table.tsx
@@ -1,0 +1,217 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+import { DataTable, Column } from '@/components/ui/data-table'
+import { StatusBadge } from '@/components/ui/status-badge'
+import { Agent } from '@/store/index'
+import { getAgentIdentity, getFreshnessLabel, FleetTier, TIER_META } from '@/lib/agent-identity'
+
+interface AgentTableProps {
+  agents: Agent[]
+  onSelectAgent: (agent: Agent) => void
+  statusFilter?: string // 'all' | 'running' | 'idle' | 'offline' | 'error'
+  className?: string
+}
+
+type MappedStatus = 'running' | 'idle' | 'offline' | 'crashed'
+
+function mapAgentStatus(status: Agent['status']): MappedStatus {
+  if (status === 'busy') return 'running'
+  if (status === 'error') return 'crashed'
+  if (status === 'idle') return 'idle'
+  if (status === 'offline') return 'offline'
+  return 'idle'
+}
+
+const TIER_COLORS: Record<FleetTier, string> = {
+  operator: 'text-[#3b82f6]',
+  primary: 'text-[#22c55e]',
+  devtools: 'text-[#71717a]',
+  external: 'text-[#f59e0b]',
+  hidden: 'text-[#71717a]',
+}
+
+type AgentRow = Record<string, unknown> & {
+  id: number
+  name: string
+  status: Agent['status']
+  last_seen?: number
+  taskStats?: Agent['taskStats']
+  _agent: Agent
+}
+
+const FILTER_BUTTONS: { key: string; label: string }[] = [
+  { key: 'all', label: 'All' },
+  { key: 'running', label: 'Running' },
+  { key: 'idle', label: 'Idle' },
+  { key: 'offline', label: 'Offline' },
+  { key: 'error', label: 'Error' },
+]
+
+export function AgentTable({
+  agents,
+  onSelectAgent,
+  statusFilter: externalFilter,
+  className,
+}: AgentTableProps) {
+  const [internalFilter, setInternalFilter] = useState<string>('all')
+
+  // If an external filter is provided, use it; otherwise use internal state
+  const activeFilter = externalFilter !== undefined ? externalFilter : internalFilter
+
+  const filteredAgents = useMemo(() => {
+    if (activeFilter === 'all') return agents
+    if (activeFilter === 'running') return agents.filter(a => a.status === 'busy' || a.status === 'idle')
+    if (activeFilter === 'idle') return agents.filter(a => a.status === 'idle')
+    if (activeFilter === 'offline') return agents.filter(a => a.status === 'offline')
+    if (activeFilter === 'error') return agents.filter(a => a.status === 'error')
+    return agents
+  }, [agents, activeFilter])
+
+  const runningCount = useMemo(
+    () => agents.filter(a => a.status === 'busy' || a.status === 'idle').length,
+    [agents]
+  )
+  const errorCount = useMemo(
+    () => agents.filter(a => a.status === 'error').length,
+    [agents]
+  )
+
+  const tableData: AgentRow[] = useMemo(
+    () =>
+      filteredAgents.map(agent => ({
+        id: agent.id,
+        name: agent.name,
+        status: agent.status,
+        last_seen: agent.last_seen,
+        taskStats: agent.taskStats,
+        _agent: agent,
+      })),
+    [filteredAgents]
+  )
+
+  const columns: Column<AgentRow>[] = [
+    {
+      key: 'name',
+      label: 'Name',
+      sortable: true,
+      width: '200px',
+      render: (row) => {
+        const identity = getAgentIdentity(row.name as string)
+        return (
+          <div className="flex flex-col gap-0.5">
+            <span className="font-mono text-sm text-[var(--text-primary)]">{row.name as string}</span>
+            <span className="text-xs text-[var(--text-muted)]">{identity.roleTitle}</span>
+          </div>
+        )
+      },
+    },
+    {
+      key: 'status',
+      label: 'Status',
+      sortable: true,
+      width: '100px',
+      render: (row) => {
+        const mapped = mapAgentStatus(row.status as Agent['status'])
+        return <StatusBadge status={mapped} size="sm" />
+      },
+    },
+    {
+      key: 'tier',
+      label: 'Tier',
+      sortable: true,
+      width: '120px',
+      render: (row) => {
+        const tier = getAgentIdentity(row.name as string).tier
+        const colorClass = TIER_COLORS[tier]
+        return (
+          <span className={`text-xs ${colorClass}`}>
+            {TIER_META[tier].label}
+          </span>
+        )
+      },
+    },
+    {
+      key: 'last_seen',
+      label: 'Last Seen',
+      sortable: true,
+      width: '140px',
+      render: (row) => (
+        <span className="font-mono text-xs text-[var(--text-secondary)]">
+          {getFreshnessLabel(row.last_seen as number | undefined)}
+        </span>
+      ),
+    },
+    {
+      key: 'taskStats',
+      label: 'Tasks',
+      sortable: true,
+      width: '100px',
+      render: (row) => {
+        const stats = row.taskStats as Agent['taskStats']
+        const active = stats?.in_progress ?? 0
+        const done = stats?.done ?? 0
+        return (
+          <span className="font-mono text-xs text-[var(--text-secondary)]">
+            {active} active / {done} done
+          </span>
+        )
+      },
+    },
+    {
+      key: 'actions',
+      label: 'Actions',
+      sortable: false,
+      width: '80px',
+      render: (row) => (
+        <button
+          className="text-xs text-[#3b82f6] hover:underline"
+          onClick={(e) => {
+            e.stopPropagation()
+            onSelectAgent(row._agent as Agent)
+          }}
+        >
+          View
+        </button>
+      ),
+    },
+  ]
+
+  return (
+    <div className={className}>
+      {/* Filter bar */}
+      <div className="flex items-center gap-4 mb-3">
+        <div className="flex items-center gap-0">
+          {FILTER_BUTTONS.map((btn) => (
+            <button
+              key={btn.key}
+              onClick={() => setInternalFilter(btn.key)}
+              className={`px-3 py-1 text-xs transition-colors ${
+                activeFilter === btn.key
+                  ? 'text-[#3b82f6] border-b-2 border-[#3b82f6]'
+                  : 'text-[var(--text-muted)] border-b-2 border-transparent hover:text-[var(--text-secondary)]'
+              }`}
+            >
+              {btn.label}
+            </button>
+          ))}
+        </div>
+        <span className="text-xs text-[var(--text-muted)] ml-auto">
+          {agents.length} agents · {runningCount} running · {errorCount} errors
+        </span>
+      </div>
+
+      {/* Table */}
+      <DataTable<AgentRow>
+        columns={columns}
+        data={tableData}
+        keyField="id"
+        emptyMessage="No agents found. Deploy one from chat: 'start an agent'"
+        maxHeight="calc(100vh - 200px)"
+        onRowClick={(row) => onSelectAgent(row._agent as Agent)}
+      />
+    </div>
+  )
+}
+
+export default AgentTable

--- a/src/components/panels/backtest-results-panel.tsx
+++ b/src/components/panels/backtest-results-panel.tsx
@@ -1,0 +1,510 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { DataTable, Column } from '@/components/ui/data-table'
+import { StatusBadge } from '@/components/ui/status-badge'
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+interface BacktestResult {
+  id: string
+  strategy: string
+  exchange: string
+  symbol: string
+  timeframe: string
+  created_at: number
+  status: 'completed' | 'running' | 'failed'
+  metrics: {
+    roi: number
+    roi_gross?: number
+    max_drawdown: number
+    sharpe_ratio: number
+    sortino_ratio: number
+    total_trades: number
+    win_rate: number
+    profit_factor: number
+    total_pnl: number
+    avg_pnl: number
+    expected_value_pct: number
+    calmar_ratio: number
+    sqn: number
+  }
+  cost_breakdown?: {
+    fees_usd: number
+    slippage_usd: number
+    funding_usd: number
+    total_usd: number
+    roi_impact_pct: number
+  }
+}
+
+interface BacktestResultsPanelProps {
+  className?: string
+}
+
+// ── Helper formatters ──────────────────────────────────────────────────
+
+function fmt2(n: number): string {
+  return n.toFixed(2)
+}
+
+function fmtPct(n: number): string {
+  return (n >= 0 ? '+' : '') + n.toFixed(2) + '%'
+}
+
+function fmtUsd(n: number): string {
+  return '$' + n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+}
+
+function roiColor(n: number): string {
+  if (n > 0) return 'text-[#22c55e]'
+  if (n < 0) return 'text-[#ef4444]'
+  return 'text-[var(--text-secondary)]'
+}
+
+function mapBacktestStatus(status: BacktestResult['status']): 'running' | 'busy' | 'crashed' {
+  switch (status) {
+    case 'completed': return 'running'
+    case 'running': return 'busy'
+    case 'failed': return 'crashed'
+  }
+}
+
+// ── Summary strip ──────────────────────────────────────────────────────
+
+function SummaryStat({ label, value, valueClass }: { label: string; value: string; valueClass?: string }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-xs text-[var(--text-muted)]">{label}</span>
+      <span className={`text-sm font-mono tabular-nums text-[var(--text-primary)] ${valueClass ?? ''}`}>
+        {value}
+      </span>
+    </div>
+  )
+}
+
+// ── Detail panel ───────────────────────────────────────────────────────
+
+interface DetailRowProps {
+  label: string
+  value: string
+  valueClass?: string
+}
+
+function DetailRow({ label, value, valueClass }: DetailRowProps) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-xs text-[var(--text-muted)] uppercase tracking-wider">{label}</span>
+      <span className={`font-mono text-sm tabular-nums text-[var(--text-primary)] ${valueClass ?? ''}`}>
+        {value}
+      </span>
+    </div>
+  )
+}
+
+interface BacktestDetailPanelProps {
+  result: BacktestResult
+  onClose: () => void
+}
+
+function BacktestDetailPanel({ result, onClose }: BacktestDetailPanelProps) {
+  const m = result.metrics
+  const cb = result.cost_breakdown
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/50 z-40"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Slide-out panel */}
+      <div
+        className="fixed right-0 top-0 h-full w-[360px] z-50 flex flex-col bg-[var(--surface)] border-l border-[var(--border)]"
+        style={{ transform: 'translateX(0)', transition: 'transform 200ms ease-out' }}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Backtest detail: ${result.strategy}`}
+      >
+        {/* Header */}
+        <div className="sticky top-0 z-10 bg-[var(--surface)] border-b border-[var(--border)] px-4 py-3 flex-shrink-0">
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0 flex-1">
+              <h2 className="font-mono text-sm font-medium text-[var(--text-primary)] truncate leading-tight">
+                {result.strategy}
+              </h2>
+              <div className="mt-1 flex items-center gap-2">
+                <StatusBadge status={mapBacktestStatus(result.status)} />
+                <span className="font-mono text-xs text-[var(--text-muted)]">
+                  {result.symbol} · {result.timeframe} · {result.exchange}
+                </span>
+              </div>
+            </div>
+            <button
+              onClick={onClose}
+              className="flex-shrink-0 w-7 h-7 flex items-center justify-center text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-hover)] rounded transition-colors duration-150"
+              aria-label="Close detail panel"
+            >
+              <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+                <path d="M1 1l12 12M13 1L1 13" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto">
+          {/* Core metrics */}
+          <div className="px-4 py-4 border-b border-[var(--border)]">
+            <p className="text-xs text-[var(--text-muted)] uppercase tracking-wider mb-3">Performance</p>
+            <div className="grid grid-cols-2 gap-3">
+              <DetailRow
+                label="ROI (Net)"
+                value={fmtPct(m.roi)}
+                valueClass={roiColor(m.roi)}
+              />
+              {m.roi_gross != null && (
+                <DetailRow
+                  label="ROI (Gross)"
+                  value={fmtPct(m.roi_gross)}
+                  valueClass={roiColor(m.roi_gross)}
+                />
+              )}
+              <DetailRow
+                label="Total PnL"
+                value={fmtUsd(m.total_pnl)}
+                valueClass={roiColor(m.total_pnl)}
+              />
+              <DetailRow
+                label="Avg PnL"
+                value={fmtUsd(m.avg_pnl)}
+                valueClass={roiColor(m.avg_pnl)}
+              />
+              <DetailRow
+                label="Max Drawdown"
+                value={fmtPct(m.max_drawdown)}
+                valueClass="text-[#ef4444]"
+              />
+              <DetailRow label="Win Rate" value={fmtPct(m.win_rate)} />
+              <DetailRow label="Total Trades" value={String(m.total_trades)} />
+              <DetailRow label="Profit Factor" value={fmt2(m.profit_factor)} />
+            </div>
+          </div>
+
+          {/* Risk metrics */}
+          <div className="px-4 py-4 border-b border-[var(--border)]">
+            <p className="text-xs text-[var(--text-muted)] uppercase tracking-wider mb-3">Risk Ratios</p>
+            <div className="grid grid-cols-2 gap-3">
+              <DetailRow label="Sharpe" value={fmt2(m.sharpe_ratio)} />
+              <DetailRow label="Sortino" value={fmt2(m.sortino_ratio)} />
+              <DetailRow label="Calmar" value={fmt2(m.calmar_ratio)} />
+              <DetailRow label="SQN" value={fmt2(m.sqn)} />
+              <DetailRow
+                label="Expected Value"
+                value={fmtPct(m.expected_value_pct)}
+                valueClass={roiColor(m.expected_value_pct)}
+              />
+            </div>
+          </div>
+
+          {/* Cost breakdown */}
+          {cb && (
+            <div className="px-4 py-4 border-b border-[var(--border)]">
+              <p className="text-xs text-[var(--text-muted)] uppercase tracking-wider mb-3">Cost Breakdown</p>
+              <div className="grid grid-cols-2 gap-3">
+                <DetailRow label="Fees" value={fmtUsd(cb.fees_usd)} valueClass="text-[#ef4444]" />
+                <DetailRow label="Slippage" value={fmtUsd(cb.slippage_usd)} valueClass="text-[#f59e0b]" />
+                <DetailRow label="Funding" value={fmtUsd(cb.funding_usd)} valueClass="text-[#f59e0b]" />
+                <DetailRow label="Total Cost" value={fmtUsd(cb.total_usd)} valueClass="text-[#ef4444]" />
+                <DetailRow
+                  label="ROI Impact"
+                  value={fmtPct(cb.roi_impact_pct)}
+                  valueClass="text-[#ef4444]"
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Metadata */}
+          <div className="px-4 py-4">
+            <p className="text-xs text-[var(--text-muted)] uppercase tracking-wider mb-3">Metadata</p>
+            <div className="grid grid-cols-2 gap-3">
+              <DetailRow label="Exchange" value={result.exchange} />
+              <DetailRow label="Symbol" value={result.symbol} />
+              <DetailRow label="Timeframe" value={result.timeframe} />
+              <DetailRow
+                label="Created"
+                value={new Date(result.created_at * 1000).toLocaleDateString()}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}
+
+// ── Table row type ─────────────────────────────────────────────────────
+
+// DataTable requires Record<string, unknown> — we expose flattened rows
+interface BacktestRow extends Record<string, unknown> {
+  id: string
+  strategy: string
+  symbol: string
+  roi: number
+  roi_gross: number | null
+  sharpe: number
+  max_drawdown: number
+  win_rate: number
+  total_trades: number
+  profit_factor: number
+  status: BacktestResult['status']
+  _raw: BacktestResult
+}
+
+function toRow(r: BacktestResult): BacktestRow {
+  return {
+    id: r.id,
+    strategy: r.strategy,
+    symbol: r.symbol,
+    roi: r.metrics.roi,
+    roi_gross: r.metrics.roi_gross ?? null,
+    sharpe: r.metrics.sharpe_ratio,
+    max_drawdown: r.metrics.max_drawdown,
+    win_rate: r.metrics.win_rate,
+    total_trades: r.metrics.total_trades,
+    profit_factor: r.metrics.profit_factor,
+    status: r.status,
+    _raw: r,
+  }
+}
+
+// ── Main panel ─────────────────────────────────────────────────────────
+
+export function BacktestResultsPanel({ className = '' }: BacktestResultsPanelProps) {
+  const [results, setResults] = useState<BacktestResult[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [selectedStrategy, setSelectedStrategy] = useState<string | null>(null)
+  const [isRunning, setIsRunning] = useState(false)
+
+  // ── Fetch on mount ───────────────────────────────────────────────────
+  useEffect(() => {
+    fetch('/api/backtest')
+      .then(res => res.ok ? res.json() : null)
+      .then(data => {
+        if (data?.results) setResults(data.results)
+      })
+      .catch(err => setError(err.message))
+      .finally(() => setIsLoading(false))
+  }, [])
+
+  // ── Run backtest handler ─────────────────────────────────────────────
+  const handleRunBacktest = async () => {
+    setIsRunning(true)
+    try {
+      const res = await fetch('/api/backtest', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'run_all' }),
+      })
+      if (res.ok) {
+        setTimeout(() => {
+          fetch('/api/backtest')
+            .then(r => r.ok ? r.json() : null)
+            .then(d => { if (d?.results) setResults(d.results) })
+        }, 2000)
+      }
+    } finally {
+      setIsRunning(false)
+    }
+  }
+
+  // ── Derived: summary stats ───────────────────────────────────────────
+  const completed = results.filter(r => r.status === 'completed')
+  const avgRoi = completed.length > 0
+    ? completed.reduce((sum, r) => sum + r.metrics.roi, 0) / completed.length
+    : 0
+  const avgSharpe = completed.length > 0
+    ? completed.reduce((sum, r) => sum + r.metrics.sharpe_ratio, 0) / completed.length
+    : 0
+  const avgWinRate = completed.length > 0
+    ? completed.reduce((sum, r) => sum + r.metrics.win_rate, 0) / completed.length
+    : 0
+
+  // ── Table columns ────────────────────────────────────────────────────
+  const columns: Column<BacktestRow>[] = [
+    {
+      key: 'strategy',
+      label: 'Strategy',
+      sortable: true,
+      render: (row) => (
+        <span className="font-mono text-sm text-[var(--text-primary)]">{String(row.strategy)}</span>
+      ),
+    },
+    {
+      key: 'symbol',
+      label: 'Symbol',
+      sortable: true,
+      render: (row) => (
+        <span className="font-mono text-xs text-[var(--text-secondary)]">{String(row.symbol)}</span>
+      ),
+    },
+    {
+      key: 'roi',
+      label: 'ROI %',
+      sortable: true,
+      numeric: true,
+      render: (row) => {
+        const roi = row.roi as number
+        const roiGross = row.roi_gross as number | null
+        return (
+          <span className={`font-mono text-xs tabular-nums ${roiColor(roi)}`}>
+            {fmtPct(roi)}
+            {roiGross != null && (
+              <span className="text-[var(--text-muted)] ml-1">
+                ({fmtPct(roiGross)})
+              </span>
+            )}
+          </span>
+        )
+      },
+    },
+    {
+      key: 'sharpe',
+      label: 'Sharpe',
+      sortable: true,
+      numeric: true,
+      render: (row) => (
+        <span className="font-mono text-xs tabular-nums text-[var(--text-secondary)]">
+          {fmt2(row.sharpe as number)}
+        </span>
+      ),
+    },
+    {
+      key: 'max_drawdown',
+      label: 'Max DD %',
+      sortable: true,
+      numeric: true,
+      render: (row) => (
+        <span className="font-mono text-xs tabular-nums text-[#ef4444]">
+          {fmtPct(row.max_drawdown as number)}
+        </span>
+      ),
+    },
+    {
+      key: 'win_rate',
+      label: 'Win Rate',
+      sortable: true,
+      numeric: true,
+      render: (row) => (
+        <span className="font-mono text-xs tabular-nums text-[var(--text-secondary)]">
+          {fmtPct(row.win_rate as number)}
+        </span>
+      ),
+    },
+    {
+      key: 'total_trades',
+      label: 'Trades',
+      sortable: true,
+      numeric: true,
+      render: (row) => (
+        <span className="font-mono text-xs tabular-nums text-[var(--text-secondary)]">
+          {String(row.total_trades)}
+        </span>
+      ),
+    },
+    {
+      key: 'profit_factor',
+      label: 'PF',
+      sortable: true,
+      numeric: true,
+      render: (row) => (
+        <span className="font-mono text-xs tabular-nums text-[var(--text-secondary)]">
+          {fmt2(row.profit_factor as number)}
+        </span>
+      ),
+    },
+    {
+      key: 'status',
+      label: 'Status',
+      sortable: true,
+      render: (row) => (
+        <StatusBadge status={mapBacktestStatus(row.status as BacktestResult['status'])} />
+      ),
+    },
+  ]
+
+  // ── Selected result for detail panel ─────────────────────────────────
+  const selectedResult = selectedStrategy
+    ? results.find(r => r.id === selectedStrategy) ?? null
+    : null
+
+  // ── Render ───────────────────────────────────────────────────────────
+  return (
+    <div className={`flex flex-col h-full bg-[var(--surface)] ${className}`}>
+      {/* Header bar */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--border)] flex-shrink-0">
+        <span className="text-sm font-medium text-[var(--text-primary)]">Backtest Results</span>
+        <button
+          onClick={handleRunBacktest}
+          disabled={isRunning}
+          className="px-3 py-1 text-xs border border-[#3b82f6]/50 text-[#3b82f6] rounded hover:bg-[#3b82f6]/10 transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
+          aria-label="Run all backtests"
+        >
+          {isRunning ? 'Running...' : 'Run Backtest'}
+        </button>
+      </div>
+
+      {/* Summary strip */}
+      {results.length > 0 && (
+        <div className="flex items-center gap-6 px-4 py-2 border-b border-[var(--border)] flex-shrink-0 bg-[var(--bg,#0f1117)]">
+          <SummaryStat label="Total Runs" value={String(results.length)} />
+          <SummaryStat
+            label="Avg ROI"
+            value={fmtPct(avgRoi)}
+            valueClass={roiColor(avgRoi)}
+          />
+          <SummaryStat label="Avg Sharpe" value={fmt2(avgSharpe)} />
+          <SummaryStat label="Avg Win Rate" value={fmtPct(avgWinRate)} />
+        </div>
+      )}
+
+      {/* Body */}
+      <div className="flex-1 overflow-auto px-4 py-3">
+        {isLoading ? (
+          <div className="flex items-center justify-center py-12">
+            <span className="text-sm text-[var(--text-muted)] animate-pulse">Loading results...</span>
+          </div>
+        ) : error ? (
+          <div className="flex flex-col items-center justify-center py-12 gap-2">
+            <span className="text-sm text-[#ef4444]">Error loading results</span>
+            <span className="font-mono text-xs text-[var(--text-muted)]">{error}</span>
+          </div>
+        ) : (
+          <DataTable<BacktestRow>
+            columns={columns}
+            data={results.map(toRow)}
+            keyField="id"
+            emptyMessage="No backtest results yet. Run a backtest to see results here."
+            emptyAction={{ label: 'Run a backtest now', onClick: handleRunBacktest }}
+            maxHeight="calc(100vh - 200px)"
+            onRowClick={(row) => setSelectedStrategy(String(row.id))}
+          />
+        )}
+      </div>
+
+      {/* Detail panel */}
+      {selectedResult && (
+        <BacktestDetailPanel
+          result={selectedResult}
+          onClose={() => setSelectedStrategy(null)}
+        />
+      )}
+    </div>
+  )
+}
+
+export default BacktestResultsPanel

--- a/src/components/panels/chat-bridge-panel.tsx
+++ b/src/components/panels/chat-bridge-panel.tsx
@@ -1,0 +1,218 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import { useMissionControl } from '@/store'
+
+interface CommandEntry {
+  id: string
+  agent_name: string
+  command: string
+  sent_at: number
+  response?: string
+  status: 'sent' | 'delivered' | 'failed'
+}
+
+export interface ChatBridgePanelProps {
+  className?: string
+}
+
+function formatTs(ms: number): string {
+  const d = new Date(ms)
+  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+}
+
+export function ChatBridgePanel({ className }: ChatBridgePanelProps) {
+  const agents = useMissionControl(s => s.agents)
+  const [selectedAgent, setSelectedAgent] = useState<string | null>(null)
+  const [command, setCommand] = useState('')
+  const [history, setHistory] = useState<CommandEntry[]>([])
+  const [isSending, setIsSending] = useState(false)
+  const historyEndRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const visibleAgents = agents.filter(a => a.status !== 'offline')
+
+  // Auto-scroll to bottom when history grows
+  useEffect(() => {
+    historyEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [history.length])
+
+  const handleSend = async () => {
+    if (!selectedAgent || !command.trim()) return
+
+    const entry: CommandEntry = {
+      id: `cmd_${Date.now()}`,
+      agent_name: selectedAgent,
+      command: command.trim(),
+      sent_at: Date.now(),
+      status: 'sent',
+    }
+
+    setHistory(prev => [...prev, entry])
+    setCommand('')
+    setIsSending(true)
+
+    try {
+      const lower = command.trim().toLowerCase()
+      if (['start', 'stop', 'restart', 'halt'].includes(lower)) {
+        const agent = agents.find(a => a.name === selectedAgent)
+        if (agent) {
+          await fetch(`/api/agents/${agent.id}/control`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ action: lower === 'halt' ? 'stop' : lower }),
+          })
+        }
+        setHistory(prev =>
+          prev.map(e => e.id === entry.id ? { ...e, status: 'delivered' as const } : e)
+        )
+      } else {
+        await fetch('/api/chat/messages', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            content: command.trim(),
+            recipient: selectedAgent,
+            type: 'command',
+          }),
+        })
+        setHistory(prev =>
+          prev.map(e => e.id === entry.id ? { ...e, status: 'delivered' as const } : e)
+        )
+      }
+    } catch {
+      setHistory(prev =>
+        prev.map(e => e.id === entry.id ? { ...e, status: 'failed' as const } : e)
+      )
+    } finally {
+      setIsSending(false)
+    }
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      handleSend()
+    }
+  }
+
+  return (
+    <div
+      className={`flex flex-col h-full bg-[var(--surface)] text-[var(--text-primary)]${className ? ` ${className}` : ''}`}
+    >
+      {/* Header */}
+      <div className="flex items-center px-4 py-2 border-b border-[var(--border)] flex-shrink-0">
+        <span className="text-sm font-medium text-[var(--text-primary)]">Agent Command Bridge</span>
+      </div>
+
+      {/* Agent selector */}
+      <div className="flex items-center gap-1 px-4 py-2 border-b border-[var(--border)] flex-shrink-0 overflow-x-auto">
+        {visibleAgents.length === 0 ? (
+          <span className="text-xs font-mono text-[var(--text-muted)]">No agents online</span>
+        ) : (
+          visibleAgents.map(agent => {
+            const isSelected = selectedAgent === agent.name
+            return (
+              <button
+                key={agent.id}
+                type="button"
+                onClick={() => setSelectedAgent(isSelected ? null : agent.name)}
+                className={[
+                  'inline-flex items-center px-2 py-0.5 rounded text-xs font-mono border transition-colors whitespace-nowrap cursor-pointer',
+                  isSelected
+                    ? 'border-[#3b82f6] text-[#3b82f6] bg-[rgba(59,130,246,0.10)]'
+                    : 'border-[var(--border)] text-[var(--text-secondary)] hover:border-[#3b82f6] hover:text-[#3b82f6]',
+                ].join(' ')}
+              >
+                {agent.name}
+              </button>
+            )
+          })
+        )}
+      </div>
+
+      {/* Command history */}
+      <div className="flex-1 overflow-y-auto min-h-0 px-4 py-2">
+        {history.length === 0 ? (
+          <div className="flex items-center justify-center h-full">
+            <p className="text-xs font-mono text-[var(--text-muted)] text-center">
+              No commands sent yet. Select an agent and type a command.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-1">
+            {history.map(entry => (
+              <div key={entry.id} className="flex items-start gap-2 py-0.5">
+                {/* Status dot */}
+                <span
+                  className="mt-[3px] w-1.5 h-1.5 rounded-full flex-shrink-0"
+                  style={{
+                    backgroundColor:
+                      entry.status === 'delivered'
+                        ? '#22c55e'
+                        : entry.status === 'failed'
+                          ? '#ef4444'
+                          : '#f59e0b',
+                  }}
+                  title={entry.status}
+                />
+                {/* Agent name */}
+                <span className="text-xs font-mono text-[var(--text-muted)] flex-shrink-0">
+                  {entry.agent_name}
+                </span>
+                {/* Command text */}
+                <span className="text-sm font-mono text-[var(--text-primary)] flex-1 break-all min-w-0">
+                  {entry.command}
+                </span>
+                {/* Timestamp */}
+                <span className="text-xs font-mono text-[var(--text-muted)] flex-shrink-0 tabular-nums">
+                  {formatTs(entry.sent_at)}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+        <div ref={historyEndRef} />
+      </div>
+
+      {/* Command input bar */}
+      <div className="flex items-center gap-2 px-4 py-2 border-t border-[var(--border)] flex-shrink-0">
+        {/* Selected agent badge */}
+        <span className="text-xs font-mono text-[var(--text-muted)] flex-shrink-0">
+          {selectedAgent ? (
+            <span className="text-[#3b82f6]">{selectedAgent}</span>
+          ) : (
+            'Select agent'
+          )}
+        </span>
+
+        {/* Divider */}
+        <span className="text-[var(--border)] flex-shrink-0 select-none">|</span>
+
+        {/* Text input */}
+        <input
+          ref={inputRef}
+          type="text"
+          value={command}
+          onChange={e => setCommand(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Type a command..."
+          disabled={isSending}
+          className="flex-1 text-sm font-mono bg-transparent border-none outline-none text-[var(--text-primary)] placeholder:text-[var(--text-muted)] disabled:opacity-50"
+        />
+
+        {/* Send button */}
+        <button
+          type="button"
+          onClick={handleSend}
+          disabled={!selectedAgent || !command.trim() || isSending}
+          className="text-xs font-mono text-[#3b82f6] hover:text-[#60a5fa] disabled:text-[var(--text-muted)] disabled:cursor-not-allowed transition-colors flex-shrink-0 cursor-pointer"
+        >
+          {isSending ? '...' : 'Send'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default ChatBridgePanel

--- a/src/components/ui/connection-pill.tsx
+++ b/src/components/ui/connection-pill.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+type ConnectionState = 'connected' | 'offline' | 'degraded'
+
+interface ConnectionPillProps {
+  state: ConnectionState
+  queuedCount?: number // shown when offline
+  latency?: number // shown when connected, in ms
+  className?: string
+}
+
+const PILL_CONFIG: Record<ConnectionState, { dot: string; text: string; label: string }> = {
+  connected: { dot: 'bg-[#22c55e]', text: 'text-[#22c55e]', label: 'MC Connected' },
+  offline: { dot: 'bg-[#ef4444]', text: 'text-[#ef4444]', label: 'MC Offline' },
+  degraded: { dot: 'bg-[#f59e0b]', text: 'text-[#f59e0b]', label: 'MC Degraded' },
+}
+
+export function ConnectionPill({ state, queuedCount, latency, className = '' }: ConnectionPillProps) {
+  const config = PILL_CONFIG[state]
+
+  let displayLabel = config.label
+  if (state === 'offline' && queuedCount != null && queuedCount > 0) {
+    displayLabel = `MC Offline (${queuedCount} queued)`
+  }
+  if (state === 'connected' && latency != null) {
+    displayLabel = `MC Connected · ${latency}ms`
+  }
+
+  return (
+    <div className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-[var(--surface)] border border-[var(--border)] ${className}`}>
+      <span className={`w-1.5 h-1.5 rounded-full ${config.dot} shrink-0`} />
+      <span className={`text-xs font-medium font-mono ${config.text}`}>
+        {displayLabel}
+      </span>
+    </div>
+  )
+}

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -1,0 +1,174 @@
+'use client'
+
+import { useState, useCallback, useMemo } from 'react'
+
+export interface Column<T> {
+  key: string
+  label: string
+  sortable?: boolean
+  numeric?: boolean // renders in monospace, right-aligned
+  monetary?: boolean // like numeric but also color-codes positive/negative
+  width?: string // e.g. '120px', '20%'
+  render?: (row: T, index: number) => React.ReactNode
+}
+
+interface DataTableProps<T> {
+  columns: Column<T>[]
+  data: T[]
+  keyField: string // field name to use as React key
+  emptyMessage?: string
+  emptyAction?: { label: string; onClick: () => void }
+  maxHeight?: string // e.g. '400px' for scrollable body with fixed header
+  className?: string
+  onRowClick?: (row: T) => void
+}
+
+type SortDir = 'asc' | 'desc'
+
+export function DataTable<T extends Record<string, unknown>>({
+  columns,
+  data,
+  keyField,
+  emptyMessage = 'No data available.',
+  emptyAction,
+  maxHeight,
+  className = '',
+  onRowClick,
+}: DataTableProps<T>) {
+  const [sortKey, setSortKey] = useState<string | null>(null)
+  const [sortDir, setSortDir] = useState<SortDir>('asc')
+
+  const handleSort = useCallback((key: string) => {
+    if (sortKey === key) {
+      setSortDir(prev => prev === 'asc' ? 'desc' : 'asc')
+    } else {
+      setSortKey(key)
+      setSortDir('asc')
+    }
+  }, [sortKey])
+
+  const sortedData = useMemo(() => {
+    if (!sortKey) return data
+    return [...data].sort((a, b) => {
+      const aVal = a[sortKey]
+      const bVal = b[sortKey]
+      if (aVal == null && bVal == null) return 0
+      if (aVal == null) return 1
+      if (bVal == null) return -1
+      if (typeof aVal === 'number' && typeof bVal === 'number') {
+        return sortDir === 'asc' ? aVal - bVal : bVal - aVal
+      }
+      const aStr = String(aVal)
+      const bStr = String(bVal)
+      return sortDir === 'asc' ? aStr.localeCompare(bStr) : bStr.localeCompare(aStr)
+    })
+  }, [data, sortKey, sortDir])
+
+  if (data.length === 0) {
+    return (
+      <div className={`flex flex-col items-center justify-center py-12 ${className}`}>
+        <p className="text-sm text-[var(--text-muted)]">{emptyMessage}</p>
+        {emptyAction && (
+          <button
+            onClick={emptyAction.onClick}
+            className="mt-2 text-sm text-[var(--blue)] hover:underline"
+          >
+            {emptyAction.label}
+          </button>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className={`border border-[var(--border)] rounded-md overflow-hidden ${className}`}>
+      <div className={maxHeight ? `overflow-auto` : ''} style={maxHeight ? { maxHeight } : undefined}>
+        <table className="w-full text-sm">
+          <thead className="sticky top-0 z-10">
+            <tr className="bg-[var(--surface)] border-b border-[var(--border)]">
+              {columns.map(col => (
+                <th
+                  key={col.key}
+                  className={`px-3 py-2 text-left text-xs font-medium text-[var(--text-muted)] uppercase tracking-wider ${
+                    col.numeric || col.monetary ? 'text-right' : ''
+                  } ${col.sortable ? 'cursor-pointer select-none hover:text-[var(--text-secondary)]' : ''}`}
+                  style={col.width ? { width: col.width } : undefined}
+                  onClick={col.sortable ? () => handleSort(col.key) : undefined}
+                >
+                  <span className="inline-flex items-center gap-1">
+                    {col.label}
+                    {col.sortable && sortKey === col.key && (
+                      <SortChevron direction={sortDir} />
+                    )}
+                  </span>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {sortedData.map((row, idx) => (
+              <tr
+                key={String(row[keyField])}
+                className={`border-b border-[var(--border)] last:border-b-0 ${
+                  idx % 2 === 0 ? 'bg-[var(--bg,var(--background))]' : 'bg-transparent'
+                } ${onRowClick ? 'cursor-pointer hover:bg-[var(--surface-hover,var(--surface-2))]' : ''}`}
+                onClick={onRowClick ? () => onRowClick(row) : undefined}
+              >
+                {columns.map(col => {
+                  const value = row[col.key]
+                  const isMonetary = col.monetary
+                  const isNumeric = col.numeric || isMonetary
+
+                  let content: React.ReactNode
+                  if (col.render) {
+                    content = col.render(row, idx)
+                  } else if (isMonetary && typeof value === 'number') {
+                    const colorClass = value > 0 ? 'text-[#22c55e]' : value < 0 ? 'text-[#ef4444]' : 'text-[var(--text-secondary)]'
+                    content = (
+                      <span className={`font-mono tabular-nums ${colorClass}`}>
+                        {value > 0 ? '+' : ''}{value.toLocaleString()}
+                      </span>
+                    )
+                  } else if (isNumeric) {
+                    content = (
+                      <span className="font-mono tabular-nums text-[var(--text-secondary)]">
+                        {value != null ? String(value) : '—'}
+                      </span>
+                    )
+                  } else {
+                    content = <span className="text-[var(--text-primary,var(--foreground))]">{value != null ? String(value) : '—'}</span>
+                  }
+
+                  return (
+                    <td
+                      key={col.key}
+                      className={`px-3 py-2 ${isNumeric ? 'text-right' : ''}`}
+                    >
+                      {content}
+                    </td>
+                  )
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+function SortChevron({ direction }: { direction: SortDir }) {
+  return (
+    <svg
+      className={`w-3 h-3 ${direction === 'desc' ? 'rotate-180' : ''}`}
+      viewBox="0 0 12 12"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M3 8L6 5L9 8" />
+    </svg>
+  )
+}

--- a/src/components/ui/halt-button.tsx
+++ b/src/components/ui/halt-button.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import { useState, useRef, useCallback } from 'react'
+
+interface HaltButtonProps {
+  onHalted?: (count: number) => void
+  className?: string
+}
+
+type ButtonState = 'default' | 'confirming' | 'halting' | 'success'
+
+export function HaltButton({ onHalted, className = '' }: HaltButtonProps) {
+  const [buttonState, setButtonState] = useState<ButtonState>('default')
+  const confirmTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const clearConfirmTimer = () => {
+    if (confirmTimerRef.current !== null) {
+      clearTimeout(confirmTimerRef.current)
+      confirmTimerRef.current = null
+    }
+  }
+
+  const handleHalt = useCallback(async () => {
+    try {
+      setButtonState('halting')
+      const res = await fetch('/api/agents/halt', { method: 'POST' })
+      const data = await res.json()
+
+      if (!res.ok) {
+        // Revert to default on API error
+        setButtonState('default')
+        return
+      }
+
+      setButtonState('success')
+      onHalted?.(data.halted_count ?? 0)
+
+      // Flash green for 1.5 s, then revert
+      setTimeout(() => {
+        setButtonState('default')
+      }, 1500)
+    } catch {
+      setButtonState('default')
+    }
+  }, [onHalted])
+
+  const handleClick = () => {
+    if (buttonState === 'halting') return
+
+    if (buttonState === 'success') return
+
+    if (buttonState === 'default') {
+      // Enter confirmation state
+      setButtonState('confirming')
+      confirmTimerRef.current = setTimeout(() => {
+        setButtonState('default')
+        confirmTimerRef.current = null
+      }, 3000)
+      return
+    }
+
+    if (buttonState === 'confirming') {
+      clearConfirmTimer()
+      handleHalt()
+    }
+  }
+
+  const isDisabled = buttonState === 'halting'
+
+  let label = 'HALT ALL'
+  if (buttonState === 'confirming') label = 'CONFIRM HALT'
+  if (buttonState === 'halting') label = 'HALTING...'
+
+  const baseClasses =
+    'inline-flex items-center justify-center px-3 py-1.5 rounded-[4px] font-mono text-xs uppercase tracking-wide transition-colors duration-150 border focus:outline-none'
+
+  let stateClasses = ''
+  if (buttonState === 'success') {
+    stateClasses = 'border-[#22c55e] text-[#22c55e] bg-transparent cursor-default'
+  } else if (buttonState === 'halting') {
+    stateClasses =
+      'border-[#ef4444]/50 text-[#ef4444] bg-transparent opacity-50 cursor-not-allowed'
+  } else if (buttonState === 'confirming') {
+    stateClasses =
+      'border-[#ef4444] text-[#ef4444] bg-[#ef4444]/10 animate-pulse cursor-pointer'
+  } else {
+    stateClasses =
+      'border-[#ef4444]/50 text-[#ef4444] bg-transparent hover:border-[#ef4444] hover:bg-[#ef4444]/10 cursor-pointer'
+  }
+
+  return (
+    <button
+      type="button"
+      disabled={isDisabled}
+      onClick={handleClick}
+      className={`${baseClasses} ${stateClasses} ${className}`}
+    >
+      {label}
+    </button>
+  )
+}
+
+export default HaltButton

--- a/src/components/ui/status-badge.tsx
+++ b/src/components/ui/status-badge.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+type AgentStatus = 'running' | 'stopped' | 'crashed' | 'degraded' | 'idle' | 'busy' | 'offline' | 'unknown'
+
+interface StatusBadgeProps {
+  status: AgentStatus
+  label?: string // Override the default label
+  size?: 'sm' | 'md' // sm = 4px dot, md = 6px dot (default)
+  showLabel?: boolean // default true
+  className?: string
+}
+
+const STATUS_CONFIG: Record<AgentStatus, { color: string; defaultLabel: string }> = {
+  running: { color: 'bg-[#22c55e]', defaultLabel: 'Running' },
+  busy: { color: 'bg-[#f59e0b]', defaultLabel: 'Busy' },
+  degraded: { color: 'bg-[#f59e0b]', defaultLabel: 'Degraded' },
+  idle: { color: 'bg-[#71717a]', defaultLabel: 'Idle' },
+  stopped: { color: 'bg-[#71717a]', defaultLabel: 'Stopped' },
+  crashed: { color: 'bg-[#ef4444]', defaultLabel: 'Crashed' },
+  offline: { color: 'bg-[#ef4444]', defaultLabel: 'Offline' },
+  unknown: { color: 'bg-[#71717a]', defaultLabel: 'Unknown' },
+}
+
+export function StatusBadge({ status, label, size = 'md', showLabel = true, className = '' }: StatusBadgeProps) {
+  const config = STATUS_CONFIG[status] || STATUS_CONFIG.unknown
+  const dotSize = size === 'sm' ? 'w-1 h-1' : 'w-1.5 h-1.5'
+
+  return (
+    <span className={`inline-flex items-center gap-1.5 ${className}`}>
+      <span className={`${dotSize} rounded-full ${config.color} shrink-0`} />
+      {showLabel && (
+        <span className="text-xs text-[var(--text-secondary)]">
+          {label || config.defaultLabel}
+        </span>
+      )}
+    </span>
+  )
+}

--- a/src/components/ui/theme-background.tsx
+++ b/src/components/ui/theme-background.tsx
@@ -1,21 +1,29 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { useTheme } from 'next-themes'
 
 /**
- * ThemeBackground — ensures dark class is never present.
- * Operator's Desk is light-only, no themed backgrounds.
+ * ThemeBackground — applies dark/light class based on current theme.
+ * Dark is default for Mission Control.
  */
 export function ThemeBackground() {
   const [mounted, setMounted] = useState(false)
+  const { theme } = useTheme()
 
   useEffect(() => { setMounted(true) }, [])
 
   useEffect(() => {
-    if (mounted) {
-      document.documentElement.classList.remove('dark')
+    if (!mounted) return
+    const root = document.documentElement
+    if (theme === 'light') {
+      root.classList.remove('dark')
+      root.classList.add('light')
+    } else {
+      root.classList.remove('light')
+      root.classList.add('dark')
     }
-  }, [mounted])
+  }, [mounted, theme])
 
   return null
 }

--- a/src/lib/hooks/use-agent-status.ts
+++ b/src/lib/hooks/use-agent-status.ts
@@ -1,0 +1,110 @@
+'use client'
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { useMissionControl } from '@/store/index'
+import type { Agent } from '@/store/index'
+import type { UnifiedAgent } from '@/lib/types/agent-status'
+
+interface UseAgentStatusOptions {
+  pollInterval?: number
+  enabled?: boolean
+}
+
+interface UseAgentStatusResult {
+  agents: UnifiedAgent[]
+  isLoading: boolean
+  error: string | null
+  refetch: () => void
+}
+
+export function useAgentStatus(options: UseAgentStatusOptions = {}): UseAgentStatusResult {
+  const { pollInterval = 10000, enabled = true } = options
+
+  const storeAgents = useMissionControl((state) => state.agents)
+  const setAgents = useMissionControl((state) => state.setAgents)
+
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const abortControllerRef = useRef<AbortController | null>(null)
+  const isMountedRef = useRef(true)
+
+  const fetchAgents = useCallback(async () => {
+    // Cancel any in-flight request
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort()
+    }
+
+    const controller = new AbortController()
+    abortControllerRef.current = controller
+
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const res = await fetch('/api/agents', {
+        signal: controller.signal,
+        cache: 'no-store',
+      })
+
+      if (!res.ok) {
+        throw new Error(`Failed to fetch agents: ${res.status} ${res.statusText}`)
+      }
+
+      const data: { agents?: Agent[] } = await res.json()
+      const agentList = Array.isArray(data?.agents) ? data.agents : []
+
+      if (isMountedRef.current) {
+        setAgents(agentList)
+        setError(null)
+      }
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        return
+      }
+      if (isMountedRef.current) {
+        setError(err instanceof Error ? err.message : 'Unknown error fetching agents')
+      }
+    } finally {
+      if (isMountedRef.current) {
+        setIsLoading(false)
+      }
+    }
+  }, [setAgents])
+
+  useEffect(() => {
+    isMountedRef.current = true
+
+    if (!enabled) {
+      return
+    }
+
+    // Immediate fetch on mount or when re-enabled
+    fetchAgents()
+
+    // Set up polling interval
+    intervalRef.current = setInterval(fetchAgents, pollInterval)
+
+    return () => {
+      isMountedRef.current = false
+
+      if (intervalRef.current !== null) {
+        clearInterval(intervalRef.current)
+        intervalRef.current = null
+      }
+
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort()
+        abortControllerRef.current = null
+      }
+    }
+  }, [enabled, pollInterval, fetchAgents])
+
+  return {
+    agents: storeAgents as UnifiedAgent[],
+    isLoading,
+    error,
+    refetch: fetchAgents,
+  }
+}

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -1,19 +1,18 @@
 export interface ThemeMeta {
   id: string
   label: string
-  group: 'light'
+  group: 'dark' | 'light'
   swatch: string
-  background?: string
 }
 
 export const THEMES: ThemeMeta[] = [
-  { id: 'light', label: "Operator's Desk", group: 'light', swatch: '#9A5D3A' },
+  { id: 'dark', label: 'Mission Control', group: 'dark', swatch: '#0f1117' },
+  { id: 'light', label: 'Light', group: 'light', swatch: '#fafafa' },
 ]
 
-/** All theme IDs for the next-themes `themes` prop. */
 export const THEME_IDS = THEMES.map(t => t.id)
 
-/** Look up whether a theme is dark or light. Always light now. */
-export function isThemeDark(_themeId: string): boolean {
-  return false
+export function isThemeDark(themeId: string): boolean {
+  const theme = THEMES.find(t => t.id === themeId)
+  return theme ? theme.group === 'dark' : true
 }

--- a/src/lib/transaction-costs.ts
+++ b/src/lib/transaction-costs.ts
@@ -1,0 +1,166 @@
+/**
+ * Transaction cost calculations for trading agent deployment assessment.
+ * Mirrors the fee schedules defined in moon-dev-ai-agents/src/models/transaction_cost_model.py
+ */
+
+export type FeeSchedule = {
+  maker: number
+  taker: number
+}
+
+export const DEFAULT_FEE_SCHEDULES: Record<string, FeeSchedule> = {
+  hyperliquid: { maker: 0.0002, taker: 0.0005 },
+  coinbase: { maker: 0.004, taker: 0.006 },
+  interactive_brokers: { maker: 0.0002, taker: 0.0003 },
+}
+
+/**
+ * Calculate entry and exit fees for a position using taker rates (worst-case assumption).
+ */
+export function calculateFees(
+  exchange: string,
+  positionSize: number
+): { entry: number; exit: number } {
+  const schedule = DEFAULT_FEE_SCHEDULES[exchange.toLowerCase()]
+  if (!schedule) {
+    // Unknown exchange: use a conservative default (0.1% taker)
+    const fee = positionSize * 0.001
+    return { entry: fee, exit: fee }
+  }
+  return {
+    entry: positionSize * schedule.taker,
+    exit: positionSize * schedule.taker,
+  }
+}
+
+/**
+ * Estimate market impact / slippage cost.
+ * @param positionSize - Position size in USD
+ * @param slippageBps  - Slippage in basis points (default: 10 bps = 0.1%)
+ */
+export function estimateSlippage(positionSize: number, slippageBps: number = 10): number {
+  return positionSize * (slippageBps / 10000)
+}
+
+/**
+ * Estimate funding cost for a leveraged position held for N hours.
+ * @param positionSize - Position size in USD
+ * @param hours        - Holding period in hours
+ * @param hourlyRate   - Hourly funding rate as a decimal (default: 0.0001 = 0.01%)
+ */
+export function estimateFunding(
+  positionSize: number,
+  hours: number,
+  hourlyRate: number = 0.0001
+): number {
+  return positionSize * hourlyRate * hours
+}
+
+export type DeploymentAssessmentParams = {
+  agent_name: string
+  strategy: string
+  exchange: string
+  symbol: string
+  position_size_usd: number
+  expected_return_pct: number
+  holding_period_hours?: number
+}
+
+export type RiskChecks = {
+  within_position_limit: boolean
+  within_exposure_limit: boolean
+  kill_switch_ok: boolean
+}
+
+export type CostBreakdown = {
+  entry_fee: number
+  exit_fee: number
+  slippage: number
+  funding: number
+  total_cost: number
+  total_cost_pct: number
+}
+
+export type DeploymentAssessment = {
+  verdict: 'profitable' | 'marginal' | 'losing'
+  strategy_info: {
+    agent_name: string
+    strategy: string
+    exchange: string
+    symbol: string
+    position_size_usd: number
+  }
+  cost_breakdown: CostBreakdown
+  expected_return_usd: number
+  net_return_usd: number
+  net_return_pct: number
+  risk_checks: RiskChecks
+}
+
+const MAX_POSITION_USD = 100
+const MAX_TOTAL_EXPOSURE_USD = 500
+const KILL_SWITCH_DRAWDOWN_PCT = 15
+
+/**
+ * Full deployment assessment combining fees, slippage, funding, and risk checks.
+ */
+export function assessDeployment(params: DeploymentAssessmentParams): DeploymentAssessment {
+  const {
+    agent_name,
+    strategy,
+    exchange,
+    symbol,
+    position_size_usd,
+    expected_return_pct,
+    holding_period_hours = 0,
+  } = params
+
+  const { entry, exit } = calculateFees(exchange, position_size_usd)
+  const slippage = estimateSlippage(position_size_usd)
+  const funding = estimateFunding(position_size_usd, holding_period_hours)
+
+  const total_cost = entry + exit + slippage + funding
+  const total_cost_pct = position_size_usd > 0 ? (total_cost / position_size_usd) * 100 : 0
+
+  const expected_return_usd = position_size_usd * (expected_return_pct / 100)
+  const net_return_usd = expected_return_usd - total_cost
+  const net_return_pct = position_size_usd > 0 ? (net_return_usd / position_size_usd) * 100 : 0
+
+  const risk_checks: RiskChecks = {
+    within_position_limit: position_size_usd <= MAX_POSITION_USD,
+    within_exposure_limit: position_size_usd <= MAX_TOTAL_EXPOSURE_USD,
+    kill_switch_ok: Math.abs(net_return_pct) < KILL_SWITCH_DRAWDOWN_PCT || net_return_pct > 0,
+  }
+
+  let verdict: 'profitable' | 'marginal' | 'losing'
+  if (net_return_pct > 1.0) {
+    verdict = 'profitable'
+  } else if (net_return_pct > 0) {
+    verdict = 'marginal'
+  } else {
+    verdict = 'losing'
+  }
+
+  return {
+    verdict,
+    strategy_info: {
+      agent_name,
+      strategy,
+      exchange,
+      symbol,
+      position_size_usd,
+    },
+    cost_breakdown: {
+      entry_fee: entry,
+      exit_fee: exit,
+      slippage,
+      funding,
+      total_cost,
+      total_cost_pct,
+    },
+    expected_return_usd,
+    net_return_usd,
+    net_return_pct,
+    risk_checks,
+  }
+}

--- a/src/lib/types/agent-events.ts
+++ b/src/lib/types/agent-events.ts
@@ -1,0 +1,197 @@
+/**
+ * Agent event types for the Python → Dashboard communication bridge.
+ *
+ * Python agents POST these events to /api/events/ingest.
+ * The event bus broadcasts them to connected SSE clients.
+ * The client-side useServerEvents hook dispatches them to the Zustand store.
+ */
+
+// All possible agent event types
+export type AgentEventType =
+  | 'agent.heartbeat'
+  | 'agent.status_changed'
+  | 'agent.trade_opened'
+  | 'agent.trade_closed'
+  | 'agent.trade_error'
+  | 'agent.signal_generated'
+  | 'agent.position_update'
+  | 'agent.pnl_update'
+  | 'agent.risk_alert'
+  | 'agent.config_changed'
+  | 'agent.backtest_started'
+  | 'agent.backtest_completed'
+  | 'agent.log'
+
+// Base event shape — all events have these fields
+export interface AgentEventBase {
+  type: AgentEventType
+  agent_name: string
+  timestamp: number // Unix ms
+  subsystem: 'mission-control' | 'moon-dev' | 'agent-zero'
+}
+
+// Heartbeat — "I'm alive"
+export interface HeartbeatEvent extends AgentEventBase {
+  type: 'agent.heartbeat'
+  status: 'idle' | 'busy' | 'error'
+  uptime_seconds?: number
+  memory_mb?: number
+}
+
+// Status change
+export interface StatusChangedEvent extends AgentEventBase {
+  type: 'agent.status_changed'
+  old_status: string
+  new_status: string
+  reason?: string
+}
+
+// Trade opened
+export interface TradeOpenedEvent extends AgentEventBase {
+  type: 'agent.trade_opened'
+  trade_id: string
+  symbol: string
+  side: 'long' | 'short'
+  size_usd: number
+  entry_price: number
+  exchange: string
+  strategy?: string
+}
+
+// Trade closed
+export interface TradeClosedEvent extends AgentEventBase {
+  type: 'agent.trade_closed'
+  trade_id: string
+  symbol: string
+  side: 'long' | 'short'
+  size_usd: number
+  entry_price: number
+  exit_price: number
+  pnl_usd: number
+  pnl_pct: number
+  exchange: string
+  duration_minutes: number
+  strategy?: string
+}
+
+// Trade error
+export interface TradeErrorEvent extends AgentEventBase {
+  type: 'agent.trade_error'
+  symbol: string
+  error_message: string
+  error_code?: string
+  exchange: string
+}
+
+// Signal generated (agent detected a trading opportunity)
+export interface SignalEvent extends AgentEventBase {
+  type: 'agent.signal_generated'
+  symbol: string
+  direction: 'long' | 'short' | 'neutral'
+  confidence: number // 0-1
+  strategy: string
+  timeframe: string
+}
+
+// Position update (periodic snapshot of open positions)
+export interface PositionUpdateEvent extends AgentEventBase {
+  type: 'agent.position_update'
+  positions: Array<{
+    symbol: string
+    side: 'long' | 'short'
+    size_usd: number
+    unrealized_pnl: number
+    entry_price: number
+    current_price: number
+  }>
+}
+
+// P&L update (periodic P&L snapshot)
+export interface PnlUpdateEvent extends AgentEventBase {
+  type: 'agent.pnl_update'
+  pnl_today: number
+  pnl_total: number
+  win_rate: number
+  open_positions: number
+}
+
+// Risk alert (kill switch, drawdown warning, etc.)
+export interface RiskAlertEvent extends AgentEventBase {
+  type: 'agent.risk_alert'
+  severity: 'warning' | 'critical'
+  alert_type: 'drawdown' | 'kill_switch' | 'exposure_limit' | 'loss_streak' | 'other'
+  message: string
+  current_value?: number
+  threshold?: number
+}
+
+// Config changed
+export interface ConfigChangedEvent extends AgentEventBase {
+  type: 'agent.config_changed'
+  changed_keys: string[]
+  source: 'dashboard' | 'agent' | 'manual'
+}
+
+// Backtest started
+export interface BacktestStartedEvent extends AgentEventBase {
+  type: 'agent.backtest_started'
+  strategy: string
+  symbol: string
+  timeframe: string
+}
+
+// Backtest completed
+export interface BacktestCompletedEvent extends AgentEventBase {
+  type: 'agent.backtest_completed'
+  strategy: string
+  symbol: string
+  roi: number
+  sharpe: number
+  total_trades: number
+  win_rate: number
+}
+
+// Generic log message
+export interface AgentLogEvent extends AgentEventBase {
+  type: 'agent.log'
+  level: 'debug' | 'info' | 'warn' | 'error'
+  message: string
+  context?: Record<string, unknown>
+}
+
+// Union type of all events
+export type AgentEvent =
+  | HeartbeatEvent
+  | StatusChangedEvent
+  | TradeOpenedEvent
+  | TradeClosedEvent
+  | TradeErrorEvent
+  | SignalEvent
+  | PositionUpdateEvent
+  | PnlUpdateEvent
+  | RiskAlertEvent
+  | ConfigChangedEvent
+  | BacktestStartedEvent
+  | BacktestCompletedEvent
+  | AgentLogEvent
+
+// Validation: check if a value is a valid AgentEventType
+export const VALID_EVENT_TYPES: AgentEventType[] = [
+  'agent.heartbeat',
+  'agent.status_changed',
+  'agent.trade_opened',
+  'agent.trade_closed',
+  'agent.trade_error',
+  'agent.signal_generated',
+  'agent.position_update',
+  'agent.pnl_update',
+  'agent.risk_alert',
+  'agent.config_changed',
+  'agent.backtest_started',
+  'agent.backtest_completed',
+  'agent.log',
+]
+
+export function isValidEventType(type: string): type is AgentEventType {
+  return VALID_EVENT_TYPES.includes(type as AgentEventType)
+}

--- a/src/lib/types/agent-status.ts
+++ b/src/lib/types/agent-status.ts
@@ -1,0 +1,88 @@
+import type { Agent } from '@/store/index'
+
+// Status type used by StatusBadge component
+export type StatusBadgeStatus =
+  | 'running'
+  | 'stopped'
+  | 'crashed'
+  | 'degraded'
+  | 'idle'
+  | 'busy'
+  | 'offline'
+  | 'unknown'
+
+// Trading-specific extension fields for agents
+export interface TradingAgentStatus {
+  subsystem: 'mission-control' | 'moon-dev' | 'agent-zero'
+  category:
+    | 'trading'
+    | 'market-analysis'
+    | 'research'
+    | 'content'
+    | 'arbitrage'
+    | 'risk'
+    | 'orchestration'
+    | 'devtools'
+  strategy?: string
+  pnl_today?: number
+  pnl_total?: number
+  open_positions?: number
+  win_rate?: number
+  uptime_pct?: number
+  last_trade?: number
+  error_count_24h?: number
+}
+
+// Combines the store Agent type with trading-specific fields
+export type UnifiedAgent = Agent & TradingAgentStatus
+
+// Filter options for agent status views
+export type AgentStatusFilter = 'all' | 'running' | 'idle' | 'offline' | 'error'
+
+// Fields that agents can be sorted by
+export type AgentSortField =
+  | 'name'
+  | 'status'
+  | 'pnl_today'
+  | 'last_seen'
+  | 'category'
+  | 'open_positions'
+
+/**
+ * Maps the store's Agent status to the StatusBadge component status type.
+ */
+export function mapAgentStatus(status: Agent['status']): StatusBadgeStatus {
+  switch (status) {
+    case 'busy':
+      return 'running'
+    case 'idle':
+      return 'idle'
+    case 'offline':
+      return 'offline'
+    case 'error':
+      return 'crashed'
+    default:
+      return 'unknown'
+  }
+}
+
+/**
+ * Returns a numeric priority for sorting agents by status severity.
+ * Lower numbers = higher severity (shown first).
+ */
+export function getAgentStatusPriority(status: string): number {
+  switch (status) {
+    case 'error':
+      return 0
+    case 'busy':
+      return 1
+    case 'degraded':
+      return 2
+    case 'idle':
+      return 3
+    case 'offline':
+      return 4
+    default:
+      return 5
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -51,12 +51,12 @@ module.exports = {
         'surface-1': 'var(--surface-1)',
         'surface-2': 'var(--surface-2)',
         'surface-3': 'var(--surface-3)',
-        // Void accent colors (kept for backward compat, mapped to warm palette)
-        'void-cyan': 'var(--void-cyan)',
-        'void-mint': 'var(--void-mint)',
-        'void-amber': 'var(--void-amber)',
-        'void-violet': 'var(--void-violet)',
-        'void-crimson': 'var(--void-crimson)',
+        // DESIGN.md semantic colors
+        'itrade-green': '#22c55e',
+        'itrade-red': '#ef4444',
+        'itrade-amber': '#f59e0b',
+        'itrade-blue': '#3b82f6',
+        'itrade-gray': '#71717a',
         // Semantic status colors
         success: {
           DEFAULT: 'var(--success)',
@@ -79,6 +79,13 @@ module.exports = {
       },
       fontSize: {
         '2xs': ['0.625rem', { lineHeight: '0.875rem' }],
+        // DESIGN.md type scale
+        'xs-itrade': ['11px', { lineHeight: '16px' }],
+        'sm-itrade': ['12px', { lineHeight: '16px' }],
+        'base-itrade': ['14px', { lineHeight: '20px' }],
+        'lg-itrade': ['16px', { lineHeight: '24px' }],
+        'xl-itrade': ['20px', { lineHeight: '28px' }],
+        '2xl-itrade': ['24px', { lineHeight: '32px' }],
       },
       spacing: {
         '18': '4.5rem',


### PR DESCRIPTION
## Summary
- **Phase 2**: Agent status table, detail panel, status badge, data table, useAgentStatus hook, and agent status API
- **Phase 3**: Transaction cost model, deploy gate modal, agent control/halt APIs, emergency halt button, trading config editor
- **Phase 4**: Backtest results panel with summary stats and detail slide-out, backtest API with auto-table creation
- **Phase 5**: 13 typed agent event interfaces, event ingestion API with auth and side effects, chat bridge panel
- Integrates DESIGN.md dark theme into globals.css, layout, nav-rail, and tailwind config

## New Files (20)
- 7 API routes (`agents/control`, `agents/halt`, `agents/status`, `backtest`, `config/trading`, `deploy/assess`, `events/ingest`)
- 5 components (`deploy-gate`, `agent-table`, `agent-detail-panel`, `backtest-results-panel`, `chat-bridge-panel`)
- 4 UI primitives (`halt-button`, `status-badge`, `connection-pill`, `data-table`)
- 2 type modules (`agent-events`, `agent-status`)
- 1 hook (`use-agent-status`)
- 1 lib (`transaction-costs`)

## Test plan
- [x] TypeScript: zero errors (`npx tsc --noEmit`)
- [x] ESLint: zero warnings on all new files
- [x] Vitest: 863/875 pass (12 pre-existing failures — Windows paths + stale theme tests)
- [x] All 20 new files verified for proper exports and structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)