### PR TITLE
fix: remove OpenClaw-specific branding from gateway UI strings

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -218,7 +218,7 @@
     "createAndQueue": "إنشاء + إضافة للقائمة"
   },
   "localModeBanner": {
-    "noGatewayDetected": "لم يتم الكشف عن بوابة OpenClaw",
+    "noGatewayDetected": "لم يتم الكشف عن بوابة",
     "runningInLocalMode": " — يعمل في الوضع المحلي. مراقبة جلسات Claude Code والمهام والبيانات المحلية.",
     "configureGateway": "تكوين البوابة"
   },
@@ -278,7 +278,7 @@
     "availableInFullMode": "{panel} متاح في الوضع الكامل.",
     "switchToFull": "التبديل إلى الوضع الكامل",
     "goToOverview": "الانتقال إلى النظرة العامة",
-    "requiresGateway": "{panel} يتطلب اتصالاً ببوابة OpenClaw.",
+    "requiresGateway": "{panel} يتطلب اتصالاً ببوابة.",
     "configureGateway": "قم بتكوين بوابة لتفعيل هذه اللوحة."
   },
   "onboarding": {
@@ -335,7 +335,7 @@
     },
     "gatewayLink": {
       "title": "رابط البوابة",
-      "description": "يسجل Mission Control أصله لدى بوابة OpenClaw للاتصال عبر WebSocket وإدارة الوكلاء عن بُعد.",
+      "description": "يسجل Mission Control أصله لدى بوابة للاتصال عبر WebSocket وإدارة الوكلاء عن بُعد.",
       "originRegistered": "تم تسجيل أصل البوابة",
       "originAdded": "تمت إضافة أصل Mission Control إلى allowedOrigins للبوابة",
       "registrationPending": "التسجيل معلق — سيتم تكوينه عند فحص القدرات التالي",
@@ -370,8 +370,8 @@
     "gatewayConnected": "البوابة متصلة",
     "gatewayDisconnected": "البوابة غير متصلة",
     "refresh": "تحديث",
-    "noChannelsConfigured": "لا توجد قنوات مُهيَّأة بعد. قم بتهيئة منصات المراسلة (WhatsApp، Telegram، Discord، Slack، إلخ) في إعدادات بوابة OpenClaw.",
-    "gatewayUnreachable": "تعذّر الوصول إلى بوابة OpenClaw. تحقق من أنها تعمل ويمكن الوصول إليها.",
+    "noChannelsConfigured": "لا توجد قنوات مُهيَّأة بعد. قم بتهيئة منصات المراسلة (WhatsApp، Telegram، Discord، Slack، إلخ) في إعدادات بوابة.",
+    "gatewayUnreachable": "تعذّر الوصول إلى بوابة. تحقق من أنها تعمل ويمكن الوصول إليها.",
     "statusConnected": "متصل",
     "statusRunning": "يعمل",
     "statusConfigured": "مُهيَّأ",
@@ -1542,7 +1542,7 @@
     "addAgent": "+ إضافة وكيل",
     "refresh": "تحديث",
     "noAgents": "لم يُعثر على وكلاء",
-    "noAgentsHint": "يتم اكتشاف الوكلاء المحليين تلقائيًا من أدلة Claude و Codex و Hermes. في وضع البوابة، سيظهر هنا أيضًا الوكلاء المسجلون في بوابة OpenClaw الخاصة بك.",
+    "noAgentsHint": "يتم اكتشاف الوكلاء المحليين تلقائيًا من أدلة Claude و Codex و Hermes. في وضع البوابة، سيظهر هنا أيضًا الوكلاء المسجلون في بوابة الخاصة بك.",
     "addFirstAgent": "أضف وكيلك الأول للبدء",
     "session": "الجلسة",
     "totalTasks": "إجمالي المهام",
@@ -1597,7 +1597,7 @@
     "noGateways": "لم يتم تكوين بوابات",
     "addGatewayHint": "أضف بوابة لبدء إدارة الاتصالات",
     "discoveredGateways": "البوابات المكتشفة",
-    "discoveredGatewaysDesc": "بوابات OpenClaw الموجودة على هذا الجهاز",
+    "discoveredGatewaysDesc": "البوابات الموجودة على هذا الجهاز",
     "refresh": "تحديث",
     "running": "تعمل",
     "stopped": "متوقفة",

--- a/messages/de.json
+++ b/messages/de.json
@@ -218,7 +218,7 @@
     "createAndQueue": "Erstellen + Einreihen"
   },
   "localModeBanner": {
-    "noGatewayDetected": "Kein OpenClaw-Gateway erkannt",
+    "noGatewayDetected": "Kein Gateway erkannt",
     "runningInLocalMode": " — läuft im lokalen Modus. Überwachung von Claude Code Sitzungen, Aufgaben und lokalen Daten.",
     "configureGateway": "Gateway konfigurieren"
   },
@@ -278,7 +278,7 @@
     "availableInFullMode": "{panel} ist im vollständigen Modus verfügbar.",
     "switchToFull": "Zum vollständigen Modus wechseln",
     "goToOverview": "Zur Übersicht",
