### PR TITLE
fix: harden proxy auth — prevent XFF spoofing and require trusted IPs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,7 @@ MC_ALLOWED_HOSTS=localhost,127.0.0.1
 # Trusted reverse proxy / header authentication
 # MC_PROXY_AUTH_HEADER=X-User-Email
 # MC_PROXY_AUTH_DEFAULT_ROLE=viewer
+# MC_PROXY_AUTH_TRUSTED_IPS=127.0.0.1,::1    # REQUIRED when MC_PROXY_AUTH_HEADER is set
 
 # Google OAuth (optional)
 GOOGLE_CLIENT_ID=

--- a/src/lib/__tests__/request.test.ts
+++ b/src/lib/__tests__/request.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { extractClientIpFromTrusted } from '@/lib/request'
+
+function makeRequest(headers: Record<string, string> = {}): Request {
+  return new Request('http://localhost/api/test', {
+    headers: new Headers(headers),
+  })
+}
+
+describe('extractClientIpFromTrusted', () => {
+  const trusted = new Set(['10.0.0.1', '10.0.0.2'])
+
+  it('returns rightmost untrusted IP from X-Forwarded-For', () => {
+    const req = makeRequest({ 'x-forwarded-for': '203.0.113.50, 10.0.0.1' })
+    expect(extractClientIpFromTrusted(req, trusted)).toBe('203.0.113.50')
+  })
+
+  it('skips multiple trusted proxies at the end of the chain', () => {
+    const req = makeRequest({ 'x-forwarded-for': '203.0.113.50, 10.0.0.2, 10.0.0.1' })
+    expect(extractClientIpFromTrusted(req, trusted)).toBe('203.0.113.50')
+  })
+
+  it('returns rightmost untrusted when attacker prepends a trusted IP', () => {
+    // Attack: client injects trusted IP at the start to spoof identity
+    const req = makeRequest({ 'x-forwarded-for': '10.0.0.1, 198.51.100.99, 10.0.0.2' })
+    // Should return 198.51.100.99 (rightmost untrusted), NOT 10.0.0.1 (leftmost)
+    expect(extractClientIpFromTrusted(req, trusted)).toBe('198.51.100.99')
+  })
+
+  it('falls back to x-real-ip when all XFF IPs are trusted', () => {
+    const req = makeRequest({
+      'x-forwarded-for': '10.0.0.1, 10.0.0.2',
+      'x-real-ip': '192.168.1.100',
+    })
+    expect(extractClientIpFromTrusted(req, trusted)).toBe('192.168.1.100')
+  })
+
+  it('falls back to x-real-ip when no X-Forwarded-For header', () => {
+    const req = makeRequest({ 'x-real-ip': '192.168.1.100' })
+    expect(extractClientIpFromTrusted(req, trusted)).toBe('192.168.1.100')
+  })
+
+  it('returns fallback when no XFF and no x-real-ip', () => {
+    const req = makeRequest({})
+    expect(extractClientIpFromTrusted(req, trusted)).toBe('unknown')
+  })
+
+  it('returns custom fallback when provided', () => {
+    const req = makeRequest({})
+    expect(extractClientIpFromTrusted(req, trusted, '')).toBe('')
+  })
+
+  it('ignores XFF when trusted set is empty', () => {
+    const req = makeRequest({
+      'x-forwarded-for': '203.0.113.50, 10.0.0.1',
+      'x-real-ip': '172.16.0.1',
+    })
+    expect(extractClientIpFromTrusted(req, new Set(), '')).toBe('172.16.0.1')
+  })
+
+  it('trims whitespace from XFF entries', () => {
+    const req = makeRequest({ 'x-forwarded-for': ' 203.0.113.50 , 10.0.0.1 ' })
+    expect(extractClientIpFromTrusted(req, trusted)).toBe('203.0.113.50')
+  })
+
+  it('handles single IP in XFF that is untrusted', () => {
+    const req = makeRequest({ 'x-forwarded-for': '203.0.113.50' })
+    expect(extractClientIpFromTrusted(req, trusted)).toBe('203.0.113.50')
+  })
+
+  it('handles single IP in XFF that is trusted', () => {
+    const req = makeRequest({ 'x-forwarded-for': '10.0.0.1' })
+    expect(extractClientIpFromTrusted(req, trusted)).toBe('unknown')
+  })
+})

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,12 +2,33 @@ import { createHash, randomBytes, timingSafeEqual } from 'crypto'
 import { getDatabase } from './db'
 import { hashPassword, verifyPassword, verifyPasswordWithRehashCheck } from './password'
 import { logSecurityEvent } from './security-events'
