### PR TITLE
fix: resolve CSRF origin mismatch behind reverse proxies

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -84,6 +84,29 @@ function hostMatches(pattern: string, hostname: string): boolean {
   return h === p
 }
 
+/** Normalize a host:port string by stripping default ports (80 for http, 443 for https). */
+function stripDefaultPort(host: string): string {
+  const h = host.toLowerCase()
+  if (h.endsWith(':443')) return h.slice(0, -4)
+  if (h.endsWith(':80')) return h.slice(0, -3)
+  return h
+}
+
+/**
+ * Compare a request host candidate with the Origin host for CSRF validation.
+ * Handles port mismatches caused by reverse proxies (e.g. Origin includes :8443
+ * but the Host header may have been rewritten or stripped by the proxy).
+ */
+function hostsMatchForCsrf(requestHost: string, originHost: string): boolean {
+  const a = normalizeHostname(requestHost)
+  const b = normalizeHostname(originHost)
+  if (!a || !b) return false
+  // Exact match first
+  if (a === b) return true
+  // Match after stripping default ports
+  return stripDefaultPort(a) === stripDefaultPort(b)
+}
+
 function nextResponseWithNonce(request: NextRequest): { response: NextResponse; nonce: string } {
   const nonce = crypto.randomBytes(16).toString('base64')
   const googleEnabled = !!(process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID || process.env.GOOGLE_CLIENT_ID)
@@ -162,10 +185,7 @@ export function proxy(request: NextRequest) {
     if (origin) {
       let originHost: string
       try { originHost = new URL(origin).host } catch { originHost = '' }
-      const requestHost = request.headers.get('host')?.split(',')[0]?.trim()
-        || request.nextUrl.host
-        || ''
-      if (originHost && requestHost && originHost !== requestHost) {
+      if (originHost && !requestHosts.some((h) => hostsMatchForCsrf(h, originHost))) {
         return addSecurityHeaders(NextResponse.json({ error: 'CSRF origin mismatch' }, { status: 403 }), request)
       }
     }


### PR DESCRIPTION
## Summary                                                                
  - CSRF validation now checks all host candidates (x-forwarded-host,       
  x-original-host, forwarded, etc.) instead of only the Host header         
  - Adds port-normalized comparison that strips default ports (80/443)      
  before matching                                                           
                                                 
  ## Why                                                                    
  When running behind Nginx Proxy Manager with a custom HTTPS port (e.g. 
  8443), the browser sends `Origin: https://host:8443` but the proxy may    
  forward `Host: host` (without port). This caused false-positive CSRF 403 
  errors on all mutating requests (login, etc.).