### PR TITLE
OpenClaw: Kanban, Linear, Skill Architect, company picker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ FROM base AS deps
 # Copy only dependency manifests first for better layer caching
 COPY package.json ./
 COPY pnpm-lock.yaml* ./
+COPY packages/mc-client ./packages/mc-client
 # better-sqlite3 requires native compilation tools
 RUN apt-get update && apt-get install -y python3 make g++ --no-install-recommends && rm -rf /var/lib/apt/lists/*
 RUN if [ -f pnpm-lock.yaml ]; then \
@@ -21,6 +22,11 @@ COPY . .
 RUN pnpm build
 
 FROM node:22.22.0-slim AS runtime
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    procps ca-certificates curl git gh jq ripgrep python3 python3-pip ffmpeg tmux \
+    && python3 -m pip install --break-system-packages uv \
+    && npm install -g @openai/codex @google/gemini-cli \
+    && rm -rf /var/lib/apt/lists/*
 
 ARG MC_VERSION=dev
 LABEL org.opencontainers.image.source="https://github.com/openclaw/mission-control"

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,28 @@
+services:
+  mission-control:
+    user: 1000:1000
+    environment:
+      - NODE_OPTIONS=--max-old-space-size=1536
+      - OPENCLAW_HOME=/openclaw-home
+      - OPENCLAW_STATE_DIR=/openclaw-home
+      - OPENCLAW_CONFIG_PATH=/openclaw-home/openclaw.json
+      - OPENCLAW_BIN=/openclaw-npm/bin/openclaw
+      - OPENCLAW_GATEWAY_HOST=127.0.0.1
+      - OPENCLAW_GATEWAY_PORT=18789
+      - OPENCLAW_TOOLS_PROFILE=coding
+      - HOSTNAME=127.0.0.1
+    volumes:
+      - mc-data:/app/.data
+      - /home/ubuntu/.openclaw:/openclaw-home
+      - /home/ubuntu/.npm-global:/openclaw-npm:ro
+      # nemoclaw plugin mkdir ~/.nemoclaw — /home/node is on read-only image layer
+      - mc-nemoclaw-home:/home/node/.nemoclaw
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+          cpus: 2.0
+          pids: 512
+
+volumes:
+  mc-nemoclaw-home:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,7 @@ services:
   mission-control:
     build: .
     container_name: mission-control
-    ports:
-      - "${MC_PORT:-3000}:${PORT:-3000}"
+    network_mode: host
     environment:
       - PORT=${PORT:-3000}
     env_file:
@@ -25,15 +24,9 @@ services:
       resources:
         limits:
           memory: 512M
-          cpus: '1.0'
+          cpus: "1.0"
           pids: 256
-    networks:
-      - mc-net
     restart: unless-stopped
 
 volumes:
   mc-data:
-
-networks:
-  mc-net:
-    driver: bridge

--- a/next.config.js
+++ b/next.config.js
@@ -6,7 +6,7 @@ const nextConfig = {
   },
   turbopack: {},
   // Transpile ESM-only packages so they resolve correctly in all environments
-  transpilePackages: ['react-markdown', 'remark-gfm'],
+  transpilePackages: ['react-markdown', 'remark-gfm', '@openclaw/mc-client'],
   
   // Security headers
   // Content-Security-Policy is set in src/proxy.ts with a per-request nonce.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mission-control",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "OpenClaw Mission Control — open-source agent orchestration dashboard",
   "scripts": {
     "verify:node": "node scripts/check-node-version.mjs",
@@ -22,6 +22,7 @@
     "quality:gate": "pnpm test:all"
   },
   "dependencies": {
+    "@openclaw/mc-client": "file:./packages/mc-client",
     "@radix-ui/react-slot": "^1.2.4",
     "@scalar/api-reference-react": "^0.8.66",
     "@xyflow/react": "^12.10.0",

--- a/packages/mc-client/README.md
+++ b/packages/mc-client/README.md
@@ -1,0 +1,119 @@
+# @openclaw/mc-client
+
+Gateway health check and persona file reader for Mission Control.
+
+## Install (from mission-control-app)
+
+```bash
+npm install ../OpenClaw/packages/mc-client
+```
+
+Or add to `package.json`:
+
+```json
+"dependencies": {
+  "@openclaw/mc-client": "file:../OpenClaw/packages/mc-client"
+}
+```
+
+## Usage
+
+### Gateway Health
+
+```js
+import { checkGatewayHealth } from '@openclaw/mc-client';
+
+const baseUrl = process.env.GATEWAY_URL || 'http://localhost:18789';
+const { ok, status, error } = await checkGatewayHealth(baseUrl, { retries: 2 });
+// ok: true when gateway responds 200
+```
+
+### Persona Files (SOUL.md, SKILLS.md, etc.)
+
+```js
+import { readPersonaFiles } from '@openclaw/mc-client';
+
+const openclawHome = process.env.OPENCLAW_HOME || require('os').homedir() + '/.openclaw-human';
+const { soul, skills, working, mission } = await readPersonaFiles(openclawHome, 'jarvis');
+```
+
+**Jarvis** resolves persona files from `workspace/` first (default Jarvis workspace), then `workspace-jarvis/`, then `workspace/agents/jarvis/`.
+
+### Multi-company (registry + active company)
+
+```js
+import { readCompanyRegistry, readActiveCompany } from '@openclaw/mc-client';
+
+const openclawHome = process.env.OPENCLAW_HOME || require('os').homedir() + '/.openclaw-human';
+const { ok, companies } = await readCompanyRegistry(openclawHome);
+// companies: [{ id, name?, summary? }, ...]
+
+const active = await readActiveCompany(openclawHome);
+// active.companyId: string | null (from workspace/.active-company)
+```
+
+Use `companies` to populate a Mission Control dropdown; use `readActiveCompany` for the current default.
+
+### Skill Architect + Matrix (`matrixPreflight`)
+
+Server-side only (token secret). See **[`docs/mission-control-matrix-integration.md`](../../docs/mission-control-matrix-integration.md)** in the OpenClaw repo.
+
+```js
+import {
+  postSkillArchitectJob,
+  getSkillArchitectJob,
+  setSkillArchitectJobStatus,
+  checkSkillArchitectHealth,
+  stripAnsi,
+} from '@openclaw/mc-client';
+
+await checkSkillArchitectHealth('http://127.0.0.1:18990');
+
+const created = await postSkillArchitectJob({
+  baseUrl: process.env.SKILL_ARCHITECT_URL,
+  token: process.env.SKILL_ARCHITECT_TOKEN,
+  urls: ['https://example.com/page'],
+  targetAgent: 'jarvis',
+  timeoutMs: 180000,
+});
+// created.job.matrixPreflight — optional Matrix hint; stripAnsi(created.job.matrixPreflight?.suggest?.stdout) for UI
+```
+
+### Kanban (file-backed, in-dashboard)
+
+Boards live under **`workspace/Projects/<companyId>/<projectSlug>/kanban/board.json`**. Use **`_`** as `projectSlug` for a company default.
+
+```js
+import {
+  loadKanbanBoard,
+  saveKanbanBoard,
+  createTask,
+  upsertTask,
+  moveTask,
+  kanbanBoardPath,
+} from '@openclaw/mc-client';
+
+const HOME = process.env.OPENCLAW_HOME || '/openclaw-home';
+const board = await loadKanbanBoard(HOME, 'gorilla-netting', '_');
+const task = createTask({ title: 'Ship Kanban UI', company: 'gorilla-netting', columnId: 'backlog' });
+const next = upsertTask(board, task);
+await saveKanbanBoard(HOME, next, 'gorilla-netting', '_');
+```
+
+See **[`docs/mission-control-kanban-spec.md`](../../docs/mission-control-kanban-spec.md)** and **[`docs/schemas/kanban-board-v1.schema.json`](../../docs/schemas/kanban-board-v1.schema.json)**.
+
+## API
+
+- **`checkGatewayHealth(baseUrl, opts?)`** — Fetches `/health`, retries on failure. Returns `{ ok, status?, error? }`.
+- **`readPersonaFiles(openclawHome, agentId)`** — Reads SOUL.md, SKILLS.md, WORKING.md, MISSION.md from workspace dirs. Returns `{ soul?, skills?, working?, mission? }`.
+- **`readCompanyRegistry(openclawHome)`** — Reads `workspace/companies/registry.yaml`. Returns `{ ok, companies, error? }`.
+- **`readActiveCompany(openclawHome)`** — Reads `workspace/.active-company` (one line). Returns `{ ok, companyId, error? }`; `companyId` is `null` if file missing.
+- **`parseCompanyRegistryYaml(text)`** — Parses registry YAML string (for tests or custom paths).
+- **`checkSkillArchitectHealth(baseUrl)`** — `GET /health` on Skill Architect (no token).
+- **`postSkillArchitectJob({ baseUrl, token, urls, targetAgent?, timeoutMs? })`** — `POST /v1/jobs`; response **`job`** may include **`matrixPreflight`**.
+- **`getSkillArchitectJob({ baseUrl, token, jobId })`** — `GET /v1/jobs/:id`.
+- **`setSkillArchitectJobStatus({ baseUrl, token, jobId, action: 'approve'|'reject' })`** — approve/reject job.
+- **`stripAnsi(string)`** — Strip ANSI from Matrix CLI stdout for dashboard preview.
+- **`loadKanbanBoard` / `saveKanbanBoard`** — File-backed Kanban under `Projects/.../kanban/board.json`.
+- **`createTask` / `upsertTask` / `moveTask` / `deleteTask` / `appendActivity` / `setBlockedBy`** — In-memory + persist via `saveKanbanBoard`.
+- **`kanbanBoardPath(home, companyId, projectSlug?)`** — Resolved path for operators.

--- a/packages/mc-client/index.js
+++ b/packages/mc-client/index.js
@@ -1,0 +1,166 @@
+/**
+ * @openclaw/mc-client — Gateway health and persona files for Mission Control
+ *
+ * Use from mission-control-app API routes or server-side to:
+ * - Check gateway health (with retry/backoff)
+ * - Read SOUL.md, SKILLS.md, WORKING.md, MISSION.md per agent
+ */
+
+/**
+ * Check gateway health. Returns { ok, status, error }.
+ * Use retries to avoid "Gateway not running" on first failed poll.
+ *
+ * @param {string} baseUrl - Gateway base URL (e.g. http://localhost:18789 or https://ops.sittingfox.co/gw)
+ * @param {object} [opts]
+ * @param {number} [opts.retries=2] - Number of retries on failure
+ * @param {number} [opts.timeout=5000] - Request timeout ms
+ */
+export async function checkGatewayHealth(baseUrl, opts = {}) {
+  const { retries = 2, timeout = 5000 } = opts;
+  const url = baseUrl.replace(/\/$/, '') + '/health';
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeout);
+      const res = await fetch(url, { signal: controller.signal });
+      clearTimeout(timer);
+
+      if (res.ok) {
+        const data = await res.json().catch(() => ({}));
+        return { ok: true, status: res.status, data };
+      }
+      const text = await res.text();
+      return { ok: false, status: res.status, error: text.slice(0, 200) };
+    } catch (err) {
+      const error = err?.message || String(err);
+      if (attempt === retries) {
+        return { ok: false, error };
+      }
+      // Exponential backoff: 500ms, 1000ms
+      await new Promise((r) => setTimeout(r, 500 * Math.pow(2, attempt)));
+    }
+  }
+  return { ok: false, error: 'Max retries exceeded' };
+}
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+/**
+ * Read persona files for an agent.
+ *
+ * @param {string} openclawHome - Path to ~/.openclaw-human or OPENCLAW_HOME
+ * @param {string} agentId - Agent id (e.g. jarvis, skill-architect)
+ * @returns {Promise<{ soul?: string; skills?: string; working?: string; mission?: string }>}
+ */
+export async function readPersonaFiles(openclawHome, agentId) {
+  const files = ['SOUL.md', 'SKILLS.md', 'WORKING.md', 'MISSION.md'];
+  const candidates = [];
+  if (agentId === 'jarvis') {
+    candidates.push(path.join(openclawHome, 'workspace'));
+  }
+  candidates.push(
+    path.join(openclawHome, 'workspace-' + agentId),
+    path.join(openclawHome, 'workspace', 'agents', agentId),
+  );
+
+  const result = {};
+  for (const name of files) {
+    const key = name.replace('.md', '').toLowerCase();
+    for (const dir of candidates) {
+      try {
+        const content = await fs.readFile(path.join(dir, name), 'utf8');
+        result[key] = content.trim();
+        break;
+      } catch {
+        /* not found, try next candidate */
+      }
+    }
+  }
+  return result;
+}
+
+/**
+ * Parse minimal registry.yaml (OpenClaw workspace/companies/registry.yaml).
+ * @param {string} text
+ * @returns {{ id: string, name?: string, summary?: string }[]}
+ */
+export function parseCompanyRegistryYaml(text) {
+  const companies = [];
+  let current = null;
+  for (const line of text.split('\n')) {
+    const idM = line.match(/^\s*-\s*id:\s*(.+)$/);
+    if (idM) {
+      if (current) companies.push(current);
+      current = { id: idM[1].trim() };
+      continue;
+    }
+    if (current) {
+      const nameM = line.match(/^\s*name:\s*(.+)$/);
+      if (nameM) current.name = nameM[1].trim();
+      const sumM = line.match(/^\s*summary:\s*(.+)$/);
+      if (sumM) current.summary = sumM[1].trim();
+    }
+  }
+  if (current) companies.push(current);
+  return companies;
+}
+
+/**
+ * Read multi-company registry from workspace/companies/registry.yaml.
+ *
+ * @param {string} openclawHome - Path to ~/.openclaw-human or OPENCLAW_HOME
+ * @returns {Promise<{ ok: boolean, companies: object[], error?: string }>}
+ */
+export async function readCompanyRegistry(openclawHome) {
+  const p = path.join(openclawHome, 'workspace', 'companies', 'registry.yaml');
+  try {
+    const text = await fs.readFile(p, 'utf8');
+    return { ok: true, companies: parseCompanyRegistryYaml(text) };
+  } catch (err) {
+    const error = err?.message || String(err);
+    return { ok: false, companies: [], error };
+  }
+}
+
+/**
+ * Read optional default company id from workspace/.active-company (single line).
+ *
+ * @param {string} openclawHome
+ * @returns {Promise<{ ok: boolean, companyId: string | null, error?: string }>}
+ */
+export async function readActiveCompany(openclawHome) {
+  const p = path.join(openclawHome, 'workspace', '.active-company');
+  try {
+    const raw = (await fs.readFile(p, 'utf8')).trim();
+    const line = raw.split(/\r?\n/)[0]?.trim() || null;
+    return { ok: true, companyId: line };
+  } catch (err) {
+    if (err?.code === 'ENOENT') {
+      return { ok: true, companyId: null };
+    }
+    return { ok: false, companyId: null, error: err?.message || String(err) };
+  }
+}
+
+export {
+  stripAnsi,
+  postSkillArchitectJob,
+  getSkillArchitectJob,
+  setSkillArchitectJobStatus,
+  checkSkillArchitectHealth,
+} from './skill-architect-client.mjs';
+
+export {
+  DEFAULT_KANBAN_COLUMNS,
+  kanbanBoardPath,
+  loadKanbanBoard,
+  saveKanbanBoard,
+  createTask,
+  moveTask,
+  appendActivity,
+  setBlockedBy,
+  upsertTask,
+  deleteTask,
+} from './kanban-store.mjs';

