### PR TITLE
Close task modal placeholder gaps

### DIFF
--- a/src/components/panels/task-board-panel.tsx
+++ b/src/components/panels/task-board-panel.tsx
@@ -1194,7 +1194,6 @@ export function TaskBoardPanel() {
   )
 }
 
-// Task Detail Modal Component (placeholder - would be implemented separately)
 function TaskDetailModal({
   task,
   agents,
@@ -2048,7 +2047,6 @@ function HermesCronSection() {
   )
 }
 
-// Create Task Modal Component (placeholder)
 function CreateTaskModal({
   agents, 
   projects,
@@ -2075,6 +2073,8 @@ function CreateTaskModal({
   const [scheduleInput, setScheduleInput] = useState('')
   const [parsedSchedule, setParsedSchedule] = useState<{ cronExpr: string; humanReadable: string } | null>(null)
   const [scheduleError, setScheduleError] = useState('')
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
   const mentionTargets = useMentionTargets()
 
   const handleScheduleChange = async (value: string) => {
@@ -2117,6 +2117,8 @@ function CreateTaskModal({
     }
 
     try {
+      setSubmitError(null)
+      setIsSubmitting(true)
       const response = await fetch('/api/tasks', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -2138,7 +2140,11 @@ function CreateTaskModal({
       onCreated()
       onClose()
     } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to create task'
+      setSubmitError(message)
       log.error('Error creating task:', error)
+    } finally {
+      setIsSubmitting(false)
     }
   }
 
@@ -2298,11 +2304,17 @@ function CreateTaskModal({
             </div>
           </div>
 
+          {submitError && (
+            <div role="alert" className="mt-4 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-300">
+              {submitError}
+            </div>
+          )}
+
           <div className="flex gap-3 mt-6">
-            <Button type="submit" className="flex-1" disabled={isRecurring && !parsedSchedule}>
-              {isRecurring ? t('createRecurringTask') : t('createTask')}
+            <Button type="submit" className="flex-1" disabled={isSubmitting || (isRecurring && !parsedSchedule)}>
+              {isSubmitting ? t('loading') : (isRecurring ? t('createRecurringTask') : t('createTask'))}
             </Button>
-            <Button type="button" variant="secondary" onClick={onClose} className="flex-1">
+            <Button type="button" variant="secondary" onClick={onClose} className="flex-1" disabled={isSubmitting}>
               {t('cancel')}
             </Button>
           </div>
@@ -2339,6 +2351,8 @@ function EditTaskModal({
   })
   const mentionTargets = useMentionTargets()
   const agentSessions = useAgentSessions(formData.assigned_to || undefined)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -2346,6 +2360,8 @@ function EditTaskModal({
     if (!formData.title.trim()) return
 
     try {
+      setSubmitError(null)
+      setIsSubmitting(true)
       const existingMeta = task.metadata || {}
       const updatedMeta = { ...existingMeta }
       if (formData.target_session) {
@@ -2374,7 +2390,11 @@ function EditTaskModal({
 
       onUpdated()
     } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to update task'
+      setSubmitError(message)
       log.error('Error updating task:', error)
+    } finally {
+      setIsSubmitting(false)
     }
   }
 
@@ -2512,11 +2532,17 @@ function EditTaskModal({
             </div>
           </div>
 
+          {submitError && (
+            <div role="alert" className="mt-4 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-300">
+              {submitError}
+            </div>
+          )}
+
           <div className="flex gap-3 mt-6">
-            <Button type="submit" className="flex-1">
-              {t('saveChanges')}
+            <Button type="submit" className="flex-1" disabled={isSubmitting}>
+              {isSubmitting ? t('loading') : t('saveChanges')}
             </Button>
-            <Button type="button" variant="secondary" onClick={onClose} className="flex-1">
+            <Button type="button" variant="secondary" onClick={onClose} className="flex-1" disabled={isSubmitting}>
               {t('cancel')}
             </Button>
           </div>

--- a/src/lib/gateway-url.ts
+++ b/src/lib/gateway-url.ts
@@ -97,12 +97,15 @@ export function buildGatewayWebSocketUrl(input: {
   if (prefixed) {
     try {
       const parsed = new URL(prefixed)
-      // Local hosts use plain ws:// unless the URL was explicitly set to wss://
-      // (e.g. wss://127.0.0.1 via reverse proxy that terminates TLS).
-      if (!isLocalHost(parsed.hostname)) {
+      // Local hosts use plain ws:// for http(s) URLs unless the user explicitly
+      // supplied a websocket protocol. This avoids producing invalid
+      // https:// URLs for the WebSocket constructor while preserving explicit
+      // wss:// reverse-proxy configurations.
+      if (isLocalHost(parsed.hostname) && (parsed.protocol === 'http:' || parsed.protocol === 'https:')) {
+        parsed.protocol = 'ws:'
+      } else if (!isLocalHost(parsed.hostname)) {
         parsed.protocol = normalizeProtocol(parsed.protocol)
       }
-      // else: preserve the protocol the user explicitly set (ws:// or wss://)
       // Keep explicit proxy paths (e.g. /gw), but collapse known dashboard/session routes to root.
       parsed.pathname = normalizeGatewayPath(parsed.pathname)
       preserveTokenQuery(parsed)


### PR DESCRIPTION
## Summary
- remove stale placeholder labels from implemented task detail/create modals
- add visible submit error states for create/edit task modal failures instead of only logging to console
- disable submit/cancel buttons while create/edit requests are in flight
- include the local gateway URL normalization fix needed for current main test pass until #624 lands

## Verification
- pnpm typecheck
- pnpm lint (passes with existing warnings)
- GIT_AUTHOR_NAME=Bob GIT_AUTHOR_EMAIL=bob@openclaw.local GIT_COMMITTER_NAME=Bob GIT_COMMITTER_EMAIL=bob@openclaw.local pnpm test (931 passed)
- pnpm build