### PR TITLE
fix: prevent injection in shell scripts — sed, jq, and JSON construction

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -44,6 +44,20 @@ die()   { err "$*"; exit 1; }
 
 command_exists() { command -v "$1" &>/dev/null; }
 
+# Escape sed replacement metacharacters (|, &, \) in a value.
+# Does not handle newlines — callers must ensure single-line input.
+sed_escape() { printf '%s' "$1" | sed 's/[|&\\]/\\&/g'; }
+
+# Portable in-place sed (macOS requires -i '', Linux uses -i)
+portable_sed() {
+  local pattern="$1" file="$2"
+  if [[ "$(uname)" == "Darwin" ]]; then
+    sed -i '' "$pattern" "$file"
+  else
+    sed -i "$pattern" "$file"
+  fi
+}
+
 detect_os() {
   local os arch
   os="$(uname -s)"
@@ -151,21 +165,13 @@ setup_env() {
 
   # Set the port if non-default
   if [[ "$MC_PORT" != "3000" ]]; then
-    if [[ "$(uname)" == "Darwin" ]]; then
-      sed -i '' "s|^# PORT=3000|PORT=$MC_PORT|" "$INSTALL_DIR/.env"
-    else
-      sed -i "s|^# PORT=3000|PORT=$MC_PORT|" "$INSTALL_DIR/.env"
-    fi
+    portable_sed "s|^# PORT=3000|PORT=$(sed_escape "$MC_PORT")|" "$INSTALL_DIR/.env"
   fi
 
   # Auto-detect and write OpenClaw home directory into .env
   local oc_home="${OPENCLAW_HOME:-$HOME/.openclaw}"
   if [[ -d "$oc_home" ]]; then
-    if [[ "$(uname)" == "Darwin" ]]; then
-      sed -i '' "s|^OPENCLAW_HOME=.*|OPENCLAW_HOME=$oc_home|" "$INSTALL_DIR/.env"
-    else
-      sed -i "s|^OPENCLAW_HOME=.*|OPENCLAW_HOME=$oc_home|" "$INSTALL_DIR/.env"
-    fi
+    portable_sed "s|^OPENCLAW_HOME=.*|OPENCLAW_HOME=$(sed_escape "$oc_home")|" "$INSTALL_DIR/.env"
     info "Set OPENCLAW_HOME=$oc_home in .env"
   fi
 
@@ -185,11 +191,7 @@ setup_env() {
       fi
     fi
     if [[ -n "$gw_host" && "$gw_host" != "127.0.0.1" ]]; then
-      if [[ "$(uname)" == "Darwin" ]]; then
-        sed -i '' "s|^OPENCLAW_GATEWAY_HOST=.*|OPENCLAW_GATEWAY_HOST=$gw_host|" "$INSTALL_DIR/.env"
-      else
-        sed -i "s|^OPENCLAW_GATEWAY_HOST=.*|OPENCLAW_GATEWAY_HOST=$gw_host|" "$INSTALL_DIR/.env"
-      fi
+      portable_sed "s|^OPENCLAW_GATEWAY_HOST=.*|OPENCLAW_GATEWAY_HOST=$(sed_escape "$gw_host")|" "$INSTALL_DIR/.env"
       info "Set OPENCLAW_GATEWAY_HOST=$gw_host in .env (Docker host IP)"
       info "  If your gateway runs in a Docker container, update OPENCLAW_GATEWAY_HOST"
       info "  to the container name and add it to the mc-net network."

--- a/scripts/agent-heartbeat.sh
+++ b/scripts/agent-heartbeat.sh
@@ -92,7 +92,7 @@ get_agent_session_key() {
     
     # Query agents API to get session key
     local agent_data
-    agent_data=$(curl -s "$MISSION_CONTROL_URL/api/agents?limit=100" 2>/dev/null | jq -r ".agents[] | select(.name == \"$agent_name\") | .session_key" 2>/dev/null || echo "")
+    agent_data=$(curl -s "$MISSION_CONTROL_URL/api/agents?limit=100" 2>/dev/null | jq -r --arg name "$agent_name" '.agents[] | select(.name == $name) | .session_key' 2>/dev/null || echo "")
     
     echo "$agent_data"
 }

--- a/scripts/generate-env.sh
+++ b/scripts/generate-env.sh
@@ -59,16 +59,23 @@ AUTH_SECRET="$(generate_password 32)"
 # Copy .env.example and replace default secrets
 cp "$EXAMPLE_FILE" "$OUTPUT"
 
+# Escape sed replacement metacharacters (|, &, \) in a value.
+# Does not handle newlines — callers must ensure single-line input.
+sed_escape() { printf '%s' "$1" | sed 's/[|&\\]/\\&/g'; }
+
+portable_sed() {
+  local pattern="$1" file="$2"
+  if [[ "$(uname)" == "Darwin" ]]; then
+    sed -i '' "$pattern" "$file"
+  else
+    sed -i "$pattern" "$file"
+  fi
+}
+
 # Replace the insecure defaults with generated values
-if [[ "$(uname)" == "Darwin" ]]; then
-  sed -i '' "s|^AUTH_PASS=.*|AUTH_PASS=$AUTH_PASS|" "$OUTPUT"
-  sed -i '' "s|^API_KEY=.*|API_KEY=$API_KEY|" "$OUTPUT"
-  sed -i '' "s|^AUTH_SECRET=.*|AUTH_SECRET=$AUTH_SECRET|" "$OUTPUT"
-else
-  sed -i "s|^AUTH_PASS=.*|AUTH_PASS=$AUTH_PASS|" "$OUTPUT"
-  sed -i "s|^API_KEY=.*|API_KEY=$API_KEY|" "$OUTPUT"
-  sed -i "s|^AUTH_SECRET=.*|AUTH_SECRET=$AUTH_SECRET|" "$OUTPUT"
-fi
+portable_sed "s|^AUTH_PASS=.*|AUTH_PASS=$(sed_escape "$AUTH_PASS")|" "$OUTPUT"
+portable_sed "s|^API_KEY=.*|API_KEY=$(sed_escape "$API_KEY")|" "$OUTPUT"
+portable_sed "s|^AUTH_SECRET=.*|AUTH_SECRET=$(sed_escape "$AUTH_SECRET")|" "$OUTPUT"
 
 # Lock down permissions
 chmod 600 "$OUTPUT"

--- a/scripts/notification-daemon.sh
+++ b/scripts/notification-daemon.sh
@@ -53,18 +53,16 @@ check_mission_control() {
 deliver_notifications() {
     log "INFO" "Starting notification delivery batch"
     
-    # Build API request
-    local api_payload="{\"limit\": $LIMIT"
-    
-    if [[ -n "$AGENT_FILTER" ]]; then
-        api_payload+=", \"agent_filter\": \"$AGENT_FILTER\""
-    fi
-    
-    if [[ "$DRY_RUN" == "true" ]]; then
-        api_payload+=", \"dry_run\": true"
-    fi
-    
-    api_payload+="}"
+    # Build API request using jq for safe JSON construction
+    local api_payload
+    api_payload=$(jq -n \
+        --argjson limit "$LIMIT" \
+        --arg agent_filter "$AGENT_FILTER" \
+        --argjson dry_run "$( if [[ "$DRY_RUN" == "true" ]]; then echo true; else echo false; fi )" \
+        '{limit: $limit}
+         + (if $agent_filter != "" then {agent_filter: $agent_filter} else {} end)
+         + (if $dry_run then {dry_run: true} else {} end)'
+    )
     
     # Call notification delivery endpoint
     local response
@@ -122,14 +120,16 @@ deliver_notifications() {
 get_delivery_stats() {
     local stats_url="$MISSION_CONTROL_URL/api/notifications/deliver"
     
-    if [[ -n "$AGENT_FILTER" ]]; then
-        stats_url+="?agent=$AGENT_FILTER"
-    fi
-    
     local response
-    response=$(curl -s "$stats_url" 2>/dev/null)
-    
-    if [[ $? -eq 0 ]]; then
+    local curl_ok=false
+    if [[ -n "$AGENT_FILTER" ]]; then
+        # Use curl --data-urlencode for safe URL parameter encoding
+        response=$(curl -s -G --data-urlencode "agent=$AGENT_FILTER" "$stats_url" 2>/dev/null) && curl_ok=true
+    else
+        response=$(curl -s "$stats_url" 2>/dev/null) && curl_ok=true
+    fi
+
+    if [[ "$curl_ok" == "true" ]]; then
         echo "$response" | jq -r '
             "Delivery Statistics:",
             "  Total notifications: \(.statistics.total)",


### PR DESCRIPTION
## Summary

Three classes of injection vulnerability across four shell scripts:

### 1. sed metacharacter injection (`install.sh`, `scripts/generate-env.sh`)
Variables (`$MC_PORT`, `$oc_home`, `$gw_host`, `$AUTH_PASS`) interpolated directly in sed replacement strings. Characters `|`, `&`, `\` are sed metacharacters that corrupt substitution or inject unintended content.

**Fix**: Add `sed_escape()` helper that escapes metacharacters before interpolation, and `portable_sed()` to deduplicate the macOS/Linux `sed -i` branching. Helpers placed in top-level scope.

### 2. jq filter injection (`scripts/agent-heartbeat.sh`)
`$agent_name` interpolated inside a jq filter via shell double-quotes — agent names containing `|`, `;`, `(` can manipulate the filter logic.

**Fix**: Use `jq --arg name "$agent_name"` with `$name` reference in the filter — jq handles escaping.

### 3. JSON string injection (`scripts/notification-daemon.sh`)
`$AGENT_FILTER` interpolated directly into a JSON string via shell concatenation — values with `"`, `\` break the JSON structure, potentially injecting fields.

**Fix**: Use `jq -n` with `--arg`/`--argjson` for safe JSON construction. Also fix URL parameter injection in stats endpoint via `curl -G --data-urlencode`, and fix a `$?` capture bug in the refactored curl control flow.

## Changes

| File | Change |
|------|--------|
| `install.sh` | Add `sed_escape()`, `portable_sed()` in Helpers section; use in `setup_env()` |
| `scripts/generate-env.sh` | Same pattern for secret replacement |
| `scripts/agent-heartbeat.sh` | `jq --arg` instead of string interpolation in filter |
| `scripts/notification-daemon.sh` | `jq -n` for JSON construction; `curl --data-urlencode` for URL params; fix `$?` capture |

## Limitations documented

`sed_escape()` does not handle newlines in values. All current callers pass single-line input (ports, paths, IPs, hex strings). This is documented in the function comment.

## Test plan

- [ ] `install.sh --local` with `MC_PORT` containing `&` or `|`
- [ ] `generate-env.sh` produces valid `.env` with special chars in generated passwords
- [ ] `agent-heartbeat.sh` with agent name containing `"); .foo`
- [ ] `notification-daemon.sh --agent 'test"inject'` produces valid JSON payload
- [ ] `notification-daemon.sh --stats --agent 'test&x=1'` encodes URL correctly