### PR TITLE
fix(validation): drop default values from updateTaskSchema

### DIFF
--- a/src/lib/__tests__/validation.test.ts
+++ b/src/lib/__tests__/validation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   createTaskSchema,
+  updateTaskSchema,
   createAgentSchema,
   createWebhookSchema,
   createAlertSchema,
@@ -82,6 +83,53 @@ describe('createTaskSchema', () => {
       },
     })
     expect(result.success).toBe(false)
+  })
+})
+
+describe('updateTaskSchema', () => {
+  // Regression: createTaskSchema.partial() preserves the underlying defaults,
+  // so a PUT that omits a field would parse with status='inbox', tags=[], etc.
+  // The route's "if (field !== undefined)" check would then overwrite the
+  // stored row. updateTaskSchema must drop those defaults.
+  it('does not inject defaults for omitted fields', () => {
+    const result = updateTaskSchema.safeParse({})
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).not.toHaveProperty('status')
+      expect(result.data).not.toHaveProperty('priority')
+      expect(result.data).not.toHaveProperty('tags')
+      expect(result.data).not.toHaveProperty('metadata')
+      expect(Object.keys(result.data)).toHaveLength(0)
+    }
+  })
+
+  it('does not inject defaults when only one field is provided', () => {
+    const result = updateTaskSchema.safeParse({ title: 'Renamed' })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toEqual({ title: 'Renamed' })
+    }
+  })
+
+  it('passes through provided fields verbatim', () => {
+    const result = updateTaskSchema.safeParse({
+      status: 'in_progress',
+      tags: ['a', 'b'],
+      metadata: { custom: 'value' },
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.status).toBe('in_progress')
+      expect(result.data.tags).toEqual(['a', 'b'])
+      expect(result.data.metadata).toEqual({ custom: 'value' })
+      expect(result.data).not.toHaveProperty('priority')
+    }
+  })
+
+  it('still validates field constraints', () => {
+    expect(updateTaskSchema.safeParse({ status: 'invalid' }).success).toBe(false)
+    expect(updateTaskSchema.safeParse({ feedback_rating: 6 }).success).toBe(false)
+    expect(updateTaskSchema.safeParse({ title: '' }).success).toBe(false)
   })
 })
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -31,29 +31,76 @@ const taskMetadataSchema = z.object({
   code_location: z.string().min(1, 'code_location cannot be empty').max(500).optional(),
 }).catchall(z.unknown())
 
