### PR TITLE
fix: persist POST /api/tokens records to token_usage table

### DIFF
--- a/src/app/api/tokens/route.ts
+++ b/src/app/api/tokens/route.ts
@@ -608,6 +608,33 @@ export async function POST(request: NextRequest) {
 
     await saveTokenData(existingData)
 
+    // Also INSERT into the token_usage SQLite table so by-agent / DB-based
+    // aggregations (which read from token_usage, not from the JSON file)
+    // include externally-posted records. Without this, worker-reported
+    // tokens land only in the JSON file and the by-agent dashboard widget
+    // stays empty even when usage exists. Failures are non-fatal so the
+    // JSON write remains the canonical record.
+    try {
+      const db = getDatabase()
+      const createdAtSec = Math.floor(Date.now() / 1000)
+      db.prepare(`
+        INSERT INTO token_usage (model, session_id, input_tokens, output_tokens, created_at, workspace_id, task_id, cost_usd, agent_name)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        model,
+        sessionId,
+        inputTokens,
+        outputTokens,
+        createdAtSec,
+        workspaceId,
+        validatedTaskId,
+        cost,
+        record.agentName,
+      )
+    } catch (err) {
+      logger.warn({ err }, 'token_usage DB insert failed (JSON record persisted)')
+    }
+
     return NextResponse.json({ success: true, record })
   } catch (error) {
     logger.error({ err: error }, 'Error saving token usage')


### PR DESCRIPTION
# Summary

`POST /api/tokens` writes only to the JSON file at `config.tokensPath`. The aggregation endpoints (`/api/tokens/by-agent`, the per-agent cost widget) read from the `token_usage` SQLite table instead. So externally-posted records — from custom workers using the public REST integration — land in the JSON file but never reach the dashboard's by-agent breakdown.

This patch adds an INSERT into `token_usage` after the JSON write, schema-aligned with the actual v2.0.1 columns. JSON remains the canonical record; DB INSERT is wrapped in try/catch so SQLite failures don't break the API call.

# Risk Level

Low. One additional INSERT per `POST /api/tokens` request, additive to existing behaviour. No request/response shape change, no schema migration. Failure mode is a logged warning while the JSON write still succeeds (existing behaviour preserved).

# Tests

```
pnpm install --frozen-lockfile  # ok
pnpm typecheck                  # ok
pnpm lint                       # ok (8 pre-existing warnings, 0 errors)
pnpm build                      # ok
```

End-to-end on a v2.0.1 install:

```
# Before patch
curl -X POST -H "X-API-Key: $K" -H "Content-Type: application/json" \
  -d '{"model":"qwen3-coder:30b","sessionId":"smoke:t1","inputTokens":10,"outputTokens":5}' \
  http://localhost:3000/api/tokens
# returns {"success": true, ...}, JSON file gets the record
curl http://localhost:3000/api/tokens/by-agent?days=1
# returns {"agents": []}                ← bug

# After patch (rebuild + restart)
curl http://localhost:3000/api/tokens/by-agent?days=1
# returns {"agents":[{"agent":"smoke","total_input_tokens":10,"total_output_tokens":5,"models":[...]}]}
```

Verified on a real install (v2.0.1 + the `.git`-exclude patch from #619): two agent workers (`claude-premium` Mac / `ollama-routine` Bazzite) reporting via the REST API, dashboard now populates correctly.

# Contribution Checklist

- [x] Tests added/updated for behavior changes — n/a, this is a 27-line additive write to a side surface; existing tests don't cover the JSON-vs-DB divergence
- [x] Lint/typecheck/build passing
- [x] Security review done if auth/data/crypto touched — n/a (uses existing `requireRole('operator')` upstream, INSERT scoped to `auth.user.workspace_id`)
- [x] DB migration tested if schema changed — n/a, no schema change

# Notes

**Schema column choices.** I match v2.0.1's actual `token_usage` columns: `model, session_id, input_tokens, output_tokens, created_at, workspace_id, task_id, cost_usd, agent_name`. Notably absent in v2.0.1: `total_tokens` and `cost` (only `cost_usd`). `src/lib/task-dispatch.ts` on `main` (line 277) uses `total_tokens, cost` in its INSERT, which would fail against a v2.0.1 schema — that's a separate bug worth checking on tagged releases vs HEAD. This PR doesn't touch task-dispatch.ts.

**Sister to #619.** Same `.git/`-bundling install I'm working on; both fixes can land together. Happy to rebase on top of #619 if you'd prefer a single merge.