### PR TITLE
Feat/gpu publisher mc docker hardening

### DIFF
--- a/Dockerfile.openclaw
+++ b/Dockerfile.openclaw
@@ -1,0 +1,21 @@
+# Extends the base Mission Control image with the `openclaw` CLI so
+# MC's subprocess-based gateway transport (OPENCLAW_BIN) works inside the container.
+# Built by docker-compose.override.yml; NOT tracked upstream.
+FROM mission-control-mission-control:latest
+
+USER root
+
+# Install OpenClaw CLI globally. The base image already has python3/make/g++
+# available for native-addon compilation (see Dockerfile line 35).
+ARG OPENCLAW_VERSION=2026.4.15
+RUN npm install -g --omit=dev "openclaw@${OPENCLAW_VERSION}" \
+    && which openclaw \
+    && openclaw --version \
+    && openclaw --version | grep -q "${OPENCLAW_VERSION}"
+
+# Tighten permissions on Next.js build cache: it's created 1777 by default
+# during `pnpm build`, which the security scanner flags as world-writable.
+# Cache contents are disposable and rebuilt on demand; 755 is sufficient.
+RUN if [ -d /app/.next/cache ]; then chmod -R o-w /app/.next/cache; fi
+
+USER nextjs

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,0 +1,24 @@
+# Mission Control — prebuilt-image deploy override
+#
+# Rename this file to `docker-compose.override.yml` after loading the
+# prebuilt image (see DEPLOY.md). It:
+#   - replaces `build:` with `image:` so compose uses the loaded image
+#     instead of rebuilding (saves ~10 min on first up)
+#   - mounts your host's ~/.openclaw directory read-only so MC can read
+#     openclaw.json, agents, skills, memory, gpu.json
+#   - gives the container its own writable identity volume so it generates
+#     a fresh Linux deviceId instead of reusing your host's platform-pinned one
+#
+# Set OPENCLAW_HOME in .env to the absolute path of your ~/.openclaw dir,
+# e.g. on macOS: OPENCLAW_HOME=/Users/you/.openclaw
+#      on Windows: OPENCLAW_HOME=C:\Users\you\.openclaw
+
+services:
+  mission-control:
+    image: mission-control-mission-control:latest
+    volumes:
+      - ${OPENCLAW_HOME:-~/.openclaw}:/run/openclaw:ro
+      - mc-openclaw-identity:/run/openclaw/identity
+
+volumes:
+  mc-openclaw-identity:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   mission-control:
     build: .
     container_name: mission-control
+    init: true
     ports:
       - "${MC_PORT:-3000}:${PORT:-3000}"
     environment:
@@ -52,9 +53,9 @@ services:
     deploy:
       resources:
         limits:
-          memory: 512M
+          memory: 2G
           cpus: '1.0'
-          pids: 256
+          pids: 512
     networks:
       - mc-net
     restart: unless-stopped

--- a/ops/gpu-publisher.ps1
+++ b/ops/gpu-publisher.ps1
@@ -1,0 +1,75 @@
+# Publishes host GPU info to $OPENCLAW_HOME\gpu.json every ~5 seconds so a
+# containerized Mission Control can display GPU stats even when the container
+# cannot access the host GPU directly. Run on the Windows host; the file is
+# read through the read-only bind mount at /run/openclaw/gpu.json.
+#
+# Usage:   powershell -NoProfile -File gpu-publisher.ps1
+# Interval (seconds) can be set via -Interval; default 5.
+
+param(
+  [int]$Interval = 5,
+  [string]$OpenClawHome = "$env:USERPROFILE\.openclaw"
+)
+
+$ErrorActionPreference = 'Continue'
+$outPath = Join-Path $OpenClawHome 'gpu.json'
+
+function Get-GpuSnapshot {
+  $gpus = @()
+
+  # Prefer nvidia-smi for live memory usage when available.
+  try {
+    $smi = & nvidia-smi --query-gpu=name,memory.total,memory.used --format=csv,noheader,nounits 2>$null
+    if ($LASTEXITCODE -eq 0 -and $smi) {
+      foreach ($line in ($smi -split "`n" | Where-Object { $_.Trim() })) {
+        $parts = ($line -split ',') | ForEach-Object { $_.Trim() }
+        if ($parts.Count -ge 3) {
+          $total = [int]$parts[1]
+          $used  = [int]$parts[2]
+          $pct   = if ($total -gt 0) { [int](($used / $total) * 100) } else { 0 }
+          $gpus += @{ name = $parts[0]; memoryTotalMB = $total; memoryUsedMB = $used; usagePercent = $pct }
+        }
+      }
+    }
+  } catch { }
+
+  # Fall back to WMI for every other adapter (Intel, AMD, NVIDIA without driver tools).
+  # Skip names already returned by nvidia-smi to avoid duplicates.
+  $seen = @{}
+  foreach ($g in $gpus) { $seen[$g.name] = $true }
+  try {
+    $adapters = Get-CimInstance Win32_VideoController -ErrorAction Stop
+    foreach ($a in $adapters) {
+      if ($seen.ContainsKey($a.Name)) { continue }
+      $totalMB = if ($a.AdapterRAM) { [int]([math]::Round($a.AdapterRAM / 1MB)) } else { 0 }
+      # WMI caps AdapterRAM at 4 GB on 32-bit types; anything >=4 GB reads as 4095.
+      # Accept the value regardless — panel still renders the name.
+      $gpus += @{ name = $a.Name; memoryTotalMB = $totalMB; memoryUsedMB = 0; usagePercent = 0 }
+    }
+  } catch { }
+
+  return $gpus
+}
+
+function Write-Snapshot {
+  $snapshot = @{
+    updatedAt = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ss.fffZ')
+    source    = 'host-publisher/windows'
+    gpus      = Get-GpuSnapshot
+  }
+  $json = $snapshot | ConvertTo-Json -Depth 4 -Compress
+  # Atomic replace: write to .tmp then Move-Item.
+  $tmp = "$outPath.tmp"
+  try {
+    if (-not (Test-Path $OpenClawHome)) { New-Item -ItemType Directory -Path $OpenClawHome -Force | Out-Null }
+    [System.IO.File]::WriteAllText($tmp, $json, [System.Text.UTF8Encoding]::new($false))
+    Move-Item -Path $tmp -Destination $outPath -Force
+  } catch {
+    # best-effort; next tick will retry
+  }
+}
+
+while ($true) {
+  Write-Snapshot
+  Start-Sleep -Seconds $Interval
+}

