### PR TITLE
mission-control:v2.0.1-v0.9 - Replaced both callGatewayAgent(...) cal…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "docker.commands.build": "docker build --platform linux/amd64 ${dockerfile} ${tag} ${context}"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
-# ── Stage 0: extraer binario openclaw desde su imagen ──────────
-FROM logstreamingacrpro.azurecr.io/openclaw:2026.4.14-secure-v0.1 AS openclaw-bin
+# ── Stage 0: extraer binario openclaw desde su imagen oficial ──
+FROM ghcr.io/openclaw/openclaw:latest AS openclaw-bin
 
 # ── Stage 1: deps ──────────────────────────────────────────────
 FROM node:22.22.0-slim AS base

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,56 +1,77 @@
+# syntax=docker/dockerfile:1.7
+# ── Stage 0: extraer binario openclaw desde su imagen ──────────
+FROM logstreamingacrpro.azurecr.io/openclaw:2026.4.14-secure-v0.1 AS openclaw-bin
+
+# ── Stage 1: deps ──────────────────────────────────────────────
 FROM node:22.22.0-slim AS base
 RUN corepack enable && corepack prepare pnpm@latest --activate
 WORKDIR /app
 
 FROM base AS deps
-# Copy only dependency manifests first for better layer caching
-COPY package.json ./
-COPY pnpm-lock.yaml* ./
-# better-sqlite3 requires native compilation tools
-RUN apt-get update && apt-get install -y python3 make g++ --no-install-recommends && rm -rf /var/lib/apt/lists/*
-RUN if [ -f pnpm-lock.yaml ]; then \
-      pnpm install --frozen-lockfile; \
-    else \
-      echo "WARN: pnpm-lock.yaml not found in build context; running non-frozen install" && \
-      pnpm install --no-frozen-lockfile; \
-    fi
+COPY package.json pnpm-lock.yaml* ./
+# better-sqlite3 necesita compilación nativa — solo en build, no en runtime
+RUN apt-get update && \
+    apt-get install -y python3 make g++ --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+RUN pnpm install --frozen-lockfile
 
+# ── Stage 2: build ─────────────────────────────────────────────
 FROM base AS build
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN pnpm build
 
+# ── Stage 3: runtime hardened ──────────────────────────────────
 FROM node:22.22.0-slim AS runtime
 
-ARG MC_VERSION=dev
 LABEL org.opencontainers.image.source="https://github.com/builderz-labs/mission-control"
-LABEL org.opencontainers.image.description="Mission Control - operations dashboard"
 LABEL org.opencontainers.image.licenses="MIT"
-LABEL org.opencontainers.image.version="${MC_VERSION}"
 
 WORKDIR /app
 ENV NODE_ENV=production
-# curl, CA certs, python3, git needed for agent runtime installers (OpenClaw, Hermes)
-# procps provides `ps` and `uptime` used by system-monitor APIs
-RUN apt-get update && apt-get install -y curl ca-certificates python3 git make g++ procps --no-install-recommends && rm -rf /var/lib/apt/lists/*
-RUN addgroup --system --gid 1001 nodejs && adduser --system --uid 1001 nextjs
-COPY --from=build /app/.next/standalone ./
-COPY --from=build /app/.next/static ./.next/static
-COPY --from=build /app/public ./public
-COPY --from=build /app/src/lib/schema.sql ./src/lib/schema.sql
-# node-pty is a native addon; Next standalone tracing can omit built artifacts.
-# Copy the fully installed package (including native binary artifacts) from deps stage.
-COPY --from=deps /app/node_modules/.pnpm/node-pty@1.1.0/node_modules/node-pty ./node_modules/.pnpm/node-pty@1.1.0/node_modules/node-pty
-# Create data directory with correct ownership for SQLite
-RUN mkdir -p .data && chown nextjs:nodejs .data
-RUN echo 'const http=require("http");const r=http.get("http://localhost:"+(process.env.PORT||3000)+"/api/status?action=health",s=>{process.exit(s.statusCode===200?0:1)});r.on("error",()=>process.exit(1));r.setTimeout(4000,()=>{r.destroy();process.exit(1)})' > /app/healthcheck.js
-COPY docker-entrypoint.sh /app/docker-entrypoint.sh
-RUN chmod 755 /app/docker-entrypoint.sh && \
-    chmod -R a+rX /app/public/ /app/src/
-USER nextjs
-ENV PORT=3000
-EXPOSE 3000
 ENV HOSTNAME=0.0.0.0
+ENV PORT=3000
+
+# ❌ ELIMINADO del oficial: curl, git, python3, make, g++, procps
+# En AKS no queremos que MC pueda instalar agentes ni compilar nada
+# Solo ca-certificates para TLS saliente hacia el gateway
+RUN apt-get update && \
+    apt-get install -y ca-certificates --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+# Copiar solo los artefactos de Next.js standalone
+COPY --from=build --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=build --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=build --chown=nextjs:nodejs /app/public ./public
+COPY --from=build --chown=nextjs:nodejs /app/src/lib/schema.sql ./src/lib/schema.sql
+
+# ❌ ELIMINADO: node-pty (terminal PTY — no necesario para POC)
+# Si en el futuro necesitas la feature de terminal, añádelo aquí
+
+# SQLite data directory + home para el usuario nextjs (evita /nonexistent)
+RUN mkdir -p .data /home/nextjs && chown -R nextjs:nodejs .data /home/nextjs
+
+# OpenClaw CLI — copiado desde la imagen openclaw en lugar de npm install
+# El binario usa import.meta.url para resolver dist/ relativo a sí mismo:
+#   new URL("./dist/entry.mjs", import.meta.url)  → /usr/local/bin/dist/entry.mjs
+# Por tanto copiamos el binario Y su dist/ al mismo directorio padre.
+COPY --from=openclaw-bin /usr/local/bin/openclaw /usr/local/bin/openclaw
+COPY --from=openclaw-bin /app/dist /usr/local/bin/dist
+COPY --from=openclaw-bin /app/node_modules /usr/local/bin/node_modules
+COPY --from=openclaw-bin /app/package.json /usr/local/bin/package.json
+
+# Healthcheck sin curl
+RUN echo 'const http=require("http");const r=http.get("http://localhost:"+(process.env.PORT||3000)+"/api/status?action=health",s=>{process.exit(s.statusCode===200?0:1)});r.on("error",()=>process.exit(1));r.setTimeout(4000,()=>{r.destroy();process.exit(1)})' \
+    > /app/healthcheck.js
+
+USER nextjs
+ENV HOME=/home/nextjs
+EXPOSE 3000
+
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD ["node", "/app/healthcheck.js"]
-ENTRYPOINT ["/app/docker-entrypoint.sh"]
+
+CMD ["node", "server.js"]

--- a/fix-git-permissions.sh
+++ b/fix-git-permissions.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# fix-git-permissions.sh
+# Fixes false git changes caused by file permission drift when copying repos between machines.
+# Usage:
+#   ./fix-git-permissions.sh              # fix current directory (must be a git repo)
+#   ./fix-git-permissions.sh /path/to/repo
+#   ./fix-git-permissions.sh /parent/dir --all   # recurse all git repos under a parent dir
+
+set -euo pipefail
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+info()  { echo -e "${GREEN}[INFO]${NC}  $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+error() { echo -e "${RED}[ERROR]${NC} $*"; }
+
+fix_repo() {
+    local repo_dir="$1"
+
+    if ! git -C "$repo_dir" rev-parse --git-dir &>/dev/null; then
+        error "'$repo_dir' is not a git repository. Skipping."
+        return 1
+    fi
+
+    info "Processing repo: $repo_dir"
+
+    # ── 1. Disable fileMode tracking ─────────────────────────────────────────
+    git -C "$repo_dir" config core.fileMode false
+    info "  core.fileMode set to false"
+
+    # ── 2. Count changes BEFORE cleanup ──────────────────────────────────────
+    local before
+    before=$(git -C "$repo_dir" status --short | grep -v "^??" | wc -l | tr -d ' ')
+    info "  Tracked changes before cleanup: $before"
+
+    # ── 3. Reset permission bits to git-expected values (644 for files, 755 for dirs/executables)
+    #       This restores what git thinks the permissions should be, without touching content.
+    git -C "$repo_dir" diff --name-only --diff-filter=M HEAD 2>/dev/null | while read -r f; do
+        local full="$repo_dir/$f"
+        if [[ -f "$full" ]]; then
+            # Get the mode git has stored for this file
+            local git_mode
+            git_mode=$(git -C "$repo_dir" ls-files -s -- "$f" | awk '{print $1}')
+            if [[ "$git_mode" == "100755" ]]; then
+                chmod 755 "$full"
+            else
+                chmod 644 "$full"
+            fi
+        fi
+    done
+    info "  File permissions restored to git-tracked values"
+
+    # ── 4. Count REAL content changes after cleanup ───────────────────────────
+    local after
+    after=$(git -C "$repo_dir" status --short | grep -v "^??" | wc -l | tr -d ' ')
+    info "  Real content changes remaining: $after"
+
+    # ── 5. Show the real changes so the user can review them ──────────────────
+    if [[ "$after" -gt 0 ]]; then
+        warn "  The following files have REAL content changes (not permission noise):"
+        git -C "$repo_dir" status --short | grep -v "^??" | sed 's/^/    /'
+    else
+        info "  No real content changes — working tree is clean."
+    fi
+
+    echo ""
+}
+
+# ── main ─────────────────────────────────────────────────────────────────────
+TARGET="${1:-.}"
+MODE="${2:-}"
+
+if [[ "$MODE" == "--all" ]]; then
+    info "Scanning for git repos under: $TARGET"
+    while IFS= read -r gitdir; do
+        repo=$(dirname "$gitdir")
+        fix_repo "$repo"
+    done < <(find "$TARGET" -maxdepth 3 -name ".git" -type d 2>/dev/null)
+else
+    fix_repo "$TARGET"
+fi
+
+info "Done."

--- a/messages/en.json
+++ b/messages/en.json
@@ -740,6 +740,7 @@
     "workspaceFilesDesc": "Files in the agent workspace directory."
   },
   "taskBoard": {
+    "taskBoard": "Task Board",
     "title": "Task Board",
     "allProjects": "All Projects",
     "projects": "Projects",

--- a/messages/es.json
+++ b/messages/es.json
@@ -741,6 +741,7 @@
     "workspaceFilesDesc": "Archivos del workspace del agente"
   },
   "taskBoard": {
+    "taskBoard": "Tablero de tareas",
     "title": "Tablero de tareas",
     "allProjects": "Todos los proyectos",
     "projects": "Proyectos",

--- a/messages/es.json
+++ b/messages/es.json
@@ -85,6 +85,7 @@
     "channels": "Canales",
     "skills": "Habilidades",
     "memory": "Memoria",
+    "workspace": "Espacio de trabajo",
     "activity": "Actividad",
     "logs": "Registros",
     "costTracker": "Seguimiento de costos",

--- a/src/app/[[...panel]]/page.tsx
+++ b/src/app/[[...panel]]/page.tsx
@@ -9,6 +9,7 @@ import { Dashboard } from '@/components/dashboard/dashboard'
 import { LogViewerPanel } from '@/components/panels/log-viewer-panel'
 import { CronManagementPanel } from '@/components/panels/cron-management-panel'
 import { MemoryBrowserPanel } from '@/components/panels/memory-browser-panel'
+import { WorkspaceBrowserPanel } from '@/components/panels/workspace-browser-panel-simple'
 import { CostTrackerPanel } from '@/components/panels/cost-tracker-panel'
 import { TaskBoardPanel } from '@/components/panels/task-board-panel'
 import { ActivityFeedPanel } from '@/components/panels/activity-feed-panel'
@@ -550,6 +551,8 @@ function ContentRouter({ tab }: { tab: string }) {
       return <CronManagementPanel />
     case 'memory':
       return <MemoryBrowserPanel />
+    case 'workspace':
+      return <WorkspaceBrowserPanel />
     case 'cost-tracker':
     case 'tokens':
     case 'agent-costs':

--- a/src/app/api/status/route.ts
+++ b/src/app/api/status/route.ts
@@ -427,7 +427,8 @@ async function getAvailableModels() {
   try {
     // Use Ollama HTTP API instead of `ollama list` CLI.
     // On macOS desktop app installs, spawning CLI commands can restart/crash the GUI process.
-    const res = await fetch('http://127.0.0.1:11434/api/tags', {
+    const ollamaBaseUrl = (process.env.OLLAMA_BASE_URL || 'http://127.0.0.1:11434').replace(/\/+$/, '').replace(/\/v1$/, '')
+    const res = await fetch(`${ollamaBaseUrl}/api/tags`, {
       signal: AbortSignal.timeout(5000),
     })
 

--- a/src/app/api/workspace/files/route.ts
+++ b/src/app/api/workspace/files/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import fs from 'fs'
+import path from 'path'
+
+// Base dir where openclaw-pvc is mounted read-only inside the MC container.
+// Populated from env var set in dep_all_in_one.yaml (OPENCLAW_WORKSPACE_DIR).
+// /mnt/openclaw-workspace/workspace/ is the git repo written by the agent.
+const OPENCLAW_BASE = process.env.OPENCLAW_WORKSPACE_DIR ?? '/mnt/openclaw-workspace'
+const WORKSPACE_DIR = path.join(OPENCLAW_BASE, 'workspace')
+
+// Directories that should never be exposed to the caller.
+const BLOCKED = new Set(['.git', 'node_modules', '__pycache__', '.venv', '.env'])
+
+/**
+ * Resolve a caller-supplied relative path safely, ensuring it stays inside
+ * WORKSPACE_DIR (prevents path-traversal attacks).
+ */
+function resolveSecure(relative: string): string | null {
+  const base = WORKSPACE_DIR
+  const resolved = path.resolve(base, relative)
+  // Must start with base + sep, or equal base exactly
+  if (resolved !== base && !resolved.startsWith(base + path.sep)) return null
+  return resolved
+}
+
+/**
+ * GET /api/workspace/files?path=<relative>
+ *
+ * - No path / path=.  → list root of workspace
+ * - path=src/foo.ts   → return file content (≤512 KB)
+ * - path=src/         → list directory entries
+ *
+ * Response (directory):
+ *   { path, entries: [{name, type, size?, mtime}] }
+ *
+ * Response (file):
+ *   { path, content, size, mtime }
+ */
+export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  if (!fs.existsSync(WORKSPACE_DIR)) {
+    return NextResponse.json(
+      {
+        error: 'Workspace not mounted',
+        hint: 'openclaw-workspace-ro-pvc is not mounted or the workspace does not exist yet',
+        expected: WORKSPACE_DIR,
+      },
+      { status: 503 }
+    )
+  }
+
+  const relativePath = request.nextUrl.searchParams.get('path') ?? '.'
+  const resolved = resolveSecure(relativePath)
+  if (!resolved) {
+    return NextResponse.json({ error: 'Invalid path — traversal outside workspace is not allowed' }, { status: 400 })
+  }
+
+  if (!fs.existsSync(resolved)) {
+    return NextResponse.json({ error: 'Not found', path: relativePath }, { status: 404 })
+  }
+
+  const stat = fs.statSync(resolved)
+
+  if (stat.isDirectory()) {
+    const entries = fs.readdirSync(resolved, { withFileTypes: true })
+      .filter(e => !BLOCKED.has(e.name))
+      .map(e => {
+        const fullPath = path.join(resolved, e.name)
+        const s = fs.statSync(fullPath)
+        return {
+          name: e.name,
+          type: e.isDirectory() ? 'dir' : 'file',
+          size: e.isFile() ? s.size : undefined,
+          mtime: s.mtime.toISOString(),
+        }
+      })
+      .sort((a, b) => {
+        // directories first, then files, alphabetical within each group
+        if (a.type !== b.type) return a.type === 'dir' ? -1 : 1
+        return a.name.localeCompare(b.name)
+      })
+    return NextResponse.json({ path: relativePath, entries })
+  }
+
+  // File — cap at 512 KB to prevent accidental large binary reads
+  const MAX_BYTES = 512 * 1024
+  if (stat.size > MAX_BYTES) {
+    return NextResponse.json(
+      { error: 'File too large to serve inline', size: stat.size, limit: MAX_BYTES, path: relativePath },
+      { status: 413 }
+    )
+  }
+
+  const content = fs.readFileSync(resolved, 'utf-8')
+  return NextResponse.json({
+    path: relativePath,
+    content,
+    size: stat.size,
+    mtime: stat.mtime.toISOString(),
+  })
+}

