### PR TITLE
fix(hermes): correct gateway status + hook callback compatibility

### DIFF
--- a/src/app/api/hermes/route.ts
+++ b/src/app/api/hermes/route.ts
@@ -343,7 +343,7 @@ def _headers():
     return h
 
 
-async def handle_event(event_name: str, payload: dict) -> None:
+async def handle(event_name: str, payload: dict) -> None:
     """
     Called by the Hermes hook registry on matching events.
     Fire-and-forget with a short timeout — never blocks the agent.

--- a/src/lib/__tests__/hermes-hook-template.test.ts
+++ b/src/lib/__tests__/hermes-hook-template.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+describe('Hermes hook template source', () => {
+  it('defines top-level async def handle for hook loader compatibility', () => {
+    const routePath = resolve(process.cwd(), 'src/app/api/hermes/route.ts')
+    const source = readFileSync(routePath, 'utf8')
+
+    expect(source).toContain('async def handle(')
+    expect(source).not.toContain('async def handle_event(')
+  })
+})

--- a/src/lib/__tests__/hermes-sessions-gateway.test.ts
+++ b/src/lib/__tests__/hermes-sessions-gateway.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+let tempHome = ''
+
+vi.mock('@/lib/config', () => ({
+  config: {
+    get homeDir() {
+      return tempHome
+    },
+    dataDir: '/tmp/test-data',
+  },
+}))
+
+vi.mock('better-sqlite3', () => ({
+  default: vi.fn(),
+}))
+
+describe('isHermesGatewayRunning', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    tempHome = mkdtempSync(join(tmpdir(), 'mc-hermes-test-'))
+    mkdirSync(join(tempHome, '.hermes'), { recursive: true })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    if (tempHome) rmSync(tempHome, { recursive: true, force: true })
+  })
+
+  it('returns true when gateway.pid is JSON with a live pid field', async () => {
+    writeFileSync(join(tempHome, '.hermes', 'gateway.pid'), '{"pid":2522,"kind":"hermes-gateway"}', 'utf8')
+
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation((() => undefined) as any)
+    const { isHermesGatewayRunning } = await import('@/lib/hermes-sessions')
+
+    expect(isHermesGatewayRunning()).toBe(true)
+    expect(killSpy).toHaveBeenCalledWith(2522, 0)
+  })
+
+  it('returns false when gateway.pid has no valid pid', async () => {
+    writeFileSync(join(tempHome, '.hermes', 'gateway.pid'), '{"kind":"hermes-gateway"}', 'utf8')
+
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation((() => undefined) as any)
+    const { isHermesGatewayRunning } = await import('@/lib/hermes-sessions')
+
+    expect(isHermesGatewayRunning()).toBe(false)
+    expect(killSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/hermes-sessions.ts
+++ b/src/lib/hermes-sessions.ts
@@ -104,14 +104,39 @@ export function isHermesInstalled(): boolean {
   return hasHermesCliBinary()
 }
 
+function parseGatewayPid(raw: string): number | null {
+  const text = raw.trim()
+  if (!text) return null
+
+  // Legacy/simple format: file contains only PID text
+  if (/^\d+$/.test(text)) {
+    const pid = Number.parseInt(text, 10)
+    return Number.isFinite(pid) && pid > 0 ? pid : null
+  }
+
+  // Current Hermes format: JSON object with pid field
+  try {
+    const parsed = JSON.parse(text) as { pid?: number | string } | null
+    const value = parsed?.pid
+    const pid = typeof value === 'number'
+      ? value
+      : typeof value === 'string'
+        ? Number.parseInt(value, 10)
+        : NaN
+    return Number.isFinite(pid) && pid > 0 ? pid : null
+  } catch {
+    return null
+  }
+}
+
 export function isHermesGatewayRunning(): boolean {
   const pidPath = getHermesPidPath()
   if (!existsSync(pidPath)) return false
 
   try {
-    const pidStr = readFileSync(pidPath, 'utf8').trim()
-    const pid = parseInt(pidStr, 10)
-    if (!Number.isFinite(pid) || pid <= 0) return false
+    const pidStr = readFileSync(pidPath, 'utf8')
+    const pid = parseGatewayPid(pidStr)
+    if (!pid) return false
     // Check if process exists (signal 0 doesn't kill, just checks)
     process.kill(pid, 0)
     return true


### PR DESCRIPTION
## Summary
- Fix Hermes gateway running detection to support JSON-formatted `~/.hermes/gateway.pid` files
- Keep backward compatibility with legacy numeric PID files
- Fix generated Hermes hook template to expose top-level `handle(...)` callback (required by Hermes hook loader)
- Add regression tests for both bugs

## Why
Issue #529 reports two integration breaks:
1. Mission Control always shows Hermes gateway offline because `gateway.pid` is JSON but code used `parseInt(rawText)`
2. Installed hook handler exported `handle_event` while Hermes loader expects `handle`

## Changes
- `src/lib/hermes-sessions.ts`
  - Added `parseGatewayPid(raw)` helper
  - `isHermesGatewayRunning()` now parses JSON `{ "pid": ... }` and falls back to legacy plain-number format
- `src/app/api/hermes/route.ts`
  - Updated generated hook template function signature from `handle_event(...)` to `handle(...)`
- `src/lib/__tests__/hermes-sessions-gateway.test.ts`
  - Verifies JSON pid files are recognized as running
  - Verifies invalid pid payload returns false
- `src/lib/__tests__/hermes-hook-template.test.ts`
  - Guards hook template source for required `async def handle(` callback

## Test evidence
- `pnpm test src/lib/__tests__/hermes-sessions-gateway.test.ts src/lib/__tests__/hermes-hook-template.test.ts` ✅

Closes #529