-    "requiresGateway": "{panel} erfordert eine OpenClaw-Gateway-Verbindung.",
+    "requiresGateway": "{panel} erfordert eine Gateway-Verbindung.",
     "configureGateway": "Konfigurieren Sie ein Gateway, um dieses Panel zu aktivieren."
   },
   "onboarding": {
@@ -335,7 +335,7 @@
     },
     "gatewayLink": {
       "title": "Gateway-Verbindung",
-      "description": "Mission Control registriert seinen Ursprung beim OpenClaw-Gateway, um sich über WebSocket zu verbinden und Agenten remote zu verwalten.",
+      "description": "Mission Control registriert seinen Ursprung beim Gateway, um sich über WebSocket zu verbinden und Agenten remote zu verwalten.",
       "originRegistered": "Gateway-Ursprung registriert",
       "originAdded": "Mission Control Ursprung zu Gateway allowedOrigins hinzugefügt",
       "registrationPending": "Registrierung ausstehend — wird bei der nächsten Fähigkeitsprüfung konfiguriert",
@@ -370,8 +370,8 @@
     "gatewayConnected": "Gateway verbunden",
     "gatewayDisconnected": "Gateway getrennt",
     "refresh": "Aktualisieren",
-    "noChannelsConfigured": "Noch keine Kanäle konfiguriert. Konfigurieren Sie Messaging-Plattformen (WhatsApp, Telegram, Discord, Slack usw.) in den OpenClaw-Gateway-Einstellungen.",
-    "gatewayUnreachable": "Das OpenClaw-Gateway ist nicht erreichbar. Überprüfen Sie, ob es läuft und zugänglich ist.",
+    "noChannelsConfigured": "Noch keine Kanäle konfiguriert. Konfigurieren Sie Messaging-Plattformen (WhatsApp, Telegram, Discord, Slack usw.) in den Gateway-Einstellungen.",
+    "gatewayUnreachable": "Das Gateway ist nicht erreichbar. Überprüfen Sie, ob es läuft und zugänglich ist.",
     "statusConnected": "Verbunden",
     "statusRunning": "Läuft",
     "statusConfigured": "Konfiguriert",
@@ -1542,7 +1542,7 @@
     "addAgent": "+ Agent hinzufügen",
     "refresh": "Aktualisieren",
     "noAgents": "Keine Agenten gefunden",
-    "noAgentsHint": "Lokale Agenten werden automatisch aus den Claude-, Codex- und Hermes-Verzeichnissen erkannt. Im Gateway-Modus werden auch beim OpenClaw-Gateway registrierte Agenten hier angezeigt.",
+    "noAgentsHint": "Lokale Agenten werden automatisch aus den Claude-, Codex- und Hermes-Verzeichnissen erkannt. Im Gateway-Modus werden auch beim Gateway registrierte Agenten hier angezeigt.",
     "addFirstAgent": "Fügen Sie Ihren ersten Agenten hinzu, um zu beginnen",
     "session": "Sitzung",
     "totalTasks": "Aufgaben gesamt",
@@ -1587,7 +1587,7 @@
   },
   "multiGateway": {
     "title": "Gateway-Manager",
-    "description": "Mehrere OpenClaw-Gateway-Verbindungen verwalten",
+    "description": "Mehrere Gateway-Verbindungen verwalten",
     "probeAll": "Alle testen",
     "addGateway": "+ Gateway hinzufügen",
     "connected": "Verbunden",
@@ -1597,7 +1597,7 @@
     "noGateways": "Keine Gateways konfiguriert",
     "addGatewayHint": "Gateway hinzufügen, um Verbindungen zu verwalten",
     "discoveredGateways": "Entdeckte Gateways",
-    "discoveredGatewaysDesc": "Auf diesem Computer gefundene OpenClaw-Gateways",
+    "discoveredGatewaysDesc": "Auf diesem Computer gefundene Gateways",
     "refresh": "Aktualisieren",
     "running": "LÄUFT",
     "stopped": "GESTOPPT",

--- a/messages/en.json
+++ b/messages/en.json
@@ -218,8 +218,8 @@
     "createAndQueue": "Create + Queue"
   },
   "localModeBanner": {
-    "noGatewayDetected": "No OpenClaw gateway detected",
-    "runningInLocalMode": " — running in Local Mode. Monitoring Claude Code sessions, tasks, and local data.",
+    "noGatewayDetected": "No gateway detected",
+    "runningInLocalMode": " — running in Local Mode. Monitoring agent sessions, tasks, and local data.",
     "configureGateway": "Configure Gateway"
   },
   "updateBanner": {
@@ -278,7 +278,7 @@
     "availableInFullMode": "{panel} is available in Full mode.",
     "switchToFull": "Switch to Full",
     "goToOverview": "Go to Overview",
-    "requiresGateway": "{panel} requires an OpenClaw gateway connection.",
+    "requiresGateway": "{panel} requires a gateway connection.",
     "configureGateway": "Configure a gateway to enable this panel."
   },
   "onboarding": {
@@ -335,7 +335,7 @@
     },
     "gatewayLink": {
       "title": "Gateway Link",
-      "description": "Mission Control registers its origin with the OpenClaw gateway so it can connect via WebSocket and manage agents remotely.",
+      "description": "Mission Control registers its origin with the gateway so it can connect via WebSocket and manage agents remotely.",
       "originRegistered": "Gateway origin registered",
       "originAdded": "Mission Control origin added to gateway allowedOrigins",
       "registrationPending": "Registration pending — will be configured on next capabilities check",
@@ -370,8 +370,8 @@
     "gatewayConnected": "Gateway Connected",
     "gatewayDisconnected": "Gateway Disconnected",
     "refresh": "Refresh",
-    "noChannelsConfigured": "No channels configured yet. Configure messaging platforms (WhatsApp, Telegram, Discord, Slack, etc.) in your OpenClaw gateway settings.",
-    "gatewayUnreachable": "Cannot reach the OpenClaw gateway. Check that it is running and accessible.",
+    "noChannelsConfigured": "No channels configured yet. Configure messaging platforms (WhatsApp, Telegram, Discord, Slack, etc.) in your gateway settings.",
+    "gatewayUnreachable": "Cannot reach the gateway. Check that it is running and accessible.",
     "statusConnected": "Connected",
     "statusRunning": "Running",
     "statusConfigured": "Configured",
@@ -1691,7 +1691,7 @@
     "addAgent": "+ Add Agent",
     "refresh": "Refresh",
     "noAgents": "No agents found",
-    "noAgentsHint": "Local agents are auto-discovered from Claude, Codex, and Hermes directories. In gateway mode, agents registered with your OpenClaw gateway will also appear here.",
+    "noAgentsHint": "Local agents are auto-discovered from Claude, Codex, and Hermes directories. In gateway mode, agents registered with your gateway will also appear here.",
     "addFirstAgent": "Add your first agent to get started",
     "session": "Session",
     "totalTasks": "Total Tasks",
@@ -1736,7 +1736,7 @@
   },
   "multiGateway": {
     "title": "Gateway Manager",
-    "description": "Manage multiple OpenClaw gateway connections",
+    "description": "Manage gateway connections",
     "probeAll": "Probe All",
     "addGateway": "+ Add Gateway",
     "connected": "Connected",
@@ -1746,7 +1746,7 @@
     "noGateways": "No gateways configured",
     "addGatewayHint": "Add a gateway to start managing connections",
     "discoveredGateways": "Discovered Gateways",
-    "discoveredGatewaysDesc": "OpenClaw gateways found on this machine",
+    "discoveredGatewaysDesc": "Gateways found on this machine",
     "refresh": "Refresh",
     "running": "RUNNING",
     "stopped": "STOPPED",
@@ -2098,7 +2098,7 @@
   },
   "logViewer": {
     "title": "Log Viewer",
-    "description": "Real-time log stream from the OpenClaw gateway",
+    "description": "Real-time log stream from the gateway",
     "filterLevel": "Level",
     "filterSource": "Source",
     "filterSession": "Session",

--- a/messages/es.json
+++ b/messages/es.json
@@ -218,7 +218,7 @@
     "createAndQueue": "Crear + Encolar"
   },
   "localModeBanner": {
-    "noGatewayDetected": "No se detectó un gateway OpenClaw",
+    "noGatewayDetected": "No se detectó un gateway",
     "runningInLocalMode": " — ejecutando en modo local. Monitoreando sesiones de Claude Code, tareas y datos locales.",
     "configureGateway": "Configurar Gateway"
   },