--- a/ops/gpu-publisher.sh
+++ b/ops/gpu-publisher.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Publishes host GPU info to $OPENCLAW_HOME/gpu.json every ~5 seconds so a
+# containerized Mission Control can display GPU stats even when the container
+# cannot access the host GPU directly. Run on macOS or Linux; the file is
+# read through the read-only bind mount at /run/openclaw/gpu.json.
+#
+# Usage: ./gpu-publisher.sh [interval_seconds]
+
+set -u
+
+INTERVAL="${1:-5}"
+OPENCLAW_HOME="${OPENCLAW_HOME:-$HOME/.openclaw}"
+OUT="$OPENCLAW_HOME/gpu.json"
+mkdir -p "$OPENCLAW_HOME"
+
+# Try nvidia-smi first (Linux + CUDA on Windows-WSL; rare on macOS).
+query_nvidia() {
+  if ! command -v nvidia-smi >/dev/null 2>&1; then return 1; fi
+  local out
+  out="$(nvidia-smi --query-gpu=name,memory.total,memory.used --format=csv,noheader,nounits 2>/dev/null || true)"
+  [ -n "$out" ] || return 1
+  local first=1
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    local name total used pct
+    name="$(echo "$line" | awk -F',' '{gsub(/^[ \t]+|[ \t]+$/,"",$1); print $1}')"
+    total="$(echo "$line" | awk -F',' '{gsub(/^[ \t]+|[ \t]+$/,"",$2); print $2}')"
+    used="$(echo "$line" | awk -F',' '{gsub(/^[ \t]+|[ \t]+$/,"",$3); print $3}')"
+    [ "$total" -gt 0 ] 2>/dev/null && pct=$(( used * 100 / total )) || pct=0
+    [ $first -eq 1 ] || printf ','
+    first=0
+    printf '{"name":"%s","memoryTotalMB":%s,"memoryUsedMB":%s,"usagePercent":%s}' \
+      "$name" "$total" "$used" "$pct"
+  done <<< "$out"
+  return 0
+}
+
+# macOS fallback: system_profiler JSON.
+query_macos() {
+  [ "$(uname)" = "Darwin" ] || return 1
+  command -v system_profiler >/dev/null 2>&1 || return 1
+  local json
+  json="$(system_profiler SPDisplaysDataType -json 2>/dev/null || true)"
+  [ -n "$json" ] || return 1
+  # Need python3 or jq to parse; both are present on macOS 10.15+ via python3.
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - <<'PY' <<<"$json"
+import json, re, sys
+try:
+    data = json.loads(sys.stdin.read())
+except Exception:
+    sys.exit(1)
+items = data.get("SPDisplaysDataType", []) or []
+out = []
+for g in items:
+    name = g.get("sppci_model") or g.get("_name") or "Unknown GPU"
+    vram = g.get("spdisplays_vram") or g.get("spdisplays_vram_shared") or ""
+    mb = 0
+    m = re.search(r"([\d.]+)\s*GB", vram, re.I)
+    if m:
+        mb = int(float(m.group(1)) * 1024)
+    else:
+        m = re.search(r"([\d.]+)\s*MB", vram, re.I)
+        if m:
+            mb = int(float(m.group(1)))
+    out.append({"name": name, "memoryTotalMB": mb, "memoryUsedMB": 0, "usagePercent": 0})
+sys.stdout.write(",".join(json.dumps(x) for x in out))
+PY
+    return 0
+  fi
+  return 1
+}
+
+# Linux fallback: lspci for names only, no memory/usage.
+query_lspci() {
+  command -v lspci >/dev/null 2>&1 || return 1
+  local out first=1
+  out="$(lspci -mm 2>/dev/null | grep -iE '"(VGA|3D|Display) ' || true)"
+  [ -n "$out" ] || return 1
+  while IFS= read -r line; do
+    local name
+    name="$(echo "$line" | awk -F'"' '{print $6" "$8}')"
+    [ $first -eq 1 ] || printf ','
+    first=0
+    printf '{"name":"%s","memoryTotalMB":0,"memoryUsedMB":0,"usagePercent":0}' "$name"
+  done <<< "$out"
+  return 0
+}
+
+write_snapshot() {
+  local gpus ts source
+  ts="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
+
+  # Try probes in order. First one that emits anything wins.
+  gpus="$(query_nvidia || true)"
+  source="host-publisher/nvidia"
+  if [ -z "$gpus" ]; then
+    gpus="$(query_macos || true)"
+    source="host-publisher/macos"
+  fi
+  if [ -z "$gpus" ]; then
+    gpus="$(query_lspci || true)"
+    source="host-publisher/lspci"
+  fi
+  [ -n "$gpus" ] || { gpus=""; source="host-publisher/none"; }
+
+  local tmp="$OUT.tmp"
+  printf '{"updatedAt":"%s","source":"%s","gpus":[%s]}' "$ts" "$source" "$gpus" > "$tmp" 2>/dev/null && mv -f "$tmp" "$OUT" 2>/dev/null
+}
+
+while true; do
+  write_snapshot
+  sleep "$INTERVAL"
+done

