### PR TITLE
Fix #518: Docs: Wrong screenshots used for multiple feature sections ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,25 +221,17 @@ Kanban board with six columns (inbox → assigned → in progress → review →
 
 Explore agent knowledge through the Memory Browser, filesystem-backed memory tree, and interactive relationship graph for sessions, memory chunks, and linked knowledge files.
 
-![Mission Control Memory Panel](docs/mission-control-memory.png)
-
 ### Skills Hub
 
 Browse, install, and manage agent skills from local directories and external registries (ClawdHub, skills.sh). Built-in security scanner checks for prompt injection, credential leaks, data exfiltration, obfuscated content, and dangerous shell commands before installation. Supports 5 skill roots across `~/.agents/skills`, `~/.codex/skills`, project-local directories, and `~/.openclaw/skills`.
-
-![Mission Control Skills Panel](docs/mission-control-skills.png)
 
 ### Cost Tracking
 
 Token usage dashboard with per-model breakdowns, trend charts, and cost analysis. Session-level granularity powered by Recharts.
 
-![Mission Control Cost Tracking](docs/mission-control-cost-tracking.png)
-
 ### Security Audit & Agent Trust
 
 Real-time posture scoring (0-100), secret detection across agent messages, MCP tool call auditing, injection attempt tracking, and per-agent trust scores. Hook profiles (minimal/standard/strict) let operators tune security strictness per deployment.
-
-![Mission Control Security Panel](docs/mission-control-security.png)
 
 ### Agent Eval Framework
 
@@ -248,8 +240,6 @@ Four-layer evaluation: output evals (task completion scoring against golden data
 ### Natural Language Recurring Tasks
 
 Create recurring tasks with natural language like "every morning at 9am" or "every 2 hours". The built-in schedule parser converts expressions to cron and stores them in task metadata. A template-clone pattern keeps the original as a template and spawns dated child tasks on schedule.
-
-![Mission Control Cron Panel](docs/mission-control-cron.png)
 
 ### Claude Code Integration
 


### PR DESCRIPTION
Closes #518

# Summary
Removes 5 broken screenshot references from `README.md` where `docs/mission-control-task-board.png` (the Kanban view) was incorrectly used as a placeholder image for unrelated feature sections. The affected sections are:

- **Memory Knowledge Graph** — removed `![Mission Control Memory Panel](docs/mission-control-memory.png)`
- **Skills Hub** — removed `![Mission Control Skills Panel](docs/mission-control-skills.png)`
- **Cost Tracking** — removed `![Mission Control Cost Tracking](docs/mission-control-cost-tracking.png)`
- **Security Audit & Agent Trust** — removed `![Mission Control Security Panel](docs/mission-control-security.png)`
- **Natural Language Recurring Tasks** — removed `![Mission Control Cron Panel](docs/mission-control-cron.png)`

Each of these `![...](docs/...)` lines was rendering the wrong screenshot (Task Board Kanban UI) rather than the actual feature UI. Rather than substitute incorrect images, the references are removed until accurate screenshots are available. The prose descriptions for each section are preserved verbatim.

# Risk Level
Low

# Tests
Manual: Rendered `README.md` locally and confirmed the five affected sections now display their text descriptions without any broken or misleading images. All other sections (e.g., Agent Management with its correct Agent Squad screenshot) are unaffected.

# Contribution Checklist
- [ ] Tests added/updated for behavior changes
- [x] Lint/typecheck/build passing
- [ ] Security review done if auth/data/crypto touched
- [ ] DB migration tested if schema changed

# Notes
The five image files referenced (`mission-control-memory.png`, `mission-control-skills.png`, `mission-control-cost-tracking.png`, `mission-control-security.png`, `mission-control-cron.png`) were all resolving to the Task Board screenshot in practice. A follow-up PR should add the correct per-feature screenshots once captured. The `### Agent Eval Framework` section (between Cost Tracking and Recurring Tasks) had no screenshot reference and is untouched.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*