--- a/packages/mc-client/kanban-store.mjs
+++ b/packages/mc-client/kanban-store.mjs
@@ -1,0 +1,183 @@
+/**
+ * File-backed Kanban boards for Mission Control — lives under OPENCLAW_HOME.
+ *
+ * Path: workspace/Projects/<companyId>/<projectSlug>/kanban/board.json
+ * Use projectSlug `_` for a company default board when no project is selected.
+ *
+ * @see docs/schemas/kanban-board-v1.schema.json
+ * @see docs/mission-control-kanban-spec.md
+ */
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+/**
+ * @typedef {{ id: string, title: string, order: number }} KanbanColumn
+ * @typedef {{ ts: number, message: string }} KanbanActivity
+ * @typedef {{
+ *   id: string,
+ *   title: string,
+ *   description?: string,
+ *   columnId: string,
+ *   order: number,
+ *   company?: string,
+ *   projectSlug?: string,
+ *   assigneeAgentId?: string,
+ *   blockedBy?: string[],
+ *   activity?: KanbanActivity[],
+ *   skillArchitectJobId?: string | null,
+ *   gatewaySessionId?: string,
+ *   reviewUrl?: string,
+ * }} KanbanTask
+ * @typedef {{
+ *   version: 1,
+ *   boardId: string,
+ *   name?: string,
+ *   columns: KanbanColumn[],
+ *   tasks: KanbanTask[],
+ * }} KanbanBoardV1
+ */
+
+/** @type {KanbanColumn[]} */
+export const DEFAULT_KANBAN_COLUMNS = [
+  { id: 'backlog', title: 'Backlog', order: 0 },
+  { id: 'in_progress', title: 'In progress', order: 1 },
+  { id: 'review', title: 'Review', order: 2 },
+  { id: 'done', title: 'Done', order: 3 },
+];
+
+/**
+ * @param {string} openclawHome
+ * @param {string} companyId
+ * @param {string} [projectSlug='_'] — folder under Projects/<companyId>/
+ */
+export function kanbanBoardPath(openclawHome, companyId, projectSlug = '_') {
+  const slug = projectSlug && projectSlug.trim() ? projectSlug.trim() : '_';
+  return path.join(openclawHome, 'workspace', 'Projects', companyId, slug, 'kanban', 'board.json');
+}
+
+/**
+ * @returns {Promise<KanbanBoardV1>}
+ */
+export async function loadKanbanBoard(openclawHome, companyId, projectSlug = '_') {
+  const fp = kanbanBoardPath(openclawHome, companyId, projectSlug);
+  try {
+    const raw = await fs.readFile(fp, 'utf8');
+    const j = JSON.parse(raw);
+    if (j?.version !== 1 || !Array.isArray(j.columns) || !Array.isArray(j.tasks)) {
+      return emptyBoard(companyId, projectSlug);
+    }
+    return j;
+  } catch (e) {
+    if (e?.code === 'ENOENT') return emptyBoard(companyId, projectSlug);
+    throw e;
+  }
+}
+
+function emptyBoard(companyId, projectSlug) {
+  const boardId = `${companyId}:${projectSlug || '_'}`;
+  return {
+    version: 1,
+    boardId,
+    name: 'Main',
+    columns: DEFAULT_KANBAN_COLUMNS.map((c) => ({ ...c })),
+    tasks: [],
+  };
+}
+
+/**
+ * @param {string} openclawHome
+ * @param {KanbanBoardV1} board
+ * @param {string} companyId
+ * @param {string} [projectSlug='_']
+ */
+export async function saveKanbanBoard(openclawHome, board, companyId, projectSlug = '_') {
+  const fp = kanbanBoardPath(openclawHome, companyId, projectSlug);
+  await fs.mkdir(path.dirname(fp), { recursive: true });
+  await fs.writeFile(fp, JSON.stringify(board, null, 2), 'utf8');
+}
+
+/**
+ * @param {Partial<KanbanTask> & { title: string, columnId?: string }} partial
+ */
+export function createTask(partial) {
+  const id = randomUUID();
+  const columnId = partial.columnId || 'backlog';
+  return {
+    id,
+    title: partial.title || 'Untitled',
+    description: partial.description || '',
+    columnId,
+    order: partial.order ?? Date.now(),
+    company: partial.company || '',
+    projectSlug: partial.projectSlug || '',
+    assigneeAgentId: partial.assigneeAgentId || '',
+    blockedBy: partial.blockedBy || [],
+    activity: partial.activity || [],
+    skillArchitectJobId: partial.skillArchitectJobId ?? null,
+    gatewaySessionId: partial.gatewaySessionId || '',
+    reviewUrl: partial.reviewUrl || '',
+  };
+}
+
+/**
+ * Move task to column and optional order.
+ * @param {KanbanBoardV1} board
+ * @param {string} taskId
+ * @param {string} columnId
+ * @param {number} [order]
+ */
+export function moveTask(board, taskId, columnId, order) {
+  const t = board.tasks.find((x) => x.id === taskId);
+  if (!t) return { ok: false, error: 'task_not_found' };
+  const col = board.columns.find((c) => c.id === columnId);
+  if (!col) return { ok: false, error: 'column_not_found' };
+  t.columnId = columnId;
+  if (typeof order === 'number') t.order = order;
+  return { ok: true, board };
+}
+
+/**
+ * @param {KanbanBoardV1} board
+ * @param {string} taskId
+ * @param {string} message
+ */
+export function appendActivity(board, taskId, message) {
+  const t = board.tasks.find((x) => x.id === taskId);
+  if (!t) return { ok: false, error: 'task_not_found' };
+  if (!t.activity) t.activity = [];
+  t.activity.push({ ts: Date.now(), message: String(message).slice(0, 2000) });
+  return { ok: true, board };
+}
+
+/**
+ * @param {KanbanBoardV1} board
+ * @param {string} taskId
+ * @param {string[]} blockedByTaskIds
+ */
+export function setBlockedBy(board, taskId, blockedByTaskIds) {
+  const t = board.tasks.find((x) => x.id === taskId);
+  if (!t) return { ok: false, error: 'task_not_found' };
+  t.blockedBy = [...new Set(blockedByTaskIds)].filter((id) => id !== taskId);
+  return { ok: true, board };
+}
+
+/**
+ * @param {KanbanBoardV1} board
+ * @param {KanbanTask} task
+ */
+export function upsertTask(board, task) {
+  const i = board.tasks.findIndex((x) => x.id === task.id);
+  if (i >= 0) board.tasks[i] = { ...board.tasks[i], ...task, id: task.id };
+  else board.tasks.push(task);
+  return board;
+}
+
+/**
+ * @param {KanbanBoardV1} board
+ * @param {string} taskId
+ */
+export function deleteTask(board, taskId) {
+  board.tasks = board.tasks.filter((x) => x.id !== taskId);
+  return board;
+}

--- a/packages/mc-client/package.json
+++ b/packages/mc-client/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@openclaw/mc-client",
+  "version": "1.0.0",
+  "description": "Gateway health check and persona file reader for Mission Control",
+  "type": "module",
+  "main": "index.js",
+  "exports": {
+    ".": "./index.js"
+  }
+}

--- a/packages/mc-client/skill-architect-client.mjs
+++ b/packages/mc-client/skill-architect-client.mjs
@@ -1,0 +1,106 @@
+/**
+ * Skill Architect HTTP client — for Mission Control (or any dashboard) on the same host as :18990.
+ *
+ * Responses may include **matrixPreflight** (Hyperspace Matrix) when the service has
+ * HYPERSPACE_USE_CLI=1 and hyperspace on PATH. See docs/mission-control-matrix-integration.md.
+ */
+
+/** @param {string} s */
+export function stripAnsi(s) {
+  if (!s || typeof s !== 'string') return '';
+  return s.replace(/\u001b\[[0-9;]*m/g, '');
+}
+
+/**
+ * @param {object} opts
+ * @param {string} opts.baseUrl - e.g. http://127.0.0.1:18990 (no trailing slash)
+ * @param {string} opts.token - contents of skill_architect_token
+ * @param {string[]} opts.urls - public https URLs only (SSRF-protected server-side)
+ * @param {string} [opts.targetAgent=jarvis]
+ * @param {AbortSignal} [opts.signal]
+ * @param {number} [opts.timeoutMs=120000]
+ */
+export async function postSkillArchitectJob(opts) {
+  const { baseUrl, token, urls, targetAgent = 'jarvis', timeoutMs = 120000 } = opts;
+  const url = `${String(baseUrl).replace(/\/$/, '')}/v1/jobs`;
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-SA-Token': token,
+      },
+      body: JSON.stringify({ urls, targetAgent }),
+      signal: controller.signal,
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      return { ok: false, status: res.status, error: data };
+    }
+    return { ok: true, status: res.status, job: data };
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+/**
+ * @param {object} opts
+ * @param {string} opts.baseUrl
+ * @param {string} opts.token
+ * @param {string} opts.jobId
+ */
+export async function getSkillArchitectJob(opts) {
+  const { baseUrl, token, jobId } = opts;
+  const url = `${String(baseUrl).replace(/\/$/, '')}/v1/jobs/${encodeURIComponent(jobId)}`;
+  const res = await fetch(url, {
+    headers: { 'X-SA-Token': token },
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) return { ok: false, status: res.status, error: data };
+  return { ok: true, job: data };
+}
+
+/**
+ * @param {object} opts
+ * @param {string} opts.baseUrl
+ * @param {string} opts.token
+ * @param {string} opts.jobId
+ * @param {'approve'|'reject'} opts.action
+ */
+export async function setSkillArchitectJobStatus(opts) {
+  const { baseUrl, token, jobId, action } = opts;
+  const path = action === 'approve' ? 'approve' : 'reject';
+  const url = `${String(baseUrl).replace(/\/$/, '')}/v1/jobs/${encodeURIComponent(jobId)}/${path}`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-SA-Token': token,
+    },
+    body: JSON.stringify({}),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) return { ok: false, status: res.status, error: data };
+  return { ok: true, job: data };
+}
+
+/**
+ * Health check (no token required).
+ * @param {string} baseUrl
+ */
+export async function checkSkillArchitectHealth(baseUrl) {
+  const url = `${String(baseUrl).replace(/\/$/, '')}/health`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5000);
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    const data = await res.json().catch(() => ({}));
+    return { ok: res.ok, status: res.status, data };
+  } catch (err) {
+    return { ok: false, error: err?.message || String(err) };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/packages/mc-client/test/kanban-store.test.mjs
+++ b/packages/mc-client/test/kanban-store.test.mjs
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import {
+  appendActivity,
+  createTask,
+  deleteTask,
+  kanbanBoardPath,
+  loadKanbanBoard,
+  moveTask,
+  saveKanbanBoard,
+  setBlockedBy,
+  upsertTask,
+} from '../kanban-store.mjs';
+
+test('kanban roundtrip + helpers', async () => {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), 'oc-kanban-'));
+  const companyId = 'test-co';
+  const project = '_';
+
+  let board = await loadKanbanBoard(home, companyId, project);
+  assert.equal(board.version, 1);
+  assert.equal(board.tasks.length, 0);
+
+  const t = createTask({ title: 'First', company: companyId, columnId: 'backlog' });
+  board = upsertTask(board, t);
+  await saveKanbanBoard(home, board, companyId, project);
+
+  const again = await loadKanbanBoard(home, companyId, project);
+  assert.equal(again.tasks.length, 1);
+  assert.equal(again.tasks[0].title, 'First');
+
+  const r1 = moveTask(again, t.id, 'in_progress', 1);
+  assert.equal(r1.ok, true);
+  const r2 = appendActivity(r1.board, t.id, 'started');
+  assert.equal(r2.ok, true);
+  const r3 = setBlockedBy(r2.board, t.id, []);
+  assert.equal(r3.ok, true);
+  let work = r3.board;
+
+  const t2 = createTask({ title: 'Second', company: companyId });
+  work = upsertTask(work, t2);
+  work = deleteTask(work, t2.id);
+  assert.equal(work.tasks.length, 1);
+
+  await fs.rm(home, { recursive: true, force: true });
+});
+
+test('kanbanBoardPath', () => {
+  const p = kanbanBoardPath('/home/x/.openclaw-human', 'acme', 'my-proj');
+  assert.ok(p.endsWith(path.join('Projects', 'acme', 'my-proj', 'kanban', 'board.json')));
+});

