### PR TITLE
feat: add runtime_type to agents + Hermes multi-agent profile provisioning

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1580,7 +1580,10 @@
     "justNow": "الآن",
     "minutesAgo": "منذ {count} د",
     "hoursAgo": "منذ {count} س",
-    "daysAgo": "منذ {count} ي"
+    "daysAgo": "منذ {count} ي",
+    "runtimeType": "Runtime",
+    "runtimeTypeAuto": "Auto-detect",
+    "runtimeTypeCustom": "Custom"
   },
   "multiGateway": {
     "title": "مدير البوابات",

--- a/messages/de.json
+++ b/messages/de.json
@@ -1580,7 +1580,10 @@
     "justNow": "Gerade eben",
     "minutesAgo": "vor {count}m",
     "hoursAgo": "vor {count}h",
-    "daysAgo": "vor {count}d"
+    "daysAgo": "vor {count}d",
+    "runtimeType": "Runtime",
+    "runtimeTypeAuto": "Auto-detect",
+    "runtimeTypeCustom": "Custom"
   },
   "multiGateway": {
     "title": "Gateway-Manager",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1729,7 +1729,10 @@
     "justNow": "Just now",
     "minutesAgo": "{count}m ago",
     "hoursAgo": "{count}h ago",
-    "daysAgo": "{count}d ago"
+    "daysAgo": "{count}d ago",
+    "runtimeType": "Runtime",
+    "runtimeTypeAuto": "Auto-detect",
+    "runtimeTypeCustom": "Custom"
   },
   "multiGateway": {
     "title": "Gateway Manager",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1580,7 +1580,10 @@
     "justNow": "Ahora mismo",
     "minutesAgo": "hace {count}m",
     "hoursAgo": "hace {count}h",
-    "daysAgo": "hace {count}d"
+    "daysAgo": "hace {count}d",
+    "runtimeType": "Runtime",
+    "runtimeTypeAuto": "Auto-detect",
+    "runtimeTypeCustom": "Custom"
   },
   "multiGateway": {
     "title": "Gestor de puertas de enlace",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1580,7 +1580,10 @@
     "justNow": "À l'instant",
     "minutesAgo": "il y a {count}m",
     "hoursAgo": "il y a {count}h",
-    "daysAgo": "il y a {count}j"
+    "daysAgo": "il y a {count}j",
+    "runtimeType": "Runtime",
+    "runtimeTypeAuto": "Auto-detect",
+    "runtimeTypeCustom": "Custom"
   },
   "multiGateway": {
     "title": "Gestionnaire de passerelles",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1580,7 +1580,10 @@
     "justNow": "たった今",
     "minutesAgo": "{count}分前",
     "hoursAgo": "{count}時間前",
-    "daysAgo": "{count}日前"
+    "daysAgo": "{count}日前",
+    "runtimeType": "Runtime",
+    "runtimeTypeAuto": "Auto-detect",
+    "runtimeTypeCustom": "Custom"
   },
   "multiGateway": {
     "title": "ゲートウェイマネージャー",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1729,7 +1729,10 @@
     "justNow": "방금",
     "minutesAgo": "{count}분 전",
     "hoursAgo": "{count}시간 전",
-    "daysAgo": "{count}일 전"
+    "daysAgo": "{count}일 전",
+    "runtimeType": "Runtime",
+    "runtimeTypeAuto": "Auto-detect",
+    "runtimeTypeCustom": "Custom"
   },
   "multiGateway": {
     "title": "게이트웨이 관리자",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1580,7 +1580,10 @@
     "justNow": "Agora mesmo",
     "minutesAgo": "há {count}m",
     "hoursAgo": "há {count}h",
-    "daysAgo": "há {count}d"
+    "daysAgo": "há {count}d",
+    "runtimeType": "Runtime",
+    "runtimeTypeAuto": "Auto-detect",
+    "runtimeTypeCustom": "Custom"
   },
   "multiGateway": {
     "title": "Gerenciador de gateways",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -1580,7 +1580,10 @@
     "justNow": "Только что",
     "minutesAgo": "{count}м назад",
     "hoursAgo": "{count}ч назад",
-    "daysAgo": "{count}д назад"
+    "daysAgo": "{count}д назад",
+    "runtimeType": "Runtime",
+    "runtimeTypeAuto": "Auto-detect",
+    "runtimeTypeCustom": "Custom"
   },
   "multiGateway": {
     "title": "Менеджер шлюзов",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1818,7 +1818,10 @@
     "justNow": "刚刚",
     "minutesAgo": "{count}分钟前",
     "hoursAgo": "{count}小时前",
-    "daysAgo": "{count}天前"
+    "daysAgo": "{count}天前",
+    "runtimeType": "Runtime",
+    "runtimeTypeAuto": "Auto-detect",
+    "runtimeTypeCustom": "Custom"
   },
   "multiGateway": {
     "title": "网关管理器",

--- a/src/app/api/agents/route.ts
+++ b/src/app/api/agents/route.ts
@@ -175,7 +175,8 @@ export async function POST(request: NextRequest) {
       gateway_config,
       write_to_gateway,
       provision_openclaw_workspace,
-      openclaw_workspace_path
+      openclaw_workspace_path,
+      runtime_type,
     } = body;
 
     const openclawId = (openclaw_id || name || 'agent')
@@ -239,11 +240,11 @@ export async function POST(request: NextRequest) {
     
     const stmt = db.prepare(`
       INSERT INTO agents (
-        name, role, session_key, soul_content, status, 
-        created_at, updated_at, config, workspace_id
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        name, role, session_key, soul_content, status,
+        created_at, updated_at, config, workspace_id, runtime_type
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
-    
+
     const dbResult = stmt.run(
       name,
       finalRole,
@@ -253,11 +254,37 @@ export async function POST(request: NextRequest) {
       now,
       now,
       JSON.stringify(finalConfig),
-      workspaceId
+      workspaceId,
+      runtime_type || null
     );
 
     const agentId = dbResult.lastInsertRowid as number;
-    
+
+    // Provision Hermes profile directory if runtime_type is hermes
+    if (runtime_type === 'hermes') {
+      try {
+        const { mkdirSync, writeFileSync, existsSync: fsExists } = require('node:fs')
+        const profileDir = path.join(appConfig.homeDir, '.hermes', 'profiles', name)
+        if (!fsExists(profileDir)) {
+          mkdirSync(profileDir, { recursive: true })
+          // Write config.yaml with model from agent config or default
+          const model = finalConfig.model || 'claude-sonnet-4-6'
+          const provider = finalConfig.provider || 'anthropic'
+          writeFileSync(
+            path.join(profileDir, 'config.yaml'),
+            `model: ${model}\nprovider: ${provider}\ntoolsets:\n- all\nmax_turns: 100\n`,
+          )
+          // Write SOUL.md if soul_content provided
+          if (soul_content) {
+            writeFileSync(path.join(profileDir, 'SOUL.md'), soul_content)
+          }
+          logger.info({ agentName: name, profileDir }, 'Provisioned Hermes profile directory')
+        }
+      } catch (err) {
+        logger.warn({ err, agentName: name }, 'Failed to provision Hermes profile (non-fatal)')
+      }
+    }
+
     // Log activity
     db_helpers.logActivity(
       'agent_created',

--- a/src/components/panels/agent-squad-panel.tsx
+++ b/src/components/panels/agent-squad-panel.tsx
@@ -26,6 +26,7 @@ interface Agent {
     in_progress: number
     completed: number
   }
+  runtime_type?: string
 }
 
 const statusColors: Record<string, string> = {
@@ -217,7 +218,14 @@ export function AgentSquadPanel() {
                 {/* Agent Header */}
                 <div className="flex items-start justify-between mb-3">
                   <div>
-                    <h3 className="font-semibold text-white text-lg">{agent.name}</h3>
+                    <div className="flex items-center gap-2">
+                      <h3 className="font-semibold text-white text-lg">{agent.name}</h3>
+                      {agent.runtime_type && (
+                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-surface-1 text-muted-foreground border border-border/30">
+                          {agent.runtime_type}
+                        </span>
+                      )}
+                    </div>
                     <p className="text-gray-400 text-sm">{agent.role}</p>
                   </div>
                   
@@ -528,6 +536,7 @@ function CreateAgentModal({
     role: '',
     session_key: '',
     soul_content: '',
+    runtime_type: '' as string,
   })
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -537,7 +546,10 @@ function CreateAgentModal({
       const response = await fetch('/api/agents', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(formData)
+        body: JSON.stringify({
+          ...formData,
+          runtime_type: formData.runtime_type || undefined,
+        })
       })
 
       if (!response.ok) throw new Error(t('failedToCreate'))
@@ -577,6 +589,22 @@ function CreateAgentModal({
                 placeholder={t('rolePlaceholder')}
                 required
               />
+            </div>
+
+            <div>
+              <label className="block text-sm text-gray-400 mb-1">{t('runtimeType')}</label>
+              <select
+                value={formData.runtime_type}
+                onChange={(e) => setFormData(prev => ({ ...prev, runtime_type: e.target.value }))}
+                className="w-full bg-gray-700 text-white rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              >
+                <option value="">{t('runtimeTypeAuto')}</option>
+                <option value="hermes">Hermes Agent</option>
+                <option value="openclaw">OpenClaw</option>
+                <option value="claude">Claude Code</option>
+                <option value="codex">Codex CLI</option>
+                <option value="custom">{t('runtimeTypeCustom')}</option>
+              </select>
             </div>
 
             <div>

--- a/src/lib/migrations.ts
+++ b/src/lib/migrations.ts
@@ -1410,6 +1410,12 @@ const migrations: Migration[] = [
         )
       `)
     }
+  },
+  {
+    id: '049_agent_runtime_type',
+    up(db: Database.Database) {
+      db.exec(`ALTER TABLE agents ADD COLUMN runtime_type TEXT DEFAULT NULL`)
+    }
   }
 ]
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -68,6 +68,7 @@ export const createAgentSchema = z.object({
   write_to_gateway: z.boolean().optional(),
   provision_openclaw_workspace: z.boolean().optional(),
   openclaw_workspace_path: z.string().min(1).max(500).optional(),
+  runtime_type: z.enum(['hermes', 'openclaw', 'claude', 'codex', 'custom']).optional(),
 })
 
 export const bulkUpdateTaskStatusSchema = z.object({


### PR DESCRIPTION
## Summary

Adds runtime type tracking to agents and automatic Hermes profile provisioning for multi-agent support.

### What changed

**Agent runtime type** — agents can now be tagged with their runtime (`hermes`, `openclaw`, `claude`, `codex`, `custom`):
- New `runtime_type` column in agents table (migration 049)
- Runtime type dropdown in Create Agent modal
- Runtime badge shown on agent cards
- Stored in DB config, available via API

**Hermes profile provisioning** — when creating a Hermes agent, MC automatically creates a profile directory at `~/.hermes/profiles/<agent-name>/` with:
- `config.yaml` — model + provider + toolsets from agent config
- `SOUL.md` — personality from soul_content field

This prepares for Hermes's native `--profile` flag (documented at hermes-agent.nousresearch.com/docs/user-guide/profiles/) which uses this exact directory structure. When Hermes ships profile support, MC-created agents will be immediately usable via `hermes -p <name>`.

### Current state

Hermes v0.4.0 doesn't yet support `--profile` — the profile directories are provisioned ahead of time. The directory structure matches the documented spec:
```
~/.hermes/profiles/<name>/
├── config.yaml
└── SOUL.md
```

## Test plan
- [x] `pnpm typecheck` — passes
- [x] `pnpm test` — 892/892 pass
- [ ] Manual: Create agent with runtime_type=hermes, verify profile dir created
- [ ] Manual: Verify runtime badge shows on agent cards
- [ ] Manual: Verify `~/.hermes/profiles/<name>/config.yaml` has correct model