@@ -278,7 +278,7 @@
     "availableInFullMode": "{panel} está disponible en modo Completo.",
     "switchToFull": "Cambiar a Completo",
     "goToOverview": "Ir a Resumen",
-    "requiresGateway": "{panel} requiere una conexión al gateway OpenClaw.",
+    "requiresGateway": "{panel} requiere una conexión al gateway.",
     "configureGateway": "Configura un gateway para habilitar este panel."
   },
   "onboarding": {
@@ -335,7 +335,7 @@
     },
     "gatewayLink": {
       "title": "Enlace del Gateway",
-      "description": "Mission Control registra su origen con el gateway OpenClaw para conectarse vía WebSocket y gestionar agentes remotamente.",
+      "description": "Mission Control registra su origen con el gateway para conectarse vía WebSocket y gestionar agentes remotamente.",
       "originRegistered": "Origen del gateway registrado",
       "originAdded": "Origen de Mission Control añadido a allowedOrigins del gateway",
       "registrationPending": "Registro pendiente — se configurará en la próxima verificación de capacidades",
@@ -370,8 +370,8 @@
     "gatewayConnected": "Puerta de enlace conectada",
     "gatewayDisconnected": "Puerta de enlace desconectada",
     "refresh": "Actualizar",
-    "noChannelsConfigured": "No hay canales configurados. Configure plataformas de mensajería (WhatsApp, Telegram, Discord, Slack, etc.) en los ajustes de la puerta de enlace OpenClaw.",
-    "gatewayUnreachable": "No se puede acceder a la puerta de enlace OpenClaw. Verifique que esté en funcionamiento.",
+    "noChannelsConfigured": "No hay canales configurados. Configure plataformas de mensajería (WhatsApp, Telegram, Discord, Slack, etc.) en los ajustes de la puerta de enlace.",
+    "gatewayUnreachable": "No se puede acceder a la puerta de enlace. Verifique que esté en funcionamiento.",
     "statusConnected": "Conectado",
     "statusRunning": "En ejecución",
     "statusConfigured": "Configurado",
@@ -1542,7 +1542,7 @@
     "addAgent": "+ Agregar agente",
     "refresh": "Actualizar",
     "noAgents": "No se encontraron agentes",
-    "noAgentsHint": "Los agentes locales se descubren automáticamente desde los directorios de Claude, Codex y Hermes. En modo gateway, los agentes registrados en tu gateway OpenClaw también aparecerán aquí.",
+    "noAgentsHint": "Los agentes locales se descubren automáticamente desde los directorios de Claude, Codex y Hermes. En modo gateway, los agentes registrados en tu gateway también aparecerán aquí.",
     "addFirstAgent": "Agrega tu primer agente para comenzar",
     "session": "Sesión",
     "totalTasks": "Tareas totales",
@@ -1587,7 +1587,7 @@
   },
   "multiGateway": {
     "title": "Gestor de puertas de enlace",
-    "description": "Gestionar múltiples conexiones de puertas de enlace OpenClaw",
+    "description": "Gestionar múltiples conexiones de puertas de enlace",
     "probeAll": "Sondear todo",
     "addGateway": "+ Agregar puerta de enlace",
     "connected": "Conectado",
@@ -1597,7 +1597,7 @@
     "noGateways": "No hay puertas de enlace configuradas",
     "addGatewayHint": "Agrega una puerta de enlace para comenzar a gestionar conexiones",
     "discoveredGateways": "Puertas de enlace descubiertas",
-    "discoveredGatewaysDesc": "Puertas de enlace OpenClaw encontradas en esta máquina",
+    "discoveredGatewaysDesc": "Puertas de enlace encontradas en esta máquina",
     "refresh": "Actualizar",
     "running": "EN EJECUCIÓN",
     "stopped": "DETENIDO",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -218,7 +218,7 @@
     "createAndQueue": "Créer + Mettre en file"
   },
   "localModeBanner": {
-    "noGatewayDetected": "Aucune passerelle OpenClaw détectée",
+    "noGatewayDetected": "Aucune passerelle détectée",
     "runningInLocalMode": " — en mode local. Surveillance des sessions Claude Code, tâches et données locales.",
     "configureGateway": "Configurer la passerelle"
   },
