### PR TITLE
fix(agents): flatten gateway_config into buildAgentConfig overrides

### DIFF
--- a/src/app/api/agents/route.ts
+++ b/src/app/api/agents/route.ts
@@ -190,7 +190,21 @@ export async function POST(request: NextRequest) {
     if (template) {
       const tpl = getTemplate(template);
       if (tpl) {
-        const builtConfig = buildAgentConfig(tpl, (gateway_config || {}) as any);
+        // gateway_config uses the nested OpenClaw shape; flatten to buildAgentConfig's
+        // overrides contract. Passing the nested object directly (as any) caused
+        // config.model.primary to be set to { primary: "..." } instead of the string.
+        const gc = (gateway_config || {}) as any;
+        const builtConfig = buildAgentConfig(tpl, {
+          id: openclawId,
+          name,
+          model: gc.model?.primary,
+          emoji: gc.identity?.emoji,
+          theme: gc.identity?.theme,
+          workspaceAccess: gc.sandbox?.workspaceAccess,
+          sandboxMode: gc.sandbox?.mode,
+          dockerNetwork: gc.sandbox?.docker?.network,
+          subagentAllowAgents: gc.subagents?.allowAgents,
+        });
         finalConfig = { ...builtConfig, ...finalConfig };
         if (!finalRole) finalRole = tpl.config.identity?.theme || tpl.type;
       }

--- a/src/lib/__tests__/agent-templates.test.ts
+++ b/src/lib/__tests__/agent-templates.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { AGENT_TEMPLATES, buildAgentConfig, getTemplate } from '@/lib/agent-templates'
+
+describe('buildAgentConfig', () => {
+  const tpl = AGENT_TEMPLATES[0]
+
+  it('sets config.model.primary as a string when overrides.model is a string', () => {
+    const result = buildAgentConfig(tpl, {
+      id: 'test',
+      name: 'Test',
+      model: 'anthropic/claude-sonnet-4-20250514',
+    })
+    expect(typeof result.model.primary).toBe('string')
+    expect(result.model.primary).toBe('anthropic/claude-sonnet-4-20250514')
+  })
+
+  it('preserves the template default model when no override is provided', () => {
+    const result = buildAgentConfig(tpl, { id: 'test', name: 'Test' })
+    expect(typeof result.model.primary).toBe('string')
+    expect(result.model.primary).toBe(tpl.config.model.primary)
+  })
+
+  it('applies identity overrides without wrapping them', () => {
+    const result = buildAgentConfig(tpl, {
+      id: 'test',
+      name: 'Test',
+      emoji: 'X',
+      theme: 'some theme',
+    })
+    expect(result.identity.name).toBe('Test')
+    expect(result.identity.emoji).toBe('X')
+    expect(result.identity.theme).toBe('some theme')
+  })
+})
+
+describe('getTemplate', () => {
+  it('returns undefined for unknown template ids', () => {
+    expect(getTemplate('nope')).toBeUndefined()
+  })
+
+  it('returns the matching template', () => {
+    const t = getTemplate(AGENT_TEMPLATES[0].type)
+    expect(t).toBe(AGENT_TEMPLATES[0])
+  })
+})


### PR DESCRIPTION
# Summary
Fixes #599 — crash in the Models and Config tabs for any agent created from a built-in template.

Root cause: `src/app/api/agents/route.ts` passed the nested `gateway_config` object straight into `buildAgentConfig` with an `as any` cast. The function declares a flat overrides contract (`model: string`, etc.), so the cast hid a real mismatch: `overrides.model` was `{ primary: "<id>" }`, which then got assigned wholesale to `config.model.primary` — leaving the DB with a doubly-wrapped primary. `ModelsTab` and `ConfigTab` render `primary` as a React child, so both tabs throw *"Objects are not valid as a React child (found: object with keys {primary})"* on open.

Fix: extract the leaf fields from `gateway_config` at the call site so the primary string is preserved and the other overrides (identity, sandbox, subagents) actually take effect.

See #599 for full repro and DB evidence.

# Risk Level
Low — scoped to one call site in the agent-create route. Behavior change is strictly "`model.primary` is now a string as documented." Pre-existing agents with the malformed shape need a one-time row fix (noted below).

# Tests
- `pnpm test src/lib/__tests__/agent-templates.test.ts` — new unit test, 5 passed
- `pnpm lint src/app/api/agents/route.ts src/lib/__tests__/agent-templates.test.ts` — clean
- `pnpm typecheck` — clean
- Full `pnpm test` — only pre-existing, unrelated Windows path / OpenCode failures

# Contribution Checklist
- [x] Tests added/updated for behavior changes
- [x] Lint/typecheck passing (build/e2e: please run in CI)
- [x] Security review done if auth/data/crypto touched (N/A)
- [x] DB migration tested if schema changed (no schema change)

# Notes
Existing rows written with the bug still crash the UI. Operators can fix with a one-off SQL update, e.g.:

```sql
UPDATE agents
   SET config = json_set(config, '$.model.primary',
                         json_extract(config, '$.model.primary.primary'))
 WHERE json_valid(config)
   AND json_type(config, '$.model.primary') = 'object';
```

# Screenshots
Tabs tested after applying fix:

<img width="1034" height="664" alt="models-tab" src="https://github.com/user-attachments/assets/3c9ab673-1139-4d2d-ad13-8261664a49aa" />

<img width="1029" height="1180" alt="config-tab" src="https://github.com/user-attachments/assets/bc7f8f25-9a33-4842-bf8d-a876d095ef24" />


