### PR TITLE
fix: configure Mission Control Docker runtime for Codex

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN if [ -f pnpm-lock.yaml ]; then \
 FROM base AS build
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-RUN pnpm build
+RUN NEXT_FONT_GOOGLE_OPTIMIZATION=0 pnpm build
 
 FROM node:22.22.0-slim AS runtime
 
@@ -32,7 +32,8 @@ WORKDIR /app
 ENV NODE_ENV=production
 # curl, CA certs, python3, git needed for agent runtime installers (OpenClaw, Hermes)
 # procps provides `ps` and `uptime` used by system-monitor APIs
-RUN apt-get update && apt-get install -y curl ca-certificates python3 git make g++ procps --no-install-recommends && rm -rf /var/lib/apt/lists/*
+# tmux is required for Claude/Codex terminal attachment in Mission Control
+RUN apt-get update && apt-get install -y curl ca-certificates python3 git make g++ procps tmux --no-install-recommends && rm -rf /var/lib/apt/lists/*
 RUN addgroup --system --gid 1001 nodejs && adduser --system --uid 1001 nextjs
 COPY --from=build /app/.next/standalone ./
 COPY --from=build /app/.next/static ./.next/static

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       - "${MC_PORT:-3000}:${PORT:-3000}"
     environment:
       - PORT=${PORT:-3000}
+      - HOME=/app/.data
+      - PATH=/app/.data/.local/bin:/app/.data/.npm-global/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games
       # ── Server-side gateway connection (MC backend → gateway) ──
       # host.docker.internal resolves to the Docker host on Docker Desktop (macOS/Windows).
       # On Linux, the extra_hosts entry below makes this work.


### PR DESCRIPTION
## Summary
- add Docker `HOME=/app/.data` and a runtime PATH that includes npm/global and local bins
- install `tmux` in the Mission Control runtime image so Codex/Claude PTY attachment works
- keep the Docker build using `NEXT_FONT_GOOGLE_OPTIMIZATION=0`

## Why
Mission Control could install Codex inside the container, but the server process was not consistently seeing the npm-global binary path, and PTY terminal attachment required `tmux`.

## Verification
- rebuilt and restarted the `mission-control` Docker container
- verified `/api/agent-runtimes` reports Codex as installed and authenticated
- verified `tmux 3.3a` is available in-container
- verified `codex-cli 0.122.0` runs successfully in-container
- verified a Codex smoke test returned `READY`
- verified Mission Control session continue API returned `STILL_READY`

## Notes
- local unrelated uncommitted change in `src/app/api/gateways/control/route.ts` was intentionally excluded from this PR