### PR TITLE
fix: prevent X-Forwarded-For IP spoofing in proxy auth

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -424,9 +424,19 @@ export function getUserFromRequest(request: Request): User | null {
   if (proxyAuthHeader) {
     const trustedIps = PROXY_AUTH_TRUSTED_IPS
     if (trustedIps.size > 0) {
-      const clientIp = request.headers.get('x-real-ip')?.trim()
-        || request.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
-        || ''
+      // Walk X-Forwarded-For right-to-left, skipping trusted proxy IPs,
+      // to find the actual client IP (prevents spoofing via prepended headers).
+      const xff = request.headers.get('x-forwarded-for')
+      let clientIp = ''
+      if (xff) {
+        const ips = xff.split(',').map(s => s.trim())
+        for (let i = ips.length - 1; i >= 0; i--) {
+          if (!trustedIps.has(ips[i])) { clientIp = ips[i]; break }
+        }
+      }
+      if (!clientIp) {
+        clientIp = request.headers.get('x-real-ip')?.trim() || ''
+      }
       if (!trustedIps.has(clientIp)) {
         // Request not from trusted proxy — ignore the proxy auth header
       } else {


### PR DESCRIPTION
## Summary

- **Fix X-Forwarded-For IP spoofing** in proxy auth (`getUserFromRequest`). The current code takes the **first (leftmost)** IP from `X-Forwarded-For`, which is attacker-controlled. An adversary can prepend a trusted proxy IP to bypass the `MC_PROXY_AUTH_TRUSTED_IPS` gate and impersonate any user, including admin.
- Walk the `X-Forwarded-For` chain **right-to-left**, skipping known trusted proxy IPs, to find the actual client IP — consistent with the approach already used in `extractClientIp()` (`src/lib/rate-limit.ts`).

## Security impact

Without this fix, when `MC_PROXY_AUTH_TRUSTED_IPS` is configured, any client can send:
```
X-Forwarded-For: <trusted-proxy-ip>, <real-attacker-ip>
```
and the code picks `<trusted-proxy-ip>` as `clientIp`, passing the `trustedIps.has(clientIp)` check. The attacker then controls the proxy auth header and assumes any identity.

## Regression introduced in

PR #462 (`fix: security hardening from audit`) added `MC_PROXY_AUTH_TRUSTED_IPS` but used `split(',')[0]` (leftmost) instead of walking right-to-left.

## Test plan

- [x] `pnpm typecheck` passes
- [ ] Verify with `X-Forwarded-For: <trusted>, <attacker>` — should reject
- [ ] Verify with `X-Forwarded-For: <attacker>, <trusted>` — should reject (attacker is rightmost untrusted)
- [ ] Verify legitimate proxy chain still works