### PR TITLE
fix: disable caching on release check endpoint and client fetch

### DIFF
--- a/src/app/[[...panel]]/page.tsx
+++ b/src/app/[[...panel]]/page.tsx
@@ -232,7 +232,7 @@ export default function Home() {
       .catch(() => { markStep('auth') })
 
     // Check for available updates
-    fetch('/api/releases/check')
+    fetch('/api/releases/check', { cache: 'no-store' })
       .then(res => res.ok ? res.json() : null)
       .then(data => {
         if (data?.updateAvailable) {

--- a/src/app/api/releases/check/route.ts
+++ b/src/app/api/releases/check/route.ts
@@ -28,7 +28,7 @@ export async function GET() {
     if (!res.ok) {
       return NextResponse.json(
         { updateAvailable: false, currentVersion: APP_VERSION },
-        { headers: { 'Cache-Control': 'public, max-age=3600' } }
+        { headers: { 'Cache-Control': 'no-store' } }
       )
     }
 
@@ -47,13 +47,13 @@ export async function GET() {
         releaseNotes: release.body ?? '',
         deploymentMode,
       },
-      { headers: { 'Cache-Control': 'public, max-age=3600' } }
+      { headers: { 'Cache-Control': 'no-store' } }
     )
   } catch {
     // Network error — fail gracefully
     return NextResponse.json(
       { updateAvailable: false, currentVersion: APP_VERSION },
-      { headers: { 'Cache-Control': 'public, max-age=600' } }
+      { headers: { 'Cache-Control': 'no-store' } }
     )
   }
 }


### PR DESCRIPTION
## Summary
- disable caching on the release check endpoint
- disable cached client fetch behavior for the same path

## Notes
- opened from the synced fork branch after rebasing onto upstream `main`
- draft PR for upstream review