### PR TITLE
fix: add per-user rate limiting to password change endpoint

### DIFF
--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -3,6 +3,7 @@ import { getUserFromRequest, updateUser, requireRole, destroyAllUserSessions, cr
 import { logAuditEvent } from '@/lib/db'
 import { verifyPassword } from '@/lib/password'
 import { getMcSessionCookieName, getMcSessionCookieOptions, isRequestSecure } from '@/lib/session-cookie'
+import { passwordChangeLimiter } from '@/lib/rate-limit'
 import { logger } from '@/lib/logger'
 
 export async function GET(request: Request) {
@@ -52,6 +53,10 @@ export async function PATCH(request: NextRequest) {
 
     // Handle password change
     if (new_password) {
+      // Rate-limit password change attempts per user (5/min, separate from login)
+      const rateCheck = passwordChangeLimiter(String(user.id))
+      if (rateCheck) return rateCheck
+
       if (!current_password) {
         return NextResponse.json({ error: 'Current password is required' }, { status: 400 })
       }

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -193,6 +193,55 @@ export const agentTaskLimiter = createAgentRateLimiter({
   message: 'Agent task polling rate limit exceeded.',
 })
 
+// ---------------------------------------------------------------------------
+// Keyed rate limiter (arbitrary string key — e.g. user ID)
+// ---------------------------------------------------------------------------
+
+export function createKeyedRateLimiter(options: RateLimiterOptions) {
+  const store = new Map<string, RateLimitEntry>()
+  const maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES
+
+  const cleanupInterval = setInterval(() => {
+    const now = Date.now()
+    for (const [key, entry] of store) {
+      if (now > entry.resetAt) store.delete(key)
+    }
+  }, 60_000)
+  if (cleanupInterval.unref) cleanupInterval.unref()
+
+  return function checkKeyedRateLimit(key: string): NextResponse | null {
+    if (process.env.MC_DISABLE_RATE_LIMIT === '1' && !options.critical && (process.env.NODE_ENV !== 'production' || process.env.MISSION_CONTROL_TEST_MODE === '1')) return null
+
+    const now = Date.now()
+    const entry = store.get(key)
+
+    if (!entry || now > entry.resetAt) {
+      if (!entry && store.size >= maxEntries) evictOldest(store)
+      store.set(key, { count: 1, resetAt: now + options.windowMs })
+      return null
+    }
+
+    entry.count++
+    if (entry.count > options.maxRequests) {
+      try { logSecurityEvent({ event_type: 'rate_limit_hit', severity: 'warning', source: 'rate-limiter', detail: JSON.stringify({ key }), ip_address: 'n/a', workspace_id: 1, tenant_id: 1 }) } catch {}
+      return NextResponse.json(
+        { error: options.message || 'Too many requests. Please try again later.' },
+        { status: 429 }
+      )
+    }
+
+    return null
+  }
+}
+
+/** Password change: 5/min per user ID (brute-force protection on current_password) */
+export const passwordChangeLimiter = createKeyedRateLimiter({
+  windowMs: 60_000,
+  maxRequests: 5,
+  message: 'Too many password change attempts. Try again in a minute.',
+  critical: true,
+})
+
 /** Self-registration: 5/min per IP (prevent spam registrations) */
 export const selfRegisterLimiter = createRateLimiter({
   windowMs: 60_000,


### PR DESCRIPTION
## Summary

PATCH `/api/auth/me` accepts `current_password` for verification but had no rate limiting — allowing unlimited brute-force attempts against the current password. The login endpoint uses `loginLimiter` (5/min per IP), but password change was unprotected.

## Design decisions

**Per-user, not per-IP**: The attacker already has an authenticated session to reach this endpoint. IP-based limiting (like `loginLimiter`) can be bypassed with multiple IPs/proxies. Keying by user ID ensures the rate limit holds regardless of source IP.

**Separate bucket**: `passwordChangeLimiter` uses its own store, independent of `loginLimiter`. Password change attempts don't consume login quota and vice versa.

**Scoped to password changes**: Rate limit is checked only when `new_password` is present in the body. Display name updates (`display_name` only) remain unrestricted.

## Changes

| File | Change |
|------|--------|
| `src/lib/rate-limit.ts` | Add `createKeyedRateLimiter(options)` — accepts arbitrary string key instead of extracting IP from request. Add `passwordChangeLimiter` (5/min per user, critical). |
| `src/app/api/auth/me/route.ts` | Apply `passwordChangeLimiter(String(user.id))` before `verifyPassword` call. |

## Note on issue #6 (broadcast command injection)

The original audit flagged `task.title`/`message` passed as CLI args in the broadcast route. After review, `runCommand` uses `spawn` with `shell: false` — args are passed as an array, not interpreted by a shell. The message is a value of `--message` (next array element), so CLI parsers treat it as a value, not a flag. No fix needed.

## Test plan

- [ ] 5 rapid PATCH `/api/auth/me` with wrong `current_password` → 429 on 6th attempt
- [ ] Rate limit resets after 60s
- [ ] Display name update (no `new_password`) is not rate-limited
- [ ] Login attempts don't affect password change quota (separate buckets)
- [ ] Different users have independent rate limit counters