--- a/packages/mc-client/test/strip-ansi.test.mjs
+++ b/packages/mc-client/test/strip-ansi.test.mjs
@@ -1,0 +1,8 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { stripAnsi } from '../skill-architect-client.mjs';
+
+test('stripAnsi removes ANSI escapes', () => {
+  assert.equal(stripAnsi('\u001b[1mMatrix\u001b[0m'), 'Matrix');
+  assert.equal(stripAnsi('plain'), 'plain');
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@openclaw/mc-client':
+        specifier: file:./packages/mc-client
+        version: file:packages/mc-client
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.13)(react@19.2.4)
@@ -573,105 +576,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -782,28 +769,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.6':
     resolution: {integrity: sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.6':
     resolution: {integrity: sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.6':
     resolution: {integrity: sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.6':
     resolution: {integrity: sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==}
@@ -832,6 +815,9 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@openclaw/mc-client@file:packages/mc-client':
+    resolution: {directory: packages/mc-client, type: directory}
 
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
@@ -1021,79 +1007,66 @@ packages:
     resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
     resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.1':
     resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.1':
     resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.1':
     resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.1':
     resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.1':
     resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.1':
     resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
@@ -1579,49 +1552,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -5394,6 +5359,8 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@openclaw/mc-client@file:packages/mc-client': {}
 
   '@opentelemetry/api@1.9.0': {}
 

--- a/src/app/[[...panel]]/page.tsx
+++ b/src/app/[[...panel]]/page.tsx
@@ -29,6 +29,8 @@ import { SuperAdminPanel } from '@/components/panels/super-admin-panel'
 import { OfficePanel } from '@/components/panels/office-panel'
 import { GitHubSyncPanel } from '@/components/panels/github-sync-panel'
 import { SkillsPanel } from '@/components/panels/skills-panel'
+import { SkillArchitectPanel } from '@/components/panels/skill-architect-panel'
+import { KanbanPanel } from '@/components/panels/kanban-panel'
 import { LocalAgentsDocPanel } from '@/components/panels/local-agents-doc-panel'
 import { ChannelsPanel } from '@/components/panels/channels-panel'
 import { DebugPanel } from '@/components/panels/debug-panel'
@@ -427,7 +429,7 @@ export default function Home() {
 }
 
 const ESSENTIAL_PANELS = new Set([
-  'overview', 'agents', 'tasks', 'chat', 'activity', 'logs', 'settings',
+  'overview', 'agents', 'tasks', 'kanban', 'chat', 'activity', 'logs', 'settings', 'skill-architect',
 ])
 
 function ContentRouter({ tab }: { tab: string }) {
@@ -479,6 +481,8 @@ function ContentRouter({ tab }: { tab: string }) {
       )
     case 'tasks':
       return <TaskBoardPanel />
+    case 'kanban':
+      return <KanbanPanel />
     case 'agents':
       return (
         <>
@@ -532,6 +536,8 @@ function ContentRouter({ tab }: { tab: string }) {
       return <OfficePanel />
     case 'skills':
       return <SkillsPanel />
+    case 'skill-architect':
+      return <SkillArchitectPanel />
     case 'channels':
       if (isLocal) return <LocalModeUnavailable panel={tab} />
       return <ChannelsPanel />

--- a/src/app/api/auth/login-form/route.ts
+++ b/src/app/api/auth/login-form/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server'
+import { authenticateUser, createSession } from '@/lib/auth'
+import { logAuditEvent } from '@/lib/db'
+import { getMcSessionCookieName, getMcSessionCookieOptions, isRequestSecure } from '@/lib/session-cookie'
+
+function redirect(path: string) {
+  // Use relative redirects so proxy/internal hostnames never leak to browsers.
+  return new NextResponse(null, { status: 303, headers: { Location: path } })
+}
+
+export async function POST(request: Request) {
+  const form = await request.formData()
+  const username = String(form.get('username') || '').trim()
+  const password = String(form.get('password') || '')
+
+  if (!username || !password) {
+    return redirect('/login?error=missing')
+  }
+
+  const ipAddress = request.headers.get('x-forwarded-for') || request.headers.get('x-real-ip') || 'unknown'
+  const userAgent = request.headers.get('user-agent') || undefined
+
+  const user = authenticateUser(username, password)
+  if (!user) {
+    logAuditEvent({ action: 'login_failed', actor: username, ip_address: ipAddress, user_agent: userAgent })
+    return redirect('/login?error=invalid')
+  }
+
+  const { token, expiresAt } = createSession(user.id, ipAddress, userAgent, user.workspace_id)
+  logAuditEvent({ action: 'login', actor: user.username, actor_id: user.id, ip_address: ipAddress, user_agent: userAgent })
+
+  const response = redirect('/')
+  const isSecureRequest = isRequestSecure(request)
+  const cookieName = getMcSessionCookieName(isSecureRequest)
+
+  response.cookies.set(cookieName, token, {
+    ...getMcSessionCookieOptions({ maxAgeSeconds: expiresAt - Math.floor(Date.now() / 1000), isSecureRequest }),
+  })
+
+  return response
+}

--- a/src/app/api/gateways/connect/route.ts
+++ b/src/app/api/gateways/connect/route.ts
@@ -118,9 +118,9 @@ function resolveRemoteGatewayUrl(
     return `wss://${browserHost}/gw`
   }
 
-  // No Tailscale Serve — try direct connection to dashboard host on gateway port
+  // No Tailscale Serve — use dashboard-hosted /gw reverse proxy (keeps gateway port private).
   const protocol = inferBrowserProtocol(request) === 'https:' ? 'wss' : 'ws'
-  return `${protocol}://${browserHost}:${gateway.port}`
+  return `${protocol}://${browserHost}/gw`
 }
 
 function ensureTable(db: ReturnType<typeof getDatabase>) {

--- a/src/app/api/integrations/linear/issues/route.ts
+++ b/src/app/api/integrations/linear/issues/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { heavyLimiter } from '@/lib/rate-limit'
+import { createLinearIssue, listLinearTeams } from '@/lib/linear-client'
+import { z } from 'zod'
+
+const bodySchema = z.object({
+  title: z.string().min(1).max(500),
+  description: z.string().max(25000).optional(),
+  teamId: z.string().uuid().optional(),
+})
+
+export async function POST(request: NextRequest) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const limited = heavyLimiter(request)
+  if (limited) return limited
+
+  const apiKey = process.env.LINEAR_API_KEY?.trim()
+  if (!apiKey) {
+    return NextResponse.json({ error: 'LINEAR_API_KEY not configured' }, { status: 503 })
+  }
+
+  const raw = await request.json().catch(() => ({}))
+  const parsed = bodySchema.safeParse(raw)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid body', details: parsed.error.flatten() }, { status: 400 })
+  }
+
+  let teamId = parsed.data.teamId || process.env.LINEAR_TEAM_ID?.trim()
+  if (!teamId) {
+    try {
+      const teams = await listLinearTeams(apiKey)
+      if (teams.length === 1) teamId = teams[0].id
+      else if (teams.length === 0) {
+        return NextResponse.json({ error: 'No Linear teams; set LINEAR_TEAM_ID' }, { status: 400 })
+      } else {
+        return NextResponse.json(
+          {
+            error: 'teamId required',
+            teams: teams.map((t) => ({ id: t.id, key: t.key, name: t.name })),
+          },
+          { status: 400 },
+        )
+      }
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e)
+      return NextResponse.json({ error: msg }, { status: 502 })
+    }
+  }
+
+  try {
+    const issue = await createLinearIssue(apiKey, {
+      teamId,
+      title: parsed.data.title,
+      description: parsed.data.description,
+    })
+    return NextResponse.json(issue)
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e)
+    return NextResponse.json({ error: msg }, { status: 502 })
+  }
+}
+
+export const dynamic = 'force-dynamic'

--- a/src/app/api/integrations/linear/route.ts
+++ b/src/app/api/integrations/linear/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { readLimiter } from '@/lib/rate-limit'
+import { listLinearTeams } from '@/lib/linear-client'
+
+/**
+ * Linear (optional): `LINEAR_API_KEY` + `LINEAR_TEAM_ID` (or single team auto-pick).
+ * `?teams=1` lists teams for the Kanban team picker (operator-only when key present).
+ */
+export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const limited = readLimiter(request)
+  if (limited) return limited
+
+  const key = process.env.LINEAR_API_KEY?.trim()
+  const team = process.env.LINEAR_TEAM_KEY?.trim() || process.env.LINEAR_TEAM_ID?.trim()
+  const workspaceUrl = process.env.LINEAR_WORKSPACE_URL?.trim() || 'https://linear.app'
+  const wantTeams = new URL(request.url).searchParams.get('teams') === '1'
+
+  let teams: { id: string; key: string; name: string }[] | undefined
+  if (key && wantTeams) {
+    try {
+      teams = await listLinearTeams(key)
+    } catch {
+      teams = undefined
+    }
+  }
+
+  return NextResponse.json({
+    configured: Boolean(key),
+    teamKey: team || null,
+    workspaceUrl,
+    docs: 'https://linear.app/docs',
+    teams,
+  })
+}
+
+export const dynamic = 'force-dynamic'

--- a/src/app/api/kanban/[companyId]/[projectSlug]/route.ts
+++ b/src/app/api/kanban/[companyId]/[projectSlug]/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { loadKanbanBoard, saveKanbanBoard } from '@openclaw/mc-client'
+import { requireRole } from '@/lib/auth'
+import { readLimiter, heavyLimiter } from '@/lib/rate-limit'
+import { getOpenClawHome } from '@/lib/openclaw-home'
+
+type RouteCtx = { params: Promise<{ companyId: string; projectSlug: string }> }
+
+function sanitizeSegment(s: string, max = 120): string | null {
+  const t = decodeURIComponent(s || '').trim()
+  if (!t || t.length > max) return null
+  if (t === '_') return '_'
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(t)) return null
+  return t
+}
+
+export async function GET(request: NextRequest, { params }: RouteCtx) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const limited = readLimiter(request)
+  if (limited) return limited
+
+  const { companyId: rawC, projectSlug: rawP } = await params
+  const companyId = sanitizeSegment(rawC)
+  const projectSlug = sanitizeSegment(rawP) || '_'
+  if (!companyId) return NextResponse.json({ error: 'Invalid companyId' }, { status: 400 })
+
+  try {
+    const home = getOpenClawHome()
+    const board = await loadKanbanBoard(home, companyId, projectSlug)
+    return NextResponse.json(board)
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e)
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
+}
+
+export async function PATCH(request: NextRequest, { params }: RouteCtx) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const limited = heavyLimiter(request)
+  if (limited) return limited
+
+  const { companyId: rawC, projectSlug: rawP } = await params
+  const companyId = sanitizeSegment(rawC)
+  const projectSlug = sanitizeSegment(rawP) || '_'
+  if (!companyId) return NextResponse.json({ error: 'Invalid companyId' }, { status: 400 })
+
+  const body = await request.json().catch(() => null)
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'Expected JSON body' }, { status: 400 })
+  }
+  const b = body as { version?: number; boardId?: string; columns?: unknown; tasks?: unknown }
+  if (b.version !== 1 || !Array.isArray(b.columns) || !Array.isArray(b.tasks)) {
+    return NextResponse.json({ error: 'Invalid board shape (need version 1, columns, tasks)' }, { status: 400 })
+  }
+
+  try {
+    const home = getOpenClawHome()
+    await saveKanbanBoard(home, b as never, companyId, projectSlug)
+    const board = await loadKanbanBoard(home, companyId, projectSlug)
+    return NextResponse.json(board)
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e)
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
+}
+
+export const dynamic = 'force-dynamic'

--- a/src/app/api/kanban/[companyId]/[projectSlug]/tasks/[taskId]/start/route.ts
+++ b/src/app/api/kanban/[companyId]/[projectSlug]/tasks/[taskId]/start/route.ts
@@ -1,0 +1,124 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { appendActivity, loadKanbanBoard, saveKanbanBoard } from '@openclaw/mc-client'
+import { requireRole } from '@/lib/auth'
+import { heavyLimiter } from '@/lib/rate-limit'
+import { getOpenClawHome } from '@/lib/openclaw-home'
+import { getDatabase } from '@/lib/db'
+import { runOpenClaw } from '@/lib/command'
+import { scanForInjection } from '@/lib/injection-guard'
+import { logger } from '@/lib/logger'
+
+type RouteCtx = { params: Promise<{ companyId: string; projectSlug: string; taskId: string }> }
+
+function sanitizeSegment(s: string, max = 120): string | null {
+  const t = decodeURIComponent(s || '').trim()
+  if (!t || t.length > max) return null
+  if (t === '_') return '_'
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(t)) return null
+  return t
+}
+
+type BoardTask = { id: string; columnId: string; blockedBy?: string[]; assigneeAgentId?: string; title?: string; description?: string }
+
+function isBlocking(
+  board: { tasks: BoardTask[] },
+  depId: string,
+): boolean {
+  const dep = board.tasks.find((x) => x.id === depId)
+  if (!dep) return false
+  return dep.columnId !== 'done'
+}
+
+export async function POST(request: NextRequest, { params }: RouteCtx) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const limited = heavyLimiter(request)
+  if (limited) return limited
+
+  const { companyId: rawC, projectSlug: rawP, taskId } = await params
+  const companyId = sanitizeSegment(rawC)
+  const projectSlug = sanitizeSegment(rawP) || '_'
+  if (!companyId || !taskId) {
+    return NextResponse.json({ error: 'Invalid path' }, { status: 400 })
+  }
+
+  const force = new URL(request.url).searchParams.get('force') === '1'
+  const home = getOpenClawHome()
+
+  let board = (await loadKanbanBoard(home, companyId, projectSlug)) as {
+    tasks: BoardTask[]
+    columns: { id: string }[]
+  }
+  const task = board.tasks.find((t) => t.id === taskId)
+  if (!task) {
+    return NextResponse.json({ error: 'Task not found' }, { status: 404 })
+  }
+
+  const blocked = (task.blockedBy || []).filter((id) => isBlocking(board, id))
+  if (blocked.length > 0 && !force) {
+    return NextResponse.json(
+      {
+        error: 'blocked',
+        message: 'Blocked by tasks not in Done — resolve or use ?force=1',
+        blockedTaskIds: blocked,
+      },
+      { status: 409 },
+    )
+  }
+
+  const targetAgent = (task.assigneeAgentId && String(task.assigneeAgentId).trim()) || 'jarvis'
+  const body = `${task.title}${task.description ? `\n\n${task.description}` : ''}`
+
+  const inj = scanForInjection(body, { context: 'prompt' })
+  if (!inj.safe && inj.matches.some((m) => m.severity === 'critical')) {
+    return NextResponse.json({ error: 'Blocked: unsafe content in task' }, { status: 422 })
+  }
+
+  const db = getDatabase()
+  const workspaceId = auth.user.workspace_id ?? 1
+  const agent = db
+    .prepare('SELECT * FROM agents WHERE name = ? AND workspace_id = ?')
+    .get(targetAgent, workspaceId) as { session_key?: string } | undefined
+
+  if (!agent?.session_key) {
+    return NextResponse.json(
+      { error: `Agent "${targetAgent}" has no session key — set in Mission Control agents` },
+      { status: 400 },
+    )
+  }
+
+  const from = auth.user.display_name || auth.user.username || 'operator'
+
+  try {
+    await runOpenClaw(
+      [
+        'gateway',
+        'sessions_send',
+        '--session',
+        agent.session_key,
+        '--message',
+        `Kanban task (${companyId}): ${from}\n\n${body}`,
+      ],
+      { timeoutMs: 30000 },
+    )
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e)
+    logger.error({ err: e, taskId, targetAgent }, 'kanban start gateway send failed')
+    return NextResponse.json({ error: `Gateway send failed: ${msg}` }, { status: 502 })
+  }
+
+  const r = appendActivity(
+    board as unknown as Record<string, unknown>,
+    taskId,
+    `Started → ${targetAgent} (${from})`,
+  )
+  if (!r.ok || !('board' in r) || !r.board) {
+    return NextResponse.json({ error: 'appendActivity failed' }, { status: 500 })
+  }
+  board = r.board as typeof board
+  await saveKanbanBoard(home, board as never, companyId, projectSlug)
+
+  return NextResponse.json({ ok: true, taskId, targetAgent })
+}
+
+export const dynamic = 'force-dynamic'

--- a/src/app/api/memory/graph/route.ts
+++ b/src/app/api/memory/graph/route.ts
@@ -3,6 +3,7 @@ import { existsSync, readdirSync, statSync } from 'fs'
 import path from 'path'
 import Database from 'better-sqlite3'
 import { config } from '@/lib/config'
+import { getDatabase } from '@/lib/db'
 import { requireRole } from '@/lib/auth'
 import { readLimiter } from '@/lib/rate-limit'
 import { logger } from '@/lib/logger'
@@ -92,22 +93,49 @@ export async function GET(request: NextRequest) {
 
   try {
     const entries = readdirSync(memoryDbDir).filter((f) => f.endsWith('.sqlite'))
-    const agents: AgentGraphData[] = []
+    const dbAgents = new Map<string, AgentGraphData>()
 
     for (const entry of entries) {
       const agentName = entry.replace('.sqlite', '')
-
-      if (agentFilter !== 'all' && agentName !== agentFilter) continue
-
       const dbPath = path.join(memoryDbDir, entry)
       const data = getAgentData(dbPath, agentName)
-      if (data) agents.push(data)
+      if (data) dbAgents.set(agentName, data)
     }
 
-    // Sort by total chunks descending
-    agents.sort((a, b) => b.totalChunks - a.totalChunks)
+    // Collapse legacy local aliasing: jarvis is the canonical agent, main is stale local history.
+    if (dbAgents.has('jarvis') && dbAgents.has('main')) {
+      dbAgents.delete('main')
+    }
 
-    return NextResponse.json({ agents })
+    const agents: AgentGraphData[] = []
+    const seen = new Set<string>()
+
+    try {
+      const db = getDatabase()
+      const rows = db.prepare('SELECT name FROM agents ORDER BY name').all() as Array<{ name: string }>
+      for (const row of rows) {
+        const name = row.name
+        if (!name || seen.has(name)) continue
+        seen.add(name)
+        const data = dbAgents.get(name)
+        agents.push(data || { name, dbSize: 0, totalChunks: 0, totalFiles: 0, files: [] })
+      }
+    } catch (err) {
+      logger.warn(`Failed to read registered agents for memory graph: ${err}`)
+    }
+
+    for (const [name, data] of dbAgents.entries()) {
+      if (seen.has(name)) continue
+      seen.add(name)
+      agents.push(data)
+    }
+
+    const filtered = agentFilter === 'all' ? agents : agents.filter((agent) => agent.name === agentFilter)
+
+    // Sort by total chunks descending, then name for stable zero-count ordering.
+    filtered.sort((a, b) => (b.totalChunks - a.totalChunks) || a.name.localeCompare(b.name))
+
+    return NextResponse.json({ agents: filtered })
   } catch (err) {
     logger.error(`Failed to build memory graph data: ${err}`)
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })

