### PR TITLE
fix(ui): guard AgentAvatar against undefined/null name prop

### DIFF
--- a/src/components/ui/agent-avatar.tsx
+++ b/src/components/ui/agent-avatar.tsx
@@ -1,13 +1,13 @@
 'use client'
 
 interface AgentAvatarProps {
-  name: string
+  name?: string | null
   size?: 'xs' | 'sm' | 'md'
   className?: string
 }
 
 function getInitials(name: string): string {
-  const parts = name
+  const parts = (name ?? '')
     .trim()
     .split(/\s+/)
     .filter(Boolean)
@@ -26,7 +26,7 @@ function hashString(value: string): number {
 }
 
 function getAvatarColors(name: string): { backgroundColor: string; color: string } {
-  const hash = hashString(name.toLowerCase())
+  const hash = hashString((name ?? '').toLowerCase())
   const hue = hash % 360
   return {
     backgroundColor: `hsl(${hue} 70% 38%)`,
@@ -41,15 +41,16 @@ const sizeClasses: Record<NonNullable<AgentAvatarProps['size']>, string> = {
 }
 
 export function AgentAvatar({ name, size = 'sm', className = '' }: AgentAvatarProps) {
-  const initials = getInitials(name)
-  const colors = getAvatarColors(name)
+  const safeName = name ?? ''
+  const initials = getInitials(safeName)
+  const colors = getAvatarColors(safeName)
 
   return (
     <div
       className={`rounded-full flex items-center justify-center font-semibold shrink-0 ${sizeClasses[size]} ${className}`}
       style={colors}
-      title={name}
-      aria-label={name}
+      title={safeName}
+      aria-label={safeName || 'Agent'}
     >
       {initials}
     </div>


### PR DESCRIPTION
Closes #563.

## The bug

Reported by @jgibson02:

```
TypeError: can't access property "trim", e is undefined
    at AgentAvatar (c522d0301b4d043a.js:544:440055)
```

`AgentAvatar` calls `getInitials(name)` which calls `name.trim()` — if `name` is `undefined`, it crashes and an `ErrorBoundary` panel error is shown.

## Root cause

Incomplete agent data pushed during gateway WebSocket reconnection cycles — one of the agent objects in the stream has an `undefined` `name` field. The DB has valid names, but the transient WebSocket payload doesn't.

## The fix

Defensive null guards in the component:

- Make `name` prop optional: `name?: string | null`
- Null-coalesce inside `getInitials()` and `getAvatarColors()`
- Fallback `aria-label` to `'Agent'` when name is empty
- Returns `'?'` placeholder initials when name has no word characters

The deeper fix (cleaning up the WebSocket payload to never send undefined names) is a separate concern — this PR addresses the symptom so the ErrorBoundary doesn't trigger.

## Test plan
- [x] Typecheck clean
- [ ] Manual: render `<AgentAvatar name={undefined} />` — should show `?` with grey background
- [ ] Manual: render `<AgentAvatar name="" />` — same as above
- [ ] Manual: render `<AgentAvatar name="Ada Lovelace" />` — should show `AL`