### PR TITLE
Stabilize gateway websocket autodetect

### DIFF
--- a/src/app/[[...panel]]/page.tsx
+++ b/src/app/[[...panel]]/page.tsx
@@ -52,6 +52,7 @@ import { OnboardingWizard } from '@/components/onboarding/onboarding-wizard'
 import { Loader } from '@/components/ui/loader'
 import { ProjectManagerModal } from '@/components/modals/project-manager-modal'
 import { ExecApprovalOverlay } from '@/components/modals/exec-approval-overlay'
+import { resolveGatewayToken, resolveGatewayWebSocketUrl } from '@/lib/gateway-url'
 import { useWebSocket } from '@/lib/websocket'
 import { useServerEvents } from '@/lib/use-server-events'
 import { completeNavigationTiming } from '@/lib/navigation-metrics'
@@ -178,19 +179,14 @@ export default function Home() {
     }
 
     const connectWithEnvFallback = (localGatewayUrl: string | null) => {
-      // localStorage user choice takes priority over env vars
-      const explicitWsUrl = localGatewayUrl || process.env.NEXT_PUBLIC_GATEWAY_URL || ''
-      if (explicitWsUrl) {
-        connect(explicitWsUrl)
-        return
-      }
-      const gatewayPort = process.env.NEXT_PUBLIC_GATEWAY_PORT || '18789'
-      const gatewayHost = process.env.NEXT_PUBLIC_GATEWAY_HOST || window.location.hostname
-      const gatewayProto =
-        process.env.NEXT_PUBLIC_GATEWAY_PROTOCOL ||
-        (window.location.protocol === 'https:' ? 'wss' : 'ws')
-      const wsUrl = `${gatewayProto}://${gatewayHost}:${gatewayPort}`
-      connect(wsUrl)
+      const wsToken = resolveGatewayToken(process.env)
+      const wsUrl = resolveGatewayWebSocketUrl({
+        locationProtocol: window.location.protocol,
+        locationHostname: window.location.hostname,
+        env: process.env,
+        explicitUrl: localGatewayUrl || undefined,
+      })
+      connect(wsUrl, wsToken)
     }
 
     const connectWithPrimaryGateway = async (): Promise<{ attempted: boolean; connected: boolean }> => {

--- a/src/lib/__tests__/gateway-url.test.ts
+++ b/src/lib/__tests__/gateway-url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildGatewayPathFallbackUrls, buildGatewayWebSocketUrl } from '@/lib/gateway-url'
+import { buildGatewayPathFallbackUrls, buildGatewayWebSocketUrl, resolveGatewayToken, resolveGatewayWebSocketUrl } from '@/lib/gateway-url'
 
 describe('buildGatewayWebSocketUrl', () => {
   it('builds ws URL with host and port for local dev', () => {
@@ -116,5 +116,60 @@ describe('buildGatewayPathFallbackUrls', () => {
 
   it('returns no fallbacks when URL already has a non-root path', () => {
     expect(buildGatewayPathFallbackUrls('wss://gateway.example.com/gateway-ws')).toEqual([])
+  })
+})
+
+describe('resolveGatewayWebSocketUrl', () => {
+  it('uses localhost and the default gateway port for local http origins', () => {
+    expect(resolveGatewayWebSocketUrl({
+      locationProtocol: 'http:',
+      locationHostname: 'localhost',
+      env: {},
+    })).toBe('ws://localhost:18789')
+  })
+
+  it('does not leak loopback env host when browser is on a non-loopback host', () => {
+    expect(resolveGatewayWebSocketUrl({
+      locationProtocol: 'http:',
+      locationHostname: 'cobran.local',
+      env: { NEXT_PUBLIC_GATEWAY_HOST: '127.0.0.1' },
+    })).toBe('ws://cobran.local:18789')
+  })
+
+  it('uses wss and omits the direct gateway port by default for https remote origins', () => {
+    expect(resolveGatewayWebSocketUrl({
+      locationProtocol: 'https:',
+      locationHostname: 'os.cobran.ai',
+      env: {},
+    })).toBe('wss://os.cobran.ai')
+  })
+
+  it('keeps an explicit non-default https gateway port', () => {
+    expect(resolveGatewayWebSocketUrl({
+      locationProtocol: 'https:',
+      locationHostname: 'os.cobran.ai',
+      env: { NEXT_PUBLIC_GATEWAY_PORT: '9443' },
+    })).toBe('wss://os.cobran.ai:9443')
+  })
+
+  it('prefers an explicit gateway url', () => {
+    expect(resolveGatewayWebSocketUrl({
+      locationProtocol: 'https:',
+      locationHostname: 'os.cobran.ai',
+      env: { NEXT_PUBLIC_GATEWAY_URL: 'wss://gateway.example/ws' },
+    })).toBe('wss://gateway.example/ws')
+  })
+})
+
+describe('resolveGatewayToken', () => {
+  it('prefers NEXT_PUBLIC_GATEWAY_TOKEN over legacy NEXT_PUBLIC_WS_TOKEN', () => {
+    expect(resolveGatewayToken({
+      NEXT_PUBLIC_GATEWAY_TOKEN: 'gateway-token',
+      NEXT_PUBLIC_WS_TOKEN: 'legacy-token',
+    })).toBe('gateway-token')
+  })
+
+  it('falls back to NEXT_PUBLIC_WS_TOKEN', () => {
+    expect(resolveGatewayToken({ NEXT_PUBLIC_WS_TOKEN: 'legacy-token' })).toBe('legacy-token')
   })
 })

--- a/src/lib/gateway-url.ts
+++ b/src/lib/gateway-url.ts
@@ -37,6 +37,22 @@ function formatWebSocketUrl(parsed: URL): string {
   return parsed.toString().replace(/\/$/, '').replace('/?', '?')
 }
 
+function clean(value?: string) {
+  return (value || '').trim()
+}
+
+function isLoopbackHost(host: string): boolean {
+  const normalized = host.toLowerCase()
+  return normalized === 'localhost' || normalized === '127.0.0.1' || normalized === '::1'
+}
+
+export type GatewayUrlOptions = {
+  locationProtocol: string
+  locationHostname: string
+  env?: Record<string, string | undefined>
+  explicitUrl?: string
+}
+
 export function buildGatewayPathFallbackUrls(rawUrl: string): string[] {
   const trimmed = String(rawUrl || '').trim()
   if (!trimmed) return []
@@ -77,11 +93,6 @@ export function buildGatewayWebSocketUrl(input: {
   const browserProtocol = input.browserProtocol === 'https:' ? 'https:' : 'http:'
 
   if (!rawHost) {
-    // Default host is localhost — use wss:// when the browser is on HTTPS and a reverse
-    // proxy is likely fronting the gateway (e.g. nginx/Caddy/Tailscale Serve).
-    // Direct localhost connections still work because browsers allow ws://127.0.0.1
-    // from HTTPS pages (mixed-content exception), but the gateway may reject the
-    // WebSocket Origin header if it doesn't match allowedOrigins.
     const useWss = browserProtocol === 'https:' && process.env.NEXT_PUBLIC_GATEWAY_REVERSE_PROXY === '1'
     return `${useWss ? 'wss' : 'ws'}://127.0.0.1:${port || 18789}`
   }
@@ -97,12 +108,15 @@ export function buildGatewayWebSocketUrl(input: {
   if (prefixed) {
     try {
       const parsed = new URL(prefixed)
-      // Local hosts use plain ws:// unless the URL was explicitly set to wss://
-      // (e.g. wss://127.0.0.1 via reverse proxy that terminates TLS).
-      if (!isLocalHost(parsed.hostname)) {
+      // Local hosts use plain ws:// for http(s) URLs unless the user explicitly
+      // supplied a websocket protocol. This avoids producing invalid
+      // https:// URLs for the WebSocket constructor while preserving explicit
+      // wss:// reverse-proxy configurations.
+      if (isLocalHost(parsed.hostname) && (parsed.protocol === 'http:' || parsed.protocol === 'https:')) {
+        parsed.protocol = 'ws:'
+      } else if (!isLocalHost(parsed.hostname)) {
         parsed.protocol = normalizeProtocol(parsed.protocol)
       }
-      // else: preserve the protocol the user explicitly set (ws:// or wss://)
       // Keep explicit proxy paths (e.g. /gw), but collapse known dashboard/session routes to root.
       parsed.pathname = normalizeGatewayPath(parsed.pathname)
       preserveTokenQuery(parsed)
@@ -113,10 +127,6 @@ export function buildGatewayWebSocketUrl(input: {
     }
   }
 
-  // Local gateway hosts use plain ws:// by default — they don't speak TLS.
-  // However, if NEXT_PUBLIC_GATEWAY_REVERSE_PROXY=1 and browser is on HTTPS, use wss://
-  // because a reverse proxy is likely fronting the gateway and the browser would block
-  // mixed-content ws:// from an HTTPS page (or the gateway would reject the Origin).
   const wsProtocol = isLocalHost(rawHost)
     ? (browserProtocol === 'https:' && process.env.NEXT_PUBLIC_GATEWAY_REVERSE_PROXY === '1' ? 'wss' : 'ws')
     : (browserProtocol === 'https:' ? 'wss' : 'ws')
@@ -128,4 +138,41 @@ export function buildGatewayWebSocketUrl(input: {
   return shouldOmitPort
     ? `${wsProtocol}://${rawHost}`
     : `${wsProtocol}://${rawHost}:${port || 18789}`
+}
+
+export function resolveGatewayWebSocketUrl({
+  locationProtocol,
+  locationHostname,
+  env = {},
+  explicitUrl,
+}: GatewayUrlOptions): string {
+  const configuredUrl = clean(explicitUrl || env.NEXT_PUBLIC_GATEWAY_URL)
+  if (configuredUrl) return buildGatewayWebSocketUrl({
+    host: configuredUrl,
+    port: Number(clean(env.NEXT_PUBLIC_GATEWAY_PORT) || '18789'),
+    browserProtocol: locationProtocol,
+  })
+
+  const isHttps = locationProtocol === 'https:'
+  const envHost = clean(env.NEXT_PUBLIC_GATEWAY_HOST)
+  const isBrowserLoopback = isLoopbackHost(locationHostname)
+  const isEnvLoopback = envHost ? isLoopbackHost(envHost) : false
+  const gatewayHost = !isBrowserLoopback && isEnvLoopback
+    ? locationHostname
+    : (envHost || locationHostname)
+
+  const envPort = clean(env.NEXT_PUBLIC_GATEWAY_PORT)
+  const gatewayPort = isHttps
+    ? ((envPort && envPort !== '18789') ? Number(envPort) : 18789)
+    : Number(envPort || '18789')
+
+  return buildGatewayWebSocketUrl({
+    host: gatewayHost,
+    port: gatewayPort,
+    browserProtocol: locationProtocol,
+  })
+}
+
+export function resolveGatewayToken(env: Record<string, string | undefined> = {}) {
+  return clean(env.NEXT_PUBLIC_GATEWAY_TOKEN) || clean(env.NEXT_PUBLIC_WS_TOKEN)
 }

--- a/src/lib/websocket.ts
+++ b/src/lib/websocket.ts
@@ -686,7 +686,8 @@ export function useWebSocket() {
     } catch {
       urlToken = ''
     }
-    authTokenRef.current = token || urlToken || ''
+    const envToken = process.env.NEXT_PUBLIC_GATEWAY_TOKEN || process.env.NEXT_PUBLIC_WS_TOKEN || ''
+    authTokenRef.current = token || urlToken || envToken || ''
 
     const normalizedUrl = normalizeWebSocketUrl(url)
     if (reconnectUrl.current !== normalizedUrl) {


### PR DESCRIPTION
## Summary
- Add a shared gateway websocket URL/token resolver.
- Avoid leaking loopback gateway hosts when Cobran-OS is accessed from a non-loopback hostname.
- Default HTTPS origins to wss/443 unless an explicit gateway port is configured.
- Respect NEXT_PUBLIC_GATEWAY_TOKEN in the websocket handshake fallback.
- Add focused unit coverage for local, hosted, explicit URL, HTTPS, and token cases.

## Validation
- pnpm lint ✅
- pnpm typecheck ✅
- pnpm test ✅ 76 tests
- pnpm build ✅