--- a/src/app/api/openclaw/companies/route.ts
+++ b/src/app/api/openclaw/companies/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { readCompanyRegistry, readActiveCompany } from '@openclaw/mc-client'
+import { requireRole } from '@/lib/auth'
+import { readLimiter, heavyLimiter } from '@/lib/rate-limit'
+import { getOpenClawHome } from '@/lib/openclaw-home'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const limited = readLimiter(request)
+  if (limited) return limited
+
+  const home = getOpenClawHome()
+  const reg = await readCompanyRegistry(home)
+  const active = await readActiveCompany(home)
+  return NextResponse.json({
+    ok: reg.ok,
+    companies: reg.companies,
+    error: reg.error,
+    activeCompanyId: active.companyId,
+  })
+}
+
+const bodySchema = (raw: unknown): { companyId: string } | null => {
+  if (!raw || typeof raw !== 'object') return null
+  const id = (raw as { companyId?: unknown }).companyId
+  if (typeof id !== 'string' || !id.trim()) return null
+  const companyId = id.trim().slice(0, 120)
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(companyId)) return null
+  return { companyId }
+}
+
+export async function POST(request: NextRequest) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const limited = heavyLimiter(request)
+  if (limited) return limited
+
+  const body = await request.json().catch(() => ({}))
+  const parsed = bodySchema(body)
+  if (!parsed) {
+    return NextResponse.json({ error: 'Invalid companyId' }, { status: 400 })
+  }
+
+  const home = getOpenClawHome()
+  const p = path.join(home, 'workspace', '.active-company')
+  try {
+    await fs.mkdir(path.dirname(p), { recursive: true })
+    await fs.writeFile(p, `${parsed.companyId}\n`, 'utf8')
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e)
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
+
+  return NextResponse.json({ ok: true, activeCompanyId: parsed.companyId })
+}
+
+export const dynamic = 'force-dynamic'

--- a/src/app/api/openclaw/doctor/route.ts
+++ b/src/app/api/openclaw/doctor/route.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs'
+import path from 'node:path'
 import { NextResponse } from 'next/server'
 import { requireRole } from '@/lib/auth'
 import { runOpenClaw } from '@/lib/command'
@@ -5,7 +7,7 @@ import { config } from '@/lib/config'
 import { getDatabase } from '@/lib/db'
 import { logger } from '@/lib/logger'
 import { archiveOrphanTranscriptsForStateDir } from '@/lib/openclaw-doctor-fix'
-import { parseOpenClawDoctorOutput } from '@/lib/openclaw-doctor'
+import { parseOpenClawDoctorOutput, type OpenClawDoctorCategory, type OpenClawDoctorStatus } from '@/lib/openclaw-doctor'
 
 function getCommandDetail(error: unknown): { detail: string; code: number | null } {
   const err = error as {
@@ -15,14 +17,153 @@ function getCommandDetail(error: unknown): { detail: string; code: number | null
     code?: number | null
   }
 
+  const stdioDetail = [err?.stdout, err?.stderr].filter(Boolean).join('\n').trim()
   return {
-    detail: [err?.stdout, err?.stderr, err?.message].filter(Boolean).join('\n').trim(),
+    detail: stdioDetail || String(err?.message || '').trim(),
     code: typeof err?.code === 'number' ? err.code : null,
   }
 }
 
 function isMissingOpenClaw(detail: string): boolean {
   return /enoent|not installed|not reachable|command not found/i.test(detail)
+}
+
+function isBannerOnlyDoctorOutput(raw: string): boolean {
+  const text = raw.replace(/\u001b\[[0-9;]*m/g, '').trim()
+  if (!text) return true
+  const lines = text.split(/\r?\n/).map(line => line.trim()).filter(Boolean)
+  return lines.length <= 8 && lines.some(line => /openclaw doctor/i.test(line))
+}
+
+function collectReferencedTranscriptNames(store: Record<string, unknown>): Set<string> {
+  const referenced = new Set<string>()
+
+  for (const entry of Object.values(store)) {
+    if (!entry || typeof entry !== 'object') continue
+    const record = entry as Record<string, unknown>
+
+    if (typeof record.sessionId === 'string' && record.sessionId.trim()) {
+      referenced.add(`${record.sessionId.trim()}.jsonl`)
+    }
+
+    if (typeof record.sessionFile === 'string' && record.sessionFile.trim()) {
+      const base = path.basename(record.sessionFile.trim())
+      if (base.endsWith('.jsonl')) referenced.add(base)
+    }
+  }
+
+  return referenced
+}
+
+function detectFallbackCategory(issues: string[]): OpenClawDoctorCategory {
+  const text = issues.join('\n').toLowerCase()
+  if (/plugin|gateway\.mode|invalid config|config/.test(text)) return 'config'
+  if (/orphan transcript|missing transcript|session/.test(text)) return 'state'
+  if (/allowlist|security|telegram/.test(text)) return 'security'
+  return 'general'
+}
+
+function buildFallbackDoctorStatus(rawOutput: string): OpenClawDoctorStatus {
+  const issues: string[] = []
+  const stateDir = config.openclawStateDir
+  const configPath = config.openclawConfigPath
+  let cfg: Record<string, any> = {}
+
+  if (!fs.existsSync(configPath)) {
+    issues.push(`Missing config file: ${configPath}`)
+  } else {
+    try {
+      cfg = JSON.parse(fs.readFileSync(configPath, 'utf8')) as Record<string, any>
+    } catch (error) {
+      issues.push(`Invalid config file: ${configPath} (${String(error)})`)
+    }
+  }
+
+  const gatewayMode = cfg?.gateway?.mode
+  if (!gatewayMode) {
+    issues.push('gateway.mode is unset; gateway start will be blocked.')
+  }
+
+  const telegram = cfg?.channels?.telegram ?? {}
+  if (
+    telegram?.groupPolicy === 'allowlist' &&
+    (!Array.isArray(telegram?.groupAllowFrom) || telegram.groupAllowFrom.length === 0) &&
+    (!Array.isArray(telegram?.allowFrom) || telegram.allowFrom.length === 0)
+  ) {
+    issues.push('channels.telegram.groupPolicy is "allowlist" but groupAllowFrom (and allowFrom) is empty — all group messages will be silently dropped.')
+  }
+
+  const extensionsDir = path.join(stateDir, 'extensions')
+  for (const pluginName of (cfg?.plugins?.allow ?? []) as string[]) {
+    if (pluginName === 'telegram') continue
+    const pluginManifest = path.join(extensionsDir, pluginName, 'openclaw.plugin.json')
+    if (!fs.existsSync(pluginManifest)) {
+      issues.push(`plugins.allow: plugin not found: ${pluginName}`)
+    }
+  }
+
+  const agentsDir = path.join(stateDir, 'agents')
+  if (fs.existsSync(agentsDir)) {
+    for (const agentName of fs.readdirSync(agentsDir)) {
+      const sessionsDir = path.join(agentsDir, agentName, 'sessions')
+      const sessionsFile = path.join(sessionsDir, 'sessions.json')
+      if (!fs.existsSync(sessionsFile)) continue
+
+      try {
+        const store = JSON.parse(fs.readFileSync(sessionsFile, 'utf8')) as Record<string, unknown>
+        const referenced = collectReferencedTranscriptNames(store)
+        let orphanCount = 0
+        let missingCount = 0
+
+        for (const transcript of referenced) {
+          if (!fs.existsSync(path.join(sessionsDir, transcript))) missingCount += 1
+        }
+
+        for (const entry of fs.readdirSync(sessionsDir, { withFileTypes: true })) {
+          if (!entry.isFile() || !entry.name.endsWith('.jsonl') || entry.name === 'sessions.json') continue
+          if (!referenced.has(entry.name)) orphanCount += 1
+        }
+
+        if (missingCount > 0) {
+          issues.push(`${agentName}: ${missingCount} referenced session transcript file(s) are missing.`)
+        }
+        if (orphanCount > 0) {
+          issues.push(`${agentName}: found ${orphanCount} orphan transcript file(s) in sessions.`)
+        }
+      } catch (error) {
+        issues.push(`${agentName}: failed to read session store (${String(error)})`)
+      }
+    }
+  }
+
+  const level = issues.length > 0 ? 'warning' : 'healthy'
+  const summary = issues[0] || 'OpenClaw doctor reports a healthy configuration.'
+  const category = detectFallbackCategory(issues)
+  const raw = [
+    'OpenClaw doctor output was truncated in the non-interactive Mission Control runtime.',
+    'Mission Control fell back to direct filesystem/config diagnostics.',
+    rawOutput.trim(),
+    ...issues.map(issue => `- ${issue}`),
+  ].filter(Boolean).join('\n')
+
+  return {
+    level,
+    category,
+    healthy: level === 'healthy',
+    summary,
+    issues,
+    canFix: true,
+    raw,
+  }
+}
+
+function resolveDoctorStatus(rawOutput: string, exitCode: number | null): OpenClawDoctorStatus {
+  const parsed = parseOpenClawDoctorOutput(rawOutput, exitCode ?? 0, {
+    stateDir: config.openclawStateDir,
+  })
+
+  if (!isBannerOnlyDoctorOutput(parsed.raw)) return parsed
+  return buildFallbackDoctorStatus(rawOutput)
 }
 
 export async function GET(request: Request) {
@@ -32,21 +173,17 @@ export async function GET(request: Request) {
   }
 
   try {
-    const result = await runOpenClaw(['doctor'], { timeoutMs: 15000 })
-    return NextResponse.json(parseOpenClawDoctorOutput(`${result.stdout}\n${result.stderr}`, result.code ?? 0, {
-      stateDir: config.openclawStateDir,
-    }), {
+    const result = await runOpenClaw(['doctor'], { timeoutMs: 15000, allowNonZeroExit: true })
+    return NextResponse.json(resolveDoctorStatus((result.stdout || '') + '\n' + (result.stderr || ''), result.code ?? 0), {
       headers: { 'Cache-Control': 'no-store' },
     })
   } catch (error) {
-    const { detail, code } = getCommandDetail(error)
-    if (isMissingOpenClaw(detail)) {
+    const info = getCommandDetail(error)
+    if (isMissingOpenClaw(info.detail)) {
       return NextResponse.json({ error: 'OpenClaw is not installed or not reachable' }, { status: 400 })
     }
 
-    return NextResponse.json(parseOpenClawDoctorOutput(detail, code ?? 1, {
-      stateDir: config.openclawStateDir,
-    }), {
+    return NextResponse.json(resolveDoctorStatus(info.detail, info.code ?? 1), {
       headers: { 'Cache-Control': 'no-store' },
     })
   }
@@ -68,8 +205,8 @@ export async function POST(request: Request) {
       await runOpenClaw(['sessions', 'cleanup', '--all-agents', '--enforce', '--fix-missing'], { timeoutMs: 120000 })
       progress.push({ step: 'sessions', detail: 'Pruned missing transcript entries from session stores.' })
     } catch (error) {
-      const { detail } = getCommandDetail(error)
-      progress.push({ step: 'sessions', detail: detail || 'Session cleanup skipped.' })
+      const info = getCommandDetail(error)
+      progress.push({ step: 'sessions', detail: info.detail || 'Session cleanup skipped.' })
     }
 
     const orphanFix = archiveOrphanTranscriptsForStateDir(config.openclawStateDir)
@@ -77,20 +214,16 @@ export async function POST(request: Request) {
       step: 'orphans',
       detail:
         orphanFix.archivedOrphans > 0
-          ? `Archived ${orphanFix.archivedOrphans} orphan transcript file(s) across ${orphanFix.storesScanned} session store(s).`
-          : `No orphan transcript files found across ${orphanFix.storesScanned} session store(s).`,
+          ? ('Archived ' + orphanFix.archivedOrphans + ' orphan transcript file(s) across ' + orphanFix.storesScanned + ' session store(s).')
+          : ('No orphan transcript files found across ' + orphanFix.storesScanned + ' session store(s).'),
     })
 
-    const postFix = await runOpenClaw(['doctor'], { timeoutMs: 15000 })
-    const status = parseOpenClawDoctorOutput(`${postFix.stdout}\n${postFix.stderr}`, postFix.code ?? 0, {
-      stateDir: config.openclawStateDir,
-    })
+    const postFix = await runOpenClaw(['doctor'], { timeoutMs: 15000, allowNonZeroExit: true })
+    const status = resolveDoctorStatus((postFix.stdout || '') + '\n' + (postFix.stderr || ''), postFix.code ?? 0)
 
     try {
       const db = getDatabase()
-      db.prepare(
-        'INSERT INTO audit_log (action, actor, detail) VALUES (?, ?, ?)'
-      ).run(
+      db.prepare('INSERT INTO audit_log (action, actor, detail) VALUES (?, ?, ?)').run(
         'openclaw.doctor.fix',
         auth.user.username,
         JSON.stringify({ level: status.level, healthy: status.healthy, issues: status.issues })
@@ -101,14 +234,26 @@ export async function POST(request: Request) {
 
     return NextResponse.json({
       success: true,
-      output: `${fixResult.stdout}\n${fixResult.stderr}`.trim(),
+      output: ((fixResult.stdout || '') + '\n' + (fixResult.stderr || '')).trim(),
       progress,
       status,
     })
   } catch (error) {
-    const { detail, code } = getCommandDetail(error)
-    if (isMissingOpenClaw(detail)) {
+    const info = getCommandDetail(error)
+    if (isMissingOpenClaw(info.detail)) {
       return NextResponse.json({ error: 'OpenClaw is not installed or not reachable' }, { status: 400 })
+    }
+
+    const parsed = resolveDoctorStatus(info.detail, info.code ?? 1)
+
+    if (parsed.level !== 'error') {
+      return NextResponse.json({
+        success: true,
+        warning: true,
+        output: info.detail,
+        progress: [{ step: 'doctor', detail: 'Doctor completed with warnings.' }],
+        status: parsed,
+      })
     }
 
     logger.error({ err: error }, 'OpenClaw doctor fix failed')
@@ -116,10 +261,8 @@ export async function POST(request: Request) {
     return NextResponse.json(
       {
         error: 'OpenClaw doctor fix failed',
-        detail,
-        status: parseOpenClawDoctorOutput(detail, code ?? 1, {
-          stateDir: config.openclawStateDir,
-        }),
+        detail: info.detail,
+        status: parsed,
       },
       { status: 500 }
     )

--- a/src/app/api/skill-architect/jobs/[id]/apply/route.ts
+++ b/src/app/api/skill-architect/jobs/[id]/apply/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { heavyLimiter } from '@/lib/rate-limit'
+import { callSkillApply } from '@/lib/skill-architect-apply-client'
+
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const limited = heavyLimiter(request)
+  if (limited) return limited
+
+  const { id } = await params
+  const body = await request.json().catch(() => ({}))
+  const dryRun = body?.dryRun !== false
+
+  try {
+    const out = await callSkillApply('/v1/apply', {
+      method: 'POST',
+      body: JSON.stringify({ jobId: id, dryRun, requestedBy: auth.user.username }),
+    })
+    return NextResponse.json(out)
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || 'apply failed' }, { status: 422 })
+  }
+}
+
+export const dynamic = 'force-dynamic'

--- a/src/app/api/skill-architect/jobs/[id]/approve/route.ts
+++ b/src/app/api/skill-architect/jobs/[id]/approve/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { heavyLimiter } from '@/lib/rate-limit'
+import { callSkillArchitect } from '@/lib/skill-architect-client'
+
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const limited = heavyLimiter(request)
+  if (limited) return limited
+
+  const { id } = await params
+  const body = await request.json().catch(() => ({}))
+  try {
+    const out = await callSkillArchitect(`/v1/jobs/${encodeURIComponent(id)}/approve`, {
+      method: 'POST',
+      body: JSON.stringify({ approver: auth.user.username, note: body?.note || '' }),
+    })
+    return NextResponse.json(out)
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || 'Failed to approve job' }, { status: 502 })
+  }
+}
+
+export const dynamic = 'force-dynamic'

--- a/src/app/api/skill-architect/jobs/[id]/reject/route.ts
+++ b/src/app/api/skill-architect/jobs/[id]/reject/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { heavyLimiter } from '@/lib/rate-limit'
+import { callSkillArchitect } from '@/lib/skill-architect-client'
+
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const limited = heavyLimiter(request)
+  if (limited) return limited
+
+  const { id } = await params
+  const body = await request.json().catch(() => ({}))
+  try {
+    const out = await callSkillArchitect(`/v1/jobs/${encodeURIComponent(id)}/reject`, {
+      method: 'POST',
+      body: JSON.stringify({ approver: auth.user.username, note: body?.note || '' }),
+    })
+    return NextResponse.json(out)
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || 'Failed to reject job' }, { status: 502 })
+  }
+}
+
+export const dynamic = 'force-dynamic'

--- a/src/app/api/skill-architect/jobs/[id]/rollback/route.ts
+++ b/src/app/api/skill-architect/jobs/[id]/rollback/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { heavyLimiter } from '@/lib/rate-limit'
+import { callSkillApply } from '@/lib/skill-architect-apply-client'
+
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const limited = heavyLimiter(request)
+  if (limited) return limited
+
+  const { id } = await params
+  const body = await request.json().catch(() => ({}))
+  const backupId = String(body?.backupId || '').trim()
+  if (!backupId) return NextResponse.json({ error: 'backupId is required' }, { status: 400 })
+
+  try {
+    const out = await callSkillApply('/v1/rollback', {
+      method: 'POST',
+      body: JSON.stringify({ jobId: id, backupId, requestedBy: auth.user.username }),
+    })
+    return NextResponse.json(out)
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || 'rollback failed' }, { status: 422 })
+  }
+}
+
+export const dynamic = 'force-dynamic'

--- a/src/app/api/skill-architect/jobs/[id]/route.ts
+++ b/src/app/api/skill-architect/jobs/[id]/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { readLimiter } from '@/lib/rate-limit'
+import { callSkillArchitect } from '@/lib/skill-architect-client'
+
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const limited = readLimiter(request)
+  if (limited) return limited
+
+  const { id } = await params
+  if (!id) return NextResponse.json({ error: 'id is required' }, { status: 400 })
+
+  try {
+    const out = await callSkillArchitect(`/v1/jobs/${encodeURIComponent(id)}`)
+    return NextResponse.json(out)
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || 'Failed to fetch job' }, { status: 502 })
+  }
+}
+
+export const dynamic = 'force-dynamic'