+import { extractClientIpFromTrusted } from './request'
 import { parseMcSessionCookieHeader } from './session-cookie'
 
 // Trusted IPs for proxy auth header (comma-separated)
 const PROXY_AUTH_TRUSTED_IPS = new Set(
   (process.env.MC_PROXY_AUTH_TRUSTED_IPS || '').split(',').map(s => s.trim()).filter(Boolean)
 )
+
+// Log once at startup if proxy auth is misconfigured.
+// Deferred to avoid DB access during module initialization.
+let _proxyAuthMisconfigWarned = false
+function warnProxyAuthMisconfigOnce(): void {
+  if (_proxyAuthMisconfigWarned) return
+  _proxyAuthMisconfigWarned = true
+  try {
+    logSecurityEvent({
+      event_type: 'proxy_auth_misconfigured',
+      severity: 'critical',
+      source: 'auth',
+      detail: JSON.stringify({
+        reason: 'MC_PROXY_AUTH_HEADER is set but MC_PROXY_AUTH_TRUSTED_IPS is empty — proxy auth disabled',
+      }),
+      workspace_id: 1,
+      tenant_id: 1,
+    })
+  } catch {}
+}
 
 // Plugin hook: extensions can register a custom API key resolver without modifying this file.
 type AuthResolverHook = (apiKey: string, agentName: string | null) => User | null