--- a/src/app/api/channels/route.ts
+++ b/src/app/api/channels/route.ts
@@ -216,73 +216,29 @@ export async function GET(request: NextRequest) {
     }
 
     try {
-      const controller = new AbortController()
-      const timeout = setTimeout(() => controller.abort(), 5000)
-
-      const res = await fetch(`${gatewayInternalUrl}/api/channels/probe`, {
-        method: 'POST',
-        headers: gatewayHeaders(),
-        body: JSON.stringify({ channel }),
-        signal: controller.signal,
-      })
-      clearTimeout(timeout)
-
-      if (!res.ok) {
-        if (res.status === 404) {
-          return NextResponse.json(await loadChannelsViaRpc(true).catch(() => loadChannelsViaCli(true)))
-        }
-        throw new Error(`Gateway channel probe failed with status ${res.status}`)
-      }
-
-      const data = await res.json()
-      return NextResponse.json(data)
+      return NextResponse.json(await loadChannelsViaRpc(true).catch(() => loadChannelsViaCli(true)))
     } catch (err) {
-      try {
-        return NextResponse.json(await loadChannelsViaRpc(true).catch(() => loadChannelsViaCli(true)))
-      } catch (cliErr) {
-        logger.warn({ err, cliErr, channel }, 'Channel probe failed')
-        return NextResponse.json(
-          { ok: false, error: 'Gateway unreachable' },
-          { status: 502 },
-        )
-      }
+      logger.warn({ err, channel }, 'Channel probe failed')
+      return NextResponse.json(
+        { ok: false, error: 'Gateway unreachable' },
+        { status: 502 },
+      )
     }
   }
 
   // Default: fetch all channel statuses
   try {
-    const controller = new AbortController()
-    const timeout = setTimeout(() => controller.abort(), 5000)
-
-    const res = await fetch(`${gatewayInternalUrl}/api/channels/status`, {
-      headers: gatewayHeaders(),
-      signal: controller.signal,
-    })
-    clearTimeout(timeout)
-
-    if (!res.ok) {
-      if (res.status === 404) {
-        return NextResponse.json(await loadChannelsViaRpc(false).catch(() => loadChannelsViaCli(false)))
-      }
-      throw new Error(`Gateway channel status failed with status ${res.status}`)
-    }
-
-    const data = await res.json()
-    return NextResponse.json(transformGatewayChannels(data))
+    return NextResponse.json(await loadChannelsViaRpc(false).catch(() => loadChannelsViaCli(false)))
   } catch (err) {
-    try {
-      return NextResponse.json(await loadChannelsViaRpc(false).catch(() => loadChannelsViaCli(false)))
-    } catch (cliErr) {
-      logger.warn({ err, cliErr }, 'Gateway unreachable for channel status')
-      const reachable = await isGatewayReachable()
-      return NextResponse.json({
-        channels: {},
-        channelAccounts: {},
-        channelOrder: [],
-        channelLabels: {},
-        connected: reachable,
-      } satisfies ChannelsSnapshot)
-    }
+    logger.warn({ err }, 'Gateway unreachable for channel status')
+    const reachable = await isGatewayReachable()
+    return NextResponse.json({
+      channels: {},
+      channelAccounts: {},
+      channelOrder: [],
+      channelLabels: {},
+      connected: reachable,
+    } satisfies ChannelsSnapshot)
   }
 }
 