@@ -278,7 +278,7 @@
     "availableInFullMode": "{panel} est disponible en mode Complet.",
     "switchToFull": "Passer en mode Complet",
     "goToOverview": "Aller à l'aperçu",
-    "requiresGateway": "{panel} nécessite une connexion à la passerelle OpenClaw.",
+    "requiresGateway": "{panel} nécessite une connexion à la passerelle.",
     "configureGateway": "Configurez une passerelle pour activer ce panneau."
   },
   "onboarding": {
@@ -335,7 +335,7 @@
     },
     "gatewayLink": {
       "title": "Lien de la passerelle",
-      "description": "Mission Control enregistre son origine auprès de la passerelle OpenClaw pour se connecter via WebSocket et gérer les agents à distance.",
+      "description": "Mission Control enregistre son origine auprès de la passerelle pour se connecter via WebSocket et gérer les agents à distance.",
       "originRegistered": "Origine de la passerelle enregistrée",
       "originAdded": "Origine de Mission Control ajoutée aux allowedOrigins de la passerelle",
       "registrationPending": "Enregistrement en attente — sera configuré lors de la prochaine vérification des capacités",
@@ -370,8 +370,8 @@
     "gatewayConnected": "Passerelle connectée",
     "gatewayDisconnected": "Passerelle déconnectée",
     "refresh": "Actualiser",
-    "noChannelsConfigured": "Aucun canal configuré. Configurez des plateformes de messagerie (WhatsApp, Telegram, Discord, Slack, etc.) dans les paramètres de la passerelle OpenClaw.",
-    "gatewayUnreachable": "Impossible d'atteindre la passerelle OpenClaw. Vérifiez qu'elle est en cours d'exécution et accessible.",
+    "noChannelsConfigured": "Aucun canal configuré. Configurez des plateformes de messagerie (WhatsApp, Telegram, Discord, Slack, etc.) dans les paramètres de la passerelle.",
+    "gatewayUnreachable": "Impossible d'atteindre la passerelle. Vérifiez qu'elle est en cours d'exécution et accessible.",
     "statusConnected": "Connecté",
     "statusRunning": "En cours d'exécution",
     "statusConfigured": "Configuré",
@@ -1542,7 +1542,7 @@
     "addAgent": "+ Ajouter un agent",
     "refresh": "Actualiser",
     "noAgents": "Aucun agent trouvé",
-    "noAgentsHint": "Les agents locaux sont découverts automatiquement depuis les répertoires Claude, Codex et Hermes. En mode passerelle, les agents enregistrés sur votre passerelle OpenClaw apparaîtront également ici.",
+    "noAgentsHint": "Les agents locaux sont découverts automatiquement depuis les répertoires Claude, Codex et Hermes. En mode passerelle, les agents enregistrés sur votre passerelle apparaîtront également ici.",
     "addFirstAgent": "Ajoutez votre premier agent pour commencer",
     "session": "Session",
     "totalTasks": "Tâches totales",
@@ -1587,7 +1587,7 @@
   },
   "multiGateway": {
     "title": "Gestionnaire de passerelles",
-    "description": "Gérer plusieurs connexions de passerelles OpenClaw",
+    "description": "Gérer plusieurs connexions de passerelles",
     "probeAll": "Sonder tout",
     "addGateway": "+ Ajouter une passerelle",
     "connected": "Connecté",
@@ -1597,7 +1597,7 @@
     "noGateways": "Aucune passerelle configurée",
     "addGatewayHint": "Ajouter une passerelle pour commencer à gérer les connexions",
     "discoveredGateways": "Passerelles découvertes",
-    "discoveredGatewaysDesc": "Passerelles OpenClaw trouvées sur cette machine",
+    "discoveredGatewaysDesc": "Passerelles trouvées sur cette machine",
     "refresh": "Actualiser",
     "running": "EN COURS",
     "stopped": "ARRÊTÉ",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -218,7 +218,7 @@
     "createAndQueue": "作成してキューに追加"
   },
   "localModeBanner": {
-    "noGatewayDetected": "OpenClaw ゲートウェイが検出されません",
+    "noGatewayDetected": "ゲートウェイが検出されません",
     "runningInLocalMode": " — ローカルモードで動作中。Claude Code セッション、タスク、ローカルデータを監視しています。",
     "configureGateway": "ゲートウェイを設定"
   },