-export const createTaskSchema = z.object({
+// Field validators reused by createTaskSchema and updateTaskSchema.
+// Defaults intentionally live on createTaskSchema only — they MUST NOT apply
+// on update, otherwise a PUT that omits a field would silently overwrite the
+// stored value (e.g. PUT {title} would reset status to 'inbox' and tags to []).
+const taskFields = {
   title: z.string().min(1, 'Title is required').max(500),
-  description: z.string().max(5000).optional(),
-  status: z.enum(['backlog', 'inbox', 'assigned', 'awaiting_owner', 'in_progress', 'review', 'quality_review', 'done', 'failed']).default('inbox'),
-  priority: z.enum(['critical', 'high', 'medium', 'low']).default('medium'),
-  project_id: z.number().int().positive().optional(),
-  assigned_to: z.string().max(100).optional(),
-  created_by: z.string().max(100).optional(),
-  due_date: z.number().int().min(0).max(4102444800).optional(), // max ~2100-01-01
-  estimated_hours: z.number().min(0).max(10000).optional(),
-  actual_hours: z.number().min(0).max(10000).optional(),
-  outcome: z.enum(['success', 'failed', 'partial', 'abandoned']).optional(),
-  error_message: z.string().max(5000).optional(),
-  resolution: z.string().max(5000).optional(),
-  feedback_rating: z.number().int().min(1).max(5).optional(),
-  feedback_notes: z.string().max(5000).optional(),
-  retry_count: z.number().int().min(0).optional(),
-  completed_at: z.number().int().min(0).max(4102444800).optional(),
-  tags: z.array(z.string().min(1).max(100)).max(50).default([] as string[]),
-  metadata: taskMetadataSchema.default({} as Record<string, unknown>),
+  description: z.string().max(5000),
+  status: z.enum(['backlog', 'inbox', 'assigned', 'awaiting_owner', 'in_progress', 'review', 'quality_review', 'done', 'failed']),
+  priority: z.enum(['critical', 'high', 'medium', 'low']),
+  project_id: z.number().int().positive(),
+  assigned_to: z.string().max(100),
+  created_by: z.string().max(100),
+  due_date: z.number().int().min(0).max(4102444800), // max ~2100-01-01
+  estimated_hours: z.number().min(0).max(10000),
+  actual_hours: z.number().min(0).max(10000),
+  outcome: z.enum(['success', 'failed', 'partial', 'abandoned']),
+  error_message: z.string().max(5000),
+  resolution: z.string().max(5000),
+  feedback_rating: z.number().int().min(1).max(5),
+  feedback_notes: z.string().max(5000),
+  retry_count: z.number().int().min(0),
+  completed_at: z.number().int().min(0).max(4102444800),
+  tags: z.array(z.string().min(1).max(100)).max(50),
+  metadata: taskMetadataSchema,
+}
+
+export const createTaskSchema = z.object({
+  title: taskFields.title,
+  description: taskFields.description.optional(),
+  status: taskFields.status.default('inbox'),
+  priority: taskFields.priority.default('medium'),
+  project_id: taskFields.project_id.optional(),
+  assigned_to: taskFields.assigned_to.optional(),
+  created_by: taskFields.created_by.optional(),
+  due_date: taskFields.due_date.optional(),
+  estimated_hours: taskFields.estimated_hours.optional(),
+  actual_hours: taskFields.actual_hours.optional(),
+  outcome: taskFields.outcome.optional(),
+  error_message: taskFields.error_message.optional(),
+  resolution: taskFields.resolution.optional(),
+  feedback_rating: taskFields.feedback_rating.optional(),
+  feedback_notes: taskFields.feedback_notes.optional(),
+  retry_count: taskFields.retry_count.optional(),
+  completed_at: taskFields.completed_at.optional(),
+  tags: taskFields.tags.default([] as string[]),
+  metadata: taskFields.metadata.default({} as Record<string, unknown>),
 })
 
-export const updateTaskSchema = createTaskSchema.partial()
+// Every field optional, NO defaults — see comment above on `taskFields`.
+export const updateTaskSchema = z.object({
+  title: taskFields.title.optional(),
+  description: taskFields.description.optional(),
+  status: taskFields.status.optional(),
+  priority: taskFields.priority.optional(),
+  project_id: taskFields.project_id.optional(),
+  assigned_to: taskFields.assigned_to.optional(),
+  created_by: taskFields.created_by.optional(),
+  due_date: taskFields.due_date.optional(),
+  estimated_hours: taskFields.estimated_hours.optional(),
+  actual_hours: taskFields.actual_hours.optional(),
+  outcome: taskFields.outcome.optional(),
+  error_message: taskFields.error_message.optional(),
+  resolution: taskFields.resolution.optional(),
+  feedback_rating: taskFields.feedback_rating.optional(),
+  feedback_notes: taskFields.feedback_notes.optional(),
+  retry_count: taskFields.retry_count.optional(),
+  completed_at: taskFields.completed_at.optional(),
+  tags: taskFields.tags.optional(),
+  metadata: taskFields.metadata.optional(),
+})
 
 export const createAgentSchema = z.object({
   name: z.string().min(1, 'Name is required').max(100),


### PR DESCRIPTION
## Summary

`updateTaskSchema = createTaskSchema.partial()` makes every field optional, but Zod's `.partial()` keeps the underlying `.default(...)` modifiers. So a `PUT /api/tasks/{id}` body that omits a field parses with the create-time default applied (`status: 'inbox'`, `priority: 'medium'`, `tags: []`, `metadata: {}`).

Combined with the route's `if (field !== undefined) UPDATE …` guards in `src/app/api/tasks/[id]/route.ts`, this means a partial update like `PUT { title }` silently overwrites the stored row: status is reset to `inbox`, tags/metadata are wiped.

## Repro (before this fix)

```sh
# create a task in done state
curl -s -X POST -H "x-api-key: $K" -H 'content-type: application/json' \
  http://localhost:3000/api/tasks \
  -d '{"title":"t1","status":"done","tags":["a","b"],"metadata":{"foo":"bar"}}'
# → status=done, tags=[a,b], metadata={foo:bar}

# update only the description
curl -s -X PUT  -H "x-api-key: $K" -H 'content-type: application/json' \
  http://localhost:3000/api/tasks/<id> \
  -d '{"description":"updated"}'

# read back
curl -s -H "x-api-key: $K" http://localhost:3000/api/tasks/<id>
# → status=inbox  ❌      tags=[]  ❌     metadata={}  ❌
```

The activity log on each affected task records the silent rewrite, e.g. `Task updated: status: done → inbox, …`.

I hit this while bulk-updating tasks via the API — every PUT that didn't include `status` reset 60+ tasks to `inbox` and emptied their `tags`/`metadata`.

## Fix

Define `updateTaskSchema` explicitly with `.optional()` and no defaults. To keep the two schemas from drifting, extract the field validators into a shared `taskFields` map; defaults remain on `createTaskSchema` only.

The existing route handler is already shaped correctly (`if (field !== undefined) push(...)`) — once the validator stops injecting defaults, partial updates round-trip as expected.

No API contract change for clients that already send full bodies. Clients that previously got an unintended reset will now correctly preserve the omitted fields.

## Test plan

- [x] `pnpm test src/lib/__tests__/validation.test.ts` — added 4 regression tests:
  - empty body parses to `{}` (no defaults)
  - single-field update doesn't inject other fields
  - provided fields pass through verbatim
  - field constraints still enforced (`status: 'invalid'`, `feedback_rating: 6`, empty title)
- [x] `pnpm typecheck`
- [x] `pnpm lint` (only pre-existing warnings)
- [x] `pnpm test` — all task-related suites green; the only failure (`gateway-url.test.ts`) is pre-existing on `main` and unrelated.

## Notes

Only one `.partial()` site in `src/lib/validation.ts`; nothing else relies on `updateTaskSchema` injecting defaults. `createTaskSchema` behavior is unchanged.