### PR TITLE
Fix task dispatch model override for critical tasks

### DIFF
--- a/src/lib/__tests__/task-dispatch.test.ts
+++ b/src/lib/__tests__/task-dispatch.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { resolveTaskDispatchModelOverride } from '@/lib/task-dispatch'
+
+describe('resolveTaskDispatchModelOverride', () => {
+  it('returns null when the agent has no explicit dispatch model override', () => {
+    expect(resolveTaskDispatchModelOverride({ agent_config: null })).toBeNull()
+    expect(resolveTaskDispatchModelOverride({ agent_config: '{"openclawId":"main"}' })).toBeNull()
+  })
+
+  it('returns the explicit dispatch model override when present', () => {
+    expect(
+      resolveTaskDispatchModelOverride({
+        agent_config: '{"openclawId":"main","dispatchModel":"openai-codex/gpt-5.4"}',
+      })
+    ).toBe('openai-codex/gpt-5.4')
+  })
+
+  it('ignores malformed agent config payloads', () => {
+    expect(resolveTaskDispatchModelOverride({ agent_config: '{not json' })).toBeNull()
+  })
+})

--- a/src/lib/task-dispatch.ts
+++ b/src/lib/task-dispatch.ts
@@ -43,62 +43,19 @@ interface DispatchableTask {
 // ---------------------------------------------------------------------------
 
 /**
- * Classify a task's complexity and return the appropriate model ID to pass
- * to the OpenClaw gateway. Uses keyword signals on title + description.
+ * Return an explicit gateway model override from Mission Control agent config.
  *
- * Tiers:
- *   ROUTINE  → cheap model (Haiku)   — file ops, status checks, formatting
- *   MODERATE → mid model  (Sonnet)   — code gen, summaries, analysis, drafts
- *   COMPLEX  → premium model (Opus)  — debugging, architecture, novel problems
- *
- * The caller may override this by setting agent.config.dispatchModel.
+ * By default, task dispatch should not inject a model override; the OpenClaw
+ * agent should use its own configured default model. A Mission Control agent
+ * may still opt into an override via agent.config.dispatchModel.
  */
-function classifyTaskModel(task: DispatchableTask): string | null {
-  // Allow per-agent config override
+export function resolveTaskDispatchModelOverride(task: Pick<DispatchableTask, 'agent_config'>): string | null {
   if (task.agent_config) {
     try {
       const cfg = JSON.parse(task.agent_config)
       if (typeof cfg.dispatchModel === 'string' && cfg.dispatchModel) return cfg.dispatchModel
     } catch { /* ignore */ }
   }
-
-  const text = `${task.title} ${task.description ?? ''}`.toLowerCase()
-  const priority = task.priority?.toLowerCase() ?? ''
-
-  // Complex signals → Opus
-  const complexSignals = [
-    'debug', 'diagnos', 'architect', 'design system', 'security audit',
-    'root cause', 'investigate', 'incident', 'failure', 'broken', 'not working',
-    'refactor', 'migration', 'performance optim', 'why is',
-  ]
-  if (priority === 'critical' || complexSignals.some(s => text.includes(s))) {
-    return '9router/cc/claude-opus-4-6'
-  }
-
-  // Size heuristics → Opus for large/complex tasks
-  const descLength = (task.description ?? '').length
-  if (descLength > 2000) return '9router/cc/claude-opus-4-6'
-  try {
-    const db = getDatabase()
-    const row = db.prepare('SELECT estimated_hours FROM tasks WHERE id = ?').get(task.id) as { estimated_hours: number | null } | undefined
-    if (row?.estimated_hours && row.estimated_hours >= 4) return '9router/cc/claude-opus-4-6'
-  } catch { /* ignore */ }
-
-  // Routine signals → Haiku
-  const routineSignals = [
-    'status check', 'health check', 'ping', 'list ', 'fetch ', 'format',
-    'rename', 'move file', 'read file', 'update readme', 'bump version',
-    'send message', 'post to', 'notify', 'summarize', 'translate',
-    'quick ', 'simple ', 'routine ', 'minor ',
-  ]
-  if (priority === 'low' && routineSignals.some(s => text.includes(s))) {
-    return '9router/cc/claude-haiku-4-5-20251001'
-  }
-  if (routineSignals.some(s => text.includes(s)) && priority !== 'high' && priority !== 'critical') {
-    return '9router/cc/claude-haiku-4-5-20251001'
-  }
-
-  // Default: let the agent's own configured model handle it (no override)
   return null
 }
 
@@ -768,7 +725,7 @@ export async function dispatchAssignedTasks(): Promise<{ ok: boolean; message: s
       } else {
         // Step 1: Invoke via gateway (new session)
         const gatewayAgentId = resolveGatewayAgentId(task)
-        const dispatchModel = classifyTaskModel(task)
+        const dispatchModel = resolveTaskDispatchModelOverride(task)
         const invokeParams: Record<string, unknown> = {
           message: prompt,
           agentId: gatewayAgentId,


### PR DESCRIPTION
# Summary
This fixes Mission Control's task dispatcher so it does not force a heuristic gateway model override during task dispatch.

Before this change, `src/lib/task-dispatch.ts` automatically injected `model: "9router/cc/claude-opus-4-6"` for `critical` tasks and some other heuristically-classified tasks. That bypassed the target OpenClaw agent's own configured default model. In environments where the agent only allowed `openai-codex/gpt-5.4`, critical tasks failed before execution with a gateway rejection like:

`Model override "9router/cc/claude-opus-4-6" is not allowed for agent "main".`

After this change, Mission Control only passes a gateway `model` override when the Mission Control agent config explicitly sets `dispatchModel`. Otherwise, OpenClaw uses the agent's configured default model as intended.

## Reproduction
1. Configure an OpenClaw agent such as `main` with a default model like `openai-codex/gpt-5.4` and no Mission Control `dispatchModel` override.
2. Create or assign a Mission Control task with `priority = critical`.
3. Let the scheduler dispatch the task.
4. On current `main` before this fix, Mission Control sends `"model":"9router/cc/claude-opus-4-6"` in the gateway call.
5. The gateway rejects the task if that override is not allowed for the agent.

This PR removes that implicit override behavior and adds a regression test for the default no-override path.

# Risk Level
Low

# Tests
- `pnpm vitest run src/lib/__tests__/task-dispatch.test.ts` ✅
- `pnpm vitest run src/lib/__tests__/openclaw-gateway.test.ts src/lib/__tests__/task-dispatch.test.ts` ✅
- `pnpm typecheck` ✅
- `pnpm lint` ✅ (9 pre-existing warnings outside this diff; no lint errors)
- `pnpm build` ✅

# Contribution Checklist
- [x] Tests added/updated for behavior changes
- [x] Lint/typecheck/build passing
- [x] Security review done if auth/data/crypto touched
- [x] DB migration tested if schema changed

# Notes
- Scope is intentionally limited to `src/lib/task-dispatch.ts` and a regression test.
- Security review / DB migration items are not applicable here because this change does not touch auth, data handling, crypto, or schema.
- Lint warnings are pre-existing and outside the files in this PR.