--- a/src/app/api/skill-architect/jobs/route.ts
+++ b/src/app/api/skill-architect/jobs/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { heavyLimiter, readLimiter } from '@/lib/rate-limit'
+import { callSkillArchitect } from '@/lib/skill-architect-client'
+import { z } from 'zod'
+
+const bodySchema = z.object({
+  requester: z.string().min(1).max(80).default('jarvis'),
+  topic: z.string().max(300).optional(),
+  urls: z.array(z.string().url()).min(1).max(10),
+  targetAgent: z.string().min(1).max(80),
+  targetSubagent: z.string().max(80).optional(),
+  mode: z.enum(['skill-only', 'spec-tree', 'mixed']).default('mixed'),
+})
+
+export async function POST(request: NextRequest) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const limited = heavyLimiter(request)
+  if (limited) return limited
+
+  const body = await request.json().catch(() => ({}))
+  const parsed = bodySchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid request', details: parsed.error.issues.map(i => i.message) }, { status: 400 })
+  }
+
+  try {
+    const out = await callSkillArchitect('/v1/jobs', {
+      method: 'POST',
+      body: JSON.stringify(parsed.data),
+    })
+    return NextResponse.json(out, { status: 202 })
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || 'Failed to create job' }, { status: 502 })
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const limited = readLimiter(request)
+  if (limited) return limited
+
+  const id = new URL(request.url).searchParams.get('id')
+  if (!id) return NextResponse.json({ error: 'id is required' }, { status: 400 })
+
+  try {
+    const out = await callSkillArchitect(`/v1/jobs/${encodeURIComponent(id)}`)
+    return NextResponse.json(out)
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || 'Failed to fetch job' }, { status: 502 })
+  }
+}
+
+export const dynamic = 'force-dynamic'

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -242,10 +242,11 @@ export default function LoginPage() {
           </div>
         )}
 
-        <form onSubmit={handleSubmit} className={`space-y-4 ${pendingApproval ? 'opacity-50 pointer-events-none' : ''}`}>
+        <form action="/api/auth/login-form" method="post" onSubmit={handleSubmit} className={`space-y-4 ${pendingApproval ? 'opacity-50 pointer-events-none' : ''}`}>
           <div>
             <label htmlFor="username" className="block text-sm font-medium text-foreground mb-1.5">Username</label>
             <input
+              name="username"
               id="username"
               type="text"
               value={username}