@@ -278,7 +278,7 @@
     "availableInFullMode": "{panel}はフルモードで利用可能です。",
     "switchToFull": "フルに切り替え",
     "goToOverview": "概要へ移動",
-    "requiresGateway": "{panel}には OpenClaw ゲートウェイ接続が必要です。",
+    "requiresGateway": "{panel}には ゲートウェイ接続が必要です。",
     "configureGateway": "このパネルを有効にするにはゲートウェイを設定してください。"
   },
   "onboarding": {
@@ -335,7 +335,7 @@
     },
     "gatewayLink": {
       "title": "ゲートウェイリンク",
-      "description": "Mission Control はそのオリジンを OpenClaw ゲートウェイに登録し、WebSocket 経由で接続してエージェントをリモート管理できるようにします。",
+      "description": "Mission Control はそのオリジンを ゲートウェイに登録し、WebSocket 経由で接続してエージェントをリモート管理できるようにします。",
       "originRegistered": "ゲートウェイオリジン登録済み",
       "originAdded": "Mission Control オリジンがゲートウェイの allowedOrigins に追加されました",
       "registrationPending": "登録保留中 — 次の能力チェック時に設定されます",
@@ -370,8 +370,8 @@
     "gatewayConnected": "ゲートウェイ接続済み",
     "gatewayDisconnected": "ゲートウェイ切断",
     "refresh": "更新",
-    "noChannelsConfigured": "チャンネルが未設定です。OpenClawゲートウェイ設定でメッセージングプラットフォーム（WhatsApp、Telegram、Discord、Slackなど）を設定してください。",
-    "gatewayUnreachable": "OpenClawゲートウェイに到達できません。稼動しているか確認してください。",
+    "noChannelsConfigured": "チャンネルが未設定です。ゲートウェイ設定でメッセージングプラットフォーム（WhatsApp、Telegram、Discord、Slackなど）を設定してください。",
+    "gatewayUnreachable": "ゲートウェイに到達できません。稼動しているか確認してください。",
     "statusConnected": "接続済み",
     "statusRunning": "実行中",
     "statusConfigured": "設定済み",
@@ -1542,7 +1542,7 @@
     "addAgent": "+ エージェントを追加",
     "refresh": "更新",
     "noAgents": "エージェントが見つかりません",
-    "noAgentsHint": "ローカルエージェントは Claude、Codex、Hermes のディレクトリから自動検出されます。ゲートウェイモードでは、OpenClaw ゲートウェイに登録されたエージェントもここに表示されます。",
+    "noAgentsHint": "ローカルエージェントは Claude、Codex、Hermes のディレクトリから自動検出されます。ゲートウェイモードでは、ゲートウェイに登録されたエージェントもここに表示されます。",
     "addFirstAgent": "最初のエージェントを追加して開始",
     "session": "セッション",
     "totalTasks": "タスク総数",
@@ -1587,7 +1587,7 @@
   },
   "multiGateway": {
     "title": "ゲートウェイマネージャー",
-    "description": "複数の OpenClaw ゲートウェイ接続を管理",
+    "description": "複数の ゲートウェイ接続を管理",
     "probeAll": "すべてを探索",
     "addGateway": "+ ゲートウェイを追加",
     "connected": "接続済み",
@@ -1597,7 +1597,7 @@
     "noGateways": "ゲートウェイが設定されていません",
     "addGatewayHint": "ゲートウェイを追加して接続の管理を開始",
     "discoveredGateways": "検出されたゲートウェイ",
-    "discoveredGatewaysDesc": "このマシンで見つかった OpenClaw ゲートウェイ",
+    "discoveredGatewaysDesc": "このマシンで見つかった ゲートウェイ",
     "refresh": "更新",
     "running": "実行中",
     "stopped": "停止済み",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -218,7 +218,7 @@
     "createAndQueue": "만들기 + 대기열 추가"
   },
   "localModeBanner": {
-    "noGatewayDetected": "OpenClaw 게이트웨이가 감지되지 않음",
+    "noGatewayDetected": "게이트웨이가 감지되지 않음",
     "runningInLocalMode": " — 로컬 모드로 실행 중. Claude Code 세션, 작업 및 로컬 데이터를 모니터링합니다.",
     "configureGateway": "게이트웨이 설정"
   },
@@ -278,7 +278,7 @@
     "availableInFullMode": "{panel}은(는) 전체 모드에서 사용할 수 있습니다.",
     "switchToFull": "전체 모드로 전환",
     "goToOverview": "개요로 이동",
