### PR TITLE
feat: gateway control panel — start, stop, restart, diagnose

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1884,5 +1884,22 @@
     "online": "متصل",
     "busy": "مشغول",
     "errors": "أخطاء"
+  },
+  "gatewayControl": {
+    "title": "Gateway Control",
+    "description": "Start, stop, restart, and diagnose your agent gateways.",
+    "noGatewaysInstalled": "No gateways installed",
+    "installHint": "Install Hermes Agent or OpenClaw from Settings to enable gateway features.",
+    "running": "Running",
+    "stopped": "Stopped",
+    "start": "Start",
+    "stop": "Stop",
+    "restart": "Restart",
+    "diagnose": "Diagnose",
+    "starting": "Starting...",
+    "stopping": "Stopping...",
+    "restarting": "Restarting...",
+    "diagnosing": "Diagnosing...",
+    "notInstalled": "Not installed"
   }
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -1884,5 +1884,22 @@
     "online": "Online",
     "busy": "Beschäftigt",
     "errors": "Fehler"
+  },
+  "gatewayControl": {
+    "title": "Gateway Control",
+    "description": "Start, stop, restart, and diagnose your agent gateways.",
+    "noGatewaysInstalled": "No gateways installed",
+    "installHint": "Install Hermes Agent or OpenClaw from Settings to enable gateway features.",
+    "running": "Running",
+    "stopped": "Stopped",
+    "start": "Start",
+    "stop": "Stop",
+    "restart": "Restart",
+    "diagnose": "Diagnose",
+    "starting": "Starting...",
+    "stopping": "Stopping...",
+    "restarting": "Restarting...",
+    "diagnosing": "Diagnosing...",
+    "notInstalled": "Not installed"
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -2171,5 +2171,22 @@
     "tabStatus": "Status",
     "unhealthy": "Unhealthy",
     "unreachable": "Unreachable"
+  },
+  "gatewayControl": {
+    "title": "Gateway Control",
+    "description": "Start, stop, restart, and diagnose your agent gateways.",
+    "noGatewaysInstalled": "No gateways installed",
+    "installHint": "Install Hermes Agent or OpenClaw from Settings to enable gateway features.",
+    "running": "Running",
+    "stopped": "Stopped",
+    "start": "Start",
+    "stop": "Stop",
+    "restart": "Restart",
+    "diagnose": "Diagnose",
+    "starting": "Starting...",
+    "stopping": "Stopping...",
+    "restarting": "Restarting...",
+    "diagnosing": "Diagnosing...",
+    "notInstalled": "Not installed"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -1938,5 +1938,22 @@
     "loadingSchema": "Cargando esquema...",
     "viewPendingChanges": "Ver {count} cambios pendientes",
     "noSettingsMatch": "Ningún ajuste coincide con '{query}'"
+  },
+  "gatewayControl": {
+    "title": "Gateway Control",
+    "description": "Start, stop, restart, and diagnose your agent gateways.",
+    "noGatewaysInstalled": "No gateways installed",
+    "installHint": "Install Hermes Agent or OpenClaw from Settings to enable gateway features.",
+    "running": "Running",
+    "stopped": "Stopped",
+    "start": "Start",
+    "stop": "Stop",
+    "restart": "Restart",
+    "diagnose": "Diagnose",
+    "starting": "Starting...",
+    "stopping": "Stopping...",
+    "restarting": "Restarting...",
+    "diagnosing": "Diagnosing...",
+    "notInstalled": "Not installed"
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1884,5 +1884,22 @@
     "online": "En ligne",
     "busy": "Occupé",
     "errors": "Erreurs"
+  },
+  "gatewayControl": {
+    "title": "Gateway Control",
+    "description": "Start, stop, restart, and diagnose your agent gateways.",
+    "noGatewaysInstalled": "No gateways installed",
+    "installHint": "Install Hermes Agent or OpenClaw from Settings to enable gateway features.",
+    "running": "Running",
+    "stopped": "Stopped",
+    "start": "Start",
+    "stop": "Stop",
+    "restart": "Restart",
+    "diagnose": "Diagnose",
+    "starting": "Starting...",
+    "stopping": "Stopping...",
+    "restarting": "Restarting...",
+    "diagnosing": "Diagnosing...",
+    "notInstalled": "Not installed"
   }
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1884,5 +1884,22 @@
     "online": "オンライン",
     "busy": "稼働中",
     "errors": "エラー"
