### PR TITLE
Document local Cobran-OS run path

### DIFF
--- a/docs/cobran-os-local-runbook.md
+++ b/docs/cobran-os-local-runbook.md
@@ -1,0 +1,120 @@
+# Cobran-OS local runbook
+
+This is the verified local path for running Cobran-OS / Mission Control on Tiago's machine.
+
+## Functional baseline
+
+Cobran-OS is considered locally functional when:
+
+1. dependencies install cleanly for the active Node version;
+2. the development server starts on the expected local port;
+3. `/setup` renders so an admin account can be created;
+4. `/` redirects unauthenticated users to `/login`;
+5. protected APIs reject unauthenticated access;
+6. lint, typecheck, unit tests, and production build pass.
+
+Gateway-connected features are a second layer: the dashboard can run without a gateway, but live OpenClaw events require gateway host/token configuration.
+
+## Prerequisites
+
+- Node.js `>=22`.
+- `pnpm` enabled/installed.
+- Native build tooling available for `better-sqlite3` and `node-pty`.
+  - Ubuntu/Debian: `python3 make g++`.
+  - macOS: Xcode command-line tools.
+
+## Fresh local setup
+
+```bash
+git clone https://github.com/builderz-labs/mission-control.git cobran-os
+cd cobran-os
+pnpm install
+cp .env.example .env.local
+```
+
+For first local use, either:
+
+- open `http://127.0.0.1:3000/setup` and create the admin account; or
+- set `AUTH_USER` / `AUTH_PASS` in `.env.local` before first run.
+
+Do not commit `.env.local` or secrets.
+
+## Start locally
+
+Default port:
+
+```bash
+pnpm dev
+```
+
+Custom port:
+
+```bash
+PORT=3020 pnpm dev
+```
+
+Open:
+
+```text
+http://127.0.0.1:3020/setup
+```
+
+## Verified on 2026-04-27
+
+Environment:
+
+- repo: `/home/agoti/.openclaw/workspace/projects/agoti-mission-control`
+- branch checked: `ago-14-cobran-os-verify-local-installstart-path`
+- Node: `22.22.0`
+- package version: `mission-control@2.0.1`
+
+Commands/results:
+
+```bash
+pnpm install
+# installed missing dependencies after upstream update; node-pty rebuilt successfully
+
+PORT=3020 pnpm dev
+# Next.js ready at http://127.0.0.1:3020
+```
+
+Smoke checks:
+
+```bash
+curl -s -o /tmp/mc_root.html -w '%{http_code}\n' http://127.0.0.1:3020/
+# 307 — redirects unauthenticated user to /login
+
+curl -s -o /tmp/mc_setup.html -w '%{http_code} %{content_type}\n' http://127.0.0.1:3020/setup
+# 200 text/html; charset=utf-8 — setup page renders
+
+curl -s -o /tmp/mc_status.json -w '%{http_code} %{content_type}\n' http://127.0.0.1:3020/api/status
+# 401 application/json — protected API correctly rejects unauthenticated access
+```
+
+## Quality gate
+
+Before calling a branch ready:
+
+```bash
+pnpm lint
+pnpm typecheck
+pnpm test
+pnpm build
+```
+
+## Gateway notes
+
+For local-only UI testing, the app can be verified through `/setup`, login, dashboard navigation, and CRUD/API smoke tests without a gateway.
+
+For gateway-connected testing:
+
+1. confirm the OpenClaw gateway is running;
+2. set server-side `OPENCLAW_GATEWAY_HOST` / `OPENCLAW_GATEWAY_PORT` as needed;
+3. set browser-side `NEXT_PUBLIC_GATEWAY_*` only when the browser needs a different host/URL;
+4. rebuild after changing any `NEXT_PUBLIC_*` values.
+
+## Current blockers / risks
+
+- If the repo has just fast-forwarded to a newer upstream version, run `pnpm install` before `pnpm dev`; otherwise `next.config.js` may fail on newly added packages such as `next-intl`.
+- The setup/login flow still needs an actual browser/manual pass after account creation to fully validate dashboard navigation.
+- Gateway-connected functionality requires a live OpenClaw gateway and appropriate host/token configuration.

--- a/src/lib/gateway-url.ts
+++ b/src/lib/gateway-url.ts
@@ -97,12 +97,15 @@ export function buildGatewayWebSocketUrl(input: {
   if (prefixed) {
     try {
       const parsed = new URL(prefixed)
-      // Local hosts use plain ws:// unless the URL was explicitly set to wss://
-      // (e.g. wss://127.0.0.1 via reverse proxy that terminates TLS).
-      if (!isLocalHost(parsed.hostname)) {
+      // Local hosts use plain ws:// for http(s) URLs unless the user explicitly
+      // supplied a websocket protocol. This avoids producing invalid
+      // https:// URLs for the WebSocket constructor while preserving explicit
+      // wss:// reverse-proxy configurations.
+      if (isLocalHost(parsed.hostname) && (parsed.protocol === 'http:' || parsed.protocol === 'https:')) {
+        parsed.protocol = 'ws:'
+      } else if (!isLocalHost(parsed.hostname)) {
         parsed.protocol = normalizeProtocol(parsed.protocol)
       }
-      // else: preserve the protocol the user explicitly set (ws:// or wss://)
       // Keep explicit proxy paths (e.g. /gw), but collapse known dashboard/session routes to root.
       parsed.pathname = normalizeGatewayPath(parsed.pathname)
       preserveTokenQuery(parsed)


### PR DESCRIPTION
## Summary
- add a Cobran-OS local runbook with prerequisites, setup/start commands, functional baseline, gateway notes, and current risks
- verify the current local install/start path after the upstream update
- normalize pasted localhost http(s) gateway URLs to ws:// so WebSocket construction remains valid during local smoke tests

## Verification
- pnpm install
- PORT=3020 pnpm dev
- curl / -> 307 to /login
- curl /setup -> 200 text/html
- curl /api/status -> 401 application/json
- pnpm lint (passes with existing warnings)
- GIT_AUTHOR_NAME=Bob GIT_AUTHOR_EMAIL=bob@openclaw.local GIT_COMMITTER_NAME=Bob GIT_COMMITTER_EMAIL=bob@openclaw.local pnpm test -- src/lib/__tests__/gateway-url.test.ts src/lib/__tests__/gnap-sync.test.ts (vitest ran full suite: 931 passed)
- pnpm typecheck
- pnpm build