### PR TITLE
fix: require MC_PROXY_AUTH_TRUSTED_IPS for proxy auth

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -437,12 +437,8 @@ export function getUserFromRequest(request: Request): User | null {
         }
       }
     } else {
-      // No trusted IPs configured — log warning and still allow (backward compat)
-      const proxyUsername = (request.headers.get(proxyAuthHeader) || '').trim()
-      if (proxyUsername) {
-        const user = resolveOrProvisionProxyUser(proxyUsername)
-        if (user) return { ...user, agent_name: agentName }
-      }
+      // No trusted IPs configured — refuse proxy auth to prevent header spoofing
+      try { logSecurityEvent({ event_type: 'proxy_auth_rejected', severity: 'warning', source: 'auth', detail: JSON.stringify({ reason: 'MC_PROXY_AUTH_TRUSTED_IPS not configured — proxy auth disabled' }), workspace_id: 1, tenant_id: 1 }) } catch {}
     }
   }
 


### PR DESCRIPTION
## Summary

- Remove backward-compat fallback that allowed proxy auth **without** `MC_PROXY_AUTH_TRUSTED_IPS` configured. When the env var is empty, any client reaching MC directly can inject the `MC_PROXY_AUTH_HEADER` and impersonate any user, including admin.
- Now proxy auth is silently ignored when trusted IPs are not configured, and a security event is logged to surface the misconfiguration.

## Breaking change

Deployments using `MC_PROXY_AUTH_HEADER` **without** `MC_PROXY_AUTH_TRUSTED_IPS` will stop authenticating via proxy header. Fix: set `MC_PROXY_AUTH_TRUSTED_IPS` to the IP(s) of the reverse proxy (e.g. `127.0.0.1`, `172.17.0.1`).

## Security impact

Without this fix, the comment on line 420-422 already warns about the risk but the code doesn't enforce it:
```
// SECURITY: MC_PROXY_AUTH_TRUSTED_IPS must be set to restrict which IPs can send
// the proxy auth header. Without it, any client reaching MC directly could spoof
// the header and impersonate any user.
```

## Related

- Companion to #568 (X-Forwarded-For IP spoofing fix)
- Regression from #462 (`fix: security hardening from audit`)

## Test plan

- [x] `pnpm quality:gate` — 870 unit tests pass, 495/510 e2e pass (15 pre-existing failures on `main`)
- [ ] Verify proxy auth rejected when `MC_PROXY_AUTH_TRUSTED_IPS` is empty
- [ ] Verify proxy auth works when `MC_PROXY_AUTH_TRUSTED_IPS` is set correctly
- [ ] Verify security event logged on rejection