+  },
+  "gatewayControl": {
+    "title": "Gateway Control",
+    "description": "Start, stop, restart, and diagnose your agent gateways.",
+    "noGatewaysInstalled": "No gateways installed",
+    "installHint": "Install Hermes Agent or OpenClaw from Settings to enable gateway features.",
+    "running": "Running",
+    "stopped": "Stopped",
+    "start": "Start",
+    "stop": "Stop",
+    "restart": "Restart",
+    "diagnose": "Diagnose",
+    "starting": "Starting...",
+    "stopping": "Stopping...",
+    "restarting": "Restarting...",
+    "diagnosing": "Diagnosing...",
+    "notInstalled": "Not installed"
   }
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -2171,5 +2171,22 @@
     "tabStatus": "상태",
     "unhealthy": "비정상",
     "unreachable": "연결 불가"
+  },
+  "gatewayControl": {
+    "title": "Gateway Control",
+    "description": "Start, stop, restart, and diagnose your agent gateways.",
+    "noGatewaysInstalled": "No gateways installed",
+    "installHint": "Install Hermes Agent or OpenClaw from Settings to enable gateway features.",
+    "running": "Running",
+    "stopped": "Stopped",
+    "start": "Start",
+    "stop": "Stop",
+    "restart": "Restart",
+    "diagnose": "Diagnose",
+    "starting": "Starting...",
+    "stopping": "Stopping...",
+    "restarting": "Restarting...",
+    "diagnosing": "Diagnosing...",
+    "notInstalled": "Not installed"
   }
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1884,5 +1884,22 @@
     "online": "Online",
     "busy": "Ocupado",
     "errors": "Erros"
+  },
+  "gatewayControl": {
+    "title": "Gateway Control",
+    "description": "Start, stop, restart, and diagnose your agent gateways.",
+    "noGatewaysInstalled": "No gateways installed",
+    "installHint": "Install Hermes Agent or OpenClaw from Settings to enable gateway features.",
+    "running": "Running",
+    "stopped": "Stopped",
+    "start": "Start",
+    "stop": "Stop",
+    "restart": "Restart",
+    "diagnose": "Diagnose",
+    "starting": "Starting...",
+    "stopping": "Stopping...",
+    "restarting": "Restarting...",
+    "diagnosing": "Diagnosing...",
+    "notInstalled": "Not installed"
   }
 }

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -1884,5 +1884,22 @@
     "online": "Онлайн",
     "busy": "Занят",
     "errors": "Ошибки"
+  },
+  "gatewayControl": {
+    "title": "Gateway Control",
+    "description": "Start, stop, restart, and diagnose your agent gateways.",
+    "noGatewaysInstalled": "No gateways installed",
+    "installHint": "Install Hermes Agent or OpenClaw from Settings to enable gateway features.",
+    "running": "Running",
+    "stopped": "Stopped",
+    "start": "Start",
+    "stop": "Stop",
+    "restart": "Restart",
+    "diagnose": "Diagnose",
+    "starting": "Starting...",
+    "stopping": "Stopping...",
+    "restarting": "Restarting...",
+    "diagnosing": "Diagnosing...",
+    "notInstalled": "Not installed"
   }
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1884,5 +1884,22 @@
     "addGatewaySubmit": "添加网关",
     "failedToAdd": "添加网关失败",
     "networkError": "网络错误"