@@ -262,6 +263,7 @@ export default function LoginPage() {
           <div>
             <label htmlFor="password" className="block text-sm font-medium text-foreground mb-1.5">Password</label>
             <input
+              name="password"
               id="password"
               type="password"
               value={password}

--- a/src/components/layout/company-picker.tsx
+++ b/src/components/layout/company-picker.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+
+type CompanyRow = { id: string; name?: string; summary?: string }
+
+export function CompanyPicker() {
+  const [companies, setCompanies] = useState<CompanyRow[]>([])
+  const [activeId, setActiveId] = useState<string>('')
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError('')
+    try {
+      const res = await fetch('/api/openclaw/companies')
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to load companies')
+      setCompanies(Array.isArray(data.companies) ? data.companies : [])
+      setActiveId(typeof data.activeCompanyId === 'string' ? data.activeCompanyId : '')
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Load failed')
+      setCompanies([])
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  async function onSelect(companyId: string) {
+    if (!companyId || companyId === activeId) return
+    setSaving(true)
+    setError('')
+    try {
+      const res = await fetch('/api/openclaw/companies', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ companyId }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to save')
+      setActiveId(companyId)
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Save failed')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading && companies.length === 0 && !error) {
+    return (
+      <div className="hidden lg:flex items-center text-2xs text-muted-foreground px-2" aria-hidden>
+        Companies…
+      </div>
+    )
+  }
+
+  if (error && companies.length === 0) {
+    return null
+  }
+
+  if (companies.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="hidden lg:flex items-center gap-1.5 min-w-0">
+      <label htmlFor="mc-active-company" className="text-2xs text-muted-foreground shrink-0">
+        Company
+      </label>
+      <select
+        id="mc-active-company"
+        className="max-w-[200px] h-8 rounded-md border border-border bg-background text-xs px-2 py-1 truncate"
+        value={activeId}
+        disabled={saving}
+        onChange={(e) => void onSelect(e.target.value)}
+        title="Default company id (workspace/.active-company)"
+      >
+        <option value="">—</option>
+        {companies.map((c) => (
+          <option key={c.id} value={c.id}>
+            {c.name || c.id}
+          </option>
+        ))}
+      </select>
+      {error ? <span className="text-2xs text-red-500 truncate max-w-[120px]" title={error}>{error}</span> : null}
+    </div>
+  )
+}

--- a/src/components/layout/header-bar.tsx
+++ b/src/components/layout/header-bar.tsx
@@ -9,6 +9,7 @@ import { useNavigateToPanel, usePrefetchPanel } from '@/lib/navigation'
 import { Button } from '@/components/ui/button'
 import { ThemeSelector } from '@/components/ui/theme-selector'
 import { DigitalClock } from '@/components/ui/digital-clock'
+import { CompanyPicker } from '@/components/layout/company-picker'
 import { getNavigationMetrics, navigationMetricEventName } from '@/lib/navigation-metrics'
 
 interface SearchResult {
@@ -26,6 +27,7 @@ const QUICK_NAV_COMMANDS: Array<{ panel: string; title: string; aliases: string[
   { panel: 'overview', title: 'Go to Overview', aliases: ['home', 'dashboard'] },
   { panel: 'chat', title: 'Go to Chat', aliases: ['sessions', 'messages'] },
   { panel: 'tasks', title: 'Go to Tasks', aliases: ['task board', 'tickets'] },
+  { panel: 'kanban', title: 'Go to Kanban', aliases: ['board', 'openclaw kanban'] },
   { panel: 'agents', title: 'Go to Agents', aliases: ['agent squad', 'workers'] },
   { panel: 'activity', title: 'Go to Activity Feed', aliases: ['events', 'feed'] },
   { panel: 'notifications', title: 'Go to Notifications', aliases: ['alerts inbox'] },
@@ -318,6 +320,7 @@ export function HeaderBar() {
           ) : null}
 
           <ModeBadge connection={connection} onReconnect={reconnect} />
+          <CompanyPicker />
         </div>
 
         {/* Center: wide command search (desktop) */}

--- a/src/components/layout/nav-rail.tsx
+++ b/src/components/layout/nav-rail.tsx
@@ -30,6 +30,7 @@ const navGroups: NavGroup[] = [
       { id: 'overview', label: 'Overview', icon: <OverviewIcon />, priority: true, essential: true },
       { id: 'agents', label: 'Agents', icon: <AgentsIcon />, priority: true, essential: true },
       { id: 'tasks', label: 'Tasks', icon: <TasksIcon />, priority: true, essential: true },
+      { id: 'kanban', label: 'Kanban', icon: <KanbanIcon />, priority: true, essential: true },
       { id: 'chat', label: 'Chat', icon: <ChatIcon />, priority: false, essential: true },
       { id: 'channels', label: 'Channels', icon: <ChannelsIcon />, priority: false },
       { id: 'skills', label: 'Skills', icon: <SkillsIcon />, priority: false },
@@ -1168,6 +1169,16 @@ function TasksIcon() {
     <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
       <rect x="2" y="1" width="12" height="14" rx="1.5" />
       <path d="M5 5h6M5 8h6M5 11h3" />
+    </svg>
+  )
+}
+
+function KanbanIcon() {
+  return (
+    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="w-4 h-4">
+      <rect x="2" y="2" width="4" height="12" rx="0.75" />
+      <rect x="8" y="2" width="4" height="5" rx="0.75" />
+      <rect x="8" y="9" width="4" height="5" rx="0.75" />
     </svg>
   )
 }

--- a/src/components/panels/kanban-panel.tsx
+++ b/src/components/panels/kanban-panel.tsx
@@ -1,0 +1,607 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { parseGitHubPrUrl } from '@/lib/github-pr-links'
+
+type KanbanColumn = { id: string; title: string; order: number }
+type KanbanTask = {
+  id: string
+  title: string
+  description?: string
+  columnId: string
+  order: number
+  blockedBy?: string[]
+  assigneeAgentId?: string
+  activity?: { ts: number; message: string }[]
+  reviewUrl?: string
+}
+
+type KanbanBoard = {
+  version: 1
+  boardId: string
+  name?: string
+  columns: KanbanColumn[]
+  tasks: KanbanTask[]
+}
+
+type CompanyRow = { id: string; name?: string }
+type AgentRow = { name: string }
+
+export function KanbanPanel() {
+  const [companies, setCompanies] = useState<CompanyRow[]>([])
+  const [companyId, setCompanyId] = useState('')
+  const [projectSlug] = useState('_')
+  const [board, setBoard] = useState<KanbanBoard | null>(null)
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [agents, setAgents] = useState<AgentRow[]>([])
+  const [linearInfo, setLinearInfo] = useState<{
+    configured: boolean
+    workspaceUrl: string
+    teams?: { id: string; key: string; name: string }[]
+  } | null>(null)
+  const [linearTeamId, setLinearTeamId] = useState('')
+  const [linearBusy, setLinearBusy] = useState(false)
+
+  const [newTitle, setNewTitle] = useState('')
+  const [newCol, setNewCol] = useState('backlog')
+  const [editTask, setEditTask] = useState<KanbanTask | null>(null)
+  const [blockedText, setBlockedText] = useState('')
+  const [descText, setDescText] = useState('')
+  const [assignee, setAssignee] = useState('')
+  const [reviewUrl, setReviewUrl] = useState('')
+  const [starting, setStarting] = useState(false)
+
+  const sortedColumns = useMemo(
+    () => [...(board?.columns || [])].sort((a, b) => a.order - b.order),
+    [board?.columns],
+  )
+
+  const loadCompanies = useCallback(async () => {
+    const res = await fetch('/api/openclaw/companies')
+    const data = await res.json()
+    if (!res.ok) throw new Error(data.error || 'Companies')
+    const list: CompanyRow[] = Array.isArray(data.companies) ? data.companies : []
+    setCompanies(list)
+    const preferred =
+      (typeof data.activeCompanyId === 'string' && data.activeCompanyId) ||
+      list[0]?.id ||
+      ''
+    setCompanyId(preferred)
+  }, [])
+
+  const loadAgents = useCallback(async () => {
+    const res = await fetch('/api/agents?limit=100')
+    const data = await res.json()
+    if (!res.ok) return
+    const list = (data.agents || []) as Array<{ name: string }>
+    setAgents(list.map((a) => ({ name: a.name })))
+  }, [])
+
+  const loadLinear = useCallback(async () => {
+    const res = await fetch('/api/integrations/linear?teams=1')
+    const data = await res.json()
+    if (res.ok) {
+      const teams = Array.isArray(data.teams) ? data.teams : undefined
+      setLinearInfo({
+        configured: data.configured === true,
+        workspaceUrl: typeof data.workspaceUrl === 'string' ? data.workspaceUrl : 'https://linear.app',
+        teams,
+      })
+      if (teams && teams.length === 1) setLinearTeamId(teams[0].id)
+    }
+  }, [])
+
+  const loadBoard = useCallback(async (cid: string) => {
+    if (!cid) {
+      setBoard(null)
+      return
+    }
+    setLoading(true)
+    setError('')
+    try {
+      const res = await fetch(
+        `/api/kanban/${encodeURIComponent(cid)}/${encodeURIComponent(projectSlug)}`,
+      )
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Kanban load failed')
+      setBoard(data as KanbanBoard)
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Load failed')
+      setBoard(null)
+    } finally {
+      setLoading(false)
+    }
+  }, [projectSlug])
+
+  useEffect(() => {
+    void loadCompanies().catch((e) => setError(e instanceof Error ? e.message : String(e)))
+  }, [loadCompanies])
+
+  useEffect(() => {
+    void loadAgents()
+    void loadLinear()
+  }, [loadAgents, loadLinear])
+
+  useEffect(() => {
+    if (companyId) void loadBoard(companyId)
+  }, [companyId, loadBoard])
+
+  async function persist(next: KanbanBoard) {
+    if (!companyId) return
+    setSaving(true)
+    setError('')
+    try {
+      const res = await fetch(
+        `/api/kanban/${encodeURIComponent(companyId)}/${encodeURIComponent(projectSlug)}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(next),
+        },
+      )
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Save failed')
+      setBoard(data as KanbanBoard)
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Save failed')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  function moveTask(taskId: string, columnId: string) {
+    if (!board) return
+    const next: KanbanBoard = {
+      ...board,
+      tasks: board.tasks.map((x) =>
+        x.id === taskId ? { ...x, columnId } : x,
+      ),
+    }
+    void persist(next)
+  }
+
+  function addTask() {
+    if (!board || !newTitle.trim()) return
+    const id = crypto.randomUUID()
+    const col = newCol
+    const task: KanbanTask = {
+      id,
+      title: newTitle.trim(),
+      columnId: col,
+      order: Date.now(),
+      blockedBy: [],
+      assigneeAgentId: 'jarvis',
+    }
+    const next: KanbanBoard = { ...board, tasks: [...board.tasks, task] }
+    setNewTitle('')
+    void persist(next)
+  }
+
+  function openEdit(t: KanbanTask) {
+    setEditTask(t)
+    setBlockedText((t.blockedBy || []).join(', '))
+    setDescText(t.description || '')
+    setAssignee(t.assigneeAgentId || 'jarvis')
+    setReviewUrl(t.reviewUrl || '')
+  }
+
+  function saveEdit() {
+    if (!board || !editTask) return
+    const ids = blockedText
+      .split(/[,\s]+/)
+      .map((s) => s.trim())
+      .filter(Boolean)
+    const next: KanbanBoard = {
+      ...board,
+      tasks: board.tasks.map((t) =>
+        t.id === editTask.id
+          ? {
+              ...t,
+              blockedBy: ids,
+              description: descText,
+              assigneeAgentId: assignee || 'jarvis',
+              reviewUrl: reviewUrl.trim() || undefined,
+            }
+          : t,
+      ),
+    }
+    setEditTask(null)
+    void persist(next)
+  }
+
+  const prLinks = useMemo(() => parseGitHubPrUrl(reviewUrl), [reviewUrl])
+
+  async function createLinearIssue() {
+    if (!editTask || !board || !companyId || !linearInfo?.configured) return
+    setLinearBusy(true)
+    setError('')
+    try {
+      const body: { title: string; description?: string; teamId?: string } = {
+        title: editTask.title,
+        description: descText || undefined,
+        teamId: linearTeamId || undefined,
+      }
+      let res = await fetch('/api/integrations/linear/issues', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      let data = await res.json()
+      if (res.status === 400 && data.teams) {
+        setLinearInfo((prev) => (prev ? { ...prev, teams: data.teams } : null))
+        setError('Select a Linear team, then retry.')
+        return
+      }
+      if (!res.ok) throw new Error(data.error || 'Linear create failed')
+      const url = data.url as string
+      const identifier = (data.identifier as string) || 'issue'
+      const next: KanbanBoard = {
+        ...board,
+        tasks: board.tasks.map((t) =>
+          t.id === editTask.id
+            ? {
+                ...t,
+                reviewUrl: url,
+                activity: [
+                  ...(t.activity || []),
+                  { ts: Date.now(), message: `Linear ${identifier}` },
+                ],
+              }
+            : t,
+        ),
+      }
+      setReviewUrl(url)
+      const updated = next.tasks.find((x) => x.id === editTask.id) || null
+      if (updated) setEditTask(updated)
+      await persist(next)
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Linear failed')
+    } finally {
+      setLinearBusy(false)
+    }
+  }
+
+  async function startTask(force?: boolean) {
+    if (!editTask || !companyId) return
+    setStarting(true)
+    setError('')
+    try {
+      const q = force ? '?force=1' : ''
+      const res = await fetch(
+        `/api/kanban/${encodeURIComponent(companyId)}/${encodeURIComponent(projectSlug)}/tasks/${encodeURIComponent(editTask.id)}/start${q}`,
+        { method: 'POST' },
+      )
+      const data = await res.json()
+      if (res.status === 409 && data.blockedTaskIds) {
+        const ok = window.confirm(
+          'Dependencies not in Done. Start anyway?',
+        )
+        if (ok) await startTask(true)
+        return
+      }
+      if (!res.ok) throw new Error(data.error || 'Start failed')
+      await loadBoard(companyId)
+      setEditTask(null)
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Start failed')
+    } finally {
+      setStarting(false)
+    }
+  }
+
+  if (loading && !board && !error) {
+    return (
+      <div className="p-6 text-sm text-muted-foreground">Loading Kanban…</div>
+    )
+  }
+
+  return (
+    <div className="p-4 space-y-4 max-w-[1600px] mx-auto">
+      <div className="flex flex-wrap items-end gap-3">
+        <div>
+          <h1 className="text-lg font-semibold">Kanban</h1>
+          <p className="text-xs text-muted-foreground">
+            Board file: workspace/Projects/&lt;company&gt;/_/kanban/board.json —{' '}
+            <span className="text-foreground/80">Start task</span> sends to the gateway agent (session key required).
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <label className="text-xs text-muted-foreground" htmlFor="kanban-company">
+            Company
+          </label>
+          <select
+            id="kanban-company"
+            className="h-9 rounded-md border border-border bg-background text-sm px-2"
+            value={companyId}
+            onChange={(e) => setCompanyId(e.target.value)}
+          >
+            <option value="">—</option>
+            {companies.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name || c.id}
+              </option>
+            ))}
+          </select>
+        </div>
+        {linearInfo ? (
+          <div className="text-2xs text-muted-foreground flex items-center gap-2">
+            <span>Linear:</span>
+            {linearInfo.configured ? (
+              <span className="text-green-600">API key set</span>
+            ) : (
+              <span>optional — set LINEAR_API_KEY in MC env</span>
+            )}
+            <a
+              href={linearInfo.workspaceUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary underline"
+            >
+              Open workspace
+            </a>
+          </div>
+        ) : null}
+        {saving ? <span className="text-xs text-muted-foreground">Saving…</span> : null}
+        {error ? <span className="text-xs text-red-500">{error}</span> : null}
+      </div>
+
+      {!companyId ? (
+        <p className="text-sm text-muted-foreground">Select a company with a registry entry.</p>
+      ) : !board ? (
+        <p className="text-sm text-muted-foreground">No board data.</p>
+      ) : (
+        <>
+          <div className="rounded-lg border bg-card p-3 flex flex-wrap gap-2 items-end">
+            <input
+              className="border rounded px-3 py-2 bg-background text-sm min-w-[200px]"
+              placeholder="New task title"
+              value={newTitle}
+              onChange={(e) => setNewTitle(e.target.value)}
+            />
+            <select
+              className="border rounded px-3 py-2 bg-background text-sm"
+              value={newCol}
+              onChange={(e) => setNewCol(e.target.value)}
+            >
+              {sortedColumns.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.title}
+                </option>
+              ))}
+            </select>
+            <Button size="sm" type="button" onClick={addTask} disabled={!newTitle.trim()}>
+              Add task
+            </Button>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-3">
+            {sortedColumns.map((col) => {
+              const tasks = board.tasks
+                .filter((t) => t.columnId === col.id)
+                .sort((a, b) => a.order - b.order)
+              return (
+                <div key={col.id} className="rounded-lg border bg-muted/20 min-h-[280px] flex flex-col">
+                  <div className="px-3 py-2 border-b font-medium text-sm">{col.title}</div>
+                  <div className="p-2 space-y-2 flex-1 overflow-auto">
+                    {tasks.map((t) => (
+                      <div
+                        key={t.id}
+                        className="rounded border bg-card p-2 text-sm space-y-1 shadow-sm"
+                      >
+                        <button
+                          type="button"
+                          className="font-medium text-left w-full hover:underline"
+                          onClick={() => openEdit(t)}
+                        >
+                          {t.title}
+                        </button>
+                        {t.description ? (
+                          <div className="text-2xs text-muted-foreground line-clamp-2">{t.description}</div>
+                        ) : null}
+                        {t.assigneeAgentId ? (
+                          <div className="text-2xs text-muted-foreground">→ {t.assigneeAgentId}</div>
+                        ) : null}
+                        {t.reviewUrl ? (
+                          <div className="space-y-0.5">
+                            <a
+                              href={t.reviewUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-2xs text-primary block truncate"
+                            >
+                              Review / diff
+                            </a>
+                            {(() => {
+                              const pr = parseGitHubPrUrl(t.reviewUrl || '')
+                              if (!pr) return null
+                              return (
+                                <div className="flex flex-wrap gap-1.5 text-2xs">
+                                  <a
+                                    href={pr.files}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-primary underline"
+                                  >
+                                    Files
+                                  </a>
+                                  <a
+                                    href={pr.commits}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-primary underline"
+                                  >
+                                    Commits
+                                  </a>
+                                  <a
+                                    href={pr.checks}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-primary underline"
+                                  >
+                                    Checks
+                                  </a>
+                                </div>
+                              )
+                            })()}
+                          </div>
+                        ) : null}
+                        {t.blockedBy && t.blockedBy.length > 0 ? (
+                          <div className="text-2xs text-amber-600">
+                            Blocked by: {t.blockedBy.join(', ')}
+                          </div>
+                        ) : null}
+                        {t.activity && t.activity.length > 0 ? (
+                          <div className="text-2xs text-muted-foreground border-t pt-1 mt-1">
+                            {t.activity[t.activity.length - 1]?.message}
+                          </div>
+                        ) : null}
+                        <div className="flex flex-wrap gap-1 pt-1">
+                          {sortedColumns
+                            .filter((c) => c.id !== col.id)
+                            .map((c) => (
+                              <button
+                                key={c.id}
+                                type="button"
+                                className="text-2xs px-2 py-0.5 rounded bg-secondary hover:bg-secondary/80"
+                                onClick={() => moveTask(t.id, c.id)}
+                              >
+                                → {c.title}
+                              </button>
+                            ))}
+                          <button
+                            type="button"
+                            className="text-2xs px-2 py-0.5 rounded border border-border"
+                            onClick={() => openEdit(t)}
+                          >
+                            Edit
+                          </button>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </>
+      )}
+
+      {editTask ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4 overflow-y-auto">
+          <div className="bg-card border rounded-lg p-4 max-w-lg w-full space-y-3 shadow-lg my-8">
+            <div className="font-medium">Task</div>
+            <p className="text-sm">{editTask.title}</p>
+            <label className="text-xs text-muted-foreground block">Description</label>
+            <textarea
+              className="w-full border rounded px-3 py-2 bg-background text-sm min-h-[80px]"
+              value={descText}
+              onChange={(e) => setDescText(e.target.value)}
+            />
+            <label className="text-xs text-muted-foreground block">Assignee (gateway agent)</label>
+            <select
+              className="w-full border rounded px-3 py-2 bg-background text-sm"
+              value={assignee}
+              onChange={(e) => setAssignee(e.target.value)}
+            >
+              {agents.length === 0 ? (
+                <option value="jarvis">jarvis</option>
+              ) : (
+                agents.map((a) => (
+                  <option key={a.name} value={a.name}>
+                    {a.name}
+                  </option>
+                ))
+              )}
+            </select>
+            <label className="text-xs text-muted-foreground block">Review / PR URL (optional)</label>
+            <input
+              className="w-full border rounded px-3 py-2 bg-background text-sm"
+              value={reviewUrl}
+              onChange={(e) => setReviewUrl(e.target.value)}
+              placeholder="https://github.com/org/repo/pull/123"
+            />
+            {prLinks ? (
+              <div className="flex flex-wrap gap-2 text-2xs">
+                <a href={prLinks.files} target="_blank" rel="noopener noreferrer" className="text-primary underline">
+                  Files
+                </a>
+                <a href={prLinks.commits} target="_blank" rel="noopener noreferrer" className="text-primary underline">
+                  Commits
+                </a>
+                <a href={prLinks.checks} target="_blank" rel="noopener noreferrer" className="text-primary underline">
+                  Checks
+                </a>
+              </div>
+            ) : null}
+            {linearInfo?.configured ? (
+              <div className="space-y-2 border rounded p-2 bg-muted/20">
+                <div className="text-2xs font-medium text-muted-foreground">Linear</div>
+                {linearInfo.teams && linearInfo.teams.length > 1 ? (
+                  <select
+                    className="w-full border rounded px-2 py-1.5 bg-background text-sm"
+                    value={linearTeamId}
+                    onChange={(e) => setLinearTeamId(e.target.value)}
+                  >
+                    <option value="">Select team…</option>
+                    {linearInfo.teams.map((t) => (
+                      <option key={t.id} value={t.id}>
+                        {t.key} — {t.name}
+                      </option>
+                    ))}
+                  </select>
+                ) : null}
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="secondary"
+                  disabled={linearBusy}
+                  onClick={() => void createLinearIssue()}
+                >
+                  {linearBusy ? 'Creating…' : 'Create Linear issue & link'}
+                </Button>
+              </div>
+            ) : null}
+            <label className="text-xs text-muted-foreground block">Blocked by (task ids)</label>
+            <input
+              className="w-full border rounded px-3 py-2 bg-background text-sm"
+              value={blockedText}
+              onChange={(e) => setBlockedText(e.target.value)}
+              placeholder="uuid, uuid2"
+            />
+            {editTask.activity && editTask.activity.length > 0 ? (
+              <div className="text-xs border rounded p-2 bg-muted/30 max-h-32 overflow-auto">
+                <div className="font-medium text-2xs mb-1">Activity</div>
+                {editTask.activity.slice(-8).map((a, i) => (
+                  <div key={i} className="text-2xs text-muted-foreground">
+                    {new Date(a.ts).toLocaleString()}: {a.message}
+                  </div>
+                ))}
+              </div>
+            ) : null}
+            <div className="flex flex-wrap gap-2 justify-between pt-2">
+              <Button
+                type="button"
+                variant="default"
+                disabled={starting}
+                onClick={() => void startTask()}
+              >
+                {starting ? 'Starting…' : 'Start task (gateway)'}
+              </Button>
+              <div className="flex gap-2">
+                <Button variant="outline" type="button" onClick={() => setEditTask(null)}>
+                  Cancel
+                </Button>
+                <Button type="button" onClick={saveEdit}>
+                  Save
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/panels/memory-graph.tsx
+++ b/src/components/panels/memory-graph.tsx
@@ -117,6 +117,24 @@ export function MemoryGraph() {
   const [hoveredNode, setHoveredNode] = useState<{ label: string; sub?: string } | null>(null)
 
   const graphRef = useRef<GraphCanvasRef | null>(null)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  const syncCanvasToContainer = useCallback(() => {
+    const host = containerRef.current
+    const canvasEl = host?.querySelector('canvas') as HTMLCanvasElement | null
+    if (!host || !canvasEl) return
+
+    const hostRect = host.getBoundingClientRect()
+    const targetWidth = Math.max(1, Math.round(hostRect.width))
+    const targetHeight = Math.max(1, Math.round(hostRect.height))
+
+    if (canvasEl.width !== targetWidth || canvasEl.height !== targetHeight) {
+      canvasEl.width = targetWidth
+      canvasEl.height = targetHeight
+      canvasEl.style.width = `${targetWidth}px`
+      canvasEl.style.height = `${targetHeight}px`
+    }
+  }, [])
 
   // Fetch data
   const fetchData = useCallback(async () => {
@@ -261,14 +279,63 @@ export function MemoryGraph() {
     return { graphNodes: nodes, graphEdges: edges }
   }, [agents, selectedAgent, searchQuery])
 
-  // Auto-fit the graph after layout settles (nodes change)
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+
+    let raf = 0
+    let prevWidth = -1
+    let prevHeight = -1
+
+    const inspectAndFit = () => {
+      const rect = el.getBoundingClientRect()
+      const width = Math.round(rect.width)
+      const height = Math.round(rect.height)
+
+      if (!graphNodes.length || width <= 0 || height <= 0 || !graphRef.current) return
+
+      const changed = Math.abs(width - prevWidth) > 12 || Math.abs(height - prevHeight) > 12
+      prevWidth = width
+      prevHeight = height
+
+      if (!changed) return
+
+      syncCanvasToContainer()
+      graphRef.current.fitNodesInView()
+    }
+
+    inspectAndFit()
+
+    const ro = new ResizeObserver(() => {
+      if (raf) cancelAnimationFrame(raf)
+      raf = requestAnimationFrame(inspectAndFit)
+    })
+    ro.observe(el)
+
+    const onWindowResize = () => {
+      if (raf) cancelAnimationFrame(raf)
+      raf = requestAnimationFrame(inspectAndFit)
+    }
+    window.addEventListener('resize', onWindowResize)
+
+    return () => {
+      if (raf) cancelAnimationFrame(raf)
+      ro.disconnect()
+      window.removeEventListener('resize', onWindowResize)
+    }
+  }, [graphNodes.length, syncCanvasToContainer])
+
+  // Auto-fit graph whenever its data changes
   useEffect(() => {
     if (!graphNodes.length) return
-    // reagraph force layout needs time to settle before fitNodesInView works
-    const t1 = setTimeout(() => graphRef.current?.fitNodesInView(), 800)
-    const t2 = setTimeout(() => graphRef.current?.fitNodesInView(), 2000)
-    return () => { clearTimeout(t1); clearTimeout(t2) }
-  }, [graphNodes.length, selectedAgent])
+
+    const raf = requestAnimationFrame(() => {
+      syncCanvasToContainer()
+      graphRef.current?.fitNodesInView()
+    })
+
+    return () => cancelAnimationFrame(raf)
+  }, [graphEdges.length, graphNodes.length, selectedAgent, syncCanvasToContainer])
 
   // Navigation helpers
   const goBack = useCallback(() => {
@@ -362,7 +429,7 @@ export function MemoryGraph() {
   const activeAgent = selectedAgent !== 'all' ? agents.find(a => a.name === selectedAgent) : null
 
   return (
-    <div className="relative h-full w-full overflow-hidden" style={{ background: '#11111b' }}>
+    <div ref={containerRef} className="relative h-full w-full overflow-hidden" style={{ background: '#11111b' }}>
       {/* Full-bleed graph canvas */}
       <GraphCanvas
         ref={graphRef}

--- a/src/components/panels/skill-architect-panel.tsx
+++ b/src/components/panels/skill-architect-panel.tsx
@@ -1,0 +1,256 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { stripAnsi } from '@/lib/strip-ansi'
+
+type JobArtifactFile = { path: string; content: string; citations?: string[] }
+type MatrixPreflight = {
+  task?: string
+  warning?: boolean
+  suggest?: { stdout?: string; exitCode?: number }
+  error?: string
+}
+type JobState = {
+  id: string
+  status: string
+  error?: string
+  targetAgent?: string
+  targetSubagent?: string
+  matrixPreflight?: MatrixPreflight
+  approval?: { state: string; approver: string; note?: string; at: string }
+  artifact?: {
+    summary?: string
+    files?: JobArtifactFile[]
+    metadata?: Record<string, unknown>
+  }
+}
+
+type ApplyResult = {
+  backupId: string
+  dryRun: boolean
+  changed: Array<{ path: string; action: string; beforeBytes: number; afterBytes: number }>
+}
+
+const TERMINAL_STATES = new Set(['failed', 'approved', 'rejected'])
+
+export function SkillArchitectPanel() {
+  const [topic, setTopic] = useState('')
+  const [urlsText, setUrlsText] = useState('')
+  const [targetAgent, setTargetAgent] = useState('jarvis')
+  const [targetSubagent, setTargetSubagent] = useState('')
+  const [mode, setMode] = useState<'skill-only' | 'spec-tree' | 'mixed'>('mixed')
+  const [job, setJob] = useState<JobState | null>(null)
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [selectedFile, setSelectedFile] = useState('')
+  const [applyResult, setApplyResult] = useState<ApplyResult | null>(null)
+  const [matrixOpen, setMatrixOpen] = useState(true)
+
+  const urls = useMemo(() => urlsText.split('\n').map(s => s.trim()).filter(Boolean), [urlsText])
+  const files = job?.artifact?.files || []
+
+  useEffect(() => {
+    if (!job?.id) return
+    if (TERMINAL_STATES.has(job.status) || job.status === 'ready_for_review') return
+
+    const t = setInterval(async () => {
+      const res = await fetch(`/api/skill-architect/jobs/${encodeURIComponent(job.id)}`)
+      const data = await res.json()
+      if (res.ok) setJob(data)
+    }, 2500)
+
+    return () => clearInterval(t)
+  }, [job?.id, job?.status])
+
+  useEffect(() => {
+    if (!selectedFile && files.length > 0) setSelectedFile(files[0].path)
+  }, [files, selectedFile])
+
+  async function refreshJob(id: string) {
+    const refreshed = await fetch(`/api/skill-architect/jobs/${encodeURIComponent(id)}`)
+    const data = await refreshed.json()
+    if (refreshed.ok) setJob(data)
+  }
+
+  async function submit() {
+    setError('')
+    setLoading(true)
+    setJob(null)
+    setSelectedFile('')
+    setApplyResult(null)
+    try {
+      const res = await fetch('/api/skill-architect/jobs', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          requester: 'jarvis',
+          topic: topic || undefined,
+          urls,
+          targetAgent,
+          targetSubagent: targetSubagent || undefined,
+          mode,
+        }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to submit job')
+      setJob(data as JobState)
+    } catch (e: any) {
+      setError(e?.message || 'Failed to submit')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function approveJob() {
+    if (!job?.id) return
+    setError('')
+    const res = await fetch(`/api/skill-architect/jobs/${encodeURIComponent(job.id)}/approve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ note: '' }),
+    })
+    const data = await res.json()
+    if (!res.ok) {
+      setError(data.error || 'Failed to approve')
+      return
+    }
+    await refreshJob(job.id)
+  }
+
+  async function rejectJob() {
+    if (!job?.id) return
+    setError('')
+    const res = await fetch(`/api/skill-architect/jobs/${encodeURIComponent(job.id)}/reject`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ note: '' }),
+    })
+    const data = await res.json()
+    if (!res.ok) {
+      setError(data.error || 'Failed to reject')
+      return
+    }
+    await refreshJob(job.id)
+  }
+
+  async function applyJob(dryRun: boolean) {
+    if (!job?.id) return
+    setError('')
+    const res = await fetch(`/api/skill-architect/jobs/${encodeURIComponent(job.id)}/apply`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ dryRun }),
+    })
+    const data = await res.json()
+    if (!res.ok) {
+      setError(data.error || 'Apply failed')
+      return
+    }
+    setApplyResult(data)
+  }
+
+  const current = files.find(f => f.path === selectedFile)
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="rounded-lg border bg-card p-4">
+        <h2 className="font-semibold mb-3">Skill Architect</h2>
+        <div className="grid gap-3 md:grid-cols-2">
+          <input className="border rounded px-3 py-2 bg-background" placeholder="Topic (optional)" value={topic} onChange={(e) => setTopic(e.target.value)} />
+          <input className="border rounded px-3 py-2 bg-background" placeholder="Target agent" value={targetAgent} onChange={(e) => setTargetAgent(e.target.value)} />
+          <input className="border rounded px-3 py-2 bg-background" placeholder="Target subagent (optional)" value={targetSubagent} onChange={(e) => setTargetSubagent(e.target.value)} />
+          <select className="border rounded px-3 py-2 bg-background" value={mode} onChange={(e) => setMode(e.target.value as 'skill-only' | 'spec-tree' | 'mixed')}>
+            <option value="mixed">mixed</option>
+            <option value="spec-tree">spec-tree</option>
+            <option value="skill-only">skill-only</option>
+          </select>
+        </div>
+        <textarea className="border rounded px-3 py-2 bg-background w-full mt-3 min-h-28" placeholder="URLs (one per line)" value={urlsText} onChange={(e) => setUrlsText(e.target.value)} />
+        <div className="mt-3 flex items-center gap-3 flex-wrap">
+          <button className="px-3 py-2 rounded bg-primary text-primary-foreground disabled:opacity-50" disabled={loading || urls.length === 0} onClick={submit}>
+            {loading ? 'Submitting...' : 'Generate review artifacts'}
+          </button>
+          {job && <span className="text-sm text-muted-foreground">Job {job.id} - {job.status}</span>}
+          {error && <span className="text-sm text-red-500">{error}</span>}
+        </div>
+      </div>
+
+      {job && (
+        <div className="rounded-lg border bg-card p-4 space-y-3">
+          <div className="text-sm flex items-center gap-2 flex-wrap">
+            <span className="font-medium">Status:</span> {job.status}
+            {job.status === 'ready_for_review' && (
+              <>
+                <button className="px-2 py-1 rounded bg-green-600 text-white text-xs" onClick={approveJob}>Approve</button>
+                <button className="px-2 py-1 rounded bg-red-600 text-white text-xs" onClick={rejectJob}>Reject</button>
+              </>
+            )}
+            {job.status === 'approved' && (
+              <>
+                <button className="px-2 py-1 rounded bg-slate-700 text-white text-xs" onClick={() => applyJob(true)}>Dry run apply</button>
+                <button className="px-2 py-1 rounded bg-blue-600 text-white text-xs" onClick={() => applyJob(false)}>Apply now</button>
+              </>
+            )}
+          </div>
+          {job.approval && (
+            <div className="text-xs text-muted-foreground">
+              decision: {job.approval.state} by {job.approval.approver} at {job.approval.at}
+            </div>
+          )}
+          {job.error && <div className="text-sm text-red-500">{job.error}</div>}
+          {job.matrixPreflight && (
+            <div className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm space-y-2">
+              {job.matrixPreflight.warning ? (
+                <p className="text-amber-800 dark:text-amber-200 font-medium">
+                  Hyperspace reports similar existing capabilities — review before approving.
+                </p>
+              ) : null}
+              {job.matrixPreflight.error ? (
+                <p className="text-xs text-muted-foreground">Matrix preflight: {job.matrixPreflight.error}</p>
+              ) : null}
+              <button
+                type="button"
+                className="text-xs text-primary underline"
+                onClick={() => setMatrixOpen((o) => !o)}
+              >
+                {matrixOpen ? 'Hide' : 'Show'} similar capabilities (Matrix)
+              </button>
+              {matrixOpen && job.matrixPreflight.suggest?.stdout ? (
+                <pre className="text-xs whitespace-pre-wrap max-h-48 overflow-auto bg-muted/40 rounded p-2 border">
+                  {stripAnsi(job.matrixPreflight.suggest.stdout)}
+                </pre>
+              ) : null}
+            </div>
+          )}
+          {job.artifact?.summary && <p className="text-sm text-muted-foreground">{job.artifact.summary}</p>}
+
+          {applyResult && (
+            <div className="border rounded p-3 text-xs bg-muted/30 space-y-1">
+              <div><strong>{applyResult.dryRun ? 'Dry run' : 'Applied'}</strong> backupId: {applyResult.backupId}</div>
+              <div>changed files: {applyResult.changed.length}</div>
+              {applyResult.changed.slice(0, 8).map((c) => (
+                <div key={c.path}>{c.action.toUpperCase()} {c.path} ({c.beforeBytes} {"->"} {c.afterBytes} bytes)</div>
+              ))}
+            </div>
+          )}
+
+          {files.length > 0 && (
+            <div className="grid md:grid-cols-[260px_1fr] gap-3">
+              <div className="border rounded max-h-[420px] overflow-auto">
+                {files.map((f) => (
+                  <button key={f.path} className={`block w-full text-left px-3 py-2 text-sm border-b hover:bg-muted ${selectedFile === f.path ? 'bg-muted' : ''}`} onClick={() => setSelectedFile(f.path)}>
+                    {f.path}
+                  </button>
+                ))}
+              </div>
+              <div className="border rounded p-3 max-h-[420px] overflow-auto">
+                <div className="text-xs text-muted-foreground mb-2">{current?.path}</div>
+                <pre className="text-xs whitespace-pre-wrap">{current?.content || ''}</pre>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -6,6 +6,7 @@ interface CommandOptions {
   env?: NodeJS.ProcessEnv
   timeoutMs?: number
   input?: string
+  allowNonZeroExit?: boolean
 }
 
 interface CommandResult {
@@ -51,7 +52,7 @@ export function runCommand(
 
     child.on('close', (code) => {
       if (timeoutId) clearTimeout(timeoutId)
-      if (code === 0) {
+      if (code === 0 || options.allowNonZeroExit) {
         resolve({ stdout, stderr, code })
         return
       }

--- a/src/lib/github-pr-links.ts
+++ b/src/lib/github-pr-links.ts
@@ -1,0 +1,25 @@
+/**
+ * Derive common GitHub PR sub-URLs for review (no iframe; links only).
+ */
+export type GitHubPrLinks = {
+  pr: string
+  files: string
+  commits: string
+  checks: string
+}
+
+export function parseGitHubPrUrl(url: string): GitHubPrLinks | null {
+  const s = url.trim()
+  const m = s.match(
+    /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)(?:\/[^?#]*)?/i,
+  )
+  if (!m) return null
+  const [, owner, repo, num] = m
+  const base = `https://github.com/${owner}/${repo}/pull/${num}`
+  return {
+    pr: base,
+    files: `${base}/files`,
+    commits: `${base}/commits`,
+    checks: `${base}/checks`,
+  }
+}

--- a/src/lib/linear-client.ts
+++ b/src/lib/linear-client.ts
@@ -1,0 +1,95 @@
+/**
+ * Linear GraphQL API (server-side only). https://developers.linear.app/docs/graphql/working-with-the-graphql-api
+ */
+
+const LINEAR_API = 'https://api.linear.app/graphql'
+
+export type LinearTeam = { id: string; key: string; name: string }
+
+export async function linearGraphql<T>(
+  apiKey: string,
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<T> {
+  const res = await fetch(LINEAR_API, {
+    method: 'POST',
+    headers: {
+      Authorization: apiKey,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query, variables }),
+    cache: 'no-store',
+  })
+  const text = await res.text()
+  let json: { data?: T; errors?: { message: string }[] }
+  try {
+    json = JSON.parse(text) as typeof json
+  } catch {
+    throw new Error(`Linear: invalid JSON (${res.status})`)
+  }
+  if (!res.ok) {
+    throw new Error(`Linear HTTP ${res.status}: ${text.slice(0, 200)}`)
+  }
+  if (json.errors?.length) {
+    throw new Error(json.errors.map((e) => e.message).join('; '))
+  }
+  if (json.data === undefined) {
+    throw new Error('Linear: empty data')
+  }
+  return json.data
+}
+
+const TEAMS_QUERY = `
+  query Teams {
+    teams {
+      nodes {
+        id
+        key
+        name
+      }
+    }
+  }
+`
+
+export async function listLinearTeams(apiKey: string): Promise<LinearTeam[]> {
+  const data = await linearGraphql<{ teams: { nodes: LinearTeam[] } }>(apiKey, TEAMS_QUERY)
+  return data.teams?.nodes ?? []
+}
+
+const ISSUE_CREATE = `
+  mutation IssueCreate($input: IssueCreateInput!) {
+    issueCreate(input: $input) {
+      success
+      issue {
+        id
+        url
+        identifier
+      }
+    }
+  }
+`
+
+export type CreateIssueResult = { url: string; identifier: string; id: string }
+
+export async function createLinearIssue(
+  apiKey: string,
+  input: { teamId: string; title: string; description?: string },
+): Promise<CreateIssueResult> {
+  const data = await linearGraphql<{
+    issueCreate: {
+      success: boolean
+      issue: { id: string; url: string; identifier: string } | null
+    }
+  }>(apiKey, ISSUE_CREATE, {
+    input: {
+      teamId: input.teamId,
+      title: input.title.slice(0, 500),
+      description: input.description?.slice(0, 25000),
+    },
+  })
+  if (!data.issueCreate?.success || !data.issueCreate.issue?.url) {
+    throw new Error('Linear: issueCreate failed')
+  }
+  const issue = data.issueCreate.issue
+  return { url: issue.url, identifier: issue.identifier, id: issue.id }
+}

--- a/src/lib/openclaw-doctor.ts
+++ b/src/lib/openclaw-doctor.ts
@@ -17,6 +17,7 @@ function normalizeLine(line: string): string {
   return line
     .replace(/\u001b\[[0-9;]*m/g, '')
     .replace(/^[\s│┃║┆┊╎╏]+/, '')
+    .replace(/[│┃║┆┊╎╏]+$/g, '')
     .trim()
 }
 
@@ -30,6 +31,18 @@ function isDecorativeLine(line: string): boolean {
 
 function isStateDirectoryListLine(line: string): boolean {
   return /^(?:\$OPENCLAW_HOME(?:\/\.openclaw)?|~\/\.openclaw|\/\S+)$/.test(line)
+}
+
+function isInformationalLine(line: string): boolean {
+  return (
+    /^no channel security warnings detected\.?$/i.test(line) ||
+    /^run:\s*openclaw security audit --deep$/i.test(line) ||
+    /^eligible:\s+\d+$/i.test(line) ||
+    /^missing requirements:\s+\d+$/i.test(line) ||
+    /^blocked by allowlist:\s+\d+$/i.test(line) ||
+    /^security$/i.test(line) ||
+    /^skills status$/i.test(line)
+  )
 }
 
 function normalizeFsPath(candidate: string): string {
@@ -130,15 +143,17 @@ export function parseOpenClawDoctorOutput(
   const issues = lines
     .filter(line => /^[-*]\s+/.test(line))
     .map(line => line.replace(/^[-*]\s+/, '').trim())
-    .filter(line => !isSessionAgingLine(line) && !isStateDirectoryListLine(line))
+    .filter(line => !isSessionAgingLine(line) && !isStateDirectoryListLine(line) && !isInformationalLine(line))
 
   const mentionsWarnings = /\bwarning|warnings|problem|problems|invalid config|fix\b/i.test(raw)
   const mentionsHealthy = /\bok\b|\bhealthy\b|\bno issues\b|\bvalid\b/i.test(raw)
 
+  const hasFatalSignals = /fatal error|allocation failed|enoent|eacces|spawn\s+|not installed|not reachable|invalid config|config invalid|syntax error|exception|segmentation fault|command not found|permission denied/i.test(raw)
+
   let level: OpenClawDoctorLevel = 'healthy'
-  if (exitCode !== 0 || /invalid config|failed|error/i.test(raw)) {
+  if (hasFatalSignals || (exitCode !== 0 && lines.length === 0 && issues.length === 0)) {
     level = 'error'
-  } else if (issues.length > 0 || mentionsWarnings) {
+  } else if (issues.length > 0 || mentionsWarnings || exitCode !== 0) {
     level = 'warning'
   } else if (!mentionsHealthy && lines.length > 0) {
     level = 'warning'
@@ -154,7 +169,8 @@ export function parseOpenClawDoctorOutput(
           !/^run:/i.test(line) &&
           !/^file:/i.test(line) &&
           !isSessionAgingLine(line) &&
-          !isDecorativeLine(line)
+          !isDecorativeLine(line) &&
+          !isInformationalLine(line)
         ) ||
         'OpenClaw doctor reported configuration issues.'
 

--- a/src/lib/openclaw-home.ts
+++ b/src/lib/openclaw-home.ts
@@ -1,0 +1,7 @@
+/**
+ * Host path for OpenClaw workspace (registry, Kanban, .active-company).
+ * Production: bind-mount host ~/.openclaw → /openclaw-home (see docker-compose.override.yml).
+ */
+export function getOpenClawHome(): string {
+  return process.env.OPENCLAW_HOME?.trim() || '/openclaw-home'
+}

--- a/src/lib/skill-architect-apply-client.ts
+++ b/src/lib/skill-architect-apply-client.ts
@@ -1,0 +1,15 @@
+export async function callSkillApply(path: string, init: RequestInit = {}) {
+  const base = process.env.MC_SKILL_APPLY_URL || 'http://172.17.0.1:19010'
+  const token = process.env.MC_SKILL_APPLY_TOKEN || ''
+  if (!token) throw new Error('MC_SKILL_APPLY_TOKEN not configured')
+
+  const headers = new Headers(init.headers || {})
+  headers.set('x-apply-token', token)
+  if (!headers.has('Content-Type') && init.body) headers.set('Content-Type', 'application/json')
+
+  const r = await fetch(`${base}${path}`, { ...init, headers, cache: 'no-store' })
+  const txt = await r.text()
+  const j = txt ? JSON.parse(txt) : {}
+  if (!r.ok) throw new Error(j?.error || `apply worker failed (${r.status})`)
+  return j
+}

--- a/src/lib/skill-architect-apply.ts
+++ b/src/lib/skill-architect-apply.ts
@@ -1,0 +1,167 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+import crypto from 'crypto'
+import { callSkillArchitect } from '@/lib/skill-architect-client'
+
+const AGENTS_ROOT = '/home/ubuntu/workspace/agents'
+const RUNTIME_ROOT = '/home/ubuntu/.openclaw/skill-architect'
+const BACKUP_ROOT = path.join(RUNTIME_ROOT, 'backups')
+const AUDIT_LOG = path.join(RUNTIME_ROOT, 'audit.log.jsonl')
+
+export type ApplyResult = {
+  ok: boolean
+  dryRun: boolean
+  jobId: string
+  targetRoot: string
+  backupId: string
+  changed: Array<{ path: string; action: 'create' | 'update' | 'unchanged'; beforeBytes: number; afterBytes: number }>
+}
+
+function sanitizeRelative(p: string) {
+  return p.replace(/^\/+/, '')
+}
+
+async function ensureDirs() {
+  await fs.mkdir(BACKUP_ROOT, { recursive: true })
+  await fs.mkdir(path.dirname(AUDIT_LOG), { recursive: true })
+}
+
+async function appendAudit(entry: Record<string, unknown>) {
+  const line = JSON.stringify({ at: new Date().toISOString(), ...entry }) + '\n'
+  await fs.appendFile(AUDIT_LOG, line, 'utf8')
+}
+
+async function loadJob(jobId: string): Promise<any> {
+  const job = await callSkillArchitect(`/v1/jobs/${encodeURIComponent(jobId)}`)
+  return job
+}
+
+function resolveTargetRoot(targetAgent: string): string {
+  const root = path.resolve(path.join(AGENTS_ROOT, targetAgent))
+  const allowedRoot = path.resolve(AGENTS_ROOT)
+  if (!root.startsWith(allowedRoot + path.sep) && root !== allowedRoot) {
+    throw new Error('target root outside allowlist')
+  }
+  return root
+}
+
+async function safeRead(filePath: string): Promise<string | null> {
+  try { return await fs.readFile(filePath, 'utf8') } catch { return null }
+}
+
+async function atomicWrite(filePath: string, content: string) {
+  const dir = path.dirname(filePath)
+  await fs.mkdir(dir, { recursive: true })
+  const tmp = `${filePath}.tmp-${process.pid}-${Date.now()}`
+  await fs.writeFile(tmp, content, 'utf8')
+  await fs.rename(tmp, filePath)
+}
+
+export async function applySkillJob(params: { jobId: string; dryRun: boolean; requestedBy: string }): Promise<ApplyResult> {
+  await ensureDirs()
+  const job = await loadJob(params.jobId)
+  if (job.status !== 'approved') {
+    throw new Error(`job status must be approved, got ${job.status}`)
+  }
+
+  const targetAgent = String(job.targetAgent || job.artifact?.metadata?.targetAgent || '').trim()
+  if (!targetAgent) throw new Error('missing targetAgent')
+
+  const files = Array.isArray(job.artifact?.files) ? job.artifact.files : []
+  if (!files.length) throw new Error('artifact has no files')
+
+  const targetRoot = resolveTargetRoot(targetAgent)
+  const backupId = `${params.jobId}-${Date.now()}`
+  const backupDir = path.join(BACKUP_ROOT, backupId)
+  await fs.mkdir(backupDir, { recursive: true })
+
+  const changed: ApplyResult['changed'] = []
+
+  for (const f of files) {
+    const rel = sanitizeRelative(String(f.path || ''))
+    if (!/^(SKILLS\.md|skills\/.+\.md|specs\/.+\.md|playbooks\/.+\.md)$/.test(rel)) continue
+
+    const dest = path.resolve(path.join(targetRoot, rel))
+    if (!dest.startsWith(targetRoot + path.sep) && dest !== targetRoot) {
+      throw new Error(`file path escapes target root: ${rel}`)
+    }
+
+    const before = await safeRead(dest)
+    const after = String(f.content || '')
+    const action: 'create' | 'update' | 'unchanged' = before === null ? 'create' : (before === after ? 'unchanged' : 'update')
+
+    changed.push({
+      path: rel,
+      action,
+      beforeBytes: before?.length || 0,
+      afterBytes: after.length,
+    })
+
+    if (before !== null) {
+      const backupPath = path.join(backupDir, rel)
+      await fs.mkdir(path.dirname(backupPath), { recursive: true })
+      await fs.writeFile(backupPath, before, 'utf8')
+    }
+
+    if (!params.dryRun && action !== 'unchanged') {
+      await atomicWrite(dest, after)
+    }
+  }
+
+  await appendAudit({
+    event: params.dryRun ? 'apply.dry_run' : 'apply.executed',
+    jobId: params.jobId,
+    targetRoot,
+    backupId,
+    requestedBy: params.requestedBy,
+    changed,
+  })
+
+  return {
+    ok: true,
+    dryRun: params.dryRun,
+    jobId: params.jobId,
+    targetRoot,
+    backupId,
+    changed,
+  }
+}
+
+export async function rollbackSkillJob(params: { targetAgent: string; backupId: string; requestedBy: string }) {
+  await ensureDirs()
+  const targetRoot = resolveTargetRoot(params.targetAgent)
+  const backupDir = path.join(BACKUP_ROOT, params.backupId)
+  const exists = await fs.stat(backupDir).then(() => true).catch(() => false)
+  if (!exists) throw new Error('backup not found')
+
+  const restored: string[] = []
+
+  async function walk(dir: string) {
+    const entries = await fs.readdir(dir, { withFileTypes: true })
+    for (const e of entries) {
+      const abs = path.join(dir, e.name)
+      const rel = path.relative(backupDir, abs)
+      if (e.isDirectory()) {
+        await walk(abs)
+        continue
+      }
+      const dest = path.resolve(path.join(targetRoot, rel))
+      if (!dest.startsWith(targetRoot + path.sep) && dest !== targetRoot) continue
+      const content = await fs.readFile(abs, 'utf8')
+      await atomicWrite(dest, content)
+      restored.push(rel)
+    }
+  }
+
+  await walk(backupDir)
+
+  await appendAudit({
+    event: 'apply.rollback',
+    backupId: params.backupId,
+    targetRoot,
+    requestedBy: params.requestedBy,
+    restored,
+  })
+
+  return { ok: true, backupId: params.backupId, restored }
+}

--- a/src/lib/skill-architect-client.ts
+++ b/src/lib/skill-architect-client.ts
@@ -1,0 +1,32 @@
+export type SkillArchitectJobRequest = {
+  requester: string
+  topic?: string
+  urls: string[]
+  targetAgent: string
+  targetSubagent?: string
+  mode?: 'skill-only' | 'spec-tree' | 'mixed'
+}
+
+export async function callSkillArchitect(path: string, init: RequestInit = {}) {
+  const base = process.env.MC_SKILL_ARCH_URL || 'http://172.31.40.35:18990'
+  const token = process.env.MC_SKILL_ARCH_TOKEN || ''
+  if (!token) throw new Error('MC_SKILL_ARCH_TOKEN not configured')
+
+  const headers = new Headers(init.headers || {})
+  headers.set('x-sa-token', token)
+  if (!headers.has('Content-Type') && init.body) headers.set('Content-Type', 'application/json')
+
+  const res = await fetch(`${base}${path}`, {
+    ...init,
+    headers,
+    cache: 'no-store',
+  })
+  const txt = await res.text()
+  let json: any = null
+  try { json = txt ? JSON.parse(txt) : null } catch { json = { raw: txt } }
+  if (!res.ok) {
+    const msg = json?.error || `Skill Architect request failed (${res.status})`
+    throw new Error(msg)
+  }
+  return json
+}

--- a/src/lib/strip-ansi.ts
+++ b/src/lib/strip-ansi.ts
@@ -1,0 +1,5 @@
+/** Strip ANSI escapes (Matrix CLI stdout) — same regex as @openclaw/mc-client */
+export function stripAnsi(s: string): string {
+  if (!s || typeof s !== 'string') return ''
+  return s.replace(/\u001b\[[0-9;]*m/g, '')
+}

--- a/src/nav-rail.tsx
+++ b/src/nav-rail.tsx
@@ -26,6 +26,7 @@ const navGroups: NavGroup[] = [
       { id: 'agents', label: 'Agents', icon: <AgentsIcon />, priority: true },
       { id: 'tasks', label: 'Tasks', icon: <TasksIcon />, priority: true },
       { id: 'chat', label: 'Chat', icon: <SessionsIcon />, priority: false },
+      { id: 'skill-architect', label: 'Skill Architect', icon: <SpawnIcon />, priority: true },
     ],
   },
   {
@@ -44,7 +45,7 @@ const navGroups: NavGroup[] = [
     items: [
       { id: 'cron', label: 'Cron', icon: <CronIcon />, priority: false },
       { id: 'spawn', label: 'Spawn', icon: <SpawnIcon />, priority: false },
-      { id: 'webhooks', label: 'Webhooks', icon: <WebhookIcon />, priority: false },
+            { id: 'webhooks', label: 'Webhooks', icon: <WebhookIcon />, priority: false },
       { id: 'alerts', label: 'Alerts', icon: <AlertIcon />, priority: false },
     ],
   },

--- a/src/types/mc-client.d.ts
+++ b/src/types/mc-client.d.ts
@@ -1,0 +1,40 @@
+declare module '@openclaw/mc-client' {
+  export function checkGatewayHealth(
+    baseUrl: string,
+    opts?: { retries?: number; timeout?: number },
+  ): Promise<{ ok: boolean; status?: number; error?: string; data?: unknown }>
+  export function readPersonaFiles(
+    openclawHome: string,
+    agentId: string,
+  ): Promise<Record<string, string>>
+  export function parseCompanyRegistryYaml(text: string): Array<{ id: string; name?: string; summary?: string }>
+  export function readCompanyRegistry(
+    openclawHome: string,
+  ): Promise<{ ok: boolean; companies: Array<{ id: string; name?: string; summary?: string }>; error?: string }>
+  export function readActiveCompany(
+    openclawHome: string,
+  ): Promise<{ ok: boolean; companyId: string | null; error?: string }>
+  export function stripAnsi(s: string): string
+  export function loadKanbanBoard(
+    openclawHome: string,
+    companyId: string,
+    projectSlug?: string,
+  ): Promise<Record<string, unknown>>
+  export function saveKanbanBoard(
+    openclawHome: string,
+    board: Record<string, unknown>,
+    companyId: string,
+    projectSlug?: string,
+  ): Promise<void>
+  export const DEFAULT_KANBAN_COLUMNS: unknown[]
+  export function kanbanBoardPath(
+    openclawHome: string,
+    companyId: string,
+    projectSlug?: string,
+  ): string
+  export function appendActivity(
+    board: Record<string, unknown>,
+    taskId: string,
+    message: string,
+  ): { ok: boolean; board?: Record<string, unknown>; error?: string }
+}


### PR DESCRIPTION
## Summary
Ships in-dashboard integrations for the consolidated OpenClaw host:

- **Kanban** — API + board UI, gateway task start, deps, `reviewUrl`, GitHub PR quick links (Files/Commits/Checks)
- **Linear** — GraphQL client, team list (`GET /api/integrations/linear?teams=1`), create issue + link (`POST /api/integrations/linear/issues`)
- **Skill Architect** — job APIs, apply flow, panel with Matrix preflight
- **Company picker** — `/api/openclaw/companies`; vendored `packages/mc-client`
- **Docker** — `docker-compose.override.yml` for EC2 OpenClaw bind mounts

**Note:** Cannot push directly to `builderz-labs/mission-control` (read-only). Branch pushed to fork.

**Commit:** `0bdc811` (also deployed to EC2 2026-03-30 via rsync + `docker compose`).

Made with [Cursor](https://cursor.com)