### PR TITLE
fix: exclude .git from output file tracing to fix self-update

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,7 +5,14 @@ const nextConfig = {
   output: 'standalone',
   outputFileTracingRoot: __dirname,
   outputFileTracingExcludes: {
-    '/*': ['./.data/**/*'],
+    // `.git` must be excluded so the Next.js file tracer does not copy the
+    // entire repo .git directory into `.next/standalone/`. When it does,
+    // Git treats the standalone dir as its own working tree and the
+    // self-update endpoint's `git status --porcelain` (run from
+    // process.cwd() under `pnpm start:standalone`) reports every file the
+    // standalone build doesn't bundle (e.g. `src/lib/__tests__/`) as
+    // deleted — blocking the dirty-tree check and breaking self-update.
+    '/*': ['./.data/**/*', './.git/**/*'],
   },
   turbopack: {
     root: __dirname,


### PR DESCRIPTION
# Summary

`output: 'standalone'` causes the Next.js file tracer to copy the entire repository `.git/` (~14 MB) into `.next/standalone/`, because `src/app/api/releases/update/route.ts` statically references the `git` binary via `execFileSync`. As a side-effect, Git treats `.next/standalone/` as its own working tree, and the self-update endpoint's `git status --porcelain` pre-flight (running from `process.cwd()` under `pnpm start:standalone`) reports every file the standalone build does not bundle (e.g. all of `src/lib/__tests__/`) as deleted. Self-update is therefore blocked on every clean install with a 409 *"Working tree has uncommitted changes"*.

This PR adds `./.git/**/*` to `outputFileTracingExcludes` so `.git` no longer ends up in the standalone output. The existing `git status` pre-flight then walks up to the real repo root and behaves correctly.

# Risk Level

Low. Build-config-only change. No runtime code, types, schema, or API surface touched. The standalone bundle gets ~14 MB smaller (no longer carries the repo `.git`) and self-update starts working — both unambiguously good.

# Tests

```
pnpm install --frozen-lockfile   # ok
pnpm typecheck                   # ok
pnpm lint                        # ok (8 pre-existing warnings, 0 errors)
pnpm build                       # ok
```

Reproduction on a clean v2.0.1 / current `main` checkout, **before** the patch:

```
pnpm install --frozen-lockfile && pnpm build
ls -la .next/standalone/.git           # full repo .git, ~14 MB
launchctl kickstart -k …               # or restart however you run MC
curl -X POST -H "X-API-Key: $KEY" \
  -H "Content-Type: application/json" \
  -d '{"targetVersion":"v9.9.9-fake"}' \
  http://localhost:3000/api/releases/update
```

returns `409 dirty:true` with phantom `D src/lib/__tests__/*.test.ts` entries.

**After** the patch (clean rebuild + restart):

```
ls -la .next/standalone/.git           # No such file or directory
```

and the same probe correctly passes the dirty-tree check (and 404s on the fake tag, as intended).

# Contribution Checklist

- [x] Tests added/updated for behavior changes — n/a, build-config-only
- [x] Lint/typecheck/build passing
- [x] Security review done if auth/data/crypto touched — n/a
- [x] DB migration tested if schema changed — n/a

# Notes

Two related observations while debugging, not addressed in this PR but worth flagging:

1. **`APP_VERSION` cosmetic lag at release time.** `package.json` was at `2.0.0` on the `v2.0.1` tag, so `/api/status?action=health` reported version `2.0.0` even on a v2.0.1 install — which made the self-update card surface a (false) "v2.0.1 available" prompt. `main` already has `package.json` bumped to `2.0.1`, so this is a release-process bump that just needs to land before tagging next time.

2. **`process.cwd()` in the update route is brittle to nested `.git`.** With this PR, `process.cwd()` works correctly because `.next/standalone/` no longer has its own `.git`. Defense-in-depth would be `git rev-parse --show-toplevel` from a known-good anchor, but that has its own failure mode against nested repos and the file-tracing fix is the actually-correct root cause. Happy to follow up with a hardening PR if useful.