+  },
+  "gatewayControl": {
+    "title": "Gateway Control",
+    "description": "Start, stop, restart, and diagnose your agent gateways.",
+    "noGatewaysInstalled": "No gateways installed",
+    "installHint": "Install Hermes Agent or OpenClaw from Settings to enable gateway features.",
+    "running": "Running",
+    "stopped": "Stopped",
+    "start": "Start",
+    "stop": "Stop",
+    "restart": "Restart",
+    "diagnose": "Diagnose",
+    "starting": "Starting...",
+    "stopping": "Stopping...",
+    "restarting": "Restarting...",
+    "diagnosing": "Diagnosing...",
+    "notInstalled": "Not installed"
   }
 }

--- a/src/app/[[...panel]]/page.tsx
+++ b/src/app/[[...panel]]/page.tsx
@@ -25,6 +25,7 @@ import { GatewayConfigPanel } from '@/components/panels/gateway-config-panel'
 import { IntegrationsPanel } from '@/components/panels/integrations-panel'
 import { AlertRulesPanel } from '@/components/panels/alert-rules-panel'
 import { MultiGatewayPanel } from '@/components/panels/multi-gateway-panel'
+import { GatewayControlPanel } from '@/components/panels/gateway-control-panel'
 import { SuperAdminPanel } from '@/components/panels/super-admin-panel'
 import { OfficePanel } from '@/components/panels/office-panel'
 import { GitHubSyncPanel } from '@/components/panels/github-sync-panel'
