### PR TITLE
feat: add native OpenCode runtime and session support

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,6 +6,10 @@ const config = [
     ignores: [
       '.data/**',
       'ops/**',
+      'test-results/**',
+      'playwright-report/**',
+      '.tmp/**',
+      '.playwright-mcp/**',
     ],
   },
   // The React 19/ESLint ecosystem is still settling. These rules are valuable,

--- a/next.config.js
+++ b/next.config.js
@@ -3,10 +3,13 @@ const withNextIntl = require('next-intl/plugin')('./src/i18n/request.ts')
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
+  outputFileTracingRoot: __dirname,
   outputFileTracingExcludes: {
     '/*': ['./.data/**/*'],
   },
-  turbopack: {},
+  turbopack: {
+    root: __dirname,
+  },
   // Transpile ESM-only packages so they resolve correctly in all environments
   transpilePackages: ['react-markdown', 'remark-gfm'],
   

--- a/openapi.json
+++ b/openapi.json
@@ -42,7 +42,7 @@
     },
     {
       "name": "Sessions",
-      "description": "Gateway session management"
+      "description": "Gateway and local runtime session management"
     },
     {
       "name": "Webhooks",
@@ -232,6 +232,9 @@
           },
           "403": {
             "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -283,7 +286,8 @@
                       "openclaw",
                       "hermes",
                       "claude",
-                      "codex"
+                      "codex",
+                      "opencode"
                     ]
                   },
                   "mode": {
@@ -712,6 +716,9 @@
           },
           "403": {
             "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -3464,6 +3471,102 @@
         }
       }
     },