-    "requiresGateway": "{panel}은(는) OpenClaw 게이트웨이 연결이 필요합니다.",
+    "requiresGateway": "{panel}은(는) 게이트웨이 연결이 필요합니다.",
     "configureGateway": "이 패널을 활성화하려면 게이트웨이를 설정하세요."
   },
   "onboarding": {
@@ -335,7 +335,7 @@
     },
     "gatewayLink": {
       "title": "게이트웨이 링크",
-      "description": "Mission Control은 오리진을 OpenClaw 게이트웨이에 등록하여 WebSocket을 통해 연결하고 에이전트를 원격으로 관리할 수 있습니다.",
+      "description": "Mission Control은 오리진을 게이트웨이에 등록하여 WebSocket을 통해 연결하고 에이전트를 원격으로 관리할 수 있습니다.",
       "originRegistered": "게이트웨이 오리진 등록됨",
       "originAdded": "Mission Control 오리진이 게이트웨이 allowedOrigins에 추가됨",
       "registrationPending": "등록 대기 중 — 다음 기능 확인 시 설정됩니다",
@@ -370,8 +370,8 @@
     "gatewayConnected": "게이트웨이 연결됨",
     "gatewayDisconnected": "게이트웨이 연결 끊김",
     "refresh": "새로고침",
-    "noChannelsConfigured": "아직 채널이 설정되지 않았습니다. OpenClaw 게이트웨이 설정에서 메시징 플랫폼(WhatsApp, Telegram, Discord, Slack 등)을 구성하세요.",
-    "gatewayUnreachable": "OpenClaw 게이트웨이에 접근할 수 없습니다. 실행 중인지 확인하세요.",
+    "noChannelsConfigured": "아직 채널이 설정되지 않았습니다. 게이트웨이 설정에서 메시징 플랫폼(WhatsApp, Telegram, Discord, Slack 등)을 구성하세요.",
+    "gatewayUnreachable": "게이트웨이에 접근할 수 없습니다. 실행 중인지 확인하세요.",
     "statusConnected": "연결됨",
     "statusRunning": "실행 중",
     "statusConfigured": "설정됨",
@@ -1691,7 +1691,7 @@
     "addAgent": "+ 에이전트 추가",
     "refresh": "새로 고침",
     "noAgents": "에이전트를 찾을 수 없습니다",
-    "noAgentsHint": "로컬 에이전트는 Claude, Codex, Hermes 디렉토리에서 자동으로 검색됩니다. 게이트웨이 모드에서는 OpenClaw 게이트웨이에 등록된 에이전트도 여기에 표시됩니다.",
+    "noAgentsHint": "로컬 에이전트는 Claude, Codex, Hermes 디렉토리에서 자동으로 검색됩니다. 게이트웨이 모드에서는 게이트웨이에 등록된 에이전트도 여기에 표시됩니다.",
     "addFirstAgent": "첫 번째 에이전트를 추가하여 시작하세요",
     "session": "세션",
     "totalTasks": "총 작업",
@@ -1736,7 +1736,7 @@
   },
   "multiGateway": {
     "title": "게이트웨이 관리자",
-    "description": "여러 OpenClaw 게이트웨이 연결 관리",
+    "description": "게이트웨이 연결 관리",
     "probeAll": "모두 탐색",
     "addGateway": "+ 게이트웨이 추가",
     "connected": "연결됨",
@@ -1746,7 +1746,7 @@
     "noGateways": "게이트웨이가 구성되지 않았습니다",
     "addGatewayHint": "게이트웨이를 추가하여 연결 관리 시작",
     "discoveredGateways": "발견된 게이트웨이",
-    "discoveredGatewaysDesc": "이 머신에서 발견된 OpenClaw 게이트웨이",
+    "discoveredGatewaysDesc": "이 머신에서 발견된 게이트웨이",
     "refresh": "새로 고침",
     "running": "실행 중",
     "stopped": "중지됨",
@@ -2098,7 +2098,7 @@
   },
   "logViewer": {
     "title": "로그 뷰어",
-    "description": "OpenClaw 게이트웨이의 실시간 로그 스트림",
+    "description": "게이트웨이의 실시간 로그 스트림",
     "filterLevel": "레벨",
     "filterSource": "소스",
     "filterSession": "세션",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -218,7 +218,7 @@
     "createAndQueue": "Criar + Enfileirar"
   },
   "localModeBanner": {
-    "noGatewayDetected": "Nenhum gateway OpenClaw detectado",
+    "noGatewayDetected": "Nenhum gateway detectado",
     "runningInLocalMode": " — executando em modo local. Monitorando sessões do Claude Code, tarefas e dados locais.",
     "configureGateway": "Configurar Gateway"
   },
@@ -278,7 +278,7 @@
     "availableInFullMode": "{panel} está disponível no modo Completo.",
     "switchToFull": "Mudar para Completo",
     "goToOverview": "Ir para Visão geral",