@@ -542,7 +543,7 @@ function ContentRouter({ tab }: { tab: string }) {
     case 'alerts':
       return <AlertRulesPanel />
     case 'gateways':
-      if (isLocal) return <LocalModeUnavailable panel={tab} />
+      if (isLocal) return <GatewayControlPanel />
       return <MultiGatewayPanel />
     case 'gateway-config':
       if (isLocal) return <LocalModeUnavailable panel={tab} />

--- a/src/app/api/gateways/control/route.ts
+++ b/src/app/api/gateways/control/route.ts
@@ -1,0 +1,163 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { logger } from '@/lib/logger'
+import { config } from '@/lib/config'
+import { isHermesGatewayRunning } from '@/lib/hermes-sessions'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+type GatewayType = 'hermes' | 'openclaw'
+type GatewayAction = 'status' | 'start' | 'stop' | 'restart' | 'diagnose'
+
+interface GatewayStatus {
+  type: GatewayType
+  name: string
+  installed: boolean
+  running: boolean
+  port?: number
+  pid?: number | null
+  version?: string | null
+  error?: string
+}
+
+function getHermesGatewayStatus(): GatewayStatus {
+  const homeDir = config.homeDir
+  const installed = existsSync(join(homeDir, '.hermes'))
+  const running = installed && isHermesGatewayRunning()
+
+  let pid: number | null = null
+  if (running) {
+    try {
+      const pidStr = require('node:fs').readFileSync(join(homeDir, '.hermes', 'gateway.pid'), 'utf8')
+      const parsed = pidStr.trim()
+      // gateway.pid can be plain number or JSON with pid field
+      if (parsed.startsWith('{')) {
+        const json = JSON.parse(parsed)
+        pid = json.pid || null
+      } else {
+        pid = parseInt(parsed, 10) || null
+      }
+    } catch { /* ignore */ }
+  }
+
+  return { type: 'hermes', name: 'Hermes Gateway', installed, running, pid }
+}
+
+function getOpenClawGatewayStatus(): GatewayStatus {
+  const installed = !!(config.openclawConfigPath && existsSync(config.openclawConfigPath))
+  let running = false
+  let port: number | undefined
+
+  if (installed) {
+    port = config.gatewayPort || 18789
+    // Check if gateway port is responding
+    try {
+      const { spawnSync } = require('node:child_process')
+      const result = spawnSync('curl', ['-sf', '--max-time', '2', `http://${config.gatewayHost || '127.0.0.1'}:${port}/health`], { stdio: 'pipe', timeout: 5000 })
+      running = result.status === 0
+    } catch { /* ignore */ }
+  }
+
+  return { type: 'openclaw', name: 'OpenClaw Gateway', installed, running, port }
+}
+
+/**
+ * GET /api/gateways/control — Get status of all gateways
+ */
+export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  const gateways: GatewayStatus[] = []
+  gateways.push(getHermesGatewayStatus())
+  gateways.push(getOpenClawGatewayStatus())
+
+  return NextResponse.json({ gateways })
+}
+
+/**
+ * POST /api/gateways/control — Start, stop, restart, or diagnose a gateway
+ * Body: { gateway: 'hermes' | 'openclaw', action: 'start' | 'stop' | 'restart' | 'diagnose' }
+ */
+export async function POST(request: NextRequest) {
+  const auth = requireRole(request, 'admin')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  try {
+    const body = await request.json()
+    const { gateway, action } = body as { gateway: GatewayType; action: GatewayAction }
+
+    if (!gateway || !action) {
+      return NextResponse.json({ error: 'gateway and action are required' }, { status: 400 })
+    }
+
+    if (!['hermes', 'openclaw'].includes(gateway)) {
+      return NextResponse.json({ error: 'Invalid gateway type' }, { status: 400 })
+    }
+
+    if (!['start', 'stop', 'restart', 'diagnose'].includes(action)) {
+      return NextResponse.json({ error: 'Invalid action' }, { status: 400 })
+    }
+
+    const { runCommand } = require('@/lib/command')
+
+    if (gateway === 'hermes') {
+      const bin = join(config.homeDir, '.local', 'bin', 'hermes')
+      const hermesBin = existsSync(bin) ? bin : 'hermes'
+
+      if (action === 'diagnose') {
+        const result = await runCommand(hermesBin, ['doctor'], { timeoutMs: 30_000 })
+        return NextResponse.json({
+          success: result.code === 0,
+          output: ((result.stdout || '') + '\n' + (result.stderr || '')).trim(),
+        })
+      }
+
+      // gateway start/stop/restart/status
+      const result = await runCommand(hermesBin, ['gateway', action], {
+        timeoutMs: 15_000,
+        env: { ...process.env, HERMES_NONINTERACTIVE: '1', CI: '1' },
+      })
+
+      logger.info({ gateway, action, code: result.code }, 'Gateway control action executed')
+
+      return NextResponse.json({
+        success: result.code === 0,
+        output: ((result.stdout || '') + '\n' + (result.stderr || '')).trim(),
+        status: getHermesGatewayStatus(),
+      })
+    }
+
+    if (gateway === 'openclaw') {
+      const openclawBin = config.openclawBin || 'openclaw'
+
+      if (action === 'diagnose') {
+        const result = await runCommand(openclawBin, ['doctor'], { timeoutMs: 30_000 })
+        return NextResponse.json({
+          success: result.code === 0,
+          output: ((result.stdout || '') + '\n' + (result.stderr || '')).trim(),
+        })
+      }
+
+      // OpenClaw gateway uses `openclaw gateway start/stop/restart`
+      const result = await runCommand(openclawBin, ['gateway', action], {
+        timeoutMs: 15_000,
+      })
+
+      logger.info({ gateway, action, code: result.code }, 'Gateway control action executed')
+
+      return NextResponse.json({
+        success: result.code === 0,
+        output: ((result.stdout || '') + '\n' + (result.stderr || '')).trim(),
+        status: getOpenClawGatewayStatus(),
+      })
+    }
+
+    return NextResponse.json({ error: 'Unknown gateway' }, { status: 400 })
+  } catch (error) {
+    logger.error({ err: error }, 'POST /api/gateways/control error')
+    return NextResponse.json({ error: 'Gateway control failed' }, { status: 500 })
+  }
+}
+
+export const dynamic = 'force-dynamic'