+    "/api/gateways/control": {
+      "get": {
+        "tags": [
+          "Agents"
+        ],
+        "summary": "Get gateway control status",
+        "operationId": "getGatewayControlStatus",
+        "responses": {
+          "200": {
+            "description": "Gateway status list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "gateways": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": { "type": "string", "enum": ["hermes", "openclaw"] },
+                          "name": { "type": "string" },
+                          "installed": { "type": "boolean" },
+                          "running": { "type": "boolean" },
+                          "port": { "type": "integer" },
+                          "pid": { "type": ["integer", "null"] },
+                          "version": { "type": ["string", "null"] },
+                          "error": { "type": "string" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" }
+        }
+      },
+      "post": {
+        "tags": [
+          "Agents"
+        ],
+        "summary": "Control a gateway",
+        "operationId": "controlGateway",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["gateway", "action"],
+                "properties": {
+                  "gateway": { "type": "string", "enum": ["hermes", "openclaw"] },
+                  "action": { "type": "string", "enum": ["start", "stop", "restart", "diagnose"] }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Gateway control result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean" },
+                    "output": { "type": "string" },
+                    "status": {
+                      "type": "object",
+                      "properties": {
+                        "type": { "type": "string" },
+                        "name": { "type": "string" },
+                        "installed": { "type": "boolean" },
+                        "running": { "type": "boolean" },
+                        "port": { "type": "integer" },
+                        "pid": { "type": ["integer", "null"] },
+                        "version": { "type": ["string", "null"] },
+                        "error": { "type": "string" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "500": { "$ref": "#/components/responses/Error" }
+        }
+      }
+    },
     "/api/docs": {
       "get": {
         "tags": [
@@ -5783,28 +5886,11 @@
         "tags": [
           "Sessions"
         ],
-        "summary": "List gateway sessions",
+        "summary": "List gateway and local sessions",
         "operationId": "listSessions",
-        "parameters": [
-          {
-            "name": "agent",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "schema": {
-              "type": "integer",
-              "default": 50
-            }
-          }
-        ],
         "responses": {
           "200": {
-            "description": "Session list",
+            "description": "Merged gateway and local session list",
             "content": {
               "application/json": {
                 "schema": {
@@ -5815,6 +5901,9 @@
                       "items": {
                         "type": "object",
                         "properties": {
+                          "id": {
+                            "type": "string"
+                          },
                           "key": {
                             "type": "string"
                           },
@@ -5824,14 +5913,66 @@
                           "model": {
                             "type": "string"
                           },
-                          "status": {
+                          "kind": {
                             "type": "string"
+                          },
+                          "channel": {
+                            "type": "string"
+                          },
+                          "source": {
+                            "type": "string",
+                            "enum": [
+                              "gateway",
+                              "local"
+                            ]
+                          },
+                          "active": {
+                            "type": "boolean"
+                          },
+                          "startTime": {
+                            "type": "integer"
+                          },
+                          "lastActivity": {
+                            "type": "integer"
                           },
                           "totalTokens": {
                             "type": "integer"
                           },
-                          "updatedAt": {
+                          "workingDir": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "userMessages": {
                             "type": "integer"
+                          },
+                          "assistantMessages": {
+                            "type": "integer"
+                          },
+                          "toolUses": {
+                            "type": "integer"
+                          },
+                          "estimatedCost": {
+                            "type": "number"
+                          },
+                          "lastUserPrompt": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "age": {
+                            "type": "string"
+                          },
+                          "tokens": {
+                            "type": "string"
+                          },
+                          "flags": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
                           }
                         }
                       }
@@ -5850,11 +5991,50 @@
         "tags": [
           "Sessions"
         ],
-        "summary": "Delete /api/sessions",
+        "summary": "Delete a session",
         "operationId": "deleteApiSessions",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "sessionKey"
+                ],
+                "properties": {
+                  "sessionKey": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "Session deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "sessionKey": {
+                      "type": "string"
+                    },
+                    "result": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
@@ -5868,11 +6048,75 @@
         "tags": [
           "Sessions"
         ],
-        "summary": "Post /api/sessions",
+        "summary": "Control session settings",
         "operationId": "postApiSessions",
+        "parameters": [
+          {
+            "name": "action",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "set-thinking",
+                "set-verbose",
+                "set-reasoning",
+                "set-label"
+              ]
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "sessionKey"
+                ],
+                "properties": {
+                  "sessionKey": {
+                    "type": "string"
+                  },
+                  "level": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "Session control applied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "action": {
+                      "type": "string"
+                    },
+                    "sessionKey": {
+                      "type": "string"
+                    },
+                    "result": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
@@ -5888,11 +6132,56 @@
         "tags": [
           "Sessions"
         ],
-        "summary": "Post /api/sessions/continue",
+        "summary": "Continue a local Claude/Codex/OpenCode session",
         "operationId": "postApiSessionsContinue",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "kind",
+                  "id",
+                  "prompt"
+                ],
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "claude-code",
+                      "codex-cli",
+                      "opencode"
+                    ]
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "prompt": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "Continue result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean" },
+                    "reply": { "type": "string" }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
@@ -5908,11 +6197,77 @@
         "tags": [
           "Sessions"
         ],
-        "summary": "Get /api/sessions/transcript",
+        "summary": "Get transcript snippets for a local session",
         "operationId": "getApiSessionsTranscript",
+        "parameters": [
+          {
+            "name": "kind",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "claude-code",
+                "codex-cli",
+                "hermes",
+                "opencode"
+              ]
+            }
+          },
+          {
+            "name": "id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 40,
+              "maximum": 200
+            }
+          }
+        ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "Transcript snippets",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "role": {
+                            "type": "string",
+                            "enum": ["user", "assistant", "system"]
+                          },
+                          "timestamp": {
+                            "type": "string"
+                          },
+                          "parts": {
+                            "type": "array",
+                            "items": {
+                              "type": "object"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
@@ -10491,6 +10846,52 @@
           "400": { "$ref": "#/components/responses/BadRequest" },
           "401": { "$ref": "#/components/responses/Unauthorized" },
           "403": { "$ref": "#/components/responses/Forbidden" }
+        }
+      }
+    },
+    "/api/hermes/events": {
+      "post": {
+        "tags": [
+          "Agents"
+        ],
+        "summary": "Receive Hermes hook events",
+        "operationId": "postHermesEvents",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["event"],
+                "properties": {
+                  "event": { "type": "string" },
+                  "session_id": { "type": "string" },
+                  "source": { "type": "string" },
+                  "timestamp": { "type": "string" },
+                  "agent_name": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Hermes event accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean" },
+                    "event": { "type": "string" }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "500": { "$ref": "#/components/responses/Error" }
         }
       }
     },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   webServer: {
     command: 'node scripts/e2e-openclaw/start-e2e-server.mjs --mode=local',
     url: 'http://127.0.0.1:3005',
-    reuseExistingServer: true,
+    reuseExistingServer: false,
     timeout: 120_000,
     env: {
       ...process.env,

--- a/scripts/e2e-openclaw/bin/opencode
+++ b/scripts/e2e-openclaw/bin/opencode
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "--version" ]]; then
+  echo "opencode 1.4.3"
+  exit 0
+fi
+if [[ "$1" == "run" ]]; then
+  shift
+  session=""
+  prompt=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --session)
+        session="$2"; shift 2 ;;
+      --prompt)
+        prompt="$2"; shift 2 ;;
+      *)
+        prompt="$1"; shift ;;
+    esac
+  done
+  if [[ "$session" == "ses_e2e_1" ]]; then
+    if [[ "$prompt" == "say exactly CONTINUE_OK and nothing else" ]]; then
+      echo "CONTINUE_OK"
+      exit 0
+    fi
+    echo "OpenCode session ${session} continued: ${prompt}"
+    exit 0
+  fi
+  echo "Session not found: ${session}" >&2
+  exit 1
+fi
+exec /opt/homebrew/bin/opencode "$@"

--- a/scripts/e2e-openclaw/start-e2e-server.mjs
+++ b/scripts/e2e-openclaw/start-e2e-server.mjs
@@ -4,6 +4,7 @@ import fs from 'node:fs'
 import net from 'node:net'
 import path from 'node:path'
 import process from 'node:process'
+import Database from 'better-sqlite3'
 
 async function findAvailablePort(host = '127.0.0.1') {
   return await new Promise((resolve, reject) => {
@@ -36,13 +37,152 @@ const repoRoot = process.cwd()
 const fixtureSource = path.join(repoRoot, 'tests', 'fixtures', 'openclaw')
 const runtimeRoot = path.join(repoRoot, '.tmp', 'e2e-openclaw', mode)
 const dataDir = path.join(runtimeRoot, 'data')
+const openCodeDir = path.join(runtimeRoot, '.local', 'share', 'opencode')
+const openCodeDbPath = path.join(openCodeDir, 'opencode-e2e.db')
 const mockBinDir = path.join(repoRoot, 'scripts', 'e2e-openclaw', 'bin')
 const skillsRoot = path.join(runtimeRoot, 'skills')
+
+function findStandaloneServer(root) {
+  const direct = path.join(root, '.next', 'standalone', 'server.js')
+  if (fs.existsSync(direct)) return direct
+
+  const standaloneRoot = path.join(root, '.next', 'standalone')
+  if (!fs.existsSync(standaloneRoot)) return null
+
+  const stack = [standaloneRoot]
+  while (stack.length > 0) {
+    const current = stack.pop()
+    if (!current) continue
+    const entries = fs.readdirSync(current, { withFileTypes: true })
+    for (const entry of entries) {
+      const full = path.join(current, entry.name)
+      if (entry.isDirectory()) {
+        stack.push(full)
+      } else if (entry.isFile() && entry.name === 'server.js') {
+        return full
+      }
+    }
+  }
+
+  return null
+}
+
+function runBlocking(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: repoRoot,
+      env: baseEnv,
+      stdio: 'inherit',
+      ...options,
+    })
+    child.on('error', reject)
+    child.on('exit', (code, signal) => {
+      if (code === 0) return resolve(undefined)
+      reject(new Error(`${command} ${args.join(' ')} exited with code ${code ?? 'null'} signal ${signal ?? 'none'}`))
+    })
+  })
+}
 
 fs.rmSync(runtimeRoot, { recursive: true, force: true })
 fs.mkdirSync(runtimeRoot, { recursive: true })
 fs.mkdirSync(dataDir, { recursive: true })
+fs.mkdirSync(openCodeDir, { recursive: true })
 fs.cpSync(fixtureSource, runtimeRoot, { recursive: true })
+
+const openCodeDb = new Database(openCodeDbPath)
+const now = Date.now()
+openCodeDb.exec(`
+  CREATE TABLE IF NOT EXISTS project (
+    id TEXT PRIMARY KEY,
+    worktree TEXT,
+    vcs TEXT,
+    name TEXT,
+    icon_url TEXT,
+    icon_color TEXT,
+    time_created INTEGER,
+    time_updated INTEGER,
+    time_initialized INTEGER,
+    sandboxes TEXT,
+    commands TEXT
+  );
+  CREATE TABLE IF NOT EXISTS session (
+    id TEXT PRIMARY KEY,
+    project_id TEXT,
+    parent_id TEXT,
+    slug TEXT,
+    title TEXT,
+    directory TEXT,
+    time_created INTEGER,
+    time_updated INTEGER,
+    version TEXT,
+    share_url TEXT,
+    summary_additions INTEGER,
+    summary_deletions INTEGER,
+    summary_files INTEGER,
+    summary_diffs TEXT,
+    revert TEXT,
+    permission TEXT,
+    time_compacting INTEGER,
+    time_archived INTEGER,
+    workspace_id TEXT
+  );
+  CREATE TABLE IF NOT EXISTS message (
+    id TEXT PRIMARY KEY,
+    session_id TEXT,
+    data TEXT,
+    time_created INTEGER,
+    time_updated INTEGER
+  );
+`)
+openCodeDb.prepare(`INSERT OR REPLACE INTO project (id, worktree, vcs, name, icon_url, icon_color, time_created, time_updated, time_initialized, sandboxes, commands) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
+  'proj_e2e',
+  '/tmp/opencode-e2e-project',
+  'git',
+  null,
+  null,
+  null,
+  now - 10000,
+  now,
+  null,
+  '[]',
+  null,
+)
+openCodeDb.prepare(`INSERT OR REPLACE INTO session (id, project_id, parent_id, slug, title, directory, time_created, time_updated, version, share_url, summary_additions, summary_deletions, summary_files, summary_diffs, revert, permission, time_compacting, time_archived, workspace_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
+  'ses_e2e_1',
+  'proj_e2e',
+  null,
+  'hidden-wolf',
+  'OpenCode E2E Session',
+  '/tmp/opencode-e2e-project',
+  now - 10000,
+  now - 1000,
+  '1.0.0',
+  null,
+  0,
+  0,
+  0,
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+)
+openCodeDb.prepare(`INSERT OR REPLACE INTO message (id, session_id, data, time_created, time_updated) VALUES (?, ?, ?, ?, ?)`).run(
+  'msg_e2e_1',
+  'ses_e2e_1',
+  JSON.stringify({ role: 'user', model: { providerID: 'anthropic', modelID: 'claude-sonnet-4-5' }, tokens: { input: 12, output: 0 } }),
+  now - 10000,
+  now - 10000,
+)
+openCodeDb.prepare(`INSERT OR REPLACE INTO message (id, session_id, data, time_created, time_updated) VALUES (?, ?, ?, ?, ?)`).run(
+  'msg_e2e_2',
+  'ses_e2e_1',
+  JSON.stringify({ role: 'assistant', providerID: 'anthropic', modelID: 'claude-sonnet-4-5', content: 'CONTINUE_OK', tokens: { input: 0, output: 6 } }),
+  now - 5000,
+  now - 1000,
+)
+openCodeDb.close()
 
 const gatewayHost = '127.0.0.1'
 const gatewayPort = String(await findAvailablePort(gatewayHost))
@@ -52,15 +192,20 @@ const baseEnv = {
   API_KEY: process.env.API_KEY || 'test-api-key-e2e-12345',
   AUTH_USER: process.env.AUTH_USER || 'admin',
   AUTH_PASS: process.env.AUTH_PASS || 'admin',
+  HOSTNAME: '127.0.0.1',
+  PORT: '3005',
   MISSION_CONTROL_TEST_MODE: process.env.MISSION_CONTROL_TEST_MODE || '1',
   MC_DISABLE_RATE_LIMIT: '1',
   MISSION_CONTROL_DATA_DIR: dataDir,
   MISSION_CONTROL_DB_PATH: path.join(dataDir, 'mission-control.db'),
+  HOME: runtimeRoot,
+  OPENCODE_DB_PATH: openCodeDbPath,
   OPENCLAW_STATE_DIR: runtimeRoot,
   OPENCLAW_CONFIG_PATH: path.join(runtimeRoot, 'openclaw.json'),
   OPENCLAW_GATEWAY_HOST: gatewayHost,
   OPENCLAW_GATEWAY_PORT: gatewayPort,
   OPENCLAW_BIN: path.join(mockBinDir, 'openclaw'),
+  OPENCODE_BIN: path.join(mockBinDir, 'opencode'),
   CLAWDBOT_BIN: path.join(mockBinDir, 'clawdbot'),
   MC_SKILLS_USER_AGENTS_DIR: path.join(skillsRoot, 'user-agents'),
   MC_SKILLS_USER_CODEX_DIR: path.join(skillsRoot, 'user-codex'),
@@ -96,15 +241,18 @@ if (mode === 'gateway') {
   children.push(gw)
 }
 
-const standaloneServerPath = path.join(repoRoot, '.next', 'standalone', 'server.js')
-app = fs.existsSync(standaloneServerPath)
+const buildIdPath = path.join(repoRoot, '.next', 'BUILD_ID')
+
+if (!fs.existsSync(buildIdPath)) {
+  await runBlocking('pnpm', ['build'])
+}
+
+const standaloneServerPath = findStandaloneServer(repoRoot)
+
+app = standaloneServerPath && fs.existsSync(standaloneServerPath)
   ? spawn('node', [standaloneServerPath], {
       cwd: repoRoot,
-      env: {
-        ...baseEnv,
-        HOSTNAME: '127.0.0.1',
-        PORT: '3005',
-      },
+      env: baseEnv,
       stdio: 'inherit',
     })
   : spawn('pnpm', ['start'], {

--- a/src/app/api/agent-runtimes/route.ts
+++ b/src/app/api/agent-runtimes/route.ts
@@ -7,7 +7,7 @@ import { clearHermesDetectionCache } from '@/lib/hermes-sessions'
 import { logAuditEvent } from '@/lib/db'
 import { logger } from '@/lib/logger'
 
-const VALID_RUNTIMES = new Set<RuntimeId>(['openclaw', 'hermes', 'claude', 'codex'])
+const VALID_RUNTIMES = new Set<RuntimeId>(['openclaw', 'hermes', 'claude', 'codex', 'opencode'])
 const VALID_MODES = new Set<DeploymentMode>(['local', 'docker'])
 
 export async function GET(request: NextRequest) {
@@ -40,7 +40,7 @@ export async function POST(request: NextRequest) {
     const runtime = body.runtime as RuntimeId
     const mode = (body.mode || 'local') as DeploymentMode
     if (!runtime || !VALID_RUNTIMES.has(runtime)) {
-      return NextResponse.json({ error: 'Invalid runtime. Use: openclaw, hermes' }, { status: 400 })
+      return NextResponse.json({ error: 'Invalid runtime. Use: openclaw, hermes, claude, codex, opencode' }, { status: 400 })
     }
     if (!VALID_MODES.has(mode)) {
       return NextResponse.json({ error: 'Invalid mode. Use: local, docker' }, { status: 400 })

--- a/src/app/api/index/route.ts
+++ b/src/app/api/index/route.ts
@@ -49,10 +49,10 @@ const endpoints: Endpoint[] = [
   { path: '/api/chat/session-prefs', methods: ['GET', 'PATCH'], description: 'Local session chat preferences (rename + color)', tag: 'Chat', auth: 'viewer/operator' },
 
   // ── Sessions ──────────────────────────────────────
-  { path: '/api/sessions', methods: ['GET'], description: 'List gateway sessions', tag: 'Sessions', auth: 'viewer' },
+  { path: '/api/sessions', methods: ['GET', 'POST', 'DELETE'], description: 'List and control gateway/local runtime sessions', tag: 'Sessions', auth: 'viewer/operator' },
   { path: '/api/sessions/:id/control', methods: ['POST'], description: 'Session control (stop, message)', tag: 'Sessions', auth: 'operator' },
-  { path: '/api/sessions/continue', methods: ['POST'], description: 'Continue a local Claude/Codex session with a prompt', tag: 'Sessions', auth: 'operator' },
-  { path: '/api/sessions/transcript', methods: ['GET'], description: 'Read local Claude/Codex session transcript snippets', tag: 'Sessions', auth: 'viewer' },
+  { path: '/api/sessions/continue', methods: ['POST'], description: 'Continue a local Claude/Codex/OpenCode session with a prompt', tag: 'Sessions', auth: 'operator' },
+  { path: '/api/sessions/transcript', methods: ['GET'], description: 'Read local Claude/Codex/Hermes/OpenCode session transcript snippets', tag: 'Sessions', auth: 'viewer' },
   { path: '/api/claude/sessions', methods: ['GET'], description: 'Claude CLI session scanner', tag: 'Sessions', auth: 'viewer' },
 
   // ── Activities & Notifications ────────────────────

--- a/src/app/api/sessions/__tests__/continue-route-opencode.test.ts
+++ b/src/app/api/sessions/__tests__/continue-route-opencode.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { POST } from '@/app/api/sessions/continue/route'
+
+const mocks = vi.hoisted(() => ({
+  runCommand: vi.fn(async () => ({ stdout: '', stderr: '', code: 0 })),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  requireRole: vi.fn(() => ({ user: { role: 'operator', username: 'tester' } })),
+}))
+
+vi.mock('@/lib/command', () => ({
+  runCommand: mocks.runCommand,
+}))
+
+vi.mock('@/lib/opencode-sessions', () => ({
+  getOpenCodeExecutable: vi.fn(() => '/custom/bin/opencode'),
+}))
+
+describe('OpenCode session continue route', () => {
+  beforeEach(() => {
+    mocks.runCommand.mockClear()
+  })
+
+  it('invokes the OpenCode CLI with the resume command for kind=opencode', async () => {
+    const request = new Request('http://localhost/api/sessions/continue', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ kind: 'opencode', id: 'ses_open_1', prompt: 'continue' }),
+    })
+    const response = await POST(request as any)
+    expect(response.status).not.toBe(400)
+    expect(mocks.runCommand).toHaveBeenCalledWith(
+      '/custom/bin/opencode',
+      ['run', '--session', 'ses_open_1', 'continue'],
+      expect.objectContaining({ timeoutMs: 180000 }),
+    )
+  })
+
+  it('surfaces OpenCode runtime failures as a 500 error', async () => {
+    mocks.runCommand.mockRejectedValueOnce(new Error('Model not found: anthropic/claude-opus-4.5'))
+
+    const request = new Request('http://localhost/api/sessions/continue', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ kind: 'opencode', id: 'ses_open_1', prompt: 'continue' }),
+    })
+
+    const response = await POST(request as any)
+    expect(response.status).toBe(500)
+    const body = await response.json()
+    expect(body.error).toContain('Model not found')
+  })
+})

--- a/src/app/api/sessions/__tests__/transcript-opencode.test.ts
+++ b/src/app/api/sessions/__tests__/transcript-opencode.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+let tempHome = ''
+let dbRowsByName: Record<string, Array<{ data: string | null; time_created: number | null; time_updated: number | null }>> = {}
+
+vi.mock('@/lib/config', () => ({
+  config: {
+    get homeDir() {
+      return tempHome
+    },
+  },
+}))
+
+vi.mock('@/lib/auth', () => ({
+  requireRole: vi.fn(() => ({ user: { role: 'viewer' } })),
+}))
+
+vi.mock('better-sqlite3', () => ({
+  default: vi.fn((dbPath?: string) => ({
+    prepare: (query: string) => ({
+      get: (...args: any[]) => {
+        if (query.includes('sqlite_master') && args[0] === 'message') return { name: 'message' }
+        return undefined
+      },
+      all: (...args: any[]) => {
+        const name = dbPath ? String(dbPath).split('/').pop() || '' : ''
+        if (query.includes('FROM message')) return dbRowsByName[name] || []
+        return []
+      },
+    }),
+    close: vi.fn(),
+  })),
+}))
+
+describe('OpenCode transcript helper', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    tempHome = mkdtempSync(join(tmpdir(), 'mc-opencode-transcript-'))
+    const base = join(tempHome, '.local', 'share', 'opencode')
+    mkdirSync(base, { recursive: true })
+    writeFileSync(join(base, 'opencode.db'), '')
+    dbRowsByName = {
+      'opencode.db': [
+        {
+          data: JSON.stringify({ role: 'user', content: 'hello from opencode' }),
+          time_created: Date.now() - 2000,
+          time_updated: Date.now() - 2000,
+        },
+        {
+          data: JSON.stringify({ role: 'assistant', content: 'world from opencode', tokens: { total: 18 } }),
+          time_created: Date.now() - 1000,
+          time_updated: Date.now() - 1000,
+        },
+      ],
+    }
+  })
+
+  afterEach(() => {
+    if (tempHome) rmSync(tempHome, { recursive: true, force: true })
+    vi.restoreAllMocks()
+  })
+
+  it('reads real OpenCode message rows instead of returning a synthetic summary', async () => {
+    const { __testables } = await import('@/app/api/sessions/transcript/route')
+    const messages = __testables.readOpenCodeTranscript('ses_e2e_1', 40)
+    expect(messages).toHaveLength(2)
+    expect(messages[0].role).toBe('user')
+    expect(messages[0].parts[0]).toMatchObject({ type: 'text', text: 'hello from opencode' })
+    expect(messages[1].role).toBe('assistant')
+    expect(messages[1].parts.some((part: any) => part.type === 'text' && part.text.includes('world from opencode'))).toBe(true)
+  })
+
+  it('returns the newest transcript window for long OpenCode sessions', async () => {
+    dbRowsByName['opencode.db'] = Array.from({ length: 220 }, (_, index) => ({
+      data: JSON.stringify({ role: 'assistant', content: `message-${index}` }),
+      time_created: 1000 + index,
+      time_updated: 1000 + index,
+    }))
+
+    const { __testables } = await import('@/app/api/sessions/transcript/route')
+    const messages = __testables.readOpenCodeTranscript('ses_e2e_1', 40)
+    expect(messages).toHaveLength(40)
+    expect(messages[0].parts[0]).toMatchObject({ type: 'text', text: 'message-180' })
+    expect(messages[39].parts[0]).toMatchObject({ type: 'text', text: 'message-219' })
+  })
+})

--- a/src/app/api/sessions/continue/route.ts
+++ b/src/app/api/sessions/continue/route.ts
@@ -4,8 +4,9 @@ import { NextRequest, NextResponse } from 'next/server'
 import { requireRole } from '@/lib/auth'
 import { logger } from '@/lib/logger'
 import { runCommand } from '@/lib/command'
+import { getOpenCodeExecutable } from '@/lib/opencode-sessions'
 
-type ContinueKind = 'claude-code' | 'codex-cli'
+type ContinueKind = 'claude-code' | 'codex-cli' | 'opencode'
 
 function sanitizePrompt(value: unknown): string {
   return typeof value === 'string' ? value.trim() : ''
@@ -13,7 +14,7 @@ function sanitizePrompt(value: unknown): string {
 
 /**
  * POST /api/sessions/continue
- * Body: { kind: 'claude-code'|'codex-cli', id: string, prompt: string }
+ * Body: { kind: 'claude-code'|'codex-cli'|'opencode', id: string, prompt: string }
  */
 export async function POST(request: NextRequest) {
   const auth = requireRole(request, 'operator')
@@ -28,7 +29,7 @@ export async function POST(request: NextRequest) {
     if (!sessionId || !/^[a-zA-Z0-9._:-]+$/.test(sessionId)) {
       return NextResponse.json({ error: 'Invalid session id' }, { status: 400 })
     }
-    if (kind !== 'claude-code' && kind !== 'codex-cli') {
+    if (kind !== 'claude-code' && kind !== 'codex-cli' && kind !== 'opencode') {
       return NextResponse.json({ error: 'Invalid kind' }, { status: 400 })
     }
     if (!prompt || prompt.length > 6000) {
@@ -42,7 +43,7 @@ export async function POST(request: NextRequest) {
         timeoutMs: 180000,
       })
       reply = (result.stdout || '').trim() || (result.stderr || '').trim()
-    } else {
+    } else if (kind === 'codex-cli') {
       const outputPath = path.join('/tmp', `mc-codex-last-${Date.now()}-${Math.random().toString(36).slice(2)}.txt`)
       try {
         await runCommand('codex', ['exec', 'resume', sessionId, prompt, '--skip-git-repo-check', '-o', outputPath], {
@@ -63,6 +64,11 @@ export async function POST(request: NextRequest) {
       } catch {
         // ignore
       }
+    } else {
+      const result = await runCommand(getOpenCodeExecutable(), ['run', '--session', sessionId, prompt], {
+        timeoutMs: 180000,
+      })
+      reply = (result.stdout || '').trim() || (result.stderr || '').trim()
     }
 
     if (!reply) {

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -3,6 +3,7 @@ import { getAllGatewaySessions } from '@/lib/sessions'
 import { syncClaudeSessions } from '@/lib/claude-sessions'
 import { scanCodexSessions } from '@/lib/codex-sessions'
 import { scanHermesSessions } from '@/lib/hermes-sessions'
+import { scanOpenCodeSessions } from '@/lib/opencode-sessions'
 import { getDatabase, db_helpers } from '@/lib/db'
 import { requireRole } from '@/lib/auth'
 import { callOpenClawGateway } from '@/lib/openclaw-gateway'
@@ -24,7 +25,8 @@ export async function GET(request: NextRequest) {
     const claudeSessions = getLocalClaudeSessions()
     const codexSessions = getLocalCodexSessions()
     const hermesSessions = getLocalHermesSessions()
-    const localMerged = mergeLocalSessions(claudeSessions, codexSessions, hermesSessions)
+    const opencodeSessions = getLocalOpenCodeSessions()
+    const localMerged = mergeLocalSessions(claudeSessions, codexSessions, hermesSessions, opencodeSessions)
 
     if (mappedGatewaySessions.length === 0 && localMerged.length === 0) {
       return NextResponse.json({ sessions: [] })
@@ -174,9 +176,9 @@ function mapGatewaySessions(gatewaySessions: ReturnType<typeof getAllGatewaySess
   }
 
   return Array.from(sessionMap.values()).map((s) => {
-    const total = s.totalTokens || 0
+    const totalTokens = s.totalTokens || 0
     const context = s.contextTokens || 35000
-    const pct = context > 0 ? Math.round((total / context) * 100) : 0
+    const pct = context > 0 ? Math.round((totalTokens / context) * 100) : 0
     return {
       id: s.sessionId || `${s.agent}:${s.key}`,
       key: s.key,
@@ -184,7 +186,7 @@ function mapGatewaySessions(gatewaySessions: ReturnType<typeof getAllGatewaySess
       kind: s.chatType || 'unknown',
       age: formatAge(s.updatedAt),
       model: s.model,
-      tokens: `${formatTokens(total)}/${formatTokens(context)} (${pct}%)`,
+      tokens: `${formatTokens(totalTokens)}/${formatTokens(context)} (${pct}%)`,
       channel: s.channel,
       flags: [],
       active: s.active,
@@ -204,7 +206,6 @@ function getLocalClaudeSessions() {
     ).all() as Array<Record<string, any>>
 
     return rows.map((s) => {
-      const total = (s.input_tokens || 0) + (s.output_tokens || 0)
       const lastMsg = s.last_message_at ? new Date(s.last_message_at).getTime() : 0
       // Trust scanner state first, but fall back to derived recency so UI doesn't
       // show stale "xh ago" when the active flag lags behind disk updates.
@@ -315,12 +316,48 @@ function getLocalHermesSessions() {
   }
 }
 
+function getLocalOpenCodeSessions() {
+  try {
+    const rows = scanOpenCodeSessions(100)
+
+    return rows.map((s) => {
+      const effectiveLastActivity = s.isActive && s.lastMessageAt ? Date.now() : (s.lastMessageAt ? new Date(s.lastMessageAt).getTime() : 0)
+      return {
+        id: s.sessionId,
+        key: s.projectSlug || s.sessionId,
+        agent: s.projectSlug || 'opencode',
+        kind: 'opencode',
+        age: s.isActive && s.lastMessageAt ? 'now' : formatAge(s.lastMessageAt ? new Date(s.lastMessageAt).getTime() : 0),
+        model: s.model || s.version || 'opencode',
+        tokens: `${formatTokens(s.inputTokens)}/${formatTokens(s.outputTokens)}`,
+        channel: 'local',
+        flags: s.provider ? [s.provider] : [],
+        active: s.isActive,
+        startTime: s.firstMessageAt ? new Date(s.firstMessageAt).getTime() : 0,
+        lastActivity: effectiveLastActivity,
+        source: 'local' as const,
+        userMessages: s.userMessages,
+        assistantMessages: s.assistantMessages,
+        toolUses: 0,
+        estimatedCost: 0,
+        lastUserPrompt: s.title || null,
+        totalTokens: s.totalTokens,
+        workingDir: s.projectPath || null,
+      }
+    })
+  } catch (err) {
+    logger.warn({ err }, 'Failed to read local OpenCode sessions')
+    return []
+  }
+}
+
 function mergeLocalSessions(
   claudeSessions: Array<Record<string, any>>,
   codexSessions: Array<Record<string, any>>,
   hermesSessions: Array<Record<string, any>> = [],
+  opencodeSessions: Array<Record<string, any>> = [],
 ) {
-  const merged = [...claudeSessions, ...codexSessions, ...hermesSessions]
+  const merged = [...claudeSessions, ...codexSessions, ...hermesSessions, ...opencodeSessions]
   return dedupeAndSortSessions(merged)
 }
 

--- a/src/app/api/sessions/transcript/route.ts
+++ b/src/app/api/sessions/transcript/route.ts
@@ -5,6 +5,7 @@ import Database from 'better-sqlite3'
 import { config } from '@/lib/config'
 import { requireRole } from '@/lib/auth'
 import { logger } from '@/lib/logger'
+import { getOpenCodeDbCandidates, epochMsToIso } from '@/lib/opencode-sessions'
 
 type MessageContentPart =
   | { type: 'text'; text: string }
@@ -16,6 +17,93 @@ type TranscriptMessage = {
   role: 'user' | 'assistant' | 'system'
   parts: MessageContentPart[]
   timestamp?: string
+}
+
+function readOpenCodeTranscript(sessionId: string, limit: number): TranscriptMessage[] {
+  for (const dbPath of getOpenCodeDbCandidates()) {
+    if (!dbPath || !fs.existsSync(dbPath)) continue
+
+    let db: Database.Database | null = null
+    try {
+      db = new Database(dbPath, { readonly: true, fileMustExist: true })
+      const hasMessage = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name = ?").get('message')
+      if (!hasMessage) continue
+
+      const rows = db.prepare(
+        `SELECT data, time_created, time_updated
+         FROM (
+           SELECT data, time_created, time_updated
+           FROM message
+           WHERE session_id = ?
+           ORDER BY COALESCE(time_updated, time_created) DESC
+           LIMIT ?
+         ) recent
+         ORDER BY COALESCE(time_updated, time_created) ASC`
+      ).all(sessionId, Math.max(1, limit * 4)) as Array<{ data: string | null; time_created: number | null; time_updated: number | null }>
+
+      if (rows.length === 0) continue
+
+      const messages: TranscriptMessage[] = []
+      for (const row of rows) {
+        if (!row.data) continue
+        let parsed: any
+        try {
+          parsed = JSON.parse(row.data)
+        } catch {
+          continue
+        }
+
+        const timestamp = epochMsToIso(row.time_updated || row.time_created) || undefined
+        const role = typeof parsed?.role === 'string' ? parsed.role : 'system'
+        const parts: MessageContentPart[] = []
+
+        if (typeof parsed?.content === 'string') {
+          const part = textPart(parsed.content)
+          if (part) parts.push(part)
+        }
+
+        if (parsed?.summary && typeof parsed.summary === 'object') {
+          const summary = JSON.stringify(parsed.summary)
+          const part = textPart(summary, 4000)
+          if (part) parts.push(part)
+        }
+
+        if (parsed?.error && typeof parsed.error === 'object') {
+          const detail = typeof parsed.error?.data?.message === 'string'
+            ? parsed.error.data.message
+            : typeof parsed.error?.name === 'string'
+              ? parsed.error.name
+              : JSON.stringify(parsed.error)
+          const part = textPart(`Error: ${detail}`, 4000)
+          if (part) parts.push(part)
+        }
+
+        if (parsed?.tokens && typeof parsed.tokens === 'object') {
+          const total = parsed.tokens.total ?? (Number(parsed.tokens.input || 0) + Number(parsed.tokens.output || 0))
+          const part = textPart(`Tokens: ${total}`, 200)
+          if (part) parts.push(part)
+        }
+
+        if (parts.length === 0) continue
+
+        if (role === 'assistant' || role === 'user' || role === 'system') {
+          messages.push({ role, parts, timestamp })
+        } else {
+          messages.push({ role: 'system', parts, timestamp })
+        }
+      }
+
+      if (messages.length > 0) {
+        return messages.slice(-limit)
+      }
+    } catch (error) {
+      logger.warn({ err: error, dbPath, sessionId }, 'Failed to read OpenCode transcript')
+    } finally {
+      try { db?.close() } catch { /* noop */ }
+    }
+  }
+
+  return []
 }
 
 function messageTimestampMs(message: TranscriptMessage): number {
@@ -340,7 +428,7 @@ function readHermesTranscript(sessionId: string, limit: number): TranscriptMessa
 /**
  * GET /api/sessions/transcript
  * Query params:
- *   kind=claude-code|codex-cli|hermes
+ *   kind=claude-code|codex-cli|hermes|opencode
  *   id=<session-id>
  *   limit=40
  */
@@ -354,7 +442,7 @@ export async function GET(request: NextRequest) {
     const sessionId = searchParams.get('id') || ''
     const limit = Math.min(parseInt(searchParams.get('limit') || '40', 10), 200)
 
-    if (!sessionId || (kind !== 'claude-code' && kind !== 'codex-cli' && kind !== 'hermes')) {
+    if (!sessionId || (kind !== 'claude-code' && kind !== 'codex-cli' && kind !== 'hermes' && kind !== 'opencode')) {
       return NextResponse.json({ error: 'kind and id are required' }, { status: 400 })
     }
 
@@ -362,7 +450,9 @@ export async function GET(request: NextRequest) {
       ? readClaudeTranscript(sessionId, limit)
       : kind === 'codex-cli'
         ? readCodexTranscript(sessionId, limit)
-        : readHermesTranscript(sessionId, limit)
+        : kind === 'hermes'
+          ? readHermesTranscript(sessionId, limit)
+          : readOpenCodeTranscript(sessionId, limit)
 
     return NextResponse.json({ messages })
   } catch (error) {
@@ -372,4 +462,4 @@ export async function GET(request: NextRequest) {
 }
 
 export const dynamic = 'force-dynamic'
-export const __testables = { readHermesTranscriptFromDbPath }
+export const __testables = { readHermesTranscriptFromDbPath, readOpenCodeTranscript }

--- a/src/components/chat/chat-workspace.tsx
+++ b/src/components/chat/chat-workspace.tsx
@@ -892,6 +892,7 @@ function getConversationStatus(agents: Array<{ name: string; status: string }>, 
     if (conversationId.includes('claude-code')) return 'Local Claude session'
     if (conversationId.includes('codex-cli')) return 'Local Codex session'
     if (conversationId.includes('hermes')) return 'Local Hermes session'
+    if (conversationId.includes('opencode')) return 'Local OpenCode session'
     return 'Gateway session'
   }
   const name = conversationId.replace('agent_', '')

--- a/src/components/chat/conversation-list.tsx
+++ b/src/components/chat/conversation-list.tsx
@@ -9,7 +9,7 @@ import { SessionKindAvatar, SessionKindPill } from './session-kind-brand'
 
 const log = createClientLogger('ConversationList')
 
-type SessionKind = 'claude-code' | 'codex-cli' | 'hermes' | 'gateway'
+type SessionKind = 'claude-code' | 'codex-cli' | 'hermes' | 'opencode' | 'gateway'
 
 type SessionRecord = {
   id: string
@@ -265,7 +265,7 @@ export function ConversationList({ onNewConversation: _onNewConversation }: Conv
           const updatedAt = lastActivityMs > 1_000_000_000_000
             ? Math.floor(lastActivityMs / 1000)
             : lastActivityMs
-          const sessionKind: SessionKind = s.kind === 'claude-code' || s.kind === 'codex-cli' || s.kind === 'hermes'
+          const sessionKind: SessionKind = s.kind === 'claude-code' || s.kind === 'codex-cli' || s.kind === 'hermes' || s.kind === 'opencode'
             ? s.kind
             : 'gateway'
           const kindLabel = sessionKind === 'codex-cli'
@@ -274,6 +274,8 @@ export function ConversationList({ onNewConversation: _onNewConversation }: Conv
               ? 'Claude'
               : sessionKind === 'hermes'
                 ? 'Hermes'
+                : sessionKind === 'opencode'
+                  ? 'OpenCode'
                 : 'Gateway'
           const prefKey = `${sessionKind}:${s.id}`
           const pref = prefs[prefKey] || {}

--- a/src/components/chat/session-kind-brand.tsx
+++ b/src/components/chat/session-kind-brand.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image'
 
-type SessionKind = 'claude-code' | 'codex-cli' | 'hermes' | 'gateway'
+type SessionKind = 'claude-code' | 'codex-cli' | 'hermes' | 'opencode' | 'gateway'
 
 const SESSION_KIND_META: Record<SessionKind, {
   label: string
@@ -31,6 +31,11 @@ const SESSION_KIND_META: Record<SessionKind, {
     pillClassName: 'bg-cyan-500/15 text-cyan-300/80',
     imageSrc: '/brand/hermes-logo.png',
     imageAlt: 'Hermes logo',
+  },
+  opencode: {
+    label: 'OpenCode',
+    shortLabel: 'OC',
+    pillClassName: 'bg-fuchsia-500/15 text-fuchsia-300/80',
   },
   gateway: {
     label: 'Gateway',

--- a/src/components/onboarding/runtime-setup-modal.tsx
+++ b/src/components/onboarding/runtime-setup-modal.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { Button } from '@/components/ui/button'
 
 interface RuntimeSetupModalProps {
-  runtime: 'openclaw' | 'hermes' | 'claude' | 'codex'
+  runtime: 'openclaw' | 'hermes' | 'claude' | 'codex' | 'opencode'
   onClose: () => void
   onComplete: () => void
 }
@@ -15,12 +15,36 @@ export function RuntimeSetupModal({ runtime, onClose, onComplete }: RuntimeSetup
     hermes: HermesSetup,
     claude: ClaudeSetup,
     codex: CodexSetup,
+    opencode: OpenCodeSetup,
   }[runtime]
 
   return (
     <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4" onClick={(e) => { if (e.target === e.currentTarget) onClose() }}>
       <div className="bg-card border border-border rounded-xl max-w-lg w-full max-h-[80vh] overflow-y-auto shadow-2xl shadow-black/30">
         <SetupComponent onClose={onClose} onComplete={onComplete} />
+      </div>
+    </div>
+  )
+}
+
+function OpenCodeSetup({ onClose, onComplete }: { onClose: () => void; onComplete: () => void }) {
+  return (
+    <div className="p-6">
+      <div className="flex items-center justify-between mb-4">
+        <div>
+          <h3 className="text-lg font-semibold">Set Up OpenCode</h3>
+          <p className="text-xs text-muted-foreground mt-0.5">OpenCode is detected locally and sessions are read from its local SQLite state store.</p>
+        </div>
+        <button type="button" onClick={onClose} className="text-muted-foreground hover:text-foreground">
+          <svg className="w-5 h-5" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"><path d="M4 4l8 8M12 4l-8 8" /></svg>
+        </button>
+      </div>
+      <div className="p-4 rounded-lg border border-border/30 bg-secondary/20 text-sm text-muted-foreground space-y-2">
+        <p>Mission Control reads OpenCode runtime status from the installed <code>opencode</code> CLI and scans session history from <code>~/.local/share/opencode/*.db</code>.</p>
+        <p>Restart OpenCode or create a new OpenCode session if you want Mission Control to pick up fresh session activity immediately.</p>
+      </div>
+      <div className="flex justify-end mt-4">
+        <Button size="sm" onClick={onComplete}>Done</Button>
       </div>
     </div>
   )
@@ -40,7 +64,7 @@ function OpenClawSetup({ onClose, onComplete }: { onClose: () => void; onComplet
     setError(null)
     setOutput('')
     try {
-      const res = await fetch('/api/agent-runtimes', {
+      await fetch('/api/agent-runtimes', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action: 'install', runtime: 'openclaw', mode: 'local' }),
@@ -926,7 +950,6 @@ function CopyableCommand({ command, label, runnable = false, onOutput }: {
 function ClaudeSetup({ onClose, onComplete }: { onClose: () => void; onComplete: () => void }) {
   const [step, setStep] = useState<'check' | 'auth' | 'done'>('check')
   const [checking, setChecking] = useState(false)
-  const [authenticated, setAuthenticated] = useState(false)
   const [version, setVersion] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
 
@@ -939,7 +962,6 @@ function ClaudeSetup({ onClose, onComplete }: { onClose: () => void; onComplete:
         const data = await res.json()
         const claude = (data.runtimes || []).find((r: any) => r.id === 'claude')
         if (claude) {
-          setAuthenticated(claude.authenticated)
           setVersion(claude.version)
           if (claude.authenticated) setStep('done')
           else setStep('auth')
@@ -1047,7 +1069,6 @@ function ClaudeSetup({ onClose, onComplete }: { onClose: () => void; onComplete:
 function CodexSetup({ onClose, onComplete }: { onClose: () => void; onComplete: () => void }) {
   const [step, setStep] = useState<'check' | 'auth' | 'done'>('check')
   const [checking, setChecking] = useState(false)
-  const [authenticated, setAuthenticated] = useState(false)
   const [version, setVersion] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
 
@@ -1060,7 +1081,6 @@ function CodexSetup({ onClose, onComplete }: { onClose: () => void; onComplete: 
         const data = await res.json()
         const codex = (data.runtimes || []).find((r: any) => r.id === 'codex')
         if (codex) {
-          setAuthenticated(codex.authenticated)
           setVersion(codex.version)
           if (codex.authenticated) setStep('done')
           else setStep('auth')

--- a/src/components/settings/agent-runtimes-section.tsx
+++ b/src/components/settings/agent-runtimes-section.tsx
@@ -35,7 +35,7 @@ export function AgentRuntimesSection({ showFeedback }: Props) {
   const [loading, setLoading] = useState(true)
   const [activeJobs, setActiveJobs] = useState<Record<string, InstallJob>>({})
   const [expandedOutput, setExpandedOutput] = useState<string | null>(null)
-  const [setupRuntime, setSetupRuntime] = useState<'openclaw' | 'hermes' | 'claude' | 'codex' | null>(null)
+  const [setupRuntime, setSetupRuntime] = useState<'openclaw' | 'hermes' | 'claude' | 'codex' | 'opencode' | null>(null)
 
   const fetchRuntimes = useCallback(async () => {
     try {
@@ -260,7 +260,7 @@ export function AgentRuntimesSection({ showFeedback }: Props) {
 
                     {(rt.installed || justInstalled) && (
                       <button
-                        onClick={() => setSetupRuntime(rt.id as 'openclaw' | 'hermes' | 'claude' | 'codex')}
+                        onClick={() => setSetupRuntime(rt.id as 'openclaw' | 'hermes' | 'claude' | 'codex' | 'opencode')}
                         className="text-2xs mt-1.5 px-2 py-1 rounded border border-primary/30 bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
                       >
                         Configure {rt.name}
@@ -307,7 +307,7 @@ export function AgentRuntimesSection({ showFeedback }: Props) {
           onComplete={() => {
             setSetupRuntime(null)
             fetchRuntimes()
-            const names: Record<string, string> = { openclaw: 'OpenClaw', hermes: 'Hermes', claude: 'Claude Code', codex: 'Codex CLI' }
+            const names: Record<string, string> = { openclaw: 'OpenClaw', hermes: 'Hermes', claude: 'Claude Code', codex: 'Codex CLI', opencode: 'OpenCode' }
             showFeedback(true, `${names[setupRuntime] || setupRuntime} setup complete`)
           }}
         />

--- a/src/components/terminal/terminal-view.tsx
+++ b/src/components/terminal/terminal-view.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState, useCallback } from 'react'
 
 interface TerminalViewProps {
   sessionId: string
-  sessionKind: 'claude-code' | 'codex-cli' | 'hermes' | 'gateway'
+  sessionKind: 'claude-code' | 'codex-cli' | 'hermes' | 'opencode' | 'gateway'
   mode: 'readonly' | 'interactive'
   onExit?: (code: number) => void
   onError?: (error: string) => void
@@ -225,7 +225,7 @@ export function TerminalView({ sessionId, sessionKind, mode, onExit, onError, on
       setErrorMessage(msg)
       onError?.(msg)
     }
-  }, [sessionId, sessionKind, mode, onExit, onError, onReady])
+  }, [sessionId, sessionKind, mode, onExit, onError, onReady, connState])
 
   useEffect(() => {
     const cleanup = connect()

--- a/src/lib/__tests__/agent-runtimes-opencode.test.ts
+++ b/src/lib/__tests__/agent-runtimes-opencode.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/hermes-sessions', () => ({
+  isHermesInstalled: vi.fn(() => false),
+  isHermesGatewayRunning: vi.fn(() => false),
+  clearHermesDetectionCache: vi.fn(),
+}))
+
+vi.mock('@/lib/opencode-sessions', () => ({
+  isOpenCodeInstalled: vi.fn(() => true),
+  getOpenCodeVersion: vi.fn(() => '1.4.3'),
+  scanOpenCodeSessions: vi.fn(() => [{ isActive: true }]),
+}))
+
+vi.mock('@/lib/logger', () => ({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } }))
+vi.mock('@/lib/config', () => ({ config: { openclawConfigPath: '', openclawBin: 'openclaw', gatewayHost: '127.0.0.1', gatewayPort: 18789, homeDir: '/tmp', dataDir: '/tmp' } }))
+
+describe('detectRuntime(opencode)', () => {
+  it('reports OpenCode as installed and running when active sessions exist', async () => {
+    const { detectRuntime } = await import('@/lib/agent-runtimes')
+    const runtime = detectRuntime('opencode')
+    expect(runtime).toMatchObject({
+      id: 'opencode',
+      installed: true,
+      version: '1.4.3',
+      running: true,
+      authenticated: true,
+    })
+  })
+})

--- a/src/lib/__tests__/opencode-sessions.test.ts
+++ b/src/lib/__tests__/opencode-sessions.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+let tempHome = ''
+let dbRowsByName: Record<string, Record<string, any[]>> = {}
+
+vi.mock('@/lib/config', () => ({
+  config: {
+    get homeDir() {
+      return tempHome
+    },
+  },
+}))
+
+vi.mock('better-sqlite3', () => ({
+  default: vi.fn((dbPath?: string) => ({
+    prepare: (query: string) => ({
+      get: (...args: any[]) => {
+        const name = dbPath ? String(dbPath).split('/').pop() || '' : ''
+        const rows = dbRowsByName[name] || dbRowsByName.default || {}
+        if (query.includes('sqlite_master') && args[0] === 'session') return { name: 'session' }
+        if (query.includes('sqlite_master') && args[0] === 'project') return { name: 'project' }
+        if (query.includes('sqlite_master') && args[0] === 'message') return { name: 'message' }
+        if (query.includes('SELECT id, worktree FROM project')) {
+          const project = rows.project || []
+          return project.find((row: any) => row.id === args[0]) || { id: args[0], worktree: '/tmp/opencode-project' }
+        }
+        return undefined
+      },
+      all: (...args: any[]) => {
+        const name = dbPath ? String(dbPath).split('/').pop() || '' : ''
+        const rows = dbRowsByName[name] || dbRowsByName.default || {}
+        if (query.includes('PRAGMA table_info(session)')) {
+          const sample = rows.session?.[0] || {}
+          return Object.keys(sample).map((key, index) => ({ cid: index, name: key }))
+        }
+        if (query.includes('FROM session')) return rows.session || []
+        if (query.includes('FROM message')) return rows.message || []
+        return []
+      },
+    }),
+    close: vi.fn(),
+  })),
+}))
+
+describe('scanOpenCodeSessions', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    tempHome = mkdtempSync(join(tmpdir(), 'mc-opencode-test-'))
+    mkdirSync(join(tempHome, '.local', 'share', 'opencode'), { recursive: true })
+    writeFileSync(join(tempHome, '.local', 'share', 'opencode', 'opencode-local.db'), '')
+    dbRowsByName = {
+      'opencode-local.db': {
+        session: [
+          {
+            id: 'ses_open_1',
+            project_id: 'proj_1',
+            parent_id: null,
+            slug: 'hidden-wolf',
+            directory: '/tmp/opencode-project',
+            title: 'OpenCode inspection',
+            version: '1.4.3',
+            share_url: null,
+            summary_additions: null,
+            summary_deletions: null,
+            summary_files: null,
+            summary_diffs: null,
+            revert: null,
+            permission: null,
+            time_created: Date.now() - 10000,
+            time_updated: Date.now() - 1000,
+            time_compacting: null,
+            time_archived: null,
+            workspace_id: null,
+          },
+        ],
+        project: [
+          {
+            id: 'proj_1',
+            worktree: '/tmp/opencode-project',
+          },
+        ],
+        message: [
+          {
+            data: JSON.stringify({ role: 'user', model: { providerID: 'anthropic', modelID: 'claude-sonnet-4-5' }, tokens: { input: 11, output: 0 } }),
+            time_created: Date.now() - 10000,
+            time_updated: Date.now() - 10000,
+          },
+          {
+            data: JSON.stringify({ role: 'assistant', providerID: 'anthropic', modelID: 'claude-sonnet-4-5', tokens: { input: 0, output: 7 } }),
+            time_created: Date.now() - 5000,
+            time_updated: Date.now() - 1000,
+          },
+        ],
+      },
+    }
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    if (tempHome) rmSync(tempHome, { recursive: true, force: true })
+  })
+
+  it('maps OpenCode SQLite sessions into Mission Control session stats', async () => {
+    const { scanOpenCodeSessions } = await import('@/lib/opencode-sessions')
+    const sessions = scanOpenCodeSessions(10)
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0]).toMatchObject({
+      sessionId: 'ses_open_1',
+      projectId: 'proj_1',
+      projectSlug: 'opencode-project',
+      projectPath: '/tmp/opencode-project',
+      title: 'OpenCode inspection',
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-5',
+      version: '1.4.3',
+      userMessages: 1,
+      assistantMessages: 1,
+      inputTokens: 11,
+      outputTokens: 7,
+      totalTokens: 18,
+      isActive: true,
+    })
+  })
+
+  it('merges sessions across multiple OpenCode databases and prefers explicit OPENCODE_DB_PATH', async () => {
+    const opencodeDir = join(tempHome, '.local', 'share', 'opencode')
+    writeFileSync(join(opencodeDir, 'opencode.db'), '')
+    writeFileSync(join(opencodeDir, 'opencode-older.db'), '')
+
+    dbRowsByName['opencode.db'] = {
+      session: [
+        {
+          id: 'ses_open_2',
+          project_id: 'proj_2',
+          parent_id: null,
+          slug: 'second-wolf',
+          directory: '/tmp/opencode-project-2',
+          title: 'Second session',
+          version: '1.4.4',
+          share_url: null,
+          summary_additions: null,
+          summary_deletions: null,
+          summary_files: null,
+          summary_diffs: null,
+          revert: null,
+          permission: null,
+          time_created: Date.now() - 20000,
+          time_updated: Date.now() - 2000,
+          time_compacting: null,
+          time_archived: null,
+          workspace_id: null,
+        },
+      ],
+      project: [{ id: 'proj_2', worktree: '/tmp/opencode-project-2' }],
+      message: [
+        {
+          data: JSON.stringify({ role: 'assistant', providerID: 'openai', modelID: 'gpt-5' }),
+          time_created: Date.now() - 2000,
+          time_updated: Date.now() - 2000,
+        },
+      ],
+    }
+    dbRowsByName['opencode-older.db'] = {
+      session: [
+        {
+          id: 'ses_open_old',
+          project_id: 'proj_old',
+          parent_id: null,
+          slug: 'old-wolf',
+          directory: '/tmp/opencode-old',
+          title: 'Old session',
+          version: '1.4.0',
+          share_url: null,
+          summary_additions: null,
+          summary_deletions: null,
+          summary_files: null,
+          summary_diffs: null,
+          revert: null,
+          permission: null,
+          time_created: Date.now() - 30000,
+          time_updated: Date.now() - 3000,
+          time_compacting: null,
+          time_archived: null,
+          workspace_id: null,
+        },
+      ],
+      project: [{ id: 'proj_old', worktree: '/tmp/opencode-old' }],
+      message: [
+        {
+          data: JSON.stringify({ role: 'assistant', providerID: 'anthropic', modelID: 'claude-opus-4-1' }),
+          time_created: Date.now() - 3000,
+          time_updated: Date.now() - 3000,
+        },
+      ],
+    }
+
+    const { scanOpenCodeSessions } = await import('@/lib/opencode-sessions')
+    const merged = scanOpenCodeSessions(10)
+    expect(merged.map((session) => session.sessionId).sort()).toEqual(['ses_open_1', 'ses_open_2', 'ses_open_old'])
+
+    process.env.OPENCODE_DB_PATH = join(opencodeDir, 'opencode.db')
+    const explicitOnly = scanOpenCodeSessions(10)
+    expect(explicitOnly.map((session) => session.sessionId)).toEqual(['ses_open_2'])
+    delete process.env.OPENCODE_DB_PATH
+  })
+})

--- a/src/lib/agent-runtimes.ts
+++ b/src/lib/agent-runtimes.ts
@@ -6,6 +6,7 @@ import { config } from './config'
 import { runCommand, runOpenClaw } from './command'
 import { scanForInjection } from './injection-guard'
 import { isHermesInstalled, isHermesGatewayRunning, clearHermesDetectionCache } from './hermes-sessions'
+import { isOpenCodeInstalled, getOpenCodeVersion, scanOpenCodeSessions } from './opencode-sessions'
 import { logger } from './logger'
 
 // ---------------------------------------------------------------------------
@@ -158,7 +159,7 @@ ${truncated}
   }
 }
 
-export type RuntimeId = 'openclaw' | 'hermes' | 'claude' | 'codex'
+export type RuntimeId = 'openclaw' | 'hermes' | 'claude' | 'codex' | 'opencode'
 export type DeploymentMode = 'local' | 'docker'
 
 export interface RuntimeStatus {
@@ -216,6 +217,12 @@ const RUNTIME_META: Record<RuntimeId, RuntimeMeta> = {
     authRequired: true,
     authHint: 'Run "codex auth" after install to authenticate.',
   },
+  opencode: {
+    name: 'OpenCode',
+    description: 'AI coding agent for the terminal with local SQLite-backed session storage.',
+    authRequired: false,
+    authHint: '',
+  },
 }
 
 export function getRuntimeMeta(id: RuntimeId): RuntimeMeta | undefined {
@@ -271,7 +278,7 @@ function detectOpenClaw(): RuntimeStatus {
     const net = require('node:net')
     const socket = new net.Socket()
     socket.setTimeout(500)
-    const connected = new Promise<boolean>((resolve) => {
+    new Promise<boolean>((resolve) => {
       socket.once('connect', () => { socket.destroy(); resolve(true) })
       socket.once('error', () => { socket.destroy(); resolve(false) })
       socket.once('timeout', () => { socket.destroy(); resolve(false) })
@@ -464,11 +471,21 @@ function detectCodex(): RuntimeStatus {
   return { id: 'codex', ...meta, installed, version, running: false, authenticated }
 }
 
+function detectOpenCode(): RuntimeStatus {
+  const meta = RUNTIME_META.opencode
+  const installed = isOpenCodeInstalled()
+  const version = installed ? getOpenCodeVersion() : null
+  const running = installed ? scanOpenCodeSessions(10).some((session) => session.isActive) : false
+
+  return { id: 'opencode', ...meta, installed, version, running, authenticated: installed }
+}
+
 const DETECTORS: Record<RuntimeId, () => RuntimeStatus> = {
   openclaw: detectOpenClaw,
   hermes: detectHermes,
   claude: detectClaude,
   codex: detectCodex,
+  opencode: detectOpenCode,
 }
 
 export function detectRuntime(id: RuntimeId): RuntimeStatus {
@@ -514,6 +531,7 @@ export function startInstall(runtime: RuntimeId, mode: DeploymentMode): InstallJ
     hermes: installHermesLocal,
     claude: installClaudeLocal,
     codex: installCodexLocal,
+    opencode: installOpenCodeLocal,
   }
   const installFn = INSTALL_FNS[runtime] || installOpenClawLocal
   installFn(job).catch((err) => {
@@ -710,6 +728,18 @@ async function installCodexLocal(job: InstallJob): Promise<void> {
   job.finishedAt = Date.now()
 }
 
+async function installOpenCodeLocal(job: InstallJob): Promise<void> {
+  job.output += '> Installing OpenCode...\n'
+  if (await runInstallCmd('brew', ['install', 'opencode'], job)) {
+    job.status = 'success'
+    job.output += '\n> OpenCode installed successfully.\n'
+  } else {
+    job.status = 'failed'
+    job.error = 'brew install failed — see output above'
+  }
+  job.finishedAt = Date.now()
+}
+
 export function getInstallJob(id: string): InstallJob | null {
   return installJobs.get(id) ?? null
 }
@@ -739,6 +769,12 @@ export function generateDockerSidecar(runtime: RuntimeId): string {
 
 # Add to volumes section:
 #   openclaw-data:`
+  }
+
+  if (runtime === 'opencode') {
+    return `# OpenCode does not provide an official sidecar template yet.
+# Install it locally with Homebrew or your preferred package manager,
+# then let Mission Control discover sessions from ~/.local/share/opencode.`
   }
 
   return `  # Hermes Agent sidecar

--- a/src/lib/opencode-sessions.ts
+++ b/src/lib/opencode-sessions.ts
@@ -1,0 +1,304 @@
+import { existsSync, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+import Database from 'better-sqlite3'
+import { config } from './config'
+import { logger } from './logger'
+
+const ACTIVE_THRESHOLD_MS = 90 * 60 * 1000
+
+export interface OpenCodeSessionStats {
+  sessionId: string
+  projectId: string | null
+  projectSlug: string
+  projectPath: string | null
+  title: string | null
+  provider: string | null
+  model: string | null
+  version: string | null
+  userMessages: number
+  assistantMessages: number
+  inputTokens: number
+  outputTokens: number
+  totalTokens: number
+  firstMessageAt: string | null
+  lastMessageAt: string | null
+  isActive: boolean
+}
+
+interface OpenCodeSessionRow {
+  id: string
+  project_id: string | null
+  directory: string | null
+  title: string | null
+  provider: string | null
+  model: string | null
+  version: string | null
+  time_created: number | null
+  time_updated: number | null
+}
+
+interface OpenCodeProjectRow {
+  id: string
+  worktree: string | null
+}
+
+interface OpenCodeMessageRow {
+  data: string | null
+  time_created: number | null
+  time_updated: number | null
+}
+
+function tableColumns(db: Database.Database, table: string): Set<string> {
+  try {
+    const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name?: string }>
+    return new Set(rows.map((row) => row.name).filter((name): name is string => typeof name === 'string'))
+  } catch {
+    return new Set()
+  }
+}
+
+export function getOpenCodeDbCandidates(): string[] {
+  const base = join(config.homeDir, '.local', 'share', 'opencode')
+  if (process.env.OPENCODE_DB_PATH) {
+    return [process.env.OPENCODE_DB_PATH]
+  }
+
+  const discovered = existsSync(base)
+    ? readdirSync(base)
+        .filter((entry) => entry.endsWith('.db'))
+        .map((entry) => join(base, entry))
+    : []
+
+  return discovered.sort((a, b) => {
+    try {
+      return statSync(b).mtimeMs - statSync(a).mtimeMs
+    } catch {
+      return 0
+    }
+  })
+}
+
+function openDatabase(path: string): Database.Database | null {
+  try {
+    return new Database(path, { readonly: true, fileMustExist: true })
+  } catch (err) {
+    logger.warn({ err, path }, 'Failed to open OpenCode database')
+    return null
+  }
+}
+
+function tableExists(db: Database.Database, name: string): boolean {
+  try {
+    const row = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name = ?").get(name) as { name?: string } | undefined
+    return row?.name === name
+  } catch {
+    return false
+  }
+}
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  return value as Record<string, unknown>
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+export function epochMsToIso(value: number | null): string | null {
+  if (!value || !Number.isFinite(value) || value <= 0) return null
+  return new Date(value).toISOString()
+}
+
+export function isOpenCodeInstalled(): boolean {
+  const candidates = getOpenCodeBinaryCandidates()
+
+  return candidates.some((bin) => {
+    try {
+      if (bin.startsWith('/') && !existsSync(bin)) return false
+      const result = spawnSync(bin, ['--version'], { stdio: 'pipe', timeout: 5000 })
+      return result.status === 0
+    } catch {
+      return false
+    }
+  })
+}
+
+export function getOpenCodeVersion(): string | null {
+  const candidates = getOpenCodeBinaryCandidates()
+
+  for (const bin of candidates) {
+    try {
+      if (bin.startsWith('/') && !existsSync(bin)) continue
+      const result = spawnSync(bin, ['--version'], { stdio: 'pipe', timeout: 5000 })
+      if (result.status === 0) {
+        const line = (result.stdout?.toString() || '').trim().split('\n')[0]?.trim()
+        if (line) return line
+      }
+    } catch {
+      continue
+    }
+  }
+
+  return null
+}
+
+export function getOpenCodeBinaryCandidates(): string[] {
+  return [
+    process.env.OPENCODE_BIN,
+    join('/opt/homebrew/bin', 'opencode'),
+    join(config.homeDir, '.local', 'bin', 'opencode'),
+    'opencode',
+  ].filter((v): v is string => Boolean(v && v.trim()))
+}
+
+export function getOpenCodeExecutable(): string {
+  const candidates = getOpenCodeBinaryCandidates()
+  for (const bin of candidates) {
+    if (!bin.startsWith('/') || existsSync(bin)) return bin
+  }
+  return 'opencode'
+}
+
+export function scanOpenCodeSessions(limit = 100): OpenCodeSessionStats[] {
+  const sessionMap = new Map<string, OpenCodeSessionStats>()
+  const dbPaths = getOpenCodeDbCandidates()
+  if (dbPaths.length === 0) return []
+
+  for (const dbPath of dbPaths) {
+    if (!existsSync(dbPath)) continue
+    const db = openDatabase(dbPath)
+    if (!db) continue
+
+    try {
+      if (!tableExists(db, 'session') || !tableExists(db, 'project')) continue
+
+      const sessionColumns = tableColumns(db, 'session')
+      const whereClauses = ['1=1']
+      if (sessionColumns.has('deleted_at')) whereClauses.push('deleted_at IS NULL')
+      if (sessionColumns.has('archived_at')) whereClauses.push('archived_at IS NULL')
+      if (sessionColumns.has('time_archived')) whereClauses.push('time_archived IS NULL')
+
+      const sessions = db.prepare(
+        `SELECT id,
+                project_id,
+                directory,
+                title,
+                ${sessionColumns.has('provider') ? 'provider' : 'NULL AS provider'},
+                ${sessionColumns.has('model') ? 'model' : 'NULL AS model'},
+                ${sessionColumns.has('version') ? 'version' : 'NULL AS version'},
+                time_created,
+                time_updated
+         FROM session
+         WHERE ${whereClauses.join(' AND ')}
+         ORDER BY COALESCE(time_updated, time_created) DESC
+         LIMIT ?`
+      ).all(limit) as OpenCodeSessionRow[]
+
+      const projectStmt = db.prepare('SELECT id, worktree FROM project WHERE id = ?')
+      const messageStmt = tableExists(db, 'message')
+        ? db.prepare('SELECT data, time_created, time_updated FROM message WHERE session_id = ? ORDER BY COALESCE(time_updated, time_created) ASC')
+        : null
+
+      for (const session of sessions) {
+        const project = session.project_id
+          ? (projectStmt.get(session.project_id) as OpenCodeProjectRow | undefined)
+          : undefined
+
+        const projectPath = project?.worktree || session.directory || null
+        const projectSlug = projectPath ? projectPath.split('/').filter(Boolean).pop() || 'opencode' : 'opencode'
+
+        let userMessages = 0
+        let assistantMessages = 0
+        let inputTokens = 0
+        let outputTokens = 0
+        let inferredProvider = session.provider
+        let inferredModel = session.model
+        let firstMessageAt = epochMsToIso(session.time_created)
+        let lastMessageAt = epochMsToIso(session.time_updated)
+
+        if (messageStmt) {
+          const messages = messageStmt.all(session.id) as OpenCodeMessageRow[]
+          for (const msg of messages) {
+            if (!firstMessageAt && msg.time_created) firstMessageAt = epochMsToIso(msg.time_created)
+            if (msg.time_updated) lastMessageAt = epochMsToIso(msg.time_updated)
+
+            if (!msg.data) continue
+            try {
+              const parsed = JSON.parse(msg.data)
+              const data = asObject(parsed)
+              if (!data) continue
+              const role = asString(data.role)
+              if (role === 'user') userMessages += 1
+              if (role === 'assistant') assistantMessages += 1
+
+              if (!inferredProvider) {
+                inferredProvider = asString(data.providerID)
+                  || asString(asObject(data.model)?.providerID)
+                  || inferredProvider
+              }
+              if (!inferredModel) {
+                inferredModel = asString(data.modelID)
+                  || asString(asObject(data.model)?.modelID)
+                  || inferredModel
+              }
+
+              const tokens = asObject(data.tokens)
+              if (tokens) {
+                inputTokens += asNumber(tokens.input) || 0
+                outputTokens += asNumber(tokens.output) || 0
+              }
+            } catch {
+              continue
+            }
+          }
+        }
+
+        const lastMs = lastMessageAt ? new Date(lastMessageAt).getTime() : 0
+        const isActive = lastMs > 0 && (Date.now() - lastMs) < ACTIVE_THRESHOLD_MS
+
+        const candidate: OpenCodeSessionStats = {
+          sessionId: session.id,
+          projectId: session.project_id,
+          projectSlug,
+          projectPath,
+          title: session.title,
+          provider: inferredProvider,
+          model: inferredModel,
+          version: session.version,
+          userMessages,
+          assistantMessages,
+          inputTokens,
+          outputTokens,
+          totalTokens: inputTokens + outputTokens,
+          firstMessageAt,
+          lastMessageAt,
+          isActive,
+        }
+
+        const existing = sessionMap.get(session.id)
+        const existingLast = existing?.lastMessageAt ? new Date(existing.lastMessageAt).getTime() : 0
+        if (!existing || lastMs >= existingLast) {
+          sessionMap.set(session.id, candidate)
+        }
+      }
+    } catch (err) {
+      logger.warn({ err, dbPath }, 'Failed to scan OpenCode sessions')
+    } finally {
+      try { db.close() } catch {}
+    }
+  }
+
+  return Array.from(sessionMap.values())
+    .sort((a, b) => {
+      const aLast = a.lastMessageAt ? new Date(a.lastMessageAt).getTime() : 0
+      const bLast = b.lastMessageAt ? new Date(b.lastMessageAt).getTime() : 0
+      return bLast - aLast
+    })
+    .slice(0, limit)
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -238,7 +238,7 @@ export interface Conversation {
     prefKey?: string
     sessionId: string
     sessionKey?: string
-    sessionKind: 'claude-code' | 'codex-cli' | 'hermes' | 'gateway'
+    sessionKind: 'claude-code' | 'codex-cli' | 'hermes' | 'opencode' | 'gateway'
     agent?: string
     displayName?: string
     colorTag?: string

--- a/tests/session-controls.spec.ts
+++ b/tests/session-controls.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from '@playwright/test'
 import { API_KEY_HEADER } from './helpers'
-
 test.describe('Session Controls API', () => {
   // ── GET /api/sessions ─────────────────────────
 
@@ -10,6 +9,55 @@ test.describe('Session Controls API', () => {
     const body = await res.json()
     expect(body).toHaveProperty('sessions')
     expect(Array.isArray(body.sessions)).toBe(true)
+  })
+
+  test('GET /api/sessions includes native OpenCode local sessions when present', async ({ request }) => {
+    const res = await request.get('/api/sessions', { headers: API_KEY_HEADER })
+    expect(res.status()).toBe(200)
+    const body = await res.json()
+    const opencodeSession = body.sessions.find((session: any) => session.kind === 'opencode')
+
+    expect(opencodeSession).toBeDefined()
+    expect(opencodeSession.source).toBe('local')
+    expect(typeof opencodeSession.id).toBe('string')
+  })
+
+  test('GET /api/sessions/transcript returns OpenCode transcript snippets', async ({ request }) => {
+    const sessionsRes = await request.get('/api/sessions', { headers: API_KEY_HEADER })
+    expect(sessionsRes.status()).toBe(200)
+    const sessionsBody = await sessionsRes.json()
+    const opencodeSession = sessionsBody.sessions.find((session: any) => session.kind === 'opencode')
+    expect(opencodeSession).toBeDefined()
+
+    const transcriptRes = await request.get(
+      `/api/sessions/transcript?kind=opencode&id=${encodeURIComponent(opencodeSession.id)}&limit=5`,
+      { headers: API_KEY_HEADER }
+    )
+    expect(transcriptRes.status()).toBe(200)
+    const transcriptBody = await transcriptRes.json()
+    expect(Array.isArray(transcriptBody.messages)).toBe(true)
+    expect(transcriptBody.messages.length).toBeGreaterThan(0)
+  })
+
+  test('POST /api/sessions/continue returns OpenCode response over HTTP', async ({ request }) => {
+    const sessionsRes = await request.get('/api/sessions', { headers: API_KEY_HEADER })
+    expect(sessionsRes.status()).toBe(200)
+    const sessionsBody = await sessionsRes.json()
+    const opencodeSession = sessionsBody.sessions.find((session: any) => session.kind === 'opencode')
+    expect(opencodeSession).toBeDefined()
+
+    const continueRes = await request.post('/api/sessions/continue', {
+      headers: API_KEY_HEADER,
+      data: {
+        kind: 'opencode',
+        id: opencodeSession.id,
+        prompt: 'say exactly CONTINUE_OK and nothing else',
+      },
+    })
+
+    expect(continueRes.status()).toBe(200)
+    const continueBody = await continueRes.json()
+    expect(continueBody).toMatchObject({ ok: true, reply: 'CONTINUE_OK' })
   })
 
   // ── POST /api/sessions – set-thinking ─────────


### PR DESCRIPTION
## Summary
- add native OpenCode runtime detection and session discovery backed by the local OpenCode SQLite state store
- expose OpenCode through Mission Control session/runtime APIs and UI surfaces, including transcript and continue-session support
- add hermetic test coverage and clean-checkout E2E harness support for the new OpenCode flows

## Verification
- `pnpm typecheck`
- `pnpm api:parity`
- `pnpm test src/lib/__tests__/opencode-sessions.test.ts src/lib/__tests__/agent-runtimes-opencode.test.ts src/app/api/sessions/__tests__/transcript-opencode.test.ts src/app/api/sessions/__tests__/continue-route-opencode.test.ts`
- `rm -rf .next test-results && E2E_BASE_URL=http://127.0.0.1:3005 API_KEY=test-api-key-e2e-12345 pnpm test:e2e tests/session-controls.spec.ts`
- `mkdir -p test-results && pnpm lint` (0 errors; only pre-existing warnings in untouched files)

## Follow-ups
- Closes #584
- Closes #585