-    "requiresGateway": "{panel} requer uma conexão com o gateway OpenClaw.",
+    "requiresGateway": "{panel} requer uma conexão com o gateway.",
     "configureGateway": "Configure um gateway para habilitar este painel."
   },
   "onboarding": {
@@ -335,7 +335,7 @@
     },
     "gatewayLink": {
       "title": "Link do Gateway",
-      "description": "O Mission Control registra sua origem no gateway OpenClaw para se conectar via WebSocket e gerenciar agentes remotamente.",
+      "description": "O Mission Control registra sua origem no gateway para se conectar via WebSocket e gerenciar agentes remotamente.",
       "originRegistered": "Origem do gateway registrada",
       "originAdded": "Origem do Mission Control adicionada ao allowedOrigins do gateway",
       "registrationPending": "Registro pendente — será configurado na próxima verificação de capacidades",
@@ -370,8 +370,8 @@
     "gatewayConnected": "Gateway conectado",
     "gatewayDisconnected": "Gateway desconectado",
     "refresh": "Atualizar",
-    "noChannelsConfigured": "Nenhum canal configurado ainda. Configure plataformas de mensagens (WhatsApp, Telegram, Discord, Slack, etc.) nas configurações do gateway OpenClaw.",
-    "gatewayUnreachable": "Não é possível acessar o gateway OpenClaw. Verifique se está em execução e acessível.",
+    "noChannelsConfigured": "Nenhum canal configurado ainda. Configure plataformas de mensagens (WhatsApp, Telegram, Discord, Slack, etc.) nas configurações do gateway.",
+    "gatewayUnreachable": "Não é possível acessar o gateway. Verifique se está em execução e acessível.",
     "statusConnected": "Conectado",
     "statusRunning": "Em execução",
     "statusConfigured": "Configurado",
@@ -1542,7 +1542,7 @@
     "addAgent": "+ Adicionar agente",
     "refresh": "Atualizar",
     "noAgents": "Nenhum agente encontrado",
-    "noAgentsHint": "Agentes locais são descobertos automaticamente dos diretórios Claude, Codex e Hermes. No modo gateway, agentes registrados no seu gateway OpenClaw também aparecerão aqui.",
+    "noAgentsHint": "Agentes locais são descobertos automaticamente dos diretórios Claude, Codex e Hermes. No modo gateway, agentes registrados no seu gateway também aparecerão aqui.",
     "addFirstAgent": "Adicione seu primeiro agente para começar",
     "session": "Sessão",
     "totalTasks": "Total de tarefas",
@@ -1587,7 +1587,7 @@
   },
   "multiGateway": {
     "title": "Gerenciador de gateways",
-    "description": "Gerenciar múltiplas conexões de gateway OpenClaw",
+    "description": "Gerenciar múltiplas conexões de gateway",
     "probeAll": "Sondar tudo",
     "addGateway": "+ Adicionar gateway",
     "connected": "Conectado",
@@ -1597,7 +1597,7 @@
     "noGateways": "Nenhum gateway configurado",
     "addGatewayHint": "Adicionar um gateway para começar a gerenciar conexões",
     "discoveredGateways": "Gateways descobertos",
-    "discoveredGatewaysDesc": "Gateways OpenClaw encontrados nesta máquina",
+    "discoveredGatewaysDesc": "Gateways encontrados nesta máquina",
     "refresh": "Atualizar",
     "running": "EM EXECUÇÃO",
     "stopped": "PARADO",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -218,7 +218,7 @@
     "createAndQueue": "Создать + В очередь"
   },
   "localModeBanner": {
-    "noGatewayDetected": "Шлюз OpenClaw не обнаружен",
+    "noGatewayDetected": "Шлюз не обнаружен",
     "runningInLocalMode": " — работа в локальном режиме. Мониторинг сессий Claude Code, задач и локальных данных.",
     "configureGateway": "Настроить шлюз"
   },
@@ -278,7 +278,7 @@
     "availableInFullMode": "{panel} доступен в полном режиме.",
     "switchToFull": "Переключить на полный",
     "goToOverview": "Перейти к обзору",
-    "requiresGateway": "{panel} требует подключения к шлюзу OpenClaw.",
+    "requiresGateway": "{panel} требует подключения к шлюзу.",
     "configureGateway": "Настройте шлюз для активации этой панели."
   },
   "onboarding": {
@@ -335,7 +335,7 @@
     },
     "gatewayLink": {
       "title": "Связь со шлюзом",
-      "description": "Mission Control регистрирует свой источник в шлюзе OpenClaw для подключения через WebSocket и удалённого управления агентами.",
+      "description": "Mission Control регистрирует свой источник в шлюзе для подключения через WebSocket и удалённого управления агентами.",
       "originRegistered": "Источник шлюза зарегистрирован",
       "originAdded": "Источник Mission Control добавлен в allowedOrigins шлюза",
       "registrationPending": "Регистрация ожидается — будет настроена при следующей проверке возможностей",
@@ -370,8 +370,8 @@
     "gatewayConnected": "Шлюз подключён",
     "gatewayDisconnected": "Шлюз отключён",
     "refresh": "Обновить",
-    "noChannelsConfigured": "Каналы ещё не настроены. Настройте платформы обмена сообщениями (WhatsApp, Telegram, Discord, Slack и др.) в настройках шлюза OpenClaw.",
-    "gatewayUnreachable": "Не удаётся подключиться к шлюзу OpenClaw. Проверьте, что он запущен и доступен.",
+    "noChannelsConfigured": "Каналы ещё не настроены. Настройте платформы обмена сообщениями (WhatsApp, Telegram, Discord, Slack и др.) в настройках шлюза.",
+    "gatewayUnreachable": "Не удаётся подключиться к шлюзу. Проверьте, что он запущен и доступен.",
     "statusConnected": "Подключено",
     "statusRunning": "Работает",
     "statusConfigured": "Настроено",
@@ -1542,7 +1542,7 @@
     "addAgent": "+ Добавить агента",
     "refresh": "Обновить",
     "noAgents": "Агенты не найдены",
-    "noAgentsHint": "Локальные агенты автоматически обнаруживаются из каталогов Claude, Codex и Hermes. В режиме шлюза здесь также будут отображаться агенты, зарегистрированные на вашем шлюзе OpenClaw.",
+    "noAgentsHint": "Локальные агенты автоматически обнаруживаются из каталогов Claude, Codex и Hermes. В режиме шлюза здесь также будут отображаться агенты, зарегистрированные на вашем шлюзе.",
     "addFirstAgent": "Добавьте первого агента для начала работы",
     "session": "Сессия",
     "totalTasks": "Всего задач",
@@ -1587,7 +1587,7 @@
   },
   "multiGateway": {
     "title": "Менеджер шлюзов",
-    "description": "Управление несколькими подключениями шлюза OpenClaw",
+    "description": "Управление несколькими подключениями шлюза",
     "probeAll": "Проверить все",
     "addGateway": "+ Добавить шлюз",
     "connected": "Подключено",
@@ -1597,7 +1597,7 @@
     "noGateways": "Шлюзы не настроены",
     "addGatewayHint": "Добавьте шлюз для управления подключениями",
     "discoveredGateways": "Обнаруженные шлюзы",
-    "discoveredGatewaysDesc": "Шлюзы OpenClaw, найденные на этом компьютере",
+    "discoveredGatewaysDesc": "Шлюзы, найденные на этом компьютере",
     "refresh": "Обновить",
     "running": "РАБОТАЕТ",
     "stopped": "ОСТАНОВЛЕН",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -218,7 +218,7 @@
     "createAndQueue": "创建并排队"
   },
   "localModeBanner": {
-    "noGatewayDetected": "未检测到 OpenClaw 网关",
+    "noGatewayDetected": "未检测到网关",
     "runningInLocalMode": " — 正在以本地模式运行。监控 Claude Code 会话、任务和本地数据。",
     "configureGateway": "配置网关"
   },