--- a/src/components/panels/gateway-control-panel.tsx
+++ b/src/components/panels/gateway-control-panel.tsx
@@ -1,0 +1,182 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { useTranslations } from 'next-intl'
+import { Button } from '@/components/ui/button'
+import { Loader } from '@/components/ui/loader'
+
+interface GatewayStatus {
+  type: string
+  name: string
+  installed: boolean
+  running: boolean
+  port?: number
+  pid?: number | null
+  version?: string | null
+  error?: string
+}
+
+export function GatewayControlPanel() {
+  const t = useTranslations('gatewayControl')
+  const [gateways, setGateways] = useState<GatewayStatus[]>([])
+  const [loading, setLoading] = useState(true)
+  const [actionInProgress, setActionInProgress] = useState<string | null>(null)
+  const [output, setOutput] = useState<{ gateway: string; text: string; ok: boolean } | null>(null)
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const res = await fetch('/api/gateways/control')
+      if (res.ok) {
+        const data = await res.json()
+        setGateways(data.gateways || [])
+      }
+    } catch { /* ignore */ }
+    finally { setLoading(false) }
+  }, [])
+
+  useEffect(() => { fetchStatus() }, [fetchStatus])
+
+  const handleAction = async (gateway: string, action: string) => {
+    const key = `${gateway}:${action}`
+    setActionInProgress(key)
+    setOutput(null)
+    try {
+      const res = await fetch('/api/gateways/control', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ gateway, action }),
+      })
+      const data = await res.json()
+      setOutput({ gateway, text: data.output || data.error || 'Done', ok: data.success !== false })
+      // Refresh status after action
+      await fetchStatus()
+    } catch (err) {
+      setOutput({ gateway, text: 'Action failed', ok: false })
+    } finally {
+      setActionInProgress(null)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="p-6">
+        <h2 className="text-lg font-semibold mb-4">{t('title')}</h2>
+        <div className="flex items-center justify-center py-12"><Loader /></div>
+      </div>
+    )
+  }
+
+  const installed = gateways.filter(g => g.installed)
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto">
+      <div className="mb-6">
+        <h2 className="text-lg font-semibold text-foreground">{t('title')}</h2>
+        <p className="text-sm text-muted-foreground mt-1">{t('description')}</p>
+      </div>
+
+      {installed.length === 0 ? (
+        <div className="text-center py-12 text-muted-foreground">
+          <p className="text-sm font-medium">{t('noGatewaysInstalled')}</p>
+          <p className="text-xs mt-1">{t('installHint')}</p>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {installed.map((gw) => {
+            const isActing = actionInProgress?.startsWith(`${gw.type}:`)
+            return (
+              <div
+                key={gw.type}
+                className={`rounded-lg border overflow-hidden transition-all ${
+                  gw.running
+                    ? 'border-emerald-500/30 bg-emerald-500/5'
+                    : 'border-border/30 bg-surface-1/10'
+                }`}
+              >
+                <div className="p-4">
+                  {/* Header */}
+                  <div className="flex items-center justify-between mb-3">
+                    <div className="flex items-center gap-3">
+                      <div className={`w-3 h-3 rounded-full ${gw.running ? 'bg-emerald-400 animate-pulse' : 'bg-muted-foreground/30'}`} />
+                      <div>
+                        <h3 className="text-sm font-semibold text-foreground">{gw.name}</h3>
+                        <p className="text-2xs text-muted-foreground">
+                          {gw.running ? t('running') : t('stopped')}
+                          {gw.pid && <span className="ml-1.5 font-mono">(PID {gw.pid})</span>}
+                          {gw.port && <span className="ml-1.5">port {gw.port}</span>}
+                        </p>
+                      </div>
+                    </div>
+
+                    <div className="flex items-center gap-1.5">
+                      {gw.running ? (
+                        <>
+                          <Button
+                            variant="ghost" size="sm"
+                            disabled={!!isActing}
+                            onClick={() => handleAction(gw.type, 'restart')}
+                            className="text-2xs h-7 px-2.5"
+                          >
+                            {actionInProgress === `${gw.type}:restart` ? t('restarting') : t('restart')}
+                          </Button>
+                          <Button
+                            variant="ghost" size="sm"
+                            disabled={!!isActing}
+                            onClick={() => handleAction(gw.type, 'stop')}
+                            className="text-2xs h-7 px-2.5 text-red-400 hover:text-red-300"
+                          >
+                            {actionInProgress === `${gw.type}:stop` ? t('stopping') : t('stop')}
+                          </Button>
+                        </>
+                      ) : (
+                        <Button
+                          variant="ghost" size="sm"
+                          disabled={!!isActing}
+                          onClick={() => handleAction(gw.type, 'start')}
+                          className="text-2xs h-7 px-2.5 text-emerald-400 hover:text-emerald-300"
+                        >
+                          {actionInProgress === `${gw.type}:start` ? t('starting') : t('start')}
+                        </Button>
+                      )}
+                      <Button
+                        variant="ghost" size="sm"
+                        disabled={!!isActing}
+                        onClick={() => handleAction(gw.type, 'diagnose')}
+                        className="text-2xs h-7 px-2.5"
+                      >
+                        {actionInProgress === `${gw.type}:diagnose` ? t('diagnosing') : t('diagnose')}
+                      </Button>
+                    </div>
+                  </div>
+
+                  {/* Output */}
+                  {output?.gateway === gw.type && (
+                    <div className={`mt-2 rounded border px-3 py-2 text-xs font-mono whitespace-pre-wrap max-h-48 overflow-y-auto ${
+                      output.ok ? 'border-border/20 bg-black/20 text-muted-foreground' : 'border-red-500/20 bg-red-500/5 text-red-400'
+                    }`}>
+                      {output.text}
+                    </div>
+                  )}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      {/* Not-installed gateways */}
+      {gateways.filter(g => !g.installed).length > 0 && (
+        <div className="mt-6 pt-4 border-t border-border/20">
+          <p className="text-xs text-muted-foreground mb-2">{t('notInstalled')}</p>
+          <div className="flex flex-wrap gap-2">
+            {gateways.filter(g => !g.installed).map(gw => (
+              <span key={gw.type} className="text-2xs px-2 py-1 rounded bg-surface-1/30 text-muted-foreground/50 border border-border/20">
+                {gw.name}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

The "Configure Gateway" button in the local mode banner was a dead end — it navigated to a panel that said "requires gateway connection." Now it opens a gateway control panel that works regardless of connection state.

### What changed

**New `POST /api/gateways/control` endpoint:**
- `{ gateway: 'hermes', action: 'start' }` — runs `hermes gateway start`
- `{ gateway: 'hermes', action: 'stop' }` — runs `hermes gateway stop`
- `{ gateway: 'hermes', action: 'restart' }` — runs `hermes gateway restart`
- `{ gateway: 'hermes', action: 'diagnose' }` — runs `hermes doctor`
- Same actions for `openclaw` gateway
- `GET` returns status of all installed gateways (running/stopped, PID, port)

**New `GatewayControlPanel` component:**
- Shows each installed gateway with running status, PID, port
- Start/Stop/Restart buttons with loading states
- Diagnose button runs health checks
- Command output displayed inline
- Graceful handling when no gateways installed

**Routing fix:**
- `gateways` panel in local mode now renders `GatewayControlPanel` instead of "requires gateway" error
- Gateway mode still shows `MultiGatewayPanel` (unchanged)

## Test plan
- [x] `pnpm typecheck` — passes
- [x] `pnpm test` — 892/892 pass
- [ ] Manual: Click "Configure Gateway" in banner → opens control panel
- [ ] Manual: Click "Start" on Hermes gateway → starts gateway process
- [ ] Manual: Click "Diagnose" → shows hermes doctor output
- [ ] Manual: Click "Stop" → stops gateway, status updates to "Stopped"