--- a/src/app/api/workspace/git-log/route.ts
+++ b/src/app/api/workspace/git-log/route.ts
@@ -1,0 +1,181 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import fs from 'fs'
+import path from 'path'
+
+const execFileAsync = promisify(execFile)
+
+const OPENCLAW_BASE = process.env.OPENCLAW_WORKSPACE_DIR ?? '/mnt/openclaw-workspace'
+const WORKSPACE_DIR = path.join(OPENCLAW_BASE, 'workspace')
+
+/**
+ * GET /api/workspace/git-log?n=20&after=2026-01-01
+ *
+ * Returns the git commit history of the openclaw agent workspace, including
+ * which files were created / modified / deleted in each commit — this shows
+ * exactly what artifacts the agent has produced over time.
+ *
+ * Query params:
+ *   n      — max commits to return (default 20, max 100)
+ *   after  — ISO date string to filter commits newer than this date
+ *   file   — if provided, show history for a specific file path only
+ *
+ * Response:
+ *   {
+ *     workspace: string,
+ *     commits: [{
+ *       hash: string,        // short SHA
+ *       fullHash: string,
+ *       author: string,
+ *       email: string,
+ *       date: string,        // ISO date
+ *       subject: string,
+ *       files: [{status: "A"|"M"|"D"|"R", path: string}]
+ *     }]
+ *   }
+ *
+ * Requires git to be available in the MC container (present in node:22-slim).
+ * If git is not installed, returns 503 with a clear message.
+ */
+export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  if (!fs.existsSync(WORKSPACE_DIR)) {
+    return NextResponse.json(
+      {
+        error: 'Workspace not mounted',
+        hint: 'openclaw-workspace-ro-pvc is not mounted or the workspace directory does not exist yet',
+        expected: WORKSPACE_DIR,
+      },
+      { status: 503 }
+    )
+  }
+
+  if (!fs.existsSync(path.join(WORKSPACE_DIR, '.git'))) {
+    return NextResponse.json(
+      {
+        error: 'Not a git repository',
+        path: WORKSPACE_DIR,
+        hint: 'openclaw has not initialized the workspace as a git repository yet',
+      },
+      { status: 404 }
+    )
+  }
+
+  const sp = request.nextUrl.searchParams
+  const n = Math.min(Math.max(1, parseInt(sp.get('n') ?? '20', 10)), 100)
+  const after = sp.get('after') // e.g. "2026-01-01" or ISO datetime
+  const filePath = sp.get('file') // filter to a specific file
+
+  // Use a unit separator (\x1f) to safely split fields that might contain spaces
+  const format = '%H\x1f%h\x1f%ae\x1f%an\x1f%aI\x1f%s'
+
+  const args: string[] = [
+    '-C', WORKSPACE_DIR,   // run git against the repo (safer than cwd)
+    'log',
+    `--max-count=${n}`,
+    `--format=${format}`,
+    '--name-status',       // show file status (A/M/D)
+    '--diff-filter=ACDMR', // Added, Copied, Deleted, Modified, Renamed
+  ]
+
+  if (after) {
+    // Validate: only allow safe date strings to prevent arg injection
+    if (!/^[\d\-T:.Z+]+$/.test(after)) {
+      return NextResponse.json({ error: 'Invalid after date format' }, { status: 400 })
+    }
+    args.push(`--after=${after}`)
+  }
+
+  if (filePath) {
+    // Validate: must be a relative path without shell metacharacters
+    if (/[;&|`$<>\\]/.test(filePath)) {
+      return NextResponse.json({ error: 'Invalid file path' }, { status: 400 })
+    }
+    args.push('--', filePath)
+  }
+
+  try {
+    const { stdout } = await execFileAsync('git', args, {
+      timeout: 15_000,
+      maxBuffer: 4 * 1024 * 1024,
+      // Do NOT use shell: true — we're passing args as array (no injection risk)
+    })
+
+    const commits = parseGitLog(stdout)
+    return NextResponse.json({ workspace: WORKSPACE_DIR, commits })
+  } catch (err: any) {
+    if (err.code === 'ENOENT') {
+      return NextResponse.json(
+        {
+          error: 'git binary not found in Mission Control container',
+          hint: 'Add git to the MC Dockerfile: RUN apt-get install -y --no-install-recommends git',
+        },
+        { status: 503 }
+      )
+    }
+    return NextResponse.json(
+      { error: 'git log failed', detail: err.message },
+      { status: 500 }
+    )
+  }
+}
+
+interface GitFile {
+  status: string
+  path: string
+  oldPath?: string // for renames
+}
+
+interface GitCommit {
+  fullHash: string
+  hash: string
+  email: string
+  author: string
+  date: string
+  subject: string
+  files: GitFile[]
+}
+
+/**
+ * Parse the raw stdout from `git log --format=<fields> --name-status`.
+ * The output interleaves commit header lines and file-status lines, separated
+ * by blank lines between commits.
+ */
+function parseGitLog(raw: string): GitCommit[] {
+  const commits: GitCommit[] = []
+  // Each commit is a block of: header line + blank line + file lines + blank line
+  const blocks = raw.trim().split(/\n(?=[\da-f]{40})/)
+
+  for (const block of blocks) {
+    if (!block.trim()) continue
+    const lines = block.split('\n')
+    const headerLine = lines[0]
+    const parts = headerLine.split('\x1f')
+    if (parts.length < 6) continue
+
+    const [fullHash, hash, email, author, date, ...subjectParts] = parts
+    const subject = subjectParts.join('\x1f')
+
+    const files: GitFile[] = []
+    for (const line of lines.slice(1)) {
+      if (!line.trim()) continue
+      const cols = line.split('\t')
+      const status = cols[0]?.trim()
+      if (!status || cols.length < 2) continue
+      if (status.startsWith('R')) {
+        // Rename: R100\told-path\tnew-path
+        files.push({ status: 'R', path: cols[2] ?? cols[1], oldPath: cols[1] })
+      } else {
+        files.push({ status, path: cols[1] })
+      }
+    }
+
+    commits.push({ fullHash, hash, email, author, date, subject, files })
+  }
+
+  return commits
+}

--- a/src/app/api/workspace/sessions/route.ts
+++ b/src/app/api/workspace/sessions/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import fs from 'fs'
+import path from 'path'
+
+const OPENCLAW_BASE = process.env.OPENCLAW_WORKSPACE_DIR ?? '/mnt/openclaw-workspace'
+
+// Strict allowlist for agent names — only alphanumeric, dash, underscore
+const AGENT_RE = /^[a-zA-Z0-9_-]{1,64}$/
+// Strict allowlist for session IDs (openclaw uses UUIDs or slug-style IDs)
+const SESSION_RE = /^[a-zA-Z0-9_-]{1,128}$/
+
+/**
+ * GET /api/workspace/sessions?agent=main
+ *   → returns sessions.json index for the agent
+ *
+ * GET /api/workspace/sessions?agent=main&session=<id>
+ *   → returns full message list from the .jsonl file for that session
+ *
+ * Sessions live at:
+ *   /mnt/openclaw-workspace/agents/<agent>/sessions/sessions.json   (index)
+ *   /mnt/openclaw-workspace/agents/<agent>/sessions/<id>.jsonl      (messages)
+ *
+ * Response (index):
+ *   { agent, sessions: [{id, title, createdAt, ...}] }
+ *
+ * Response (single session):
+ *   { agent, sessionId, messages: [{role, content, ...}] }
+ */
+export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  const agent = request.nextUrl.searchParams.get('agent') ?? 'main'
+  if (!AGENT_RE.test(agent)) {
+    return NextResponse.json({ error: 'Invalid agent name' }, { status: 400 })
+  }
+
+  const agentsBase = path.join(OPENCLAW_BASE, 'agents')
+  if (!fs.existsSync(agentsBase)) {
+    return NextResponse.json(
+      {
+        error: 'Agents directory not found',
+        hint: 'openclaw-workspace-ro-pvc may not be mounted or openclaw has not run yet',
+        expected: agentsBase,
+      },
+      { status: 503 }
+    )
+  }
+
+  const sessionsDir = path.join(agentsBase, agent, 'sessions')
+  if (!fs.existsSync(sessionsDir)) {
+    return NextResponse.json({ agent, sessions: [], hint: 'No sessions directory for this agent' })
+  }
+
+  const sessionId = request.nextUrl.searchParams.get('session')
+
+  // ── Return a specific session's messages ──────────────────────────────────
+  if (sessionId) {
+    if (!SESSION_RE.test(sessionId)) {
+      return NextResponse.json({ error: 'Invalid session id' }, { status: 400 })
+    }
+
+    const jsonlPath = path.join(sessionsDir, `${sessionId}.jsonl`)
+    // Double-check the resolved path stays inside sessionsDir (paranoid)
+    if (!jsonlPath.startsWith(sessionsDir + path.sep)) {
+      return NextResponse.json({ error: 'Invalid session id' }, { status: 400 })
+    }
+    if (!fs.existsSync(jsonlPath)) {
+      return NextResponse.json({ error: 'Session not found', sessionId }, { status: 404 })
+    }
+
+    const messages = fs.readFileSync(jsonlPath, 'utf-8')
+      .split('\n')
+      .filter(Boolean)
+      .flatMap(line => {
+        try { return [JSON.parse(line)] } catch { return [] }
+      })
+
+    return NextResponse.json({ agent, sessionId, messages })
+  }
+
+  // ── Return the session index ───────────────────────────────────────────────
+  const indexPath = path.join(sessionsDir, 'sessions.json')
+  let sessions: unknown[] = []
+  if (fs.existsSync(indexPath)) {
+    try {
+      sessions = JSON.parse(fs.readFileSync(indexPath, 'utf-8'))
+    } catch {
+      sessions = []
+    }
+  }
+
+  // Also enumerate .jsonl files present on disk as a fallback if index is empty
+  const jsonlFiles = fs.readdirSync(sessionsDir)
+    .filter(f => f.endsWith('.jsonl'))
+    .map(f => {
+      const s = fs.statSync(path.join(sessionsDir, f))
+      return { id: f.replace(/\.jsonl$/, ''), size: s.size, mtime: s.mtime.toISOString() }
+    })
+    .sort((a, b) => b.mtime.localeCompare(a.mtime))
+
+  return NextResponse.json({ agent, sessions, jsonlFiles })
+}

--- a/src/app/workspace/page.tsx
+++ b/src/app/workspace/page.tsx
@@ -1,0 +1,9 @@
+import { WorkspaceBrowserPanel } from '@/components/panels/workspace-browser-panel-simple'
+
+export default function WorkspacePage() {
+  return (
+    <div className="h-screen">
+      <WorkspaceBrowserPanel />
+    </div>
+  )
+}

--- a/src/components/layout/nav-rail.tsx
+++ b/src/components/layout/nav-rail.tsx
@@ -48,6 +48,7 @@ const navGroups: NavGroup[] = [
       { id: 'exec-approvals', label: 'Approvals', icon: <ApprovalsIcon />, priority: false },
       { id: 'office', label: 'Office', icon: <OfficeIcon />, priority: false },
       { id: 'monitor', label: 'Monitor', icon: <MonitorIcon />, priority: false },
+      { id: 'workspace', label: 'Workspace', icon: <WorkspaceIcon />, priority: false, essential: true },
     ],
   },
   {
@@ -1520,6 +1521,16 @@ function MonitorIcon() {
       <rect x="1" y="2" width="14" height="10" rx="1.5" />
       <polyline points="4,9 6,6 8,8 12,4" />
       <path d="M5 14h6" />
+    </svg>
+  )
+}
+
+function WorkspaceIcon() {
+  return (
+    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M2 4.5v8c0 .8.7 1.5 1.5 1.5h9c.8 0 1.5-.7 1.5-1.5v-8" />
+      <path d="M1 4.5L8 2l7 2.5" />
+      <path d="M5 7h6M5 10h4" />
     </svg>
   )
 }

--- a/src/components/panels/workspace-browser-panel-simple.tsx
+++ b/src/components/panels/workspace-browser-panel-simple.tsx
@@ -1,0 +1,287 @@
+'use client'
+
+import React, { useState, useEffect, useCallback } from 'react'
+import { Button } from '@/components/ui/button'
+import { Loader } from '@/components/ui/loader'
+import { createClientLogger } from '@/lib/client-logger'
+
+const log = createClientLogger('WorkspaceBrowser')
+
+interface WorkspaceFile {
+  path: string
+  name: string
+  type: 'file' | 'directory'
+  size?: number
+  modified?: number
+  children?: WorkspaceFile[]
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes === 0) return '0 B'
+  const k = 1024
+  const sizes = ['B', 'KB', 'MB', 'GB']
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i]
+}
+
+function fileIcon(name: string): string {
+  if (name.endsWith('.py')) return '🐍'
+  if (name.endsWith('.js') || name.endsWith('.ts')) return '📜'
+  if (name.endsWith('.sh')) return '⚙️'
+  if (name.endsWith('.json') || name.endsWith('.yaml')) return '⚙️'
+  if (name.endsWith('.md')) return '📄'
+  if (name.endsWith('.txt') || name.endsWith('.log')) return '📝'
+  return '📄'
+}
+
+function isCodeFile(name: string): boolean {
+  return name.endsWith('.py') || name.endsWith('.js') || name.endsWith('.ts') || 
+         name.endsWith('.sh') || name.endsWith('.go') || name.endsWith('.rs')
+}
+
+export function WorkspaceBrowserPanel() {
+  const [files, setFiles] = useState<WorkspaceFile[]>([])
+  const [selectedFile, setSelectedFile] = useState<string | null>(null)
+  const [fileContent, setFileContent] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [expandedFolders, setExpandedFolders] = useState<Set<string>>(new Set())
+  const [error, setError] = useState<string | null>(null)
+
+  const loadFileTree = useCallback(async (path: string = '') => {
+    setIsLoading(true)
+    setError(null)
+    try {
+      const params = new URLSearchParams()
+      if (path) params.set('path', path)
+      
+      const response = await fetch(`/api/workspace/files?${params.toString()}`)
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+      }
+      
+      const data = await response.json()
+      
+      if (data.error) {
+        setError(data.error)
+        return
+      }
+      
+      // Transform API entries to add path field and normalize type
+      const transformedEntries = (data.entries || []).map((entry: any) => ({
+        ...entry,
+        path: path ? `${path}/${entry.name}` : entry.name,
+        type: entry.type === 'dir' ? 'directory' : 'file',
+      }))
+      
+      if (path === '') {
+        // Root load
+        setFiles(transformedEntries)
+      } else {
+        // Folder expansion - merge into existing tree
+        setFiles(prev => mergeChildren(prev, path, transformedEntries))
+      }
+    } catch (error) {
+      log.error('Failed to load workspace files:', error)
+      setError(error instanceof Error ? error.message : 'Failed to load files')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  const mergeChildren = (files: WorkspaceFile[], targetPath: string, children: WorkspaceFile[]): WorkspaceFile[] => {
+    return files.map((file) => {
+      if (file.path === targetPath && file.type === 'directory') {
+        return { ...file, children }
+      }
+      if (file.children) {
+        return { ...file, children: mergeChildren(file.children, targetPath, children) }
+      }
+      return file
+    })
+  }
+
+  useEffect(() => {
+    loadFileTree()
+  }, [loadFileTree])
+
+  const loadFileContent = async (filePath: string) => {
+    setIsLoading(true)
+    setError(null)
+    try {
+      const response = await fetch(`/api/workspace/files?path=${encodeURIComponent(filePath)}`)
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`)
+      }
+      
+      const data = await response.json()
+      
+      if (data.error) {
+        setError(data.error)
+        return
+      }
+      
+      if (data.type === 'file' && data.content !== undefined) {
+        setSelectedFile(filePath)
+        setFileContent(data.content)
+      }
+    } catch (error) {
+      log.error('Failed to load file content:', error)
+      setError(error instanceof Error ? error.message : 'Failed to load file')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const toggleFolder = async (folderPath: string) => {
+    const isExpanded = expandedFolders.has(folderPath)
+    
+    if (isExpanded) {
+      setExpandedFolders(prev => {
+        const next = new Set(prev)
+        next.delete(folderPath)
+        return next
+      })
+    } else {
+      setExpandedFolders(prev => new Set(prev).add(folderPath))
+      
+      // Check if we need to load children
+      const folder = findFile(files, folderPath)
+      if (folder && folder.type === 'directory' && !folder.children) {
+        await loadFileTree(folderPath)
+      }
+    }
+  }
+
+  const findFile = (files: WorkspaceFile[], path: string): WorkspaceFile | null => {
+    for (const file of files) {
+      if (file.path === path) return file
+      if (file.children) {
+        const found = findFile(file.children, path)
+        if (found) return found
+      }
+    }
+    return null
+  }
+
+  const renderFileTree = (files: WorkspaceFile[], level: number = 0) => {
+    return files.map((file) => {
+      const isExpanded = expandedFolders.has(file.path)
+      const isSelected = selectedFile === file.path
+      const isCode = isCodeFile(file.name)
+      
+      return (
+        <div key={file.path} style={{ marginLeft: `${level * 20}px` }}>
+          <div
+            className={`flex items-center gap-2 px-2 py-1 rounded cursor-pointer hover:bg-gray-800 ${
+              isSelected ? 'bg-blue-900' : ''
+            } ${isCode ? 'font-semibold text-green-400' : ''}`}
+            onClick={() => {
+              if (file.type === 'directory') {
+                toggleFolder(file.path)
+              } else {
+                loadFileContent(file.path)
+              }
+            }}
+          >
+            {file.type === 'directory' && (
+              <span className="text-gray-500">{isExpanded ? '▼' : '▶'}</span>
+            )}
+            <span className="text-xl">{fileIcon(file.name)}</span>
+            <span className="flex-1">{file.name}</span>
+            {file.size !== undefined && (
+              <span className="text-xs text-gray-500">{formatFileSize(file.size)}</span>
+            )}
+          </div>
+          
+          {file.type === 'directory' && isExpanded && file.children && (
+            <div>
+              {renderFileTree(file.children, level + 1)}
+            </div>
+          )}
+        </div>
+      )
+    })
+  }
+
+  const countCodeFiles = (files: WorkspaceFile[]): number => {
+    return files.reduce((acc, file) => {
+      if (file.type === 'file' && isCodeFile(file.name)) {
+        return acc + 1
+      }
+      if (file.children) {
+        return acc + countCodeFiles(file.children)
+      }
+      return acc
+    }, 0)
+  }
+
+  const codeCount = countCodeFiles(files)
+
+  return (
+    <div className="flex h-full bg-gray-950 text-gray-100">
+      {/* Sidebar - File Tree */}
+      <div className="w-1/3 border-r border-gray-800 overflow-y-auto p-4">
+        <div className="mb-4">
+          <h2 className="text-xl font-bold mb-2">📁 OpenClaw Workspace</h2>
+          <div className="text-sm text-gray-400">
+            {codeCount > 0 && <div>🐍 {codeCount} archivos de código</div>}
+            {error && <div className="text-red-400 mt-2">⚠️ {error}</div>}
+          </div>
+        </div>
+        
+        {isLoading && files.length === 0 ? (
+          <Loader variant="inline" />
+        ) : (
+          <div className="space-y-1">
+            {renderFileTree(files)}
+          </div>
+        )}
+      </div>
+
+      {/* Content Area */}
+      <div className="flex-1 overflow-y-auto p-6">
+        {selectedFile ? (
+          <div>
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-lg font-semibold">{selectedFile}</h3>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  setSelectedFile(null)
+                  setFileContent(null)
+                }}
+              >
+                ✕ Cerrar
+              </Button>
+            </div>
+            
+            {isLoading ? (
+              <Loader />
+            ) : fileContent !== null ? (
+              <div>
+                <pre className="bg-gray-900 p-4 rounded-lg overflow-x-auto text-sm">
+                  <code>{fileContent}</code>
+                </pre>
+                
+                {/* TODO: Botón "Ver tarea relacionada" cuando tengamos metadata */}
+                <div className="mt-4 p-3 bg-gray-900 rounded-lg text-sm text-gray-400">
+                  💡 Futuro: Aquí se mostrará la tarea que creó este archivo
+                </div>
+              </div>
+            ) : (
+              <div className="text-gray-500">No se pudo cargar el contenido</div>
+            )}
+          </div>
+        ) : (
+          <div className="flex items-center justify-center h-full text-gray-500">
+            <div className="text-center">
+              <div className="text-6xl mb-4">📂</div>
+              <div>Selecciona un archivo del árbol para ver su contenido</div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/panels/workspace-browser-panel-simple.tsx
+++ b/src/components/panels/workspace-browser-panel-simple.tsx
@@ -120,9 +120,13 @@ export function WorkspaceBrowserPanel() {
         return
       }
       
-      if (data.type === 'file' && data.content !== undefined) {
+      // API returns { content, ... } for files, { entries: [...] } for directories
+      if (data.content !== undefined) {
         setSelectedFile(filePath)
         setFileContent(data.content)
+      } else if (data.entries) {
+        // It's a directory, not a file - should not happen if called correctly
+        log.warn('Tried to load directory as file:', filePath)
       }
     } catch (error) {
       log.error('Failed to load file content:', error)

--- a/src/components/panels/workspace-browser-panel.tsx
+++ b/src/components/panels/workspace-browser-panel.tsx
@@ -1,0 +1,1016 @@
+'use client'
+
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react'
+import { useTranslations } from 'next-intl'
+import { Button } from '@/components/ui/button'
+import { Loader } from '@/components/ui/loader'
+import { useMissionControl } from '@/store'
+import { createClientLogger } from '@/lib/client-logger'
+import { MemoryGraph } from './memory-graph'
+
+const log = createClientLogger('MemoryBrowser')
+
+interface MemoryFile {
+  path: string
+  name: string
+  type: 'file' | 'directory'
+  size?: number
+  modified?: number
+  children?: MemoryFile[]
+}
+
+function mergeDirectoryChildren(files: MemoryFile[], targetPath: string, children: MemoryFile[]): MemoryFile[] {
+  return files.map((file) => {
+    if (file.path === targetPath && file.type === 'directory') {
+      return { ...file, children }
+    }
+    if (!file.children?.length) return file
+    return { ...file, children: mergeDirectoryChildren(file.children, targetPath, children) }
+  })
+}
+
+interface HealthCategory {
+  name: string
+  status: 'healthy' | 'warning' | 'critical'
+  score: number
+  issues: string[]
+  suggestions: string[]
+}
+
+interface HealthReport {
+  overall: 'healthy' | 'warning' | 'critical'
+  overallScore: number
+  categories: HealthCategory[]
+  generatedAt: number
+}
+
+interface MOCGroup {
+  directory: string
+  entries: { title: string; path: string; linkCount: number }[]
+}
+
+interface ProcessingResult {
+  action: string
+  filesProcessed: number
+  changes: string[]
+  suggestions: string[]
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes === 0) return '0 B'
+  const k = 1024
+  const sizes = ['B', 'KB', 'MB', 'GB']
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i]
+}
+
+function countFiles(files: MemoryFile[]): number {
+  return files.reduce((acc, f) => {
+    if (f.type === 'file') return acc + 1
+    return acc + countFiles(f.children || [])
+  }, 0)
+}
+
+function totalSize(files: MemoryFile[]): number {
+  return files.reduce((acc, f) => {
+    if (f.type === 'file' && f.size) return acc + f.size
+    return acc + totalSize(f.children || [])
+  }, 0)
+}
+
+function fileIcon(name: string): string {
+  if (name.endsWith('.md')) return '#'
+  if (name.endsWith('.json') || name.endsWith('.jsonl')) return '{}'
+  if (name.endsWith('.txt') || name.endsWith('.log')) return '|'
+  return '~'
+}
+
+function statusColor(status: 'healthy' | 'warning' | 'critical'): string {
+  if (status === 'healthy') return 'text-green-400'
+  if (status === 'warning') return 'text-amber-400'
+  return 'text-red-400'
+}
+
+function statusBg(status: 'healthy' | 'warning' | 'critical'): string {
+  if (status === 'healthy') return 'bg-green-500'
+  if (status === 'warning') return 'bg-amber-500'
+  return 'bg-red-500'
+}
+
+export function MemoryBrowserPanel() {
+  const t = useTranslations('memoryBrowser')
+  const {
+    memoryFiles,
+    selectedMemoryFile,
+    memoryContent,
+    memoryFileLinks,
+    memoryHealth,
+    dashboardMode,
+    setMemoryFiles,
+    setSelectedMemoryFile,
+    setMemoryContent,
+    setMemoryFileLinks,
+    setMemoryHealth
+  } = useMissionControl()
+  const isLocal = dashboardMode === 'local'
+
+  const [isLoading, setIsLoading] = useState(false)
+  const [expandedFolders, setExpandedFolders] = useState<Set<string>>(new Set())
+  const [searchResults, setSearchResults] = useState<{ path: string; name: string; matches: number }[]>([])
+  const [searchQuery, setSearchQuery] = useState('')
+  const [isSearching, setIsSearching] = useState(false)
+  const [isEditing, setIsEditing] = useState(false)
+  const [editedContent, setEditedContent] = useState('')
+  const [showCreateModal, setShowCreateModal] = useState(false)
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+  const [activeView, setActiveView] = useState<'files' | 'graph' | 'health' | 'pipeline' | 'hermes'>(!isLocal ? 'graph' : 'files')
+  const [hermesMemory, setHermesMemory] = useState<{ agentMemory: string | null; userMemory: string | null; agentMemorySize: number; userMemorySize: number; agentMemoryEntries: number; userMemoryEntries: number } | null>(null)
+  const [hermesInstalled, setHermesInstalled] = useState<boolean | null>(null)
+  const [isLoadingHermes, setIsLoadingHermes] = useState(false)
+  const [sidebarOpen, setSidebarOpen] = useState(true)
+  const [fileFilter, setFileFilter] = useState<'all' | 'daily' | 'knowledge'>('all')
+  const [schemaWarnings, setSchemaWarnings] = useState<string[]>([])
+  const [linksOpen, setLinksOpen] = useState(false)
+  const [healthReport, setHealthReport] = useState<HealthReport | null>(null)
+  const [isLoadingHealth, setIsLoadingHealth] = useState(false)
+  const [pipelineResult, setPipelineResult] = useState<ProcessingResult | null>(null)
+  const [mocGroups, setMocGroups] = useState<MOCGroup[]>([])
+  const [isRunningPipeline, setIsRunningPipeline] = useState(false)
+  const [isHydratingTree, setIsHydratingTree] = useState(false)
+  const memoryFilesRef = useRef(memoryFiles)
+
+  useEffect(() => {
+    memoryFilesRef.current = memoryFiles
+  }, [memoryFiles])
+
+  const fetchTree = useCallback(async (options?: { path?: string; depth?: number }) => {
+    const params = new URLSearchParams({ action: 'tree' })
+    if (typeof options?.depth === 'number') params.set('depth', String(options.depth))
+    if (options?.path) params.set('path', options.path)
+    const response = await fetch(`/api/memory?${params.toString()}`)
+    return response.json()
+  }, [])
+
+  const loadFileTree = useCallback(async () => {
+    setIsLoading(true)
+    try {
+      const data = await fetchTree({ depth: 1 })
+      setMemoryFiles(data.tree || [])
+      setExpandedFolders(new Set(['daily', 'knowledge', 'memory', 'knowledge-base']))
+      setIsHydratingTree(true)
+      void fetchTree()
+        .then((fullData) => {
+          setMemoryFiles(fullData.tree || [])
+        })
+        .catch((error) => {
+          log.error('Failed to hydrate full file tree:', error)
+        })
+        .finally(() => {
+          setIsHydratingTree(false)
+        })
+    } catch (error) {
+      log.error('Failed to load file tree:', error)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [fetchTree, setMemoryFiles])
+
+  useEffect(() => {
+    loadFileTree()
+  }, [loadFileTree])
+
+  const filteredFiles = useMemo(() => {
+    if (fileFilter === 'all') return memoryFiles
+    const prefixes = fileFilter === 'daily'
+      ? ['daily/', 'memory/']
+      : ['knowledge/', 'knowledge-base/']
+    return memoryFiles.filter((file) => {
+      const p = `${file.path.replace(/\\/g, '/')}/`
+      return prefixes.some((prefix) => p.startsWith(prefix))
+    })
+  }, [memoryFiles, fileFilter])
+
+  const loadFileContent = async (filePath: string) => {
+    setIsLoading(true)
+    try {
+      const response = await fetch(`/api/memory?action=content&path=${encodeURIComponent(filePath)}`)
+      const data = await response.json()
+      if (data.content !== undefined) {
+        setSelectedMemoryFile(filePath)
+        setMemoryContent(data.content)
+        setIsEditing(false)
+        setEditedContent('')
+        setSchemaWarnings([])
+        if (data.wikiLinks) {
+          setMemoryFileLinks({
+            wikiLinks: data.wikiLinks,
+            incoming: [],
+            outgoing: [],
+          })
+          fetch(`/api/memory/links?file=${encodeURIComponent(filePath)}`)
+            .then((r) => r.json())
+            .then((linkData) => {
+              setMemoryFileLinks({
+                wikiLinks: linkData.wikiLinks || data.wikiLinks,
+                incoming: linkData.incoming || [],
+                outgoing: linkData.outgoing || [],
+              })
+            })
+            .catch(() => {})
+        }
+        if (activeView === 'graph' || activeView === 'health' || activeView === 'pipeline') {
+          setActiveView('files')
+        }
+      }
+    } catch (error) {
+      log.error('Failed to load file content:', error)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const searchFiles = async () => {
+    if (!searchQuery.trim()) return
+    setIsSearching(true)
+    try {
+      const response = await fetch(`/api/memory?action=search&query=${encodeURIComponent(searchQuery)}`)
+      const data = await response.json()
+      setSearchResults(data.results || [])
+    } catch (error) {
+      log.error('Search failed:', error)
+      setSearchResults([])
+    } finally {
+      setIsSearching(false)
+    }
+  }
+
+  const toggleFolder = async (folderPath: string, needsChildren: boolean) => {
+    if (!expandedFolders.has(folderPath) && needsChildren) {
+      try {
+        const data = await fetchTree({ path: folderPath, depth: 1 })
+        setMemoryFiles(mergeDirectoryChildren(memoryFilesRef.current, folderPath, data.tree || []))
+      } catch (error) {
+        log.error('Failed to load folder children:', error)
+      }
+    }
+    const next = new Set(expandedFolders)
+    if (next.has(folderPath)) next.delete(folderPath)
+    else next.add(folderPath)
+    setExpandedFolders(next)
+  }
+
+  const saveFile = async () => {
+    if (!selectedMemoryFile) return
+    setIsSaving(true)
+    try {
+      const response = await fetch('/api/memory', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'save', path: selectedMemoryFile, content: editedContent })
+      })
+      const data = await response.json()
+      if (data.success) {
+        setMemoryContent(editedContent)
+        setIsEditing(false)
+        setEditedContent('')
+        setSchemaWarnings(data.schemaWarnings || [])
+        loadFileTree()
+      }
+    } catch (error) {
+      log.error('Failed to save file:', error)
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const createNewFile = async (filePath: string, content: string = '') => {
+    try {
+      const response = await fetch('/api/memory', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'create', path: filePath, content })
+      })
+      const data = await response.json()
+      if (data.success) {
+        loadFileTree()
+        loadFileContent(filePath)
+      }
+    } catch (error) {
+      log.error('Failed to create file:', error)
+    }
+  }
+
+  const deleteFile = async () => {
+    if (!selectedMemoryFile) return
+    try {
+      const response = await fetch('/api/memory', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'delete', path: selectedMemoryFile })
+      })
+      const data = await response.json()
+      if (data.success) {
+        setSelectedMemoryFile('')
+        setMemoryContent('')
+        setMemoryFileLinks(null)
+        setShowDeleteConfirm(false)
+        loadFileTree()
+      }
+    } catch (error) {
+      log.error('Failed to delete file:', error)
+    }
+  }
+
+  const loadHealth = useCallback(async () => {
+    setIsLoadingHealth(true)
+    try {
+      const response = await fetch('/api/memory/health')
+      const data = await response.json()
+      if (data.categories) {
+        setHealthReport(data)
+        setMemoryHealth(data)
+      }
+    } catch (error) {
+      log.error('Failed to load health:', error)
+    } finally {
+      setIsLoadingHealth(false)
+    }
+  }, [setMemoryHealth])
+
+  useEffect(() => {
+    if (activeView === 'health' && !healthReport) {
+      loadHealth()
+    }
+  }, [activeView, healthReport, loadHealth])
+
+  useEffect(() => {
+    if (hermesInstalled === null) {
+      fetch('/api/hermes').then(r => r.json()).then(d => setHermesInstalled(d.installed === true)).catch(() => setHermesInstalled(false))
+    }
+  }, [hermesInstalled])
+
+  useEffect(() => {
+    if (activeView === 'hermes' && !hermesMemory && !isLoadingHermes) {
+      setIsLoadingHermes(true)
+      fetch('/api/hermes/memory')
+        .then(r => r.json())
+        .then(d => setHermesMemory(d))
+        .catch(() => {})
+        .finally(() => setIsLoadingHermes(false))
+    }
+  }, [activeView, hermesMemory, isLoadingHermes])
+
+  const runPipelineAction = async (action: string) => {
+    setIsRunningPipeline(true)
+    setPipelineResult(null)
+    setMocGroups([])
+    try {
+      const response = await fetch('/api/memory/process', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action })
+      })
+      const data = await response.json()
+      if (action === 'generate-moc') {
+        setMocGroups(data.groups || [])
+      } else {
+        setPipelineResult(data)
+      }
+    } catch (error) {
+      log.error('Pipeline action failed:', error)
+    } finally {
+      setIsRunningPipeline(false)
+    }
+  }
+
+  const fileCount = useMemo(() => countFiles(memoryFiles), [memoryFiles])
+  const sizeTotal = useMemo(() => totalSize(memoryFiles), [memoryFiles])
+
+  const navigateToWikiLink = (target: string) => {
+    const findFile = (files: MemoryFile[]): string | null => {
+      for (const f of files) {
+        if (f.type === 'file') {
+          const stem = f.name.replace(/\.[^.]+$/, '')
+          if (stem === target || f.name === target || f.name === `${target}.md`) {
+            return f.path
+          }
+        }
+        if (f.children) {
+          const found = findFile(f.children)
+          if (found) return found
+        }
+      }
+      return null
+    }
+    const found = findFile(memoryFiles)
+    if (found) {
+      loadFileContent(found)
+    }
+  }
+
+  const renderTree = (files: MemoryFile[], depth = 0): React.ReactElement[] => {
+    return files.map((file) => {
+      const isDir = file.type === 'directory'
+      const isExpanded = expandedFolders.has(file.path)
+      const isSelected = selectedMemoryFile === file.path
+      return (
+        <div key={file.path}>
+          <div
+            className={`flex items-center gap-1 py-[3px] pr-2 cursor-pointer text-[13px] font-mono hover:bg-[hsl(var(--surface-2))] rounded-sm transition-colors duration-75 ${isSelected ? 'bg-[hsl(var(--surface-2))] text-foreground' : 'text-muted-foreground'}`}
+            style={{ paddingLeft: `${8 + depth * 14}px` }}
+            onClick={() => void (isDir ? toggleFolder(file.path, file.children === undefined) : loadFileContent(file.path))}
+          >
+            {isDir ? (
+              <span className={`text-[10px] w-3 text-center shrink-0 transition-transform duration-100 ${isExpanded ? 'rotate-90' : ''}`}>&#9656;</span>
+            ) : (
+              <span className="w-3 shrink-0" />
+            )}
+            <span className={`text-[11px] w-4 text-center shrink-0 ${isDir ? 'text-muted-foreground/60' : 'text-muted-foreground/40'}`}>
+              {isDir ? '/' : fileIcon(file.name)}
+            </span>
+            <span className="truncate flex-1">{file.name}</span>
+            {!isDir && file.size != null && (
+              <span className="text-[10px] text-muted-foreground/40 shrink-0 tabular-nums">{formatFileSize(file.size)}</span>
+            )}
+          </div>
+          {isDir && isExpanded && file.children && <div>{renderTree(file.children, depth + 1)}</div>}
+        </div>
+      )
+    })
+  }
+
+  const renderInline = (text: string): React.ReactNode[] => {
+    const parts: React.ReactNode[] = []
+    const pattern = /(`[^`]+`|\*\*[^*]+\*\*|\*[^*]+\*|\[\[([^\]|]+)(?:\|([^\]]+))?\]\])/g
+    let lastIndex = 0
+    let match: RegExpExecArray | null
+    let key = 0
+    while ((match = pattern.exec(text)) !== null) {
+      if (match.index > lastIndex) parts.push(text.slice(lastIndex, match.index))
+      const m = match[0]
+      if (m.startsWith('[[') && m.endsWith(']]')) {
+        const target = match[2]?.trim() || ''
+        const display = (match[3] || match[2] || '').trim()
+        parts.push(
+          <button
+            key={key++}
+            onClick={() => navigateToWikiLink(target)}
+            className="text-primary/80 hover:text-primary underline underline-offset-2 decoration-primary/30 hover:decoration-primary/60 transition-colors font-mono text-[12px] cursor-pointer"
+            title={`Navigate to [[${target}]]`}
+          >
+            {display}
+          </button>
+        )
+      } else if (m.startsWith('`') && m.endsWith('`')) {
+        parts.push(<code key={key++} className="bg-[hsl(var(--surface-2))] px-1 py-0.5 rounded text-[12px] font-mono text-primary/80">{m.slice(1, -1)}</code>)
+      } else if (m.startsWith('**') && m.endsWith('**')) {
+        parts.push(<strong key={key++} className="font-semibold text-foreground">{m.slice(2, -2)}</strong>)
+      } else if (m.startsWith('*') && m.endsWith('*')) {
+        parts.push(<em key={key++}>{m.slice(1, -1)}</em>)
+      }
+      lastIndex = pattern.lastIndex
+    }
+    if (lastIndex < text.length) parts.push(text.slice(lastIndex))
+    return parts
+  }
+
+  const renderMarkdown = (content: string) => {
+    const lines = content.split('\n')
+    const elements: React.ReactElement[] = []
+    const seenHeaders = new Set<string>()
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]
+      const trimmed = line.trim()
+      if (trimmed.startsWith('# ')) {
+        const text = trimmed.slice(2)
+        const id = `h1-${text.toLowerCase().replace(/\s+/g, '-')}`
+        if (seenHeaders.has(id)) continue
+        seenHeaders.add(id)
+        elements.push(<h1 key={i} className="text-xl font-bold mt-6 mb-2 text-foreground font-mono">{renderInline(text)}</h1>)
+      } else if (trimmed.startsWith('## ')) {
+        const text = trimmed.slice(3)
+        const id = `h2-${text.toLowerCase().replace(/\s+/g, '-')}`
+        if (seenHeaders.has(id)) continue
+        seenHeaders.add(id)
+        elements.push(<h2 key={i} className="text-lg font-semibold mt-5 mb-2 text-foreground/90 font-mono">{renderInline(text)}</h2>)
+      } else if (trimmed.startsWith('### ')) {
+        const text = trimmed.slice(4)
+        const id = `h3-${text.toLowerCase().replace(/\s+/g, '-')}`
+        if (seenHeaders.has(id)) continue
+        seenHeaders.add(id)
+        elements.push(<h3 key={i} className="text-base font-semibold mt-4 mb-1.5 text-foreground/80 font-mono">{renderInline(text)}</h3>)
+      } else if (trimmed.startsWith('- ')) {
+        elements.push(
+          <li key={i} className="ml-5 mb-0.5 list-disc text-foreground/80 text-sm leading-relaxed">{renderInline(trimmed.slice(2))}</li>
+        )
+      } else if (trimmed === '') {
+        elements.push(<div key={i} className="h-2" />)
+      } else if (trimmed.startsWith('```')) {
+        const codeLang = trimmed.slice(3)
+        const codeLines: string[] = []
+        let j = i + 1
+        while (j < lines.length && !lines[j].trim().startsWith('```')) {
+          codeLines.push(lines[j])
+          j++
+        }
+        elements.push(
+          <pre key={i} className="bg-[hsl(var(--surface-1))] border border-border/50 rounded-md px-3 py-2 my-2 text-xs font-mono overflow-x-auto">
+            {codeLang && <span className="text-muted-foreground/40 text-[10px] block mb-1">{codeLang}</span>}
+            <code className="text-foreground/80">{codeLines.join('\n')}</code>
+          </pre>
+        )
+        i = j
+      } else {
+        elements.push(
+          <p key={i} className="mb-1.5 text-sm text-foreground/80 leading-relaxed">{renderInline(trimmed)}</p>
+        )
+      }
+    }
+    return elements
+  }
+
+  const viewTabs = ['files', ...(!isLocal ? ['graph'] : []), 'health', 'pipeline', ...(hermesInstalled ? ['hermes'] : [])] as const
+
+  return (
+    <div className="h-[calc(100vh-3.5rem)] flex flex-col overflow-hidden">
+      {/* Top bar */}
+      <div className="flex items-center gap-1 px-3 py-2 border-b border-border bg-[hsl(var(--surface-0))]">
+        <button
+          onClick={() => setSidebarOpen(!sidebarOpen)}
+          className="p-1.5 rounded hover:bg-[hsl(var(--surface-2))] text-muted-foreground text-xs font-mono"
+          title={sidebarOpen ? t('hideSidebar') : t('showSidebar')}
+        >|||</button>
+        <div className="w-px h-4 bg-border mx-1" />
+        {viewTabs.map((view) => (
+          <button
+            key={view}
+            onClick={() => setActiveView(view as typeof activeView)}
+            className={`px-2.5 py-1 rounded text-xs font-mono transition-colors capitalize ${activeView === view ? 'bg-[hsl(var(--surface-2))] text-foreground' : 'text-muted-foreground hover:text-foreground'}`}
+          >{view}</button>
+        ))}
+        <div className="flex-1" />
+        {healthReport && (
+          <span className={`text-[10px] font-mono ${statusColor(healthReport.overall)} tabular-nums mr-1`}>{healthReport.overallScore}%</span>
+        )}
+        <span className="text-[10px] text-muted-foreground/50 font-mono tabular-nums">{t('fileCountSize', { count: fileCount, size: formatFileSize(sizeTotal) })}</span>
+        {isHydratingTree && <span className="ml-2 text-[10px] text-muted-foreground/35 font-mono">{t('indexing')}</span>}
+        <div className="w-px h-4 bg-border mx-1" />
+        <button onClick={() => setShowCreateModal(true)} className="px-2 py-1 rounded text-xs font-mono text-muted-foreground hover:text-foreground hover:bg-[hsl(var(--surface-2))] transition-colors">{t('newFile')}</button>
+      </div>
+
+      <div className="flex flex-1 min-h-0">
+        {/* Sidebar */}
+        {sidebarOpen && (
+          <div className="w-60 shrink-0 border-r border-border bg-[hsl(var(--surface-0))] flex flex-col min-h-0">
+            <div className="p-2">
+              <input type="text" value={searchQuery} onChange={(e) => setSearchQuery(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && searchFiles()} placeholder={t('searchPlaceholder')} className="w-full px-2 py-1.5 text-xs font-mono bg-[hsl(var(--surface-1))] border border-border/50 rounded text-foreground placeholder-muted-foreground/40 focus:outline-none focus:border-primary/30" />
+            </div>
+            <div className="flex gap-0.5 px-2 pb-2">
+              {(['all', 'daily', 'knowledge'] as const).map((f) => (
+                <button key={f} onClick={() => setFileFilter(f)} className={`px-2 py-0.5 rounded text-[11px] font-mono transition-colors ${fileFilter === f ? 'bg-[hsl(var(--surface-2))] text-foreground' : 'text-muted-foreground/60 hover:text-muted-foreground'}`}>{f}</button>
+              ))}
+            </div>
+            {searchResults.length > 0 && (
+              <div className="px-2 pb-2 border-b border-border/50">
+                <div className="text-[10px] text-muted-foreground/50 font-mono mb-1">{t('searchResults', { count: searchResults.length })}</div>
+                <div className="max-h-28 overflow-y-auto space-y-px">
+                  {searchResults.map((r, i) => (
+                    <div key={i} className="flex items-center gap-1.5 py-1 px-1.5 rounded text-xs font-mono cursor-pointer hover:bg-[hsl(var(--surface-2))] text-muted-foreground" onClick={() => { loadFileContent(r.path); setSearchResults([]) }}>
+                      <span className="truncate flex-1">{r.name}</span>
+                      <span className="text-[10px] text-muted-foreground/40">{r.matches}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+            <div className="flex-1 overflow-y-auto py-1">
+              {isLoading ? (
+                <div className="flex items-center justify-center h-20"><Loader variant="inline" /></div>
+              ) : filteredFiles.length === 0 ? (
+                <div className="text-center text-muted-foreground/40 text-xs font-mono py-8">{t('noFiles')}</div>
+              ) : renderTree(filteredFiles)}
+            </div>
+            <div className="p-2 border-t border-border/50">
+              <button onClick={loadFileTree} disabled={isLoading} className="w-full py-1 text-[11px] font-mono text-muted-foreground/50 hover:text-muted-foreground rounded hover:bg-[hsl(var(--surface-1))] transition-colors">{t('refresh')}</button>
+            </div>
+          </div>
+        )}
+
+        {/* Main content */}
+        <div className="flex-1 min-w-0 flex flex-col bg-[hsl(var(--surface-0))]">
+          {activeView === 'graph' && !isLocal ? (
+            <div className="flex-1 p-4 overflow-hidden flex flex-col"><MemoryGraph /></div>
+          ) : activeView === 'health' ? (
+            <div className="flex-1 overflow-auto p-6"><HealthView report={healthReport} isLoading={isLoadingHealth} onRefresh={loadHealth} /></div>
+          ) : activeView === 'pipeline' ? (
+            <div className="flex-1 overflow-auto p-6"><PipelineView result={pipelineResult} mocGroups={mocGroups} isRunning={isRunningPipeline} onRunAction={runPipelineAction} onNavigate={loadFileContent} /></div>
+          ) : activeView === 'hermes' ? (
+            <div className="flex-1 overflow-auto p-6">
+              <HermesMemoryView data={hermesMemory} isLoading={isLoadingHermes} onRefresh={() => { setHermesMemory(null); setIsLoadingHermes(false) }} />
+            </div>
+          ) : (
+            <div className="flex-1 flex min-h-0">
+              <div className="flex-1 flex flex-col min-h-0">
+                {selectedMemoryFile && (
+                  <div className="flex items-center gap-2 px-4 py-2 border-b border-border/50 bg-[hsl(var(--surface-0))]">
+                    <span className="text-xs font-mono text-muted-foreground/60 truncate flex-1">{selectedMemoryFile}</span>
+                    {memoryContent != null && (
+                      <span className="text-[10px] font-mono text-muted-foreground/30 tabular-nums shrink-0">{memoryContent.length} chars</span>
+                    )}
+                    <div className="flex items-center gap-1 shrink-0">
+                      <button onClick={() => setLinksOpen(!linksOpen)} className={`px-2 py-0.5 text-[11px] font-mono rounded transition-colors ${linksOpen ? 'bg-primary/10 text-primary' : 'text-muted-foreground hover:text-foreground hover:bg-[hsl(var(--surface-2))]'}`} title={t('toggleBacklinks')}>{t('links')}</button>
+                      {!isEditing ? (
+                        <>
+                          <button onClick={() => { setIsEditing(true); setEditedContent(memoryContent ?? '') }} className="px-2 py-0.5 text-[11px] font-mono text-muted-foreground hover:text-foreground rounded hover:bg-[hsl(var(--surface-2))] transition-colors">{t('edit')}</button>
+                          <button onClick={() => setShowDeleteConfirm(true)} className="px-2 py-0.5 text-[11px] font-mono text-red-400/60 hover:text-red-400 rounded hover:bg-red-500/10 transition-colors">{t('delete')}</button>
+                        </>
+                      ) : (
+                        <>
+                          <button onClick={saveFile} disabled={isSaving} className="px-2 py-0.5 text-[11px] font-mono text-green-400/80 hover:text-green-400 rounded hover:bg-green-500/10 transition-colors">{isSaving ? t('saving') : t('save')}</button>
+                          <button onClick={() => { setIsEditing(false); setEditedContent('') }} className="px-2 py-0.5 text-[11px] font-mono text-muted-foreground hover:text-foreground rounded hover:bg-[hsl(var(--surface-2))] transition-colors">{t('cancel')}</button>
+                        </>
+                      )}
+                      <button onClick={() => { setSelectedMemoryFile(''); setMemoryContent(''); setMemoryFileLinks(null); setIsEditing(false); setEditedContent(''); setSchemaWarnings([]); setLinksOpen(false) }} className="px-1.5 py-0.5 text-[11px] font-mono text-muted-foreground/40 hover:text-muted-foreground rounded hover:bg-[hsl(var(--surface-2))] transition-colors">x</button>
+                    </div>
+                  </div>
+                )}
+                {schemaWarnings.length > 0 && (
+                  <div className="px-4 py-2 bg-amber-500/5 border-b border-amber-500/15">
+                    <div className="text-[11px] font-mono text-amber-400">{t('schemaWarnings')}</div>
+                    {schemaWarnings.map((w, i) => (
+                      <div key={i} className="text-[11px] font-mono text-amber-400/70 ml-2">- {w}</div>
+                    ))}
+                  </div>
+                )}
+                <div className="flex-1 overflow-auto">
+                  {isLoading ? (
+                    <div className="flex items-center justify-center h-full"><Loader variant="inline" /></div>
+                  ) : memoryContent != null && selectedMemoryFile ? (
+                    <div className="p-6 max-w-3xl">
+                      {isEditing ? (
+                        <textarea value={editedContent} onChange={(e) => setEditedContent(e.target.value)} className="w-full min-h-[500px] p-3 bg-[hsl(var(--surface-1))] text-foreground font-mono text-sm border border-border/50 rounded-md resize-none focus:outline-none focus:border-primary/30 leading-relaxed" placeholder={t('editPlaceholder')} />
+                      ) : selectedMemoryFile.endsWith('.md') ? (
+                        <div>{renderMarkdown(memoryContent)}</div>
+                      ) : selectedMemoryFile.endsWith('.json') ? (
+                        <pre className="text-sm font-mono overflow-auto whitespace-pre-wrap break-words text-foreground/80 leading-relaxed">
+                          <code>{(() => { try { return JSON.stringify(JSON.parse(memoryContent), null, 2) } catch { return memoryContent } })()}</code>
+                        </pre>
+                      ) : (
+                        <pre className="text-sm font-mono whitespace-pre-wrap break-words text-foreground/80 leading-relaxed">{memoryContent}</pre>
+                      )}
+                    </div>
+                  ) : (
+                    <div className="flex flex-col items-center justify-center h-full text-muted-foreground/30">
+                      <span className="text-4xl font-mono mb-3">/</span>
+                      <span className="text-sm font-mono">{t('selectFilePrompt')}</span>
+                      <span className="text-xs font-mono mt-1 text-muted-foreground/20">{t('orSwitchView')}</span>
+                    </div>
+                  )}
+                </div>
+              </div>
+              {linksOpen && selectedMemoryFile && memoryFileLinks && (
+                <LinksSidebar fileLinks={memoryFileLinks} onNavigate={loadFileContent} />
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {showCreateModal && <CreateFileModal onClose={() => setShowCreateModal(false)} onCreate={createNewFile} />}
+      {showDeleteConfirm && selectedMemoryFile && <DeleteConfirmModal fileName={selectedMemoryFile} onClose={() => setShowDeleteConfirm(false)} onConfirm={deleteFile} />}
+    </div>
+  )
+}
+
+function HermesMemoryView({ data, isLoading, onRefresh }: { data: { agentMemory: string | null; userMemory: string | null; agentMemorySize: number; userMemorySize: number; agentMemoryEntries: number; userMemoryEntries: number } | null; isLoading: boolean; onRefresh: () => void }) {
+  const t = useTranslations('memoryBrowser')
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <Loader variant="inline" label={t('loadingHermes')} />
+      </div>
+    )
+  }
+  if (!data) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-muted-foreground/30">
+        <span className="text-sm font-mono mb-3">{t('noHermesData')}</span>
+        <Button onClick={onRefresh} size="sm" variant="secondary">{t('refresh')}</Button>
+      </div>
+    )
+  }
+
+  const AGENT_CAP = 2200
+  const USER_CAP = 1375
+  const agentPct = Math.min(100, Math.round((data.agentMemorySize / AGENT_CAP) * 100))
+  const userPct = Math.min(100, Math.round((data.userMemorySize / USER_CAP) * 100))
+
+  return (
+    <div className="max-w-3xl space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold font-mono text-foreground mb-1">{t('hermesMemoryTitle')}</h2>
+          <p className="text-xs text-muted-foreground font-mono">{t('hermesMemoryDesc')}</p>
+        </div>
+        <Button onClick={onRefresh} size="sm" variant="secondary">{t('refresh')}</Button>
+      </div>
+
+      {/* MEMORY.md */}
+      <div className="bg-[hsl(var(--surface-1))] border border-border/50 rounded-lg p-4">
+        <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-semibold font-mono text-foreground">MEMORY.md</span>
+            <span className="text-[10px] font-mono text-purple-400">{data.agentMemoryEntries} entries</span>
+          </div>
+          <span className="text-[10px] font-mono text-muted-foreground tabular-nums">
+            {data.agentMemorySize}/{AGENT_CAP} chars ({agentPct}%)
+          </span>
+        </div>
+        <div className="h-1.5 bg-[hsl(var(--surface-0))] rounded-full overflow-hidden mb-3">
+          <div
+            className={`h-full rounded-full transition-all ${agentPct > 90 ? 'bg-red-500' : agentPct > 70 ? 'bg-amber-500' : 'bg-purple-500'}`}
+            style={{ width: `${agentPct}%`, opacity: 0.7 }}
+          />
+        </div>
+        {data.agentMemory ? (
+          <pre className="text-xs font-mono whitespace-pre-wrap break-words text-foreground/80 leading-relaxed max-h-80 overflow-y-auto bg-[hsl(var(--surface-0))] rounded-md p-3 border border-border/30">{data.agentMemory}</pre>
+        ) : (
+          <div className="text-xs font-mono text-muted-foreground/40 py-4 text-center">{t('noAgentMemory')}</div>
+        )}
+      </div>
+
+      {/* USER.md */}
+      <div className="bg-[hsl(var(--surface-1))] border border-border/50 rounded-lg p-4">
+        <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-semibold font-mono text-foreground">USER.md</span>
+            <span className="text-[10px] font-mono text-purple-400">{data.userMemoryEntries} entries</span>
+          </div>
+          <span className="text-[10px] font-mono text-muted-foreground tabular-nums">
+            {data.userMemorySize}/{USER_CAP} chars ({userPct}%)
+          </span>
+        </div>
+        <div className="h-1.5 bg-[hsl(var(--surface-0))] rounded-full overflow-hidden mb-3">
+          <div
+            className={`h-full rounded-full transition-all ${userPct > 90 ? 'bg-red-500' : userPct > 70 ? 'bg-amber-500' : 'bg-purple-500'}`}
+            style={{ width: `${userPct}%`, opacity: 0.7 }}
+          />
+        </div>
+        {data.userMemory ? (
+          <pre className="text-xs font-mono whitespace-pre-wrap break-words text-foreground/80 leading-relaxed max-h-80 overflow-y-auto bg-[hsl(var(--surface-0))] rounded-md p-3 border border-border/30">{data.userMemory}</pre>
+        ) : (
+          <div className="text-xs font-mono text-muted-foreground/40 py-4 text-center">{t('noUserMemory')}</div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function LinksSidebar({ fileLinks, onNavigate }: { fileLinks: { wikiLinks: unknown[]; incoming: string[]; outgoing: string[] }; onNavigate: (path: string) => void }) {
+  const t = useTranslations('memoryBrowser')
+  const links = fileLinks.wikiLinks as { target: string; display: string; line: number }[]
+  return (
+    <div className="w-56 shrink-0 border-l border-border bg-[hsl(var(--surface-0))] flex flex-col min-h-0 overflow-y-auto">
+      <div className="p-3 border-b border-border/50">
+        <div className="text-[10px] font-mono text-muted-foreground/50 uppercase tracking-wider mb-2">{t('outgoing', { count: fileLinks.outgoing.length })}</div>
+        {fileLinks.outgoing.length === 0 ? (
+          <div className="text-[11px] font-mono text-muted-foreground/30">none</div>
+        ) : (
+          <div className="space-y-0.5">
+            {fileLinks.outgoing.map((path, i) => (
+              <button key={i} onClick={() => onNavigate(path)} className="block w-full text-left px-1.5 py-1 rounded text-[11px] font-mono text-primary/70 hover:text-primary hover:bg-[hsl(var(--surface-2))] transition-colors truncate">
+                {path.split('/').pop()?.replace(/\.[^.]+$/, '')}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+      <div className="p-3 border-b border-border/50">
+        <div className="text-[10px] font-mono text-muted-foreground/50 uppercase tracking-wider mb-2">{t('backlinks', { count: fileLinks.incoming.length })}</div>
+        {fileLinks.incoming.length === 0 ? (
+          <div className="text-[11px] font-mono text-muted-foreground/30">none</div>
+        ) : (
+          <div className="space-y-0.5">
+            {fileLinks.incoming.map((path, i) => (
+              <button key={i} onClick={() => onNavigate(path)} className="block w-full text-left px-1.5 py-1 rounded text-[11px] font-mono text-primary/70 hover:text-primary hover:bg-[hsl(var(--surface-2))] transition-colors truncate">
+                {path.split('/').pop()?.replace(/\.[^.]+$/, '')}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+      <div className="p-3">
+        <div className="text-[10px] font-mono text-muted-foreground/50 uppercase tracking-wider mb-2">{t('wikiLinks', { count: links.length })}</div>
+        {links.length === 0 ? (
+          <div className="text-[11px] font-mono text-muted-foreground/30">none</div>
+        ) : (
+          <div className="space-y-0.5">
+            {links.map((link, i) => (
+              <div key={i} className="flex items-center gap-1 text-[11px] font-mono text-muted-foreground">
+                <span className="text-muted-foreground/30 tabular-nums shrink-0">L{link.line}</span>
+                <span className="text-primary/60 truncate">[[{link.target}]]</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function HealthView({ report, isLoading, onRefresh }: { report: HealthReport | null; isLoading: boolean; onRefresh: () => void }) {
+  const t = useTranslations('memoryBrowser')
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <Loader variant="inline" label={t('runningDiagnostics')} />
+      </div>
+    )
+  }
+  if (!report) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-muted-foreground/30">
+        <span className="text-sm font-mono mb-3">{t('noHealthData')}</span>
+        <Button onClick={onRefresh} size="sm" variant="secondary">{t('runDiagnostics')}</Button>
+      </div>
+    )
+  }
+  return (
+    <div className="max-w-2xl space-y-6">
+      <div className="flex items-center gap-4">
+        <div className={`text-4xl font-bold font-mono tabular-nums ${statusColor(report.overall)}`}>{report.overallScore}</div>
+        <div>
+          <div className={`text-sm font-semibold font-mono uppercase ${statusColor(report.overall)}`}>{report.overall}</div>
+          <div className="text-[11px] text-muted-foreground/50 font-mono">{t('healthCategories', { time: new Date(report.generatedAt).toLocaleTimeString() })}</div>
+        </div>
+        <div className="flex-1" />
+        <Button onClick={onRefresh} size="sm" variant="secondary">{t('refresh')}</Button>
+      </div>
+      <div className="grid gap-3">
+        {report.categories.map((cat) => (
+          <div key={cat.name} className="bg-[hsl(var(--surface-1))] border border-border/50 rounded-lg p-4">
+            <div className="flex items-center gap-3 mb-2">
+              <span className={`text-lg font-bold font-mono tabular-nums ${statusColor(cat.status)}`}>{cat.score}</span>
+              <span className="text-sm font-mono text-foreground flex-1">{cat.name}</span>
+              <span className={`text-[10px] font-mono uppercase ${statusColor(cat.status)}`}>{cat.status}</span>
+            </div>
+            <div className="h-1.5 bg-[hsl(var(--surface-0))] rounded-full overflow-hidden mb-2">
+              <div className={`h-full rounded-full transition-all ${statusBg(cat.status)}`} style={{ width: `${cat.score}%`, opacity: 0.7 }} />
+            </div>
+            {cat.issues.length > 0 && (
+              <div className="mt-2 space-y-0.5">
+                {cat.issues.map((issue, i) => <div key={i} className="text-[11px] font-mono text-muted-foreground/70">- {issue}</div>)}
+              </div>
+            )}
+            {cat.suggestions.length > 0 && (
+              <div className="mt-2 space-y-0.5">
+                {cat.suggestions.map((sug, i) => <div key={i} className="text-[11px] font-mono text-primary/50">{sug}</div>)}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function PipelineView({ result, mocGroups, isRunning, onRunAction, onNavigate }: { result: ProcessingResult | null; mocGroups: MOCGroup[]; isRunning: boolean; onRunAction: (action: string) => void; onNavigate: (path: string) => void }) {
+  const t = useTranslations('memoryBrowser')
+  return (
+    <div className="max-w-2xl space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold font-mono text-foreground mb-1">{t('pipelineTitle')}</h2>
+        <p className="text-xs text-muted-foreground font-mono">{t('pipelineDesc')}</p>
+      </div>
+      <div className="grid grid-cols-3 gap-3">
+        <button onClick={() => onRunAction('reflect')} disabled={isRunning} className="bg-[hsl(var(--surface-1))] border border-border/50 rounded-lg p-4 text-left hover:border-primary/30 transition-colors disabled:opacity-50">
+          <div className="text-sm font-semibold font-mono text-foreground mb-1">{t('pipelineReflect')}</div>
+          <div className="text-[11px] text-muted-foreground font-mono">{t('pipelineReflectDesc')}</div>
+        </button>
+        <button onClick={() => onRunAction('reweave')} disabled={isRunning} className="bg-[hsl(var(--surface-1))] border border-border/50 rounded-lg p-4 text-left hover:border-primary/30 transition-colors disabled:opacity-50">
+          <div className="text-sm font-semibold font-mono text-foreground mb-1">{t('pipelineReweave')}</div>
+          <div className="text-[11px] text-muted-foreground font-mono">{t('pipelineReweaveDesc')}</div>
+        </button>
+        <button onClick={() => onRunAction('generate-moc')} disabled={isRunning} className="bg-[hsl(var(--surface-1))] border border-border/50 rounded-lg p-4 text-left hover:border-primary/30 transition-colors disabled:opacity-50">
+          <div className="text-sm font-semibold font-mono text-foreground mb-1">{t('pipelineGenerateMoc')}</div>
+          <div className="text-[11px] text-muted-foreground font-mono">{t('pipelineGenerateMocDesc')}</div>
+        </button>
+      </div>
+      {isRunning && (
+        <Loader variant="inline" label={t('processing')} />
+      )}
+      {result && (
+        <div className="bg-[hsl(var(--surface-1))] border border-border/50 rounded-lg p-4">
+          <div className="flex items-center gap-2 mb-3">
+            <span className="text-sm font-semibold font-mono text-foreground capitalize">{result.action}</span>
+            <span className="text-[10px] font-mono text-muted-foreground/50">{t('filesProcessed', { count: result.filesProcessed })}</span>
+          </div>
+          {result.suggestions.length === 0 ? (
+            <div className="text-[11px] font-mono text-green-400/70">{t('noSuggestions')}</div>
+          ) : (
+            <div className="space-y-1.5">
+              {result.suggestions.map((sug, i) => <div key={i} className="text-[11px] font-mono text-muted-foreground/80 leading-relaxed">{sug}</div>)}
+            </div>
+          )}
+        </div>
+      )}
+      {mocGroups.length > 0 && (
+        <div className="space-y-3">
+          <div className="text-sm font-semibold font-mono text-foreground">{t('mapsOfContent', { count: mocGroups.length })}</div>
+          {mocGroups.map((group) => (
+            <div key={group.directory} className="bg-[hsl(var(--surface-1))] border border-border/50 rounded-lg p-4">
+              <div className="text-xs font-semibold font-mono text-foreground/80 mb-2">{group.directory}</div>
+              <div className="space-y-0.5">
+                {group.entries.map((entry, i) => (
+                  <div key={i} className="flex items-center gap-2">
+                    <button onClick={() => onNavigate(entry.path)} className="text-[11px] font-mono text-primary/70 hover:text-primary truncate flex-1 text-left">{entry.title}</button>
+                    {entry.linkCount > 0 && <span className="text-[10px] font-mono text-muted-foreground/40 tabular-nums shrink-0">{entry.linkCount} links</span>}
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function CreateFileModal({ onClose, onCreate }: { onClose: () => void; onCreate: (path: string, content: string) => void }) {
+  const t = useTranslations('memoryBrowser')
+  const [fileName, setFileName] = useState('')
+  const [filePath, setFilePath] = useState('knowledge/')
+  const [initialContent, setInitialContent] = useState('')
+  const [fileType, setFileType] = useState('md')
+  const templates: Record<string, string> = { md: '# New Document\n\n', json: '{\n  \n}', txt: '', log: '' }
+  const handleCreate = () => {
+    if (!fileName.trim()) return
+    onCreate(filePath + fileName + '.' + fileType, initialContent)
+    onClose()
+  }
+  return (
+    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+      <div className="bg-[hsl(var(--surface-1))] border border-border rounded-lg max-w-md w-full p-5 shadow-xl">
+        <div className="flex justify-between items-center mb-4">
+          <h3 className="text-sm font-semibold text-foreground font-mono">{t('newFileTitle')}</h3>
+          <button onClick={onClose} className="text-muted-foreground hover:text-foreground text-lg leading-none">x</button>
+        </div>
+        <div className="space-y-3">
+          <div>
+            <label className="block text-[11px] font-mono text-muted-foreground mb-1">{t('directory')}</label>
+            <select value={filePath} onChange={(e) => setFilePath(e.target.value)} className="w-full px-2.5 py-1.5 text-xs font-mono bg-[hsl(var(--surface-0))] border border-border/50 rounded text-foreground focus:outline-none focus:border-primary/30">
+              <option value="knowledge-base/">knowledge-base/</option>
+              <option value="memory/">memory/</option>
+              <option value="knowledge/">knowledge/</option>
+              <option value="daily/">daily/</option>
+              <option value="logs/">logs/</option>
+              <option value="">root/</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-[11px] font-mono text-muted-foreground mb-1">{t('fileName')}</label>
+            <input type="text" value={fileName} onChange={(e) => setFileName(e.target.value)} placeholder="my-file" className="w-full px-2.5 py-1.5 text-xs font-mono bg-[hsl(var(--surface-0))] border border-border/50 rounded text-foreground focus:outline-none focus:border-primary/30" autoFocus />
+          </div>
+          <div>
+            <label className="block text-[11px] font-mono text-muted-foreground mb-1">{t('fileType')}</label>
+            <select value={fileType} onChange={(e) => { setFileType(e.target.value); setInitialContent(templates[e.target.value] || '') }} className="w-full px-2.5 py-1.5 text-xs font-mono bg-[hsl(var(--surface-0))] border border-border/50 rounded text-foreground focus:outline-none focus:border-primary/30">
+              <option value="md">.md</option>
+              <option value="json">.json</option>
+              <option value="txt">.txt</option>
+              <option value="log">.log</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-[11px] font-mono text-muted-foreground mb-1">{t('content')}</label>
+            <textarea value={initialContent} onChange={(e) => setInitialContent(e.target.value)} className="w-full h-20 px-2.5 py-1.5 text-xs font-mono bg-[hsl(var(--surface-0))] border border-border/50 rounded text-foreground focus:outline-none focus:border-primary/30 resize-none" placeholder={t('contentOptional')} />
+          </div>
+          <div className="text-[10px] font-mono text-muted-foreground/40 bg-[hsl(var(--surface-0))] px-2 py-1 rounded">{filePath}{fileName || '...'}.{fileType}</div>
+          <div className="flex gap-2 pt-2">
+            <Button onClick={handleCreate} disabled={!fileName.trim()} size="sm" className="flex-1">{t('create')}</Button>
+            <Button onClick={onClose} variant="secondary" size="sm">{t('cancel')}</Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function DeleteConfirmModal({ fileName, onClose, onConfirm }: { fileName: string; onClose: () => void; onConfirm: () => void }) {
+  const t = useTranslations('memoryBrowser')
+  return (
+    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+      <div className="bg-[hsl(var(--surface-1))] border border-border rounded-lg max-w-sm w-full p-5 shadow-xl">
+        <h3 className="text-sm font-semibold text-red-400 font-mono mb-3">{t('deleteFileTitle')}</h3>
+        <div className="bg-red-500/5 border border-red-500/15 rounded-md p-3 mb-4">
+          <p className="text-xs text-muted-foreground font-mono">{t('permanentlyDelete')}</p>
+          <p className="text-xs font-mono text-foreground mt-1 bg-[hsl(var(--surface-0))] px-2 py-1 rounded">{fileName}</p>
+        </div>
+        <div className="flex gap-2">
+          <Button onClick={onConfirm} variant="destructive" size="sm" className="flex-1">{t('delete')}</Button>
+          <Button onClick={onClose} variant="secondary" size="sm">{t('cancel')}</Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/fix-git-permissions.sh
+++ b/src/fix-git-permissions.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# fix-git-permissions.sh
+# Fixes false git changes caused by file permission drift when copying repos between machines.
+# Usage:
+#   ./fix-git-permissions.sh              # fix current directory (must be a git repo)
+#   ./fix-git-permissions.sh /path/to/repo
+#   ./fix-git-permissions.sh /parent/dir --all   # recurse all git repos under a parent dir
+
+set -euo pipefail
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+info()  { echo -e "${GREEN}[INFO]${NC}  $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+error() { echo -e "${RED}[ERROR]${NC} $*"; }
+
+fix_repo() {
+    local repo_dir="$1"
+
+    if ! git -C "$repo_dir" rev-parse --git-dir &>/dev/null; then
+        error "'$repo_dir' is not a git repository. Skipping."
+        return 1
+    fi
+
+    info "Processing repo: $repo_dir"
+
+    # ── 1. Disable fileMode tracking ─────────────────────────────────────────
+    git -C "$repo_dir" config core.fileMode false
+    info "  core.fileMode set to false"
+
+    # ── 2. Count changes BEFORE cleanup ──────────────────────────────────────
+    local before
+    before=$(git -C "$repo_dir" status --short | grep -v "^??" | wc -l | tr -d ' ')
+    info "  Tracked changes before cleanup: $before"
+
+    # ── 3. Reset permission bits to git-expected values (644 for files, 755 for dirs/executables)
+    #       This restores what git thinks the permissions should be, without touching content.
+    git -C "$repo_dir" diff --name-only --diff-filter=M HEAD 2>/dev/null | while read -r f; do
+        local full="$repo_dir/$f"
+        if [[ -f "$full" ]]; then
+            # Get the mode git has stored for this file
+            local git_mode
+            git_mode=$(git -C "$repo_dir" ls-files -s -- "$f" | awk '{print $1}')
+            if [[ "$git_mode" == "100755" ]]; then
+                chmod 755 "$full"
+            else
+                chmod 644 "$full"
+            fi
+        fi
+    done
+    info "  File permissions restored to git-tracked values"
+
+    # ── 4. Count REAL content changes after cleanup ───────────────────────────
+    local after
+    after=$(git -C "$repo_dir" status --short | grep -v "^??" | wc -l | tr -d ' ')
+    info "  Real content changes remaining: $after"
+
+    # ── 5. Show the real changes so the user can review them ──────────────────
+    if [[ "$after" -gt 0 ]]; then
+        warn "  The following files have REAL content changes (not permission noise):"
+        git -C "$repo_dir" status --short | grep -v "^??" | sed 's/^/    /'
+    else
+        info "  No real content changes — working tree is clean."
+    fi
+
+    echo ""
+}
+
+# ── main ─────────────────────────────────────────────────────────────────────
+TARGET="${1:-.}"
+MODE="${2:-}"
+
+if [[ "$MODE" == "--all" ]]; then
+    info "Scanning for git repos under: $TARGET"
+    while IFS= read -r gitdir; do
+        repo=$(dirname "$gitdir")
+        fix_repo "$repo"
+    done < <(find "$TARGET" -maxdepth 3 -name ".git" -type d 2>/dev/null)
+else
+    fix_repo "$TARGET"
+fi
+
+info "Done."

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -19,14 +19,13 @@ export const MODEL_CATALOG: ModelConfig[] = [
   // Google
   { alias: 'gemini-2.5-pro', name: 'google/gemini-2.5-pro', provider: 'google', description: 'Gemini 2.5 Pro', costPer1k: 1.25 },
   { alias: 'gemini-2.5-flash', name: 'google/gemini-2.5-flash', provider: 'google', description: 'Gemini 2.5 Flash, fast', costPer1k: 0.15 },
-  // Local / open-source
-  { alias: 'deepseek', name: 'ollama/deepseek-r1:14b', provider: 'ollama', description: 'Local reasoning (free)', costPer1k: 0.0 },
-  // Groq (hosted inference)
-  { alias: 'groq-fast', name: 'groq/llama-3.1-8b-instant', provider: 'groq', description: '840 tok/s, ultra fast', costPer1k: 0.05 },
-  { alias: 'groq', name: 'groq/llama-3.3-70b-versatile', provider: 'groq', description: 'Fast + quality balance', costPer1k: 0.59 },
+  // Local Ollama models (must match openclaw config whitelist)
+  { alias: 'qwen7b', name: 'ollama/qwen2.5:7b', provider: 'ollama', description: 'Qwen 2.5 7B (local, fast)', costPer1k: 0.0 },
+  { alias: 'qwen14b', name: 'ollama/qwen2.5:14b', provider: 'ollama', description: 'Qwen 2.5 14B (local, quality)', costPer1k: 0.0 },
+  { alias: 'llama8b', name: 'ollama/llama3.1:8b', provider: 'ollama', description: 'Llama 3.1 8B (local)', costPer1k: 0.0 },
+  { alias: 'mistral7b', name: 'ollama/mistral:7b', provider: 'ollama', description: 'Mistral 7B (local)', costPer1k: 0.0 },
   // Other providers
   { alias: 'kimi', name: 'moonshot/kimi-k2.5', provider: 'moonshot', description: 'Alternative provider', costPer1k: 1.0 },
-  { alias: 'venice-llama-3.3-70b', name: 'venice/llama-3.3-70b', provider: 'venice', description: 'Venice AI Llama 3.3 70B', costPer1k: 0.7 },
   { alias: 'minimax', name: 'minimax/minimax-m2.1', provider: 'minimax', description: 'Cost-effective, strong coding', costPer1k: 0.3 },
 ]
 

--- a/src/lib/openclaw-gateway.ts
+++ b/src/lib/openclaw-gateway.ts
@@ -1,39 +1,68 @@
-import { runOpenClaw } from './command'
+import { WebSocket } from 'ws'
+import { config } from './config'
+import { getDetectedGatewayToken } from './gateway-runtime'
+import { logger } from './logger'
 
-export function parseGatewayJsonOutput(raw: string): unknown | null {
-  const trimmed = String(raw || '').trim()
-  if (!trimmed) return null
+const GATEWAY_CLIENT_ID = 'openclaw-tui'
+const GATEWAY_SCOPES = [
+  'operator.admin',
+  'operator.read',
+  'operator.write',
+  'operator.approvals',
+  'operator.pairing',
+]
 
-  const objectStart = trimmed.indexOf('{')
-  const arrayStart = trimmed.indexOf('[')
-  const hasObject = objectStart >= 0
-  const hasArray = arrayStart >= 0
-
-  let start = -1
-  let end = -1
-
-  if (hasObject && hasArray) {
-    if (objectStart < arrayStart) {
-      start = objectStart
-      end = trimmed.lastIndexOf('}')
-    } else {
-      start = arrayStart
-      end = trimmed.lastIndexOf(']')
+/**
+ * Maps legacy CLI method names (underscore notation) to gateway RPC method names
+ * (dot notation) and transforms params accordingly.
+ */
+function translateMethod(
+  method: string,
+  params: Record<string, unknown>,
+): { rpcMethod: string; rpcParams: Record<string, unknown> } {
+  // Rename sessionKey → key for all session operations
+  const withKey = (p: Record<string, unknown>): Record<string, unknown> => {
+    if ('sessionKey' in p) {
+      const { sessionKey, ...rest } = p
+      return { key: sessionKey, ...rest }
     }
-  } else if (hasObject) {
-    start = objectStart
-    end = trimmed.lastIndexOf('}')
-  } else if (hasArray) {
-    start = arrayStart
-    end = trimmed.lastIndexOf(']')
+    return p
   }
 
-  if (start < 0 || end < start) return null
+  switch (method) {
+    case 'sessions_spawn': {
+      // sessions.create only accepts: task, label, model, agentId — strip CLI-only fields
+      const { runTimeoutSeconds: _rts, tools: _tools, ...createParams } = params as Record<string, unknown>
+      logger.debug({ stripped: { runTimeoutSeconds: _rts, tools: _tools }, createParams }, 'translateMethod: sessions_spawn → sessions.create')
+      return { rpcMethod: 'sessions.create', rpcParams: createParams }
+    }
 
-  try {
-    return JSON.parse(trimmed.slice(start, end + 1))
-  } catch {
-    return null
+    case 'session_setThinking': {
+      const { sessionKey, level, ...rest } = params as Record<string, unknown>
+      return { rpcMethod: 'sessions.patch', rpcParams: { key: sessionKey, thinkingLevel: level, ...rest } }
+    }
+    case 'session_setVerbose': {
+      const { sessionKey, level, ...rest } = params as Record<string, unknown>
+      return { rpcMethod: 'sessions.patch', rpcParams: { key: sessionKey, verboseLevel: level, ...rest } }
+    }
+    case 'session_setReasoning': {
+      const { sessionKey, level, ...rest } = params as Record<string, unknown>
+      return { rpcMethod: 'sessions.patch', rpcParams: { key: sessionKey, reasoningLevel: level, ...rest } }
+    }
+    case 'session_setLabel': {
+      const { sessionKey, label, ...rest } = params as Record<string, unknown>
+      return { rpcMethod: 'sessions.patch', rpcParams: { key: sessionKey, label, ...rest } }
+    }
+    case 'session_delete':
+      return { rpcMethod: 'sessions.delete', rpcParams: withKey(params) }
+    case 'sessions_kill':
+      return { rpcMethod: 'sessions.abort', rpcParams: withKey(params) }
+    case 'sessions_send':
+      return { rpcMethod: 'sessions.send', rpcParams: withKey(params) }
+
+    default:
+      // dot-notation methods (web.login.start, device.pair.*, channels.logout, etc.) pass through
+      return { rpcMethod: method, rpcParams: params }
   }
 }
 
@@ -42,24 +71,326 @@ export async function callOpenClawGateway<T = unknown>(
   params: unknown,
   timeoutMs = 10000,
 ): Promise<T> {
-  const result = await runOpenClaw(
-    [
-      'gateway',
-      'call',
-      method,
-      '--timeout',
-      String(Math.max(1000, Math.floor(timeoutMs))),
-      '--params',
-      JSON.stringify(params ?? {}),
-      '--json',
-    ],
-    { timeoutMs: timeoutMs + 2000 },
-  )
+  const host = config.gatewayHost || '127.0.0.1'
+  const port = config.gatewayPort || 18789
+  const token = getDetectedGatewayToken()
 
-  const payload = parseGatewayJsonOutput(result.stdout)
-  if (payload == null) {
-    throw new Error(`Invalid JSON response from gateway method ${method}`)
+  const protocol = (String(host).startsWith('wss://') || port === 443) ? 'wss' : 'ws'
+  const gatewayUrl = `${protocol}://${host}:${port}`
+
+  const { rpcMethod, rpcParams } = translateMethod(method, (params ?? {}) as Record<string, unknown>)
+
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      try { ws.terminate() } catch {}
+      reject(new Error(`Gateway method ${method} timed out after ${timeoutMs}ms`))
+    }, timeoutMs)
+
+    const ws = new WebSocket(gatewayUrl, {
+      headers: token ? { authorization: `Bearer ${token}` } : undefined,
+    })
+
+    let connected = false
+
+    ws.on('open', () => {
+      ws.send(JSON.stringify({
+        type: 'req',
+        id: 'connect',
+        method: 'connect',
+        params: {
+          auth: { token },
+          client: { id: GATEWAY_CLIENT_ID, mode: 'backend', version: '1.0.0', platform: 'linux' },
+          role: 'operator',
+          minProtocol: 3,
+          maxProtocol: 3,
+          scopes: GATEWAY_SCOPES,
+        },
+      }))
+    })
+
+    ws.on('message', (raw: WebSocket.RawData) => {
+      let msg: Record<string, unknown>
+      try {
+        msg = JSON.parse(raw.toString())
+      } catch {
+        return
+      }
+
+      const msgType = msg.type as string
+      const msgEvent = msg.event as string | undefined
+
+      // Skip challenge and health events
+      if (msgType === 'event' && (msgEvent === 'connect.challenge' || msgEvent === 'health')) {
+        return
+      }
+
+      if (msg.id === 'connect') {
+        if (!msg.ok) {
+          clearTimeout(timer)
+          ws.terminate()
+          reject(new Error(`Gateway connect failed: ${JSON.stringify(msg.error)}`))
+          return
+        }
+        connected = true
+        ws.send(JSON.stringify({ type: 'req', id: 'call', method: rpcMethod, params: rpcParams }))
+        return
+      }
+
+      if (msg.id === 'call') {
+        clearTimeout(timer)
+        ws.terminate()
+        if (!msg.ok) {
+          const err = msg.error as Record<string, unknown> | undefined
+          reject(new Error(
+            err?.message
+              ? String(err.message)
+              : `Gateway method ${method} failed: ${JSON.stringify(msg.error)}`,
+          ))
+          return
+        }
+        resolve((msg.payload ?? msg.result ?? {}) as T)
+      }
+    })
+
+    ws.on('error', (err: Error) => {
+      clearTimeout(timer)
+      if (connected) {
+        try { ws.terminate() } catch {}
+      }
+      logger.warn({ err, method }, 'Gateway WebSocket error')
+      reject(new Error(`Gateway connection error for ${method}: ${err.message}`))
+    })
+
+    ws.on('close', (code: number) => {
+      clearTimeout(timer)
+      // If we haven't resolved or rejected yet, the connection closed unexpectedly
+      reject(new Error(`Gateway connection closed unexpectedly (code ${code}) for method ${method}`))
+    })
+  })
+}
+
+/**
+ * Invoke a gateway agent and wait for its final response.
+ * Equivalent to CLI `openclaw gateway call agent --expect-final`.
+ */
+export async function callGatewayAgent(
+  params: {
+    message: string
+    agentId: string
+    idempotencyKey: string
+    deliver?: boolean
+    model?: string
+  },
+  timeoutMs = 300_000,
+): Promise<{ text: string | null; sessionId: string | null }> {
+  const host = config.gatewayHost || '127.0.0.1'
+  const port = config.gatewayPort || 18789
+  const token = getDetectedGatewayToken()
+  const protocol = port === 443 ? 'wss' : 'ws'
+  const gatewayUrl = `${protocol}://${host}:${port}`
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      try { ws.terminate() } catch {}
+      reject(new Error(`Gateway agent call timed out after ${timeoutMs}ms`))
+    }, timeoutMs)
+
+    const ws = new WebSocket(gatewayUrl, {
+      headers: token ? { authorization: `Bearer ${token}` } : undefined,
+    })
+
+    let step: 'connect' | 'agent' | 'wait' = 'connect'
+    let runId: string | null = null
+
+    const done = (result: { text: string | null; sessionId: string | null }) => {
+      clearTimeout(timer)
+      try { ws.terminate() } catch {}
+      resolve(result)
+    }
+    const fail = (err: Error) => {
+      clearTimeout(timer)
+      try { ws.terminate() } catch {}
+      reject(err)
+    }
+
+    ws.on('open', () => {
+      ws.send(JSON.stringify({
+        type: 'req', id: 'connect', method: 'connect',
+        params: {
+          auth: { token },
+          client: { id: GATEWAY_CLIENT_ID, mode: 'backend', version: '1.0.0', platform: 'linux' },
+          role: 'operator', minProtocol: 3, maxProtocol: 3, scopes: GATEWAY_SCOPES,
+        },
+      }))
+    })
+
+    ws.on('message', (raw: WebSocket.RawData) => {
+      let msg: Record<string, unknown>
+      try { msg = JSON.parse(raw.toString()) } catch { return }
+
+      if (msg.type === 'event') return // skip health, challenge, session events
+
+      if (msg.id === 'connect') {
+        if (!msg.ok) { fail(new Error(`Gateway connect failed: ${JSON.stringify(msg.error)}`)); return }
+        step = 'agent'
+        ws.send(JSON.stringify({ type: 'req', id: 'agent', method: 'agent', params }))
+        return
+      }
+
+      if (msg.id === 'agent') {
+        if (!msg.ok) { fail(new Error(`Gateway agent call failed: ${(msg.error as any)?.message ?? JSON.stringify(msg.error)}`)); return }
+        const p = msg.payload as Record<string, unknown>
+        runId = String(p.runId ?? '')
+        if (!runId) { fail(new Error('Gateway agent returned no runId')); return }
+        step = 'wait'
+        ws.send(JSON.stringify({ type: 'req', id: 'wait', method: 'agent.wait', params: { runId, timeoutMs: timeoutMs - 5000 } }))
+        return
+      }
+
+      if (msg.id === 'wait') {
+        if (!msg.ok) { fail(new Error(`agent.wait failed: ${(msg.error as any)?.message ?? JSON.stringify(msg.error)}`)); return }
+        const p = msg.payload as Record<string, unknown>
+        logger.warn({ waitPayload: p }, 'callGatewayAgent: agent.wait raw payload')
+
+        // Handle agent failure signalled in the payload itself
+        if (p.error || (p as any).isError === true) {
+          const errMsg = (p.error as any)?.message || JSON.stringify(p.error)
+          fail(new Error(`Agent run failed: ${errMsg}`))
+          return
+        }
+
+        const result = p.result as Record<string, unknown> | undefined
+        const text: string | null =
+          // Standard: result.payloads[0].text
+          (result?.payloads as any)?.[0]?.text ??
+          // Alt: result.output string
+          (typeof result?.output === 'string' ? result.output : null) ??
+          // Alt: result.text directly
+          (typeof result?.text === 'string' ? result.text : null) ??
+          // Alt: payloads at payload root level
+          (p?.payloads as any)?.[0]?.text ??
+          (typeof p?.output === 'string' ? p.output : null) ??
+          (typeof p?.text === 'string' ? p.text : null) ??
+          // Last resort: stringify result if present
+          (result ? JSON.stringify(result) : null)
+        const sessionId: string | null =
+          typeof (result?.meta as any)?.agentMeta?.sessionId === 'string'
+            ? (result!.meta as any).agentMeta.sessionId
+            : typeof p.sessionId === 'string' ? p.sessionId : null
+        done({ text, sessionId })
+      }
+    })
+
+    ws.on('error', (err: Error) => {
+      fail(new Error(`Gateway WebSocket error: ${err.message}`))
+    })
+    ws.on('close', (code: number) => {
+      // Only fail if we haven't yet got a wait response
+      if (step !== 'wait' || !runId) {
+        fail(new Error(`Gateway closed unexpectedly (${code}) during ${step}`))
+      } else {
+        // If connection closed while waiting, the agent.wait may have timed out server-side
+        fail(new Error(`Gateway closed while waiting for agent.wait response (runId=${runId})`))        
+      }
+    })
+  })
+}
+
+/**
+ * Call openclaw gateway via HTTP /v1/chat/completions (OpenAI-compatible).
+ * Uses model "openclaw/<agentId>" to route to the correct agent.
+ * This is the preferred method as it returns the LLM text directly.
+ */
+export async function callGatewayAgentHTTP(
+  params: {
+    message: string
+    agentId: string
+    model?: string
+  },
+  timeoutMs = 300_000,
+): Promise<{ text: string | null; sessionId: string | null }> {
+  const http = await import('http')
+  const host = config.gatewayHost || '127.0.0.1'
+  const port = config.gatewayPort || 18789
+  const token = getDetectedGatewayToken()
+
+  // openclaw chat completions model format: "openclaw/<agentId>"
+  const ocModel = `openclaw/${params.agentId}`
+
+  const body = JSON.stringify({
+    model: ocModel,
+    messages: [{ role: 'user', content: params.message }],
+    stream: false,
+  })
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      req.destroy()
+      reject(new Error(`Gateway HTTP chat completions timed out after ${timeoutMs}ms`))
+    }, timeoutMs)
+
+    const req = http.request(
+      {
+        hostname: host,
+        port,
+        path: '/v1/chat/completions',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(body),
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+      },
+      (res) => {
+        let raw = ''
+        res.on('data', (chunk: Buffer) => { raw += chunk.toString() })
+        res.on('end', () => {
+          clearTimeout(timer)
+          try {
+            const parsed = JSON.parse(raw)
+            if (parsed.error) {
+              reject(new Error(`Gateway chat completions error: ${parsed.error.message ?? JSON.stringify(parsed.error)}`))
+              return
+            }
+            const text: string | null = parsed.choices?.[0]?.message?.content ?? null
+            const sessionId: string | null = parsed.id ?? null
+            logger.debug({ model: ocModel, statusCode: res.statusCode, textLen: text?.length }, 'callGatewayAgentHTTP: response received')
+            resolve({ text, sessionId })
+          } catch (e: any) {
+            reject(new Error(`Gateway chat completions parse error: ${e.message} — body: ${raw.substring(0, 200)}`))
+          }
+        })
+      },
+    )
+
+    req.on('error', (err: Error) => {
+      clearTimeout(timer)
+      reject(new Error(`Gateway HTTP request error: ${err.message}`))
+    })
+
+    req.write(body)
+    req.end()
+  })
+}
+
+// Keep parseGatewayJsonOutput exported so existing tests that import it don't break
+export function parseGatewayJsonOutput(raw: string): unknown | null {
+  const trimmed = String(raw || '').trim()
+  if (!trimmed) return null
+  const objectStart = trimmed.indexOf('{')
+  const arrayStart = trimmed.indexOf('[')
+  const hasObject = objectStart >= 0
+  const hasArray = arrayStart >= 0
+  let start = -1
+  let end = -1
+  if (hasObject && hasArray) {
+    start = objectStart < arrayStart ? objectStart : arrayStart
+    end = objectStart < arrayStart ? trimmed.lastIndexOf('}') : trimmed.lastIndexOf(']')
+  } else if (hasObject) {
+    start = objectStart; end = trimmed.lastIndexOf('}')
+  } else if (hasArray) {
+    start = arrayStart; end = trimmed.lastIndexOf(']')
   }
-
-  return payload as T
+  if (start < 0 || end < start) return null
+  try { return JSON.parse(trimmed.slice(start, end + 1)) } catch { return null }
 }

--- a/src/lib/task-dispatch.ts
+++ b/src/lib/task-dispatch.ts
@@ -1,6 +1,5 @@
 import { getDatabase, db_helpers } from './db'
-import { runOpenClaw } from './command'
-import { callOpenClawGateway } from './openclaw-gateway'
+import { callOpenClawGateway, callGatewayAgentHTTP } from './openclaw-gateway'
 import { eventBus } from './event-bus'
 import { logger } from './logger'
 import { config } from './config'
@@ -416,22 +415,7 @@ export async function runAegisReviews(): Promise<{ ok: boolean; message: string 
       } else {
         // Resolve the gateway agent ID from config, falling back to assigned_to or default
         const reviewAgent = resolveGatewayAgentIdForReview(task)
-
-        const invokeParams = {
-          message: prompt,
-          agentId: reviewAgent,
-          idempotencyKey: `aegis-review-${task.id}-${Date.now()}`,
-          deliver: false,
-        }
-        const finalResult = await runOpenClaw(
-          ['gateway', 'call', 'agent', '--expect-final', '--timeout', '120000', '--params', JSON.stringify(invokeParams), '--json'],
-          { timeoutMs: 125_000 }
-        )
-        const finalPayload = parseGatewayJson(finalResult.stdout)
-          ?? parseGatewayJson(String((finalResult as any)?.stderr || ''))
-        agentResponse = parseAgentResponse(
-          finalPayload?.result ? JSON.stringify(finalPayload.result) : finalResult.stdout
-        )
+        agentResponse = await callGatewayAgentHTTP({ message: prompt, agentId: reviewAgent }, 300_000)
       }
 
       if (!agentResponse.text) {
@@ -723,35 +707,13 @@ export async function dispatchAssignedTasks(): Promise<{ ok: boolean; message: s
           sessionId: sendResult?.runId || targetSession,
         }
       } else {
-        // Step 1: Invoke via gateway (new session)
+        // Invoke via gateway HTTP chat completions (returns text directly)
         const gatewayAgentId = resolveGatewayAgentId(task)
         const dispatchModel = resolveTaskDispatchModelOverride(task)
-        const invokeParams: Record<string, unknown> = {
-          message: prompt,
-          agentId: gatewayAgentId,
-          idempotencyKey: `task-dispatch-${task.id}-${Date.now()}`,
-          deliver: false,
-        }
-        // Route to appropriate model tier based on task complexity.
-        // null = no override, agent uses its own configured default model.
-        if (dispatchModel) invokeParams.model = dispatchModel
-
-        // Use --expect-final to block until the agent completes and returns the full
-        // response payload (result.payloads[0].text). The two-step agent → agent.wait
-        // pattern only returns lifecycle metadata and never includes the agent's text.
-        const finalResult = await runOpenClaw(
-          ['gateway', 'call', 'agent', '--expect-final', '--timeout', '120000', '--params', JSON.stringify(invokeParams), '--json'],
-          { timeoutMs: 125_000 }
+        agentResponse = await callGatewayAgentHTTP(
+          { message: prompt, agentId: gatewayAgentId, ...(dispatchModel ? { model: dispatchModel } : {}) },
+          300_000,
         )
-        const finalPayload = parseGatewayJson(finalResult.stdout)
-          ?? parseGatewayJson(String((finalResult as any)?.stderr || ''))
-
-        agentResponse = parseAgentResponse(
-          finalPayload?.result ? JSON.stringify(finalPayload.result) : finalResult.stdout
-        )
-        if (!agentResponse.sessionId && finalPayload?.result?.meta?.agentMeta?.sessionId) {
-          agentResponse.sessionId = finalPayload.result.meta.agentMeta.sessionId
-        }
       } // end else (new session dispatch)
 
       if (!agentResponse.text) {

--- a/src/nav-rail.tsx
+++ b/src/nav-rail.tsx
@@ -36,6 +36,7 @@ const navGroups: NavGroup[] = [
       { id: 'logs', label: 'Logs', icon: <LogsIcon />, priority: true },
       { id: 'tokens', label: 'Tokens', icon: <TokensIcon />, priority: false },
       { id: 'memory', label: 'Memory', icon: <MemoryIcon />, priority: false },
+      { id: 'workspace', label: 'Workspace', icon: <WorkspaceIcon />, priority: false },
     ],
   },
   {
@@ -403,6 +404,16 @@ function MemoryIcon() {
       <ellipse cx="8" cy="8" rx="6" ry="3" />
       <path d="M2 8v3c0 1.7 2.7 3 6 3s6-1.3 6-3V8" />
       <path d="M2 5v3c0 1.7 2.7 3 6 3s6-1.3 6-3V5" />
+    </svg>
+  )
+}
+
+function WorkspaceIcon() {
+  return (
+    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M2 4.5v8c0 .8.7 1.5 1.5 1.5h9c.8 0 1.5-.7 1.5-1.5v-8" />
+      <path d="M1 4.5L8 2l7 2.5" />
+      <path d="M5 7h6M5 10h4" />
     </svg>
   )
 }

--- a/src/nav-rail.tsx
+++ b/src/nav-rail.tsx
@@ -10,6 +10,7 @@ interface NavItem {
   label: string
   icon: React.ReactNode
   priority: boolean // Show in mobile bottom bar
+  essential?: boolean // Visible in Essential interface mode
 }
 
 interface NavGroup {
@@ -36,7 +37,7 @@ const navGroups: NavGroup[] = [
       { id: 'logs', label: 'Logs', icon: <LogsIcon />, priority: true },
       { id: 'tokens', label: 'Tokens', icon: <TokensIcon />, priority: false },
       { id: 'memory', label: 'Memory', icon: <MemoryIcon />, priority: false },
-      { id: 'workspace', label: 'Workspace', icon: <WorkspaceIcon />, priority: false },
+      { id: 'workspace', label: 'Workspace', icon: <WorkspaceIcon />, priority: false, essential: true },
     ],
   },
   {


### PR DESCRIPTION
# Summary

Closes #608 
Replace the CLI-subprocess-based openclaw gateway integration with a native
WebSocket client and an HTTP chat completions transport for task/aegis dispatch.

Previously `callOpenClawGateway` shelled out to the `openclaw` CLI binary and
`callGatewayAgent` used `agent` + `agent.wait` RPC which only returns lifecycle
metadata — the LLM response text was never surfaced to MC. Tasks would
accumulate `dispatch_attempts` and never transition out of `assigned`.

Changes:
- **`callOpenClawGateway`**: now a native `ws` WebSocket client — no CLI dependency,
  correct auth handshake, `translateMethod()` maps all legacy method names to
  gateway RPC dot-notation transparently.
- **`callGatewayAgentHTTP`** (new): uses `POST /v1/chat/completions` with model
  `openclaw/<agentId>` — returns full text via `choices[0].message.content`.
- **`task-dispatch.ts`**: both task dispatch and aegis review switched from
  `runOpenClaw([…gateway call agent…])` to `callGatewayAgentHTTP(…, 300_000)`.
- **`Dockerfile`**: 3-stage build — openclaw binary copied from its own image
  (stage 0), not downloaded at runtime.

Verified in production: both test tasks transitioned to `status=done, outcome=success`
with full LLM text stored as comments.

# Risk Level
Medium

The gateway communication layer is completely replaced. The new WS client is
protocol-compatible (tested against the same gateway). HTTP completions endpoint
was confirmed working before being adopted as the dispatch path. The `parseGatewayJsonOutput`
export is kept for test backward compatibility.

# Tests

```bash
# Build and push
docker build --platform linux/amd64 \
  -t builderz-labs/mission-control:v2.0.1-v0.9 \
  /path/to/mission-control
docker push builderz-labs/mission-control:v2.0.1-v0.9

# Deploy
kubectl apply -f dep_all_in_one.yaml
kubectl rollout status deployment/mission-control -n mission-control
# → successfully rolled out

# Reset tasks and observe dispatch
kubectl exec -n mission-control <pod> -- node -e "
  const db = require('better-sqlite3')('/app/.data/mission-control.db');
  db.prepare(\"UPDATE tasks SET status='assigned', dispatch_attempts=0 WHERE id IN (1,2)\").run();
"

# Verify result (60–90 seconds later)
kubectl exec -n mission-control <pod> -- node -e "
  const db = require('better-sqlite3')('/app/.data/mission-control.db');
  console.log(db.prepare('SELECT id,status,outcome FROM tasks WHERE id IN (1,2)').all());
  console.log(db.prepare('SELECT task_id, content FROM comments WHERE task_id IN (1,2) ORDER BY created_at DESC LIMIT 4').all());
"
# → [{ id:1, status:'done', outcome:'success' }, { id:2, status:'done', outcome:'success' }]
# → comments contain full LLM text responses in Spanish and English