@@ -278,7 +278,7 @@
     "availableInFullMode": "{panel}在完整模式下可用。",
     "switchToFull": "切换到完整模式",
     "goToOverview": "前往概览",
-    "requiresGateway": "{panel}需要 OpenClaw 网关连接。",
+    "requiresGateway": "{panel}需要 网关连接。",
     "configureGateway": "配置网关以启用此面板。"
   },
   "onboarding": {
@@ -335,7 +335,7 @@
     },
     "gatewayLink": {
       "title": "网关链接",
-      "description": "Mission Control 将其来源注册到 OpenClaw 网关，以便通过 WebSocket 连接并远程管理智能体。",
+      "description": "Mission Control 将其来源注册到 网关，以便通过 WebSocket 连接并远程管理智能体。",
       "originRegistered": "网关来源已注册",
       "originAdded": "Mission Control 来源已添加到网关 allowedOrigins",
       "registrationPending": "注册待处理 — 将在下次能力检查时配置",
@@ -370,8 +370,8 @@
     "gatewayConnected": "网关已连接",
     "gatewayDisconnected": "网关已断开",
     "refresh": "刷新",
-    "noChannelsConfigured": "尚未配置频道。请在 OpenClaw 网关设置中配置消息平台（WhatsApp、Telegram、Discord、Slack 等）。",
-    "gatewayUnreachable": "无法连接 OpenClaw 网关，请确认其正在运行并可访问。",
+    "noChannelsConfigured": "尚未配置频道。请在 网关设置中配置消息平台（WhatsApp、Telegram、Discord、Slack 等）。",
+    "gatewayUnreachable": "无法连接 网关，请确认其正在运行并可访问。",
     "statusConnected": "已连接",
     "statusRunning": "运行中",
     "statusConfigured": "已配置",
@@ -1780,7 +1780,7 @@
     "addAgent": "+ 添加代理",
     "refresh": "刷新",
     "noAgents": "未找到代理",
-    "noAgentsHint": "本地代理会从 Claude、Codex 和 Hermes 目录自动发现。在网关模式下，注册到 OpenClaw 网关的代理也会显示在此处。",
+    "noAgentsHint": "本地代理会从 Claude、Codex 和 Hermes 目录自动发现。在网关模式下，注册到 网关的代理也会显示在此处。",
     "addFirstAgent": "添加您的第一个代理以开始使用",
     "session": "会话",
     "totalTasks": "任务总数",
@@ -1825,7 +1825,7 @@
   },
   "multiGateway": {
     "title": "网关管理器",
-    "description": "管理多个 OpenClaw 网关连接",
+    "description": "管理多个 网关连接",
     "probeAll": "探测全部",
     "addGateway": "+ 添加网关",
     "connected": "已连接",
@@ -1835,7 +1835,7 @@
     "noGateways": "未配置网关",
     "addGatewayHint": "添加网关以开始管理连接",
     "discoveredGateways": "发现的网关",
-    "discoveredGatewaysDesc": "在此计算机上发现的 OpenClaw 网关",
+    "discoveredGatewaysDesc": "在此计算机上发现的 网关",
     "refresh": "刷新",
     "running": "运行中",
     "stopped": "已停止",


### PR DESCRIPTION
## Summary

The gateway banner and several UI strings referenced "OpenClaw gateway" specifically, but the gateway could be a Hermes Agent gateway or other provider. Updated all 10 locale files to use generic "gateway" terminology.

### Before
> No OpenClaw gateway detected — running in Local Mode. Monitoring Claude Code sessions, tasks, and local data.

### After
> No gateway detected — running in Local Mode. Monitoring agent sessions, tasks, and local data.

### Scope
- `localModeBanner.noGatewayDetected` — banner text
- `panelLocked.requiresGateway` — panel access message
- `onboarding.welcome.gatewayLink.description` — onboarding step
- `channels.noChannelsConfigured` — channel setup hint
- `channels.gatewayUnreachable` — error message
- `agentSquad.noAgentsHint` — agent discovery hint
- `gatewayManager.description` / `discoveredGatewaysDesc` — gateway panel
- `logViewer.description` — log stream label

Legitimate OpenClaw product references (e.g., "Install OpenClaw", "OpenClaw config") are preserved — only gateway-as-infrastructure strings were genericized.

## Test plan
- [x] `pnpm test` — 892/892 pass
- [ ] Manual: Verify banner shows "No gateway detected" instead of "No OpenClaw gateway detected"