### PR TITLE
feat(gateway): add WebSocket gateway URL config on login page

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -69,7 +69,13 @@
     "creatingAdminAccount": "Creating admin account",
     "configuringSession": "Configuring session",
     "launchingDashboard": "Launching dashboard",
-    "usernameHint": "Lowercase letters, numbers, dots, hyphens, and underscores only"
+    "usernameHint": "Lowercase letters, numbers, dots, hyphens, and underscores only",
+    "gatewayUrl": "Gateway URL",
+    "gatewayUrlPlaceholder": "ws://127.0.0.1:18789",
+    "testConnection": "Test Connection",
+    "connectionSuccess": "Connection successful",
+    "connectionFailed": "Connection failed",
+    "advancedSettings": "Advanced Settings"
   },
   "nav": {
     "overview": "Overview",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -69,7 +69,13 @@
     "creatingAdminAccount": "正在创建管理员账户",
     "configuringSession": "正在配置会话",
     "launchingDashboard": "正在启动仪表板",
-    "usernameHint": "仅允许小写字母、数字、点、连字符和下划线"
+    "usernameHint": "仅允许小写字母、数字、点、连字符和下划线",
+    "gatewayUrl": "网关 URL",
+    "gatewayUrlPlaceholder": "ws://127.0.0.1:18789",
+    "testConnection": "测试连接",
+    "connectionSuccess": "连接成功",
+    "connectionFailed": "连接失败",
+    "advancedSettings": "高级设置"
   },
   "nav": {
     "overview": "概览",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -732,6 +732,7 @@
     "tabPipelines": "管道",
     "tabFleet": "集群",
     "selectAgent": "选择代理...",
+    "noAgentsRegistered": "暂无注册的代理",
     "commandPlaceholder": "向代理发送命令或消息...",
     "send": "发送",
     "noTemplates": "暂无工作流模板",

--- a/src/app/[[...panel]]/page.tsx
+++ b/src/app/[[...panel]]/page.tsx
@@ -38,6 +38,7 @@ import { ExecApprovalPanel } from '@/components/panels/exec-approval-panel'
 import { SystemMonitorPanel } from '@/components/panels/system-monitor-panel'
 import { ChatPagePanel } from '@/components/panels/chat-page-panel'
 import { ChatPanel } from '@/components/chat/chat-panel'
+import { STORAGE_GATEWAY_URL } from '@/lib/device-identity'
 import { getPluginPanel } from '@/lib/plugins'
 import { shouldRedirectDashboardToHttps } from '@/lib/browser-security'
 import { useTranslations } from 'next-intl'
@@ -175,9 +176,8 @@ export default function Home() {
       return
     }
 
-    const connectWithEnvFallback = () => {
+    const connectWithEnvFallback = (localGatewayUrl: string | null) => {
       // localStorage user choice takes priority over env vars
-      const localGatewayUrl = localStorage.getItem('mc-gateway-url')
       const explicitWsUrl = localGatewayUrl || process.env.NEXT_PUBLIC_GATEWAY_URL || ''
       const gatewayPort = process.env.NEXT_PUBLIC_GATEWAY_PORT || '18789'
       const gatewayHost = process.env.NEXT_PUBLIC_GATEWAY_HOST || window.location.hostname
@@ -266,9 +266,7 @@ export default function Home() {
     fetch('/api/status?action=capabilities')
       .then(res => res.ok ? res.json() : null)
       .then(async data => {
-        // User's explicit gateway URL choice (localStorage) takes PRIORITY.
-        // If user chose a URL from login page, always connect to it regardless of server's gateway flag.
-        const localGatewayUrl = localStorage.getItem('mc-gateway-url')
+        const localGatewayUrl = localStorage.getItem(STORAGE_GATEWAY_URL)
 
         if (data?.subscription) {
           setSubscription(data.subscription)
@@ -286,6 +284,9 @@ export default function Home() {
           if (data?.gateway === false) {
             setDashboardMode('full')
             setGatewayAvailable(true)
+          }
+          if (data?.claudeHome) {
+            setLocalSessionsAvailable(true)
           }
           setCapabilitiesChecked(true)
           markStep('capabilities')
@@ -317,7 +318,7 @@ export default function Home() {
         // No user choice + server gateway flag false → try primary gateway / env fallback
         const primaryConnect = await connectWithPrimaryGateway()
         if (!primaryConnect.connected && !primaryConnect.attempted) {
-          connectWithEnvFallback()
+          connectWithEnvFallback(null)
         }
         markStep('connect')
       })
@@ -326,7 +327,7 @@ export default function Home() {
         setCapabilitiesChecked(true)
         markStep('capabilities')
         markStep('connect')
-        connectWithEnvFallback()
+        connectWithEnvFallback(null)
       })
 
     // Check onboarding state

--- a/src/app/[[...panel]]/page.tsx
+++ b/src/app/[[...panel]]/page.tsx
@@ -281,10 +281,9 @@ export default function Home() {
         // User's explicit gateway URL choice (localStorage) takes PRIORITY over server's gateway flag.
         // If user chose a URL from login page, always connect to it.
         if (localGatewayUrl) {
-          if (data?.gateway === false) {
-            setDashboardMode('full')
-            setGatewayAvailable(true)
-          }
+          // User explicitly chose a gateway URL — always set full mode
+          setDashboardMode('full')
+          setGatewayAvailable(true)
           if (data?.claudeHome) {
             setLocalSessionsAvailable(true)
           }

--- a/src/app/[[...panel]]/page.tsx
+++ b/src/app/[[...panel]]/page.tsx
@@ -176,7 +176,9 @@ export default function Home() {
     }
 
     const connectWithEnvFallback = () => {
-      const explicitWsUrl = process.env.NEXT_PUBLIC_GATEWAY_URL || ''
+      // localStorage user choice takes priority over env vars
+      const localGatewayUrl = localStorage.getItem('mc-gateway-url')
+      const explicitWsUrl = localGatewayUrl || process.env.NEXT_PUBLIC_GATEWAY_URL || ''
       const gatewayPort = process.env.NEXT_PUBLIC_GATEWAY_PORT || '18789'
       const gatewayHost = process.env.NEXT_PUBLIC_GATEWAY_HOST || window.location.hostname
       const gatewayProto =
@@ -264,6 +266,10 @@ export default function Home() {
     fetch('/api/status?action=capabilities')
       .then(res => res.ok ? res.json() : null)
       .then(async data => {
+        // User's explicit gateway URL choice (localStorage) takes PRIORITY.
+        // If user chose a URL from login page, always connect to it regardless of server's gateway flag.
+        const localGatewayUrl = localStorage.getItem('mc-gateway-url')
+
         if (data?.subscription) {
           setSubscription(data.subscription)
         }
@@ -273,6 +279,22 @@ export default function Home() {
         if (data?.interfaceMode === 'essential' || data?.interfaceMode === 'full') {
           setInterfaceMode(data.interfaceMode)
         }
+
+        // User's explicit gateway URL choice (localStorage) takes PRIORITY over server's gateway flag.
+        // If user chose a URL from login page, always connect to it.
+        if (localGatewayUrl) {
+          if (data?.gateway === false) {
+            setDashboardMode('full')
+            setGatewayAvailable(true)
+          }
+          setCapabilitiesChecked(true)
+          markStep('capabilities')
+          connect(localGatewayUrl)
+          markStep('connect')
+          return
+        }
+
+        // No user-chosen URL — use server's gateway flag to decide
         if (data && data.gateway === false) {
           setDashboardMode('local')
           setGatewayAvailable(false)
@@ -292,6 +314,7 @@ export default function Home() {
         setCapabilitiesChecked(true)
         markStep('capabilities')
 
+        // No user choice + server gateway flag false → try primary gateway / env fallback
         const primaryConnect = await connectWithPrimaryGateway()
         if (!primaryConnect.connected && !primaryConnect.attempted) {
           connectWithEnvFallback()

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image'
 import { useTranslations } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import { LanguageSwitcherSelect } from '@/components/ui/language-switcher'
+import { STORAGE_GATEWAY_URL } from '@/lib/device-identity'
 
 interface GoogleCredentialResponse {
   credential?: string
@@ -66,7 +67,7 @@ const GATEWAY_URL_PRESETS = [
   'ws://localhost:18789',
 ]
 
-const LS_GATEWAY_URL_KEY = 'mc-gateway-url'
+const GATEWAY_CONNECTION_TIMEOUT_MS = 5000
 
 type ConnectionStatus = 'idle' | 'testing' | 'success' | 'failed'
 
@@ -92,7 +93,7 @@ export default function LoginPage() {
 
   // Initialize gateway URL from localStorage on mount
   useEffect(() => {
-    const saved = localStorage.getItem(LS_GATEWAY_URL_KEY)
+    const saved = localStorage.getItem(STORAGE_GATEWAY_URL)
     if (saved) {
       if (GATEWAY_URL_PRESETS.includes(saved)) {
         setGatewayPreset(saved)
@@ -110,7 +111,7 @@ export default function LoginPage() {
   const handleGatewayUrlChange = (value: string) => {
     setGatewayPreset(value)
     if (value !== 'custom') {
-      localStorage.setItem(LS_GATEWAY_URL_KEY, value)
+      localStorage.setItem(STORAGE_GATEWAY_URL, value)
       setConnectionStatus('idle')
     }
   }
@@ -119,12 +120,12 @@ export default function LoginPage() {
     setGatewayCustom(value)
     const trimmed = value.trim()
     if (trimmed) {
-      localStorage.setItem(LS_GATEWAY_URL_KEY, trimmed)
+      localStorage.setItem(STORAGE_GATEWAY_URL, trimmed)
       setConnectionStatus('idle')
     }
   }
 
-  const handleTestConnection = async () => {
+  const handleTestConnection = () => {
     const url = getEffectiveGatewayUrl()
     if (!url) return
     setConnectionStatus('testing')
@@ -138,7 +139,7 @@ export default function LoginPage() {
           setConnectionStatus('failed')
           setConnectionError('Connection timed out')
           resolve()
-        }, 5000)
+        }, GATEWAY_CONNECTION_TIMEOUT_MS)
 
         ws.onopen = () => {
           clearTimeout(timeout)
@@ -149,6 +150,7 @@ export default function LoginPage() {
 
         ws.onerror = () => {
           clearTimeout(timeout)
+          ws.close()
           setConnectionStatus('failed')
           setConnectionError('Could not connect')
           resolve()

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -64,7 +64,9 @@ function GoogleIcon({ className }: { className?: string }) {
 
 const GATEWAY_URL_PRESETS = [
   'ws://127.0.0.1:18789',
+  'wss://127.0.0.1:18789',
   'ws://localhost:18789',
+  'wss://localhost:18789',
 ]
 
 const GATEWAY_CONNECTION_TIMEOUT_MS = 5000

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -61,6 +61,15 @@ function GoogleIcon({ className }: { className?: string }) {
   )
 }
 
+const GATEWAY_URL_PRESETS = [
+  'ws://127.0.0.1:18789',
+  'ws://localhost:18789',
+]
+
+const LS_GATEWAY_URL_KEY = 'mc-gateway-url'
+
+type ConnectionStatus = 'idle' | 'testing' | 'success' | 'failed'
+
 export default function LoginPage() {
   const t = useTranslations('auth')
   const tc = useTranslations('common')
@@ -73,6 +82,84 @@ export default function LoginPage() {
   const [googleLoading, setGoogleLoading] = useState(false)
   const [googleReady, setGoogleReady] = useState(false)
   const googleCallbackRef = useRef<((response: GoogleCredentialResponse) => void) | null>(null)
+
+  // Advanced settings state
+  const [advancedOpen, setAdvancedOpen] = useState(false)
+  const [gatewayPreset, setGatewayPreset] = useState<string>('ws://127.0.0.1:18789')
+  const [gatewayCustom, setGatewayCustom] = useState('')
+  const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('idle')
+  const [connectionError, setConnectionError] = useState('')
+
+  // Initialize gateway URL from localStorage on mount
+  useEffect(() => {
+    const saved = localStorage.getItem(LS_GATEWAY_URL_KEY)
+    if (saved) {
+      if (GATEWAY_URL_PRESETS.includes(saved)) {
+        setGatewayPreset(saved)
+      } else {
+        setGatewayPreset('custom')
+        setGatewayCustom(saved)
+      }
+    }
+  }, [])
+
+  const getEffectiveGatewayUrl = (): string => {
+    return gatewayPreset === 'custom' ? gatewayCustom.trim() : gatewayPreset
+  }
+
+  const handleGatewayUrlChange = (value: string) => {
+    setGatewayPreset(value)
+    if (value !== 'custom') {
+      localStorage.setItem(LS_GATEWAY_URL_KEY, value)
+      setConnectionStatus('idle')
+    }
+  }
+
+  const handleGatewayCustomChange = (value: string) => {
+    setGatewayCustom(value)
+    const trimmed = value.trim()
+    if (trimmed) {
+      localStorage.setItem(LS_GATEWAY_URL_KEY, trimmed)
+      setConnectionStatus('idle')
+    }
+  }
+
+  const handleTestConnection = async () => {
+    const url = getEffectiveGatewayUrl()
+    if (!url) return
+    setConnectionStatus('testing')
+    setConnectionError('')
+
+    return new Promise<void>((resolve) => {
+      try {
+        const ws = new WebSocket(url)
+        const timeout = setTimeout(() => {
+          ws.close()
+          setConnectionStatus('failed')
+          setConnectionError('Connection timed out')
+          resolve()
+        }, 5000)
+
+        ws.onopen = () => {
+          clearTimeout(timeout)
+          ws.close()
+          setConnectionStatus('success')
+          resolve()
+        }
+
+        ws.onerror = () => {
+          clearTimeout(timeout)
+          setConnectionStatus('failed')
+          setConnectionError('Could not connect')
+          resolve()
+        }
+      } catch {
+        setConnectionStatus('failed')
+        setConnectionError('Invalid URL')
+        resolve()
+      }
+    })
+  }
 
   const googleClientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID || ''
 
@@ -263,6 +350,100 @@ export default function LoginPage() {
             {error}
           </div>
         )}
+
+        {/* Advanced Settings — WebSocket gateway URL configuration */}
+        <div className="mb-4 rounded-lg border border-border overflow-hidden">
+          <button
+            type="button"
+            onClick={() => setAdvancedOpen(o => !o)}
+            className="w-full px-3 py-2 flex items-center justify-between text-sm text-muted-foreground hover:text-foreground hover:bg-secondary/50 transition-colors"
+          >
+            <span>{t('advancedSettings')}</span>
+            <svg
+              className={`w-4 h-4 transition-transform ${advancedOpen ? 'rotate-180' : ''}`}
+              viewBox="0 0 16 16"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M4 6l4 4 4-4" />
+            </svg>
+          </button>
+
+          {advancedOpen && (
+            <div className="px-3 pb-3 pt-1 space-y-3 border-t border-border">
+              <div>
+                <label htmlFor="gateway-url" className="block text-sm font-medium text-foreground mb-1.5">
+                  {t('gatewayUrl')}
+                </label>
+                <div className="flex gap-2">
+                  <select
+                    id="gateway-url"
+                    value={gatewayPreset}
+                    onChange={e => handleGatewayUrlChange(e.target.value)}
+                    className="flex-1 h-10 px-3 rounded-lg bg-secondary border border-border text-foreground text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-smooth appearance-none cursor-pointer"
+                  >
+                    {GATEWAY_URL_PRESETS.map(url => (
+                      <option key={url} value={url}>{url}</option>
+                    ))}
+                    <option value="custom">Custom</option>
+                  </select>
+                </div>
+                {gatewayPreset === 'custom' && (
+                  <input
+                    type="text"
+                    value={gatewayCustom}
+                    onChange={e => handleGatewayCustomChange(e.target.value)}
+                    placeholder={t('gatewayUrlPlaceholder')}
+                    className="mt-2 w-full h-10 px-3 rounded-lg bg-secondary border border-border text-foreground text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-smooth"
+                  />
+                )}
+              </div>
+
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={handleTestConnection}
+                  disabled={connectionStatus === 'testing' || !getEffectiveGatewayUrl()}
+                  className="h-9 px-3 rounded-lg bg-secondary border border-border text-foreground text-sm hover:bg-muted-foreground/10 focus:outline-none focus:ring-2 focus:ring-primary/50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1.5"
+                >
+                  {connectionStatus === 'testing' ? (
+                    <>
+                      <div className="w-3.5 h-3.5 border-2 border-muted-foreground/40 border-t-muted-foreground rounded-full animate-spin" />
+                      {t('testConnection')}...
+                    </>
+                  ) : (
+                    <>
+                      <svg className="w-3.5 h-3.5" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M13.5 2.5L2.5 13.5M13.5 2.5l-4 4m4-4l-4-4m4 4l-4 4" />
+                      </svg>
+                      {t('testConnection')}
+                    </>
+                  )}
+                </button>
+
+                {connectionStatus === 'success' && (
+                  <span className="text-xs text-green-500 flex items-center gap-1">
+                    <svg className="w-3.5 h-3.5" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M13 3L6 10l-3-3" />
+                    </svg>
+                    {t('connectionSuccess')}
+                  </span>
+                )}
+                {connectionStatus === 'failed' && (
+                  <span className="text-xs text-destructive flex items-center gap-1">
+                    <svg className="w-3.5 h-3.5" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M12 4L4 12M4 4l8 8" />
+                    </svg>
+                    {t('connectionFailed')}{connectionError ? `: ${connectionError}` : ''}
+                  </span>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
 
         {/* Google Sign-In button — shown only when client ID is configured */}
         {googleClientId && (

--- a/src/lib/device-identity.ts
+++ b/src/lib/device-identity.ts
@@ -19,6 +19,9 @@ const STORAGE_DEVICE_ID = 'mc-device-id'
 const STORAGE_PUBKEY = 'mc-device-pubkey'
 const STORAGE_PRIVKEY = 'mc-device-privkey'
 const STORAGE_DEVICE_TOKEN = 'mc-device-token'
+const STORAGE_GATEWAY_URL = 'mc-gateway-url'
+
+export { STORAGE_GATEWAY_URL }
 
 export interface DeviceIdentity {
   deviceId: string


### PR DESCRIPTION
Body:

  ## Summary

  Adds configurable WebSocket gateway URL support to the Mission Control dashboard. This solves the scenario where
  Mission Control and OpenClaw run on the same machine, but Mission Control needs to be accessed by other machines on
  the LAN — the default WebSocket auto-detection may connect to the local machine's OpenClaw instead of the intended
  gateway. Users can now specify a custom gateway URL from the login page, which takes priority over server-side gateway
   flags and environment variables.

  ## Changes

  - `src/app/login/page.tsx` — adds gateway URL selector with presets, custom input, and connection test button with
  status feedback
  - `src/app/[[...panel]]/page.tsx` — respects user's localStorage gateway URL choice with highest priority over server
  flags and env vars
  - `src/lib/device-identity.ts` — exports `STORAGE_GATEWAY_URL` constant for localStorage key
  - `messages/en.json` / `messages/zh.json` — adds i18n strings for gateway config UI and missing `noAgentsRegistered`
  Chinese translation

  ## Test plan

  - [ ] Open login page and verify "Advanced Settings" section is collapsible
  - [ ] Select a gateway preset and verify it saves to localStorage
  - [ ] Enter custom URL and verify it persists
  - [ ] Test connection button — verify it shows success/failure
  - [ ] After login, verify dashboard connects to the configured gateway URL
  - [ ] Verify Chinese translation displays correctly for new strings