@@ -417,31 +438,20 @@ export function getUserFromRequest(request: Request): User | null {
   // When the gateway has already authenticated the user and injects their username
   // as a trusted header (e.g. X-Auth-Username from Envoy OIDC claimToHeaders),
   // skip the local login form entirely.
-  // SECURITY: MC_PROXY_AUTH_TRUSTED_IPS must be set to restrict which IPs can send
-  // the proxy auth header. Without it, any client reaching MC directly could spoof
-  // the header and impersonate any user.
+  // Requires MC_PROXY_AUTH_TRUSTED_IPS — without it, proxy auth is disabled
+  // and a critical security event is logged on the first request.
   const proxyAuthHeader = (process.env.MC_PROXY_AUTH_HEADER || '').trim()
   if (proxyAuthHeader) {
-    const trustedIps = PROXY_AUTH_TRUSTED_IPS
-    if (trustedIps.size > 0) {
-      const clientIp = request.headers.get('x-real-ip')?.trim()
-        || request.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
-        || ''
-      if (!trustedIps.has(clientIp)) {
-        // Request not from trusted proxy — ignore the proxy auth header
-      } else {
+    if (PROXY_AUTH_TRUSTED_IPS.size === 0) {
+      warnProxyAuthMisconfigOnce()
+    } else {
+      const clientIp = extractClientIpFromTrusted(request, PROXY_AUTH_TRUSTED_IPS, '')
+      if (clientIp && PROXY_AUTH_TRUSTED_IPS.has(clientIp)) {
         const proxyUsername = (request.headers.get(proxyAuthHeader) || '').trim()
         if (proxyUsername) {
           const user = resolveOrProvisionProxyUser(proxyUsername)
           if (user) return { ...user, agent_name: agentName }
         }
-      }
-    } else {
-      // No trusted IPs configured — log warning and still allow (backward compat)
-      const proxyUsername = (request.headers.get(proxyAuthHeader) || '').trim()
-      if (proxyUsername) {
-        const user = resolveOrProvisionProxyUser(proxyUsername)
-        if (user) return { ...user, agent_name: agentName }
       }
     }
   }

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import { extractClientIpFromTrusted } from './request'
 import { logSecurityEvent } from './security-events'
 
 interface RateLimitEntry {
@@ -36,24 +37,14 @@ const TRUSTED_PROXIES = new Set(
   (process.env.MC_TRUSTED_PROXIES || '').split(',').map(s => s.trim()).filter(Boolean)
 )
 
+// Re-export for external consumers
+export { extractClientIpFromTrusted } from './request'
+
 /**
- * Extract client IP from request headers.
- * When MC_TRUSTED_PROXIES is set, takes the rightmost untrusted IP from x-forwarded-for.
- * Without trusted proxies, falls back to x-real-ip or 'unknown'.
+ * Extract client IP using the global MC_TRUSTED_PROXIES set.
  */
 export function extractClientIp(request: Request): string {
-  const xff = request.headers.get('x-forwarded-for')
-
-  if (xff && TRUSTED_PROXIES.size > 0) {
-    // Walk the chain from right to left, skip trusted proxies, return first untrusted
-    const ips = xff.split(',').map(s => s.trim())
-    for (let i = ips.length - 1; i >= 0; i--) {
-      if (!TRUSTED_PROXIES.has(ips[i])) return ips[i]
-    }
-  }
-
-  // Fallback: x-real-ip (set by nginx/caddy) or 'unknown'
-  return request.headers.get('x-real-ip')?.trim() || 'unknown'
+  return extractClientIpFromTrusted(request, TRUSTED_PROXIES)
 }
 
 export function createRateLimiter(options: RateLimiterOptions) {

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -1,0 +1,33 @@
+/**
+ * HTTP request utilities — header parsing, client IP extraction.
+ *
+ * SECURITY NOTE on X-Forwarded-For and X-Real-IP:
+ * Both headers are client-settable. They are only trustworthy when injected
+ * by a reverse proxy (nginx, caddy, envoy) that overwrites or appends to them.
+ * The rightmost-walk algorithm assumes the trusted proxy is the last hop that
+ * appended to XFF — any IP to the left of a trusted proxy is untrusted.
+ */
+
+/**
+ * Extract the rightmost untrusted client IP from X-Forwarded-For.
+ *
+ * Walks the XFF chain right-to-left, skipping IPs present in `trusted`.
+ * Returns the first (rightmost) IP not in the trusted set.
+ *
+ * Falls back to X-Real-IP (only meaningful when set by a trusted proxy,
+ * e.g. nginx proxy_set_header X-Real-IP $remote_addr), then `fallback`.
+ */
+export function extractClientIpFromTrusted(
+  request: Request,
+  trusted: Set<string>,
+  fallback = 'unknown',
+): string {
+  const xff = request.headers.get('x-forwarded-for')
+  if (xff && trusted.size > 0) {
+    const ips = xff.split(',').map(s => s.trim())
+    for (let i = ips.length - 1; i >= 0; i--) {
+      if (!trusted.has(ips[i])) return ips[i]
+    }
+  }
+  return request.headers.get('x-real-ip')?.trim() || fallback
+}


### PR DESCRIPTION
## Summary

Fixes two vulnerabilities in proxy auth introduced by #462:

- **X-Forwarded-For IP spoofing**: `clientIp` extraction used `split(',')[0]` — the leftmost IP, which is attacker-controlled. A malicious client can prepend a trusted proxy IP to bypass `MC_PROXY_AUTH_TRUSTED_IPS` and impersonate any user including admin. Now walks the chain **right-to-left**, skipping trusted IPs, consistent with `extractClientIp()` in the rate-limiter.

- **Missing trusted IPs enforcement**: When `MC_PROXY_AUTH_TRUSTED_IPS` was empty, proxy auth accepted the header from any client (backward-compat fallback). Now proxy auth is disabled without explicit trusted IP configuration. A `critical` security event is logged **once** on the first request to surface the misconfiguration (deferred — no DB access at module load).

## Changes

| File | Change |
|------|--------|
| `src/lib/request.ts` | **New** — `extractClientIpFromTrusted(request, trustedSet, fallback)` shared utility with security documentation on XFF/X-Real-IP trust model |
| `src/lib/rate-limit.ts` | Delegate to shared utility, re-export for compat |
| `src/lib/auth.ts` | Use shared utility. Replace backward-compat fallback with `warnProxyAuthMisconfigOnce()` (lazy, fires once). Update comments to match new behavior. |
| `.env.example` | Document `MC_PROXY_AUTH_TRUSTED_IPS` as required |
| `src/lib/__tests__/request.test.ts` | **New** — 11 unit tests covering rightmost walk, spoofing, all-trusted fallback, whitespace, empty set |

Net: **+143 −33 lines**.

## Breaking change

Deployments using `MC_PROXY_AUTH_HEADER` **without** `MC_PROXY_AUTH_TRUSTED_IPS` will stop authenticating via proxy header. Fix: set `MC_PROXY_AUTH_TRUSTED_IPS` to the reverse proxy IP(s) (e.g. `127.0.0.1,::1`).

## Supersedes

Closes #568, closes #569 (consolidated into this single PR).

## Test plan

- [x] `pnpm quality:gate` — 903 unit tests (11 new), 495/510 e2e (15 pre-existing failures on `main`)
- [x] `pnpm typecheck` clean
- [x] Unit tests cover: rightmost walk, attacker-prepended trusted IP, all-trusted fallback, empty set, whitespace trimming
- [ ] Integration: verify proxy auth rejected when `MC_PROXY_AUTH_TRUSTED_IPS` is empty
- [ ] Integration: verify legitimate proxy chain with correct `MC_PROXY_AUTH_TRUSTED_IPS`
- [ ] Integration: verify security event logged once on misconfiguration