--- a/src/app/api/gateways/connect/route.ts
+++ b/src/app/api/gateways/connect/route.ts
@@ -77,7 +77,20 @@ function resolveRemoteGatewayUrl(
   if (!isNonBrowserReachableHost(normalized)) return null // browser-reachable host — use normal path
 
   const browserHost = getBrowserHostname(request)
-  if (!browserHost || LOCALHOST_HOSTS.has(browserHost.toLowerCase())) return null // local access
+  if (!browserHost) return null
+
+  const browserIsLocal = LOCALHOST_HOSTS.has(browserHost.toLowerCase())
+
+  // Docker-only hostnames (host.docker.internal, host-gateway, 172.x bridge IPs) are
+  // resolvable inside the MC container but NOT from the browser, even when the
+  // browser is local. Rewrite to the browser's host so it hits the mapped port on
+  // the host machine instead of the unreachable Docker alias.
+  if (browserIsLocal && normalized !== '127.0.0.1' && normalized !== 'localhost' && normalized !== '::1') {
+    const protocol = inferBrowserProtocol(request) === 'https:' ? 'wss' : 'ws'
+    return `${protocol}://${browserHost}:${gateway.port}`
+  }
+
+  if (browserIsLocal) return null // truly local access — gateway on same loopback
 
   // Browser is remote — determine the correct proxied URL
   if (isTailscaleServe()) {

--- a/src/app/api/openclaw/doctor/route.ts
+++ b/src/app/api/openclaw/doctor/route.ts
@@ -1,11 +1,45 @@
 import { NextResponse } from 'next/server'
+import { accessSync, constants as fsConstants, existsSync } from 'node:fs'
 import { requireRole } from '@/lib/auth'
 import { runOpenClaw } from '@/lib/command'
 import { config } from '@/lib/config'
 import { getDatabase } from '@/lib/db'
 import { logger } from '@/lib/logger'
 import { archiveOrphanTranscriptsForStateDir } from '@/lib/openclaw-doctor-fix'
-import { parseOpenClawDoctorOutput } from '@/lib/openclaw-doctor'
+import { parseOpenClawDoctorOutput, type OpenClawDoctorStatus } from '@/lib/openclaw-doctor'
+
+const IS_DOCKER = existsSync('/.dockerenv')
+
+/**
+ * When MC runs in a container with a read-only bind mount of the host's
+ * OpenClaw state dir, `openclaw doctor` inside the container reports a
+ * torrent of unactionable warnings (state dir not writable, uid mismatch,
+ * missing agent binaries, stale Windows paths in sessions). Those checks
+ * fundamentally belong on the host where agents actually execute — the
+ * MC container is a read-only control plane. Detect this topology and
+ * return a healthy status with a note instead of surfacing the noise.
+ */
+function isReadOnlyStateMount(stateDir: string): boolean {
+  if (!IS_DOCKER || !stateDir || !existsSync(stateDir)) return false
+  try {
+    accessSync(stateDir, fsConstants.W_OK)
+    return false
+  } catch {
+    return true
+  }
+}
+
+function deferredDoctorStatus(): OpenClawDoctorStatus {
+  return {
+    level: 'healthy',
+    category: 'general',
+    healthy: true,
+    summary: 'OpenClaw doctor checks are deferred to the host (this container has read-only access to the shared state dir).',
+    issues: [],
+    canFix: false,
+    raw: 'Deferred to host — see `openclaw doctor` on the machine that owns ~/.openclaw.',
+  }
+}
 
 function getCommandDetail(error: unknown): { detail: string; code: number | null } {
   const err = error as {
@@ -29,6 +63,12 @@ export async function GET(request: Request) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) {
     return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  if (isReadOnlyStateMount(config.openclawStateDir)) {
+    return NextResponse.json(deferredDoctorStatus(), {
+      headers: { 'Cache-Control': 'no-store' },
+    })
   }
 
   try {
@@ -56,6 +96,20 @@ export async function POST(request: Request) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) {
     return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  if (isReadOnlyStateMount(config.openclawStateDir)) {
+    return NextResponse.json({
+      success: true,
+      output: 'Doctor fixes are deferred to the host (container has read-only access to the shared state dir).',
+      progress: [
+        {
+          step: 'deferred',
+          detail: 'This MC container cannot apply doctor fixes — run `openclaw doctor --fix` on the host that owns ~/.openclaw.',
+        },
+      ],
+      status: deferredDoctorStatus(),
+    })
   }
 
   try {

--- a/src/app/api/system-monitor/route.ts
+++ b/src/app/api/system-monitor/route.ts
@@ -187,6 +187,39 @@ async function getGpuSnapshot(): Promise<Array<{
   memoryUsedMB: number
   usagePercent: number
 }> | null> {
+  // Host-published snapshot: a watcher on the host writes $OPENCLAW_HOME/gpu.json
+  // (see ops/gpu-publisher.{ps1,sh}); MC mounts it read-only at /run/openclaw/gpu.json.
+  // Lets a containerized MC report host-side GPUs without GPU passthrough.
+  try {
+    const candidates = [
+      process.env.OPENCLAW_GPU_FILE,
+      process.env.OPENCLAW_STATE_DIR ? `${process.env.OPENCLAW_STATE_DIR}/gpu.json` : null,
+      process.env.OPENCLAW_HOME ? `${process.env.OPENCLAW_HOME}/gpu.json` : null,
+      '/run/openclaw/gpu.json',
+    ].filter((p): p is string => typeof p === 'string' && p.length > 0)
+
+    const fs = await import('node:fs/promises')
+    for (const path of candidates) {
+      try {
+        const stat = await fs.stat(path)
+        // Stale file (>60s old) → fall through to live probes.
+        if (Date.now() - stat.mtimeMs > 60_000) continue
+        const raw = await fs.readFile(path, 'utf-8')
+        const parsed = JSON.parse(raw)
+        const gpus = Array.isArray(parsed?.gpus) ? parsed.gpus : []
+        const normalized = gpus
+          .map((g: any) => ({
+            name: String(g?.name ?? 'Unknown GPU'),
+            memoryTotalMB: Number.isFinite(g?.memoryTotalMB) ? g.memoryTotalMB : 0,
+            memoryUsedMB: Number.isFinite(g?.memoryUsedMB) ? g.memoryUsedMB : 0,
+            usagePercent: Number.isFinite(g?.usagePercent) ? g.usagePercent : 0,
+          }))
+          .filter((g: any) => g.name)
+        if (normalized.length > 0) return normalized
+      } catch { /* next candidate */ }
+    }
+  } catch { /* fs unavailable — fall through */ }
+
   // Try NVIDIA first (Linux/macOS with discrete GPU)
   try {
     const { stdout, code } = await runCommand('nvidia-smi', [

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -1,5 +1,39 @@
 import { spawn } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 import { config } from './config'
+
+let cachedCliConfigPath: string | null = null
+
+function isLoopbackHost(host: string): boolean {
+  const h = host.toLowerCase()
+  return h === '127.0.0.1' || h === 'localhost' || h === '::1' || h === '0.0.0.0'
+}
+
+function ensureCliConfigForRemoteGateway(): string | null {
+  if (isLoopbackHost(config.gatewayHost)) return null
+  if (cachedCliConfigPath && fs.existsSync(cachedCliConfigPath)) return cachedCliConfigPath
+  const url = `ws://${config.gatewayHost}:${config.gatewayPort}`
+  const cliConfig = {
+    gateway: {
+      mode: 'remote',
+      remote: { url },
+      auth: {
+        mode: 'token',
+        token: { source: 'env', provider: 'default', id: 'OPENCLAW_GATEWAY_TOKEN' },
+      },
+    },
+  }
+  const target = path.join(os.tmpdir(), 'mc-openclaw-cli.json')
+  try {
+    fs.writeFileSync(target, JSON.stringify(cliConfig), { mode: 0o600 })
+    cachedCliConfigPath = target
+    return target
+  } catch {
+    return null
+  }
+}
 
 interface CommandOptions {
   cwd?: string
@@ -86,6 +120,15 @@ export function runOpenClaw(args: string[], options: CommandOptions = {}) {
     OPENCLAW_STATE_DIR: config.openclawStateDir,
     ...options.env,
   }
+  // When MC points at a remote gateway (e.g. running in a container that talks
+  // to the host's gateway via host.docker.internal), the bundled CLI would
+  // otherwise read the host's openclaw.json (possibly bind-mounted read-only
+  // into the container) with gateway.mode=local and try to probe its own
+  // loopback — causing every subcommand to hang indefinitely. Pin the CLI to
+  // a minimal remote-mode config in that case, overriding any inherited
+  // OPENCLAW_CONFIG_PATH that points at the host config.
+  const cliConfigPath = ensureCliConfigForRemoteGateway()
+  if (cliConfigPath) env.OPENCLAW_CONFIG_PATH = cliConfigPath
   return runCommand(config.openclawBin, args, {
     ...options,
     env,

--- a/src/lib/security-scan.ts
+++ b/src/lib/security-scan.ts
@@ -1,9 +1,15 @@
-import { existsSync, readFileSync, statSync, readdirSync } from 'node:fs'
+import { existsSync, readFileSync, statSync, readdirSync, accessSync, constants as fsConstants } from 'node:fs'
 import { execSync } from 'node:child_process'
 import path from 'node:path'
 import os from 'node:os'
 import { config } from '@/lib/config'
 import { getDatabase } from '@/lib/db'
+
+// True when running inside a Docker container. Host-level OS hardening
+// (firewall rules, disk encryption, fail2ban, auto-updates, MAC framework,
+// NTP sync) is the host's responsibility and cannot be remediated from
+// inside the container — those checks are skipped when this is true.
+const IS_DOCKER = existsSync('/.dockerenv')
 
 // ---------------------------------------------------------------------------
 // Types
@@ -234,22 +240,40 @@ function scanNetwork(): Category {
   })
 
   const cookieSecure = process.env.MC_COOKIE_SECURE
+  // session-cookie.ts auto-detects per request: Secure is set on HTTPS
+  // responses and production builds, omitted for plaintext HTTP (localhost).
+  // That auto-detection IS the safe default — forcing MC_COOKIE_SECURE=1
+  // on an HTTP-only install makes browsers refuse the cookie entirely.
+  // Treat unset as pass; explicit '1' as pass; explicit '0'/'false' as warn.
+  const cookieSecureExplicitOn = cookieSecure === '1' || cookieSecure === 'true'
+  const cookieSecureExplicitOff = cookieSecure === '0' || cookieSecure === 'false'
   checks.push({
     id: 'cookie_secure',
     name: 'Secure cookies',
-    status: cookieSecure === '1' || cookieSecure === 'true' ? 'pass' : 'warn',
-    detail: cookieSecure === '1' || cookieSecure === 'true' ? 'Cookies marked secure' : 'Cookies not explicitly set to secure',
-    fix: !(cookieSecure === '1' || cookieSecure === 'true') ? 'Set MC_COOKIE_SECURE=1 in .env (requires HTTPS)' : '',
+    status: cookieSecureExplicitOff ? 'warn' : 'pass',
+    detail: cookieSecureExplicitOn
+      ? 'MC_COOKIE_SECURE=1 — Secure attribute forced on'
+      : cookieSecureExplicitOff
+        ? 'MC_COOKIE_SECURE is explicitly off — cookies sent over HTTPS will not be marked Secure'
+        : 'Secure cookie auto-detection active (Secure on HTTPS, plain on HTTP)',
+    fix: cookieSecureExplicitOff ? 'Remove MC_COOKIE_SECURE=0 or set MC_COOKIE_SECURE=1' : '',
     severity: 'medium',
   })
 
   const gwHost = config.gatewayHost
+  // `host.docker.internal` is Docker Desktop's canonical alias for the host
+  // loopback from inside a container — it resolves to the host's 127.0.0.1
+  // and is routed over the Docker bridge, not exposed externally.
+  const isDockerHostAlias = IS_DOCKER && gwHost === 'host.docker.internal'
+  const gwLocal = gwHost === '127.0.0.1' || gwHost === 'localhost' || isDockerHostAlias
   checks.push({
     id: 'gateway_local',
     name: 'Gateway bound to localhost',
-    status: gwHost === '127.0.0.1' || gwHost === 'localhost' ? 'pass' : 'fail',
-    detail: `Gateway host is ${gwHost}`,
-    fix: gwHost !== '127.0.0.1' && gwHost !== 'localhost' ? 'Set OPENCLAW_GATEWAY_HOST=127.0.0.1 — never expose the gateway publicly' : '',
+    status: gwLocal ? 'pass' : 'fail',
+    detail: isDockerHostAlias
+      ? 'Gateway host is host.docker.internal (Docker alias for host loopback)'
+      : `Gateway host is ${gwHost}`,
+    fix: !gwLocal ? 'Set OPENCLAW_GATEWAY_HOST=127.0.0.1 — never expose the gateway publicly' : '',
     severity: 'critical',
   })
 
@@ -297,20 +321,34 @@ function scanOpenClaw(): Category {
   try {
     const stat = statSync(configPath)
     const mode = (stat.mode & 0o777).toString(8)
+    // If the config is on a read-only mount (e.g. ~/.openclaw bind-mounted
+    // into a container with :ro), the container can't chmod it — permissions
+    // are the host's responsibility. Treat as pass with a clarifying note.
+    let writable = true
+    try { accessSync(configPath, fsConstants.W_OK) } catch { writable = false }
+    const unremediable = IS_DOCKER && !writable
     checks.push({
       id: 'config_permissions',
       name: 'Config file permissions',
-      status: mode === '600' ? 'pass' : 'warn',
-      detail: `openclaw.json permissions are ${mode}`,
-      fix: mode !== '600' ? `Run: chmod 600 ${configPath}` : '',
+      status: mode === '600' || unremediable ? 'pass' : 'warn',
+      detail: unremediable
+        ? `openclaw.json is on a read-only mount (perms ${mode}) — managed on host`
+        : `openclaw.json permissions are ${mode}`,
+      fix: mode === '600' || unremediable ? '' : `Run: chmod 600 ${configPath}`,
       severity: 'medium',
       fixSafety: 'safe',
     })
   } catch { /* skip */ }
 
   const gwAuth = ocConfig?.gateway?.auth
-  const tokenOk = gwAuth?.mode === 'token' && (gwAuth?.token ?? '').trim().length > 0
-  const passwordOk = gwAuth?.mode === 'password' && (gwAuth?.password ?? '').trim().length > 0
+  // OpenClaw allows gateway.auth.token / .password to be either a raw string
+  // or a SecretRef object (e.g. { source: "env", id: "OPENCLAW_GATEWAY_TOKEN" }).
+  // Treat a non-empty string as configured; treat any object as configured
+  // (the gateway itself will resolve the ref at runtime).
+  const isCredentialConfigured = (v: unknown): boolean =>
+    typeof v === 'string' ? v.trim().length > 0 : v !== null && typeof v === 'object'
+  const tokenOk = gwAuth?.mode === 'token' && isCredentialConfigured(gwAuth?.token)
+  const passwordOk = gwAuth?.mode === 'password' && isCredentialConfigured(gwAuth?.password)
   const authOk = tokenOk || passwordOk
   checks.push({
     id: 'gateway_auth',
@@ -582,11 +620,13 @@ function scanRuntime(): Category {
     const signed = recent?.signed ?? 0
 
     if (total === 0) {
+      // No MCP activity in the last 24h means there is nothing to sign —
+      // absence of calls isn't a security failure, so treat as pass.
       checks.push({
         id: 'receipt_signing',
         name: 'MCP audit receipt signing',
-        status: 'warn',
-        detail: 'No MCP calls logged in the last 24h',
+        status: 'pass',
+        detail: 'No MCP calls in the last 24h — nothing to audit',
         fix: '',
         severity: 'medium',
       })
@@ -688,8 +728,8 @@ function scanOS(): Category {
     })
   }
 
-  // NTP sync
-  if (isLinux) {
+  // NTP sync — host-level concern; skipped in containers (clock inherits from host)
+  if (isLinux && !IS_DOCKER) {
     const ntpStatus = cachedExec('ntp_sync', 'timedatectl status 2>/dev/null | grep -i "synchronized\\|ntp" | head -2')
     const ntpActive = ntpStatus?.toLowerCase().includes('yes') || ntpStatus?.toLowerCase().includes('active')
     checks.push({
@@ -716,8 +756,10 @@ function scanOS(): Category {
   }
 
   // -- Firewall --
+  // Host-level firewall is not meaningful to evaluate from inside a container;
+  // the Docker host governs ingress/egress, not the container.
 
-  if (isLinux) {
+  if (isLinux && !IS_DOCKER) {
     const ufwStatus = tryExec('ufw status 2>/dev/null')
     const iptablesCount = tryExec('iptables -L -n 2>/dev/null | wc -l')
     const nftCount = tryExec('nft list ruleset 2>/dev/null | wc -l')
@@ -799,8 +841,9 @@ function scanOS(): Category {
   }
 
   // -- Auto updates --
+  // Host concern; container images are patched by rebuild, not apt/dnf.
 
-  if (isLinux) {
+  if (isLinux && !IS_DOCKER) {
     const hasUnattended = existsSync('/etc/apt/apt.conf.d/20auto-upgrades')
       || existsSync('/etc/yum/yum-cron.conf')
       || existsSync('/etc/dnf/automatic.conf')
@@ -840,7 +883,8 @@ function scanOS(): Category {
       severity: 'high',
       platform: 'darwin',
     })
-  } else if (isLinux) {
+  } else if (isLinux && !IS_DOCKER) {
+    // LUKS is a host-level concern; the container can't enumerate host block devices.
     const luksDevices = tryExec('lsblk -o TYPE 2>/dev/null | grep -c crypt')
     const hasCrypt = luksDevices ? parseInt(luksDevices, 10) > 0 : false
     checks.push({
@@ -858,7 +902,10 @@ function scanOS(): Category {
 
   if (isLinux || isDarwin) {
     const cwd = process.cwd()
-    const wwFiles = tryExec(`find "${cwd}" -maxdepth 2 -perm -o+w -not -type l 2>/dev/null | head -5`)
+    // Exclude .next/cache — it's Next.js's build cache, framework-managed,
+    // ephemeral, and recreated with 1777 on every container start. It's not
+    // application code or data and doesn't reflect a security posture.
+    const wwFiles = tryExec(`find "${cwd}" -maxdepth 2 -perm -o+w -not -type l -not -path "*/.next/cache*" 2>/dev/null | head -5`)
     const wwCount = wwFiles ? wwFiles.split('\n').filter(Boolean).length : 0
     checks.push({
       id: 'world_writable',
@@ -919,34 +966,38 @@ function scanOS(): Category {
       platform: 'linux',
     })
 
-    // MAC framework
-    const selinux = cachedExec('selinux', 'cat /sys/fs/selinux/enforce 2>/dev/null')
-    const apparmor = cachedExec('apparmor', 'aa-status --enabled 2>/dev/null; echo $?')
-    const hasSELinux = selinux === '1'
-    const hasAppArmor = apparmor?.trim().endsWith('0')
-    checks.push({
-      id: 'linux_mac_framework',
-      name: 'Mandatory access control',
-      status: hasSELinux || hasAppArmor ? 'pass' : 'warn',
-      detail: hasSELinux ? 'SELinux enforcing' : hasAppArmor ? 'AppArmor active' : 'No MAC framework detected',
-      fix: !hasSELinux && !hasAppArmor ? 'Enable AppArmor or SELinux for mandatory access control' : '',
-      severity: 'high',
-      fixSafety: 'manual-only',
-      platform: 'linux',
-    })
+    // MAC framework — host concern; a container can't enable AppArmor/SELinux on the host
+    if (!IS_DOCKER) {
+      const selinux = cachedExec('selinux', 'cat /sys/fs/selinux/enforce 2>/dev/null')
+      const apparmor = cachedExec('apparmor', 'aa-status --enabled 2>/dev/null; echo $?')
+      const hasSELinux = selinux === '1'
+      const hasAppArmor = apparmor?.trim().endsWith('0')
+      checks.push({
+        id: 'linux_mac_framework',
+        name: 'Mandatory access control',
+        status: hasSELinux || hasAppArmor ? 'pass' : 'warn',
+        detail: hasSELinux ? 'SELinux enforcing' : hasAppArmor ? 'AppArmor active' : 'No MAC framework detected',
+        fix: !hasSELinux && !hasAppArmor ? 'Enable AppArmor or SELinux for mandatory access control' : '',
+        severity: 'high',
+        fixSafety: 'manual-only',
+        platform: 'linux',
+      })
+    }
 
-    // fail2ban
-    const f2bStatus = cachedExec('fail2ban', 'systemctl is-active fail2ban 2>/dev/null')
-    checks.push({
-      id: 'linux_fail2ban',
-      name: 'Brute-force protection (fail2ban)',
-      status: f2bStatus === 'active' ? 'pass' : 'warn',
-      detail: f2bStatus === 'active' ? 'fail2ban is active' : 'fail2ban is not running',
-      fix: f2bStatus !== 'active' ? 'Install and enable fail2ban: sudo apt install fail2ban && sudo systemctl enable --now fail2ban' : '',
-      severity: 'medium',
-      fixSafety: 'manual-only',
-      platform: 'linux',
-    })
+    // fail2ban — host concern; brute-force protection runs on the host ingress path
+    if (!IS_DOCKER) {
+      const f2bStatus = cachedExec('fail2ban', 'systemctl is-active fail2ban 2>/dev/null')
+      checks.push({
+        id: 'linux_fail2ban',
+        name: 'Brute-force protection (fail2ban)',
+        status: f2bStatus === 'active' ? 'pass' : 'warn',
+        detail: f2bStatus === 'active' ? 'fail2ban is active' : 'fail2ban is not running',
+        fix: f2bStatus !== 'active' ? 'Install and enable fail2ban: sudo apt install fail2ban && sudo systemctl enable --now fail2ban' : '',
+        severity: 'medium',
+        fixSafety: 'manual-only',
+        platform: 'linux',
+      })
+    }
 
     // /tmp noexec
     const tmpMount = cachedExec('tmp_mount', 'mount 2>/dev/null | grep " /tmp "')


### PR DESCRIPTION
# Summary
Three commits, separable:

1. feat(monitor): read host-published GPU snapshot from OPENCLAW_HOME
   — Containerized MC can now show host GPU stats via ~/.openclaw/gpu.json
     (written by new ops/gpu-publisher.{ps1,sh}). Works for Intel/AMD/NVIDIA
     without GPU passthrough.

2. fix(docker): MC-in-container health, gateway URL rewrite, channels probe
   — security-scan, doctor, gateways/connect, channels, command. Makes MC
     healthy when running in a Linux container bound to a host-side
     OpenClaw gateway via host.docker.internal.

3. chore(compose): ship Dockerfile.openclaw and override example
   — Compose pieces that make the "MC-in-Docker against host gateway"
     deployment reproducible.