### PR TITLE
fix(status): avoid Ollama CLI crash on macOS by using HTTP tags API

### DIFF
--- a/src/app/api/status/route.ts
+++ b/src/app/api/status/route.ts
@@ -421,38 +421,39 @@ async function getGatewayStatus() {
 }
 
 async function getAvailableModels() {
-  // This would typically query the gateway or config files
   // Model catalog is the single source of truth
   const models = [...MODEL_CATALOG]
 
   try {
-    // Check which Ollama models are available locally
-    const { stdout: ollamaOutput } = await runCommand('ollama', ['list'], {
-      timeoutMs: 5000
+    // Use Ollama HTTP API instead of `ollama list` CLI.
+    // On macOS desktop app installs, spawning CLI commands can restart/crash the GUI process.
+    const res = await fetch('http://127.0.0.1:11434/api/tags', {
+      signal: AbortSignal.timeout(5000),
     })
-    const ollamaModels = ollamaOutput.split('\n')
-      .slice(1) // Skip header
-      .filter(line => line.trim())
-      .map(line => {
-        const parts = line.split(/\s+/)
-        return {
-          alias: parts[0],
-          name: `ollama/${parts[0]}`,
-          provider: 'ollama',
-          description: 'Local model',
-          costPer1k: 0.0,
-          size: parts[1] || 'unknown'
-        }
-      })
 
-    // Add Ollama models that aren't already in the list
-    ollamaModels.forEach(model => {
-      if (!models.find(m => m.name === model.name)) {
+    if (!res.ok) {
+      throw new Error(`Ollama tags endpoint returned ${res.status}`)
+    }
+
+    const data = await res.json() as { models?: Array<{ name?: string; size?: number }> }
+    const ollamaModels = (data.models || [])
+      .filter((m) => typeof m?.name === 'string' && m.name.trim().length > 0)
+      .map((m) => ({
+        alias: m.name!.trim(),
+        name: `ollama/${m.name!.trim()}`,
+        provider: 'ollama',
+        description: 'Local model',
+        costPer1k: 0.0,
+        size: typeof m.size === 'number' ? String(m.size) : 'unknown',
+      }))
+
+    for (const model of ollamaModels) {
+      if (!models.find((m) => m.name === model.name)) {
         models.push(model)
       }
-    })
+    }
   } catch (error) {
-    logger.error({ err: error }, 'Error checking Ollama models')
+    logger.error({ err: error }, 'Error checking Ollama models via HTTP API')
   }
 
   return models

--- a/src/lib/__tests__/status-route-ollama.test.ts
+++ b/src/lib/__tests__/status-route-ollama.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const runCommandMock = vi.fn()
+const loggerErrorMock = vi.fn()
+
+vi.mock('@/lib/auth', () => ({
+  requireRole: vi.fn(() => ({ user: { role: 'viewer', workspace_id: 1 } })),
+}))
+
+vi.mock('@/lib/command', () => ({
+  runCommand: runCommandMock,
+  runOpenClaw: vi.fn(),
+  runClawdbot: vi.fn(),
+}))
+
+vi.mock('@/lib/config', () => ({
+  config: {
+    gatewayHost: '127.0.0.1',
+    gatewayPort: 8080,
+    dbPath: '/tmp/mission-control.db',
+    dataDir: '/tmp',
+  },
+}))
+
+vi.mock('@/lib/db', () => ({ getDatabase: vi.fn() }))
+vi.mock('@/lib/sessions', () => ({ getAllGatewaySessions: vi.fn(() => []), getAgentLiveStatuses: vi.fn(() => []) }))
+vi.mock('@/lib/provider-subscriptions', () => ({
+  detectProviderSubscriptions: vi.fn(() => ({})),
+  getPrimarySubscription: vi.fn(() => null),
+}))
+vi.mock('@/lib/version', () => ({ APP_VERSION: 'test' }))
+vi.mock('@/lib/hermes-sessions', () => ({ isHermesInstalled: vi.fn(() => false), scanHermesSessions: vi.fn(() => []) }))
+vi.mock('@/lib/gateway-runtime', () => ({ registerMcAsDashboard: vi.fn() }))
+vi.mock('@/lib/logger', () => ({ logger: { error: loggerErrorMock, info: vi.fn(), warn: vi.fn() } }))
+vi.mock('@/lib/models', () => ({
+  MODEL_CATALOG: [
+    {
+      alias: 'gpt-4.1-mini',
+      name: 'openai/gpt-4.1-mini',
+      provider: 'openai',
+      description: 'baseline',
+      costPer1k: 0.001,
+    },
+  ],
+}))
+
+describe('status route Ollama model discovery', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('uses Ollama HTTP API instead of spawning ollama CLI', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        models: [
+          { name: 'qwen2.5-coder:14b', size: 123456 },
+        ],
+      }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { GET } = await import('@/app/api/status/route')
+    const request = new NextRequest('http://localhost/api/status?action=models')
+
+    const response = await GET(request)
+    expect(response.status).toBe(200)
+
+    const payload = await response.json() as { models: Array<{ name: string }> }
+    expect(payload.models.some((m) => m.name === 'ollama/qwen2.5-coder:14b')).toBe(true)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://127.0.0.1:11434/api/tags',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    )
+    expect(runCommandMock).not.toHaveBeenCalledWith('ollama', ['list'], expect.anything())
+  })
+
+  it('falls back to catalog models when Ollama API is unavailable', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('connect ECONNREFUSED')))
+
+    const { GET } = await import('@/app/api/status/route')
+    const request = new NextRequest('http://localhost/api/status?action=models')
+    const response = await GET(request)
+    const payload = await response.json() as { models: Array<{ name: string }> }
+
+    expect(response.status).toBe(200)
+    expect(payload.models.some((m) => m.name === 'openai/gpt-4.1-mini')).toBe(true)
+    expect(loggerErrorMock).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- Replace `ollama list` CLI invocation in `/api/status?action=models` with Ollama HTTP API (`GET /api/tags`)
- Prevent macOS desktop Ollama GUI restart/crash triggered by subprocess CLI calls
- Keep graceful fallback to `MODEL_CATALOG` when local Ollama is unavailable
- Add regression tests for both happy path and fallback behavior

## Root cause
`getAvailableModels()` used `runCommand('ollama', ['list'])`. On macOS desktop installs, invoking the Ollama CLI from subprocess can trigger app lifecycle restarts/crashes.

## What changed
- `src/app/api/status/route.ts`
  - `getAvailableModels()` now calls `fetch('http://127.0.0.1:11434/api/tags', { signal: AbortSignal.timeout(5000) })`
  - Maps API response models into Mission Control model shape
  - Dedupes against existing catalog entries
  - Logs and falls back cleanly when Ollama API is unreachable
- `src/lib/__tests__/status-route-ollama.test.ts`
  - Verifies `/api/status?action=models` uses HTTP API and surfaces local model
  - Verifies fallback behavior when Ollama API is unavailable

## Test evidence
- `pnpm test src/lib/__tests__/status-route-ollama.test.ts` ✅

Closes #526
