### PR TITLE
Add Cobran-OS functional smoke test runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ For the full walkthrough, see the **[Quickstart Guide](docs/quickstart.md)**.
 | [CLI Reference](docs/cli-agent-control.md) | Full CLI command list for headless/scripted usage |
 | [CLI Integration](docs/cli-integration.md) | Connect Claude Code, Codex, or any CLI tool directly |
 | [Deployment](docs/deployment.md) | Production deployment, reverse proxy, VPS setup |
+| [Cobran-OS Functional Smoke Test](docs/cobran-os-functional-smoke-test.md) | Local functional checklist for setup, gateway, agents, tasks, and quality gates |
 | [Security Hardening](docs/SECURITY-HARDENING.md) | Docker hardening, CSP, network isolation |
 | [Release Process](RELEASE.md) | SemVer policy, branch strategy, tag/release checklist |
 | [API Reference](openapi.json) | OpenAPI 3.1 spec — 101 REST endpoints with Scalar UI at `/api-docs` |

--- a/docs/cobran-os-functional-smoke-test.md
+++ b/docs/cobran-os-functional-smoke-test.md
@@ -1,0 +1,151 @@
+# Cobran-OS functional smoke test
+
+Use this checklist to decide whether a local Cobran-OS / Mission Control build is functional enough for Tiago to use and report product bugs.
+
+## Functional definition for v1
+
+Cobran-OS v1 is functional when the operator can:
+
+1. install dependencies and start the app locally;
+2. create or log into an admin account;
+3. open the main dashboard without runtime errors;
+4. confirm gateway configuration status;
+5. see agents/sessions/tasks from the configured OpenClaw environment when the gateway is running;
+6. create, edit, comment on, and move a task through the board;
+7. run the quality gate: lint, typecheck, tests, and production build.
+
+The following are **not required** for v1 functional status:
+
+- polished visual design;
+- public deployment;
+- signed installers;
+- multi-tenant production hardening;
+- every integration panel being fully configured;
+- gateway-connected live data when the OpenClaw gateway is intentionally offline.
+
+## Prerequisites
+
+- Node.js `>=22`.
+- `pnpm`.
+- Native build tooling for `better-sqlite3` and `node-pty`.
+- Optional for gateway smoke: local OpenClaw gateway running and reachable.
+
+## Local start
+
+```bash
+git clone https://github.com/builderz-labs/mission-control.git cobran-os
+cd cobran-os
+pnpm install
+cp .env.example .env.local
+PORT=3020 pnpm dev
+```
+
+Open:
+
+```text
+http://127.0.0.1:3020/setup
+```
+
+Expected first-run behaviour:
+
+- `/setup` renders an admin setup page if no admin user exists.
+- `/` redirects unauthenticated users to `/login`.
+- protected APIs return `401` until authenticated.
+
+Quick unauthenticated HTTP smoke:
+
+```bash
+curl -s -o /tmp/cobran-root.html -w '%{http_code}\n' http://127.0.0.1:3020/
+curl -s -o /tmp/cobran-setup.html -w '%{http_code} %{content_type}\n' http://127.0.0.1:3020/setup
+curl -s -o /tmp/cobran-status.json -w '%{http_code} %{content_type}\n' http://127.0.0.1:3020/api/status
+```
+
+Expected:
+
+- root: `307` redirect to `/login`;
+- setup: `200 text/html`;
+- status API: `401 application/json` before login.
+
+## Manual browser smoke
+
+After creating/logging into the admin account:
+
+### Shell/dashboard
+
+- [ ] Main dashboard loads with no red error screen.
+- [ ] Left navigation/panels render.
+- [ ] Browser console has no repeating runtime error loop.
+- [ ] Refreshing the current route keeps the user on a valid panel.
+
+### Gateway
+
+- [ ] Gateway config panel loads.
+- [ ] If gateway is offline, the UI shows a clear disconnected/offline state.
+- [ ] If gateway is online, connection status becomes connected/healthy.
+- [ ] Browser-side gateway URL matches the local access mode:
+  - local direct: `ws://127.0.0.1:18789`;
+  - HTTPS reverse proxy: `wss://...` through the proxy path/host.
+
+### Agents and sessions
+
+- [ ] Agents panel renders.
+- [ ] Existing configured agents are listed when gateway data exists.
+- [ ] Opening an agent detail view does not crash.
+- [ ] Sessions/transcripts render for at least one agent/session when available.
+
+### Tasks
+
+- [ ] Task board renders all core columns.
+- [ ] Create Task modal opens.
+- [ ] Creating a minimal task succeeds, or shows a visible error message if the API rejects it.
+- [ ] Task Detail modal opens from the created task/card.
+- [ ] Comment submission works, or shows a visible error message.
+- [ ] Edit Task modal opens.
+- [ ] Editing title/status/priority succeeds, or shows a visible error message.
+- [ ] Dragging/moving status updates the task or shows a clear failure.
+
+### Quality review / dispatch basics
+
+- [ ] Quality Review tab renders in task detail.
+- [ ] Approve/reject review action succeeds or shows a visible error.
+- [ ] Dispatch controls are either usable with configured agents or clearly disabled/explained.
+
+## Automated quality gate
+
+Run before merging a Cobran-OS functional change:
+
+```bash
+pnpm typecheck
+pnpm lint
+GIT_AUTHOR_NAME=Bob GIT_AUTHOR_EMAIL=bob@openclaw.local \
+GIT_COMMITTER_NAME=Bob GIT_COMMITTER_EMAIL=bob@openclaw.local \
+pnpm test
+pnpm build
+```
+
+Notes:
+
+- The `GIT_*` environment variables keep GNAP sync tests deterministic in environments without global git identity.
+- Current lint may pass with existing React hook dependency warnings; treat new warnings as regressions.
+
+## Known functional risks to check before calling it done
+
+- Auth/setup can block manual dashboard smoke if the local `.data` state already contains users with unknown credentials.
+- Gateway-connected panels depend on a running OpenClaw gateway and correct `OPENCLAW_GATEWAY_*` / `NEXT_PUBLIC_GATEWAY_*` values.
+- `NEXT_PUBLIC_*` changes require a rebuild for production mode.
+- Native dependencies may need rebuild after Node version changes: `pnpm rebuild better-sqlite3 node-pty`.
+
+## Reporting result
+
+When reporting a smoke run, include:
+
+```text
+Repo/branch/commit:
+Environment: OS, Node, pnpm
+Start command:
+Gateway state: offline / connected / not tested
+Automated gate: typecheck, lint, test, build
+Manual smoke: pass/fail list
+Blockers:
+Next action:
+```

--- a/src/lib/gateway-url.ts
+++ b/src/lib/gateway-url.ts
@@ -97,12 +97,15 @@ export function buildGatewayWebSocketUrl(input: {
   if (prefixed) {
     try {
       const parsed = new URL(prefixed)
-      // Local hosts use plain ws:// unless the URL was explicitly set to wss://
-      // (e.g. wss://127.0.0.1 via reverse proxy that terminates TLS).
-      if (!isLocalHost(parsed.hostname)) {
+      // Local hosts use plain ws:// for http(s) URLs unless the user explicitly
+      // supplied a websocket protocol. This avoids producing invalid
+      // https:// URLs for the WebSocket constructor while preserving explicit
+      // wss:// reverse-proxy configurations.
+      if (isLocalHost(parsed.hostname) && (parsed.protocol === 'http:' || parsed.protocol === 'https:')) {
+        parsed.protocol = 'ws:'
+      } else if (!isLocalHost(parsed.hostname)) {
         parsed.protocol = normalizeProtocol(parsed.protocol)
       }
-      // else: preserve the protocol the user explicitly set (ws:// or wss://)
       // Keep explicit proxy paths (e.g. /gw), but collapse known dashboard/session routes to root.
       parsed.pathname = normalizeGatewayPath(parsed.pathname)
       preserveTokenQuery(parsed)


### PR DESCRIPTION
## Summary
- add a Cobran-OS functional smoke test runbook covering v1 functional definition, local start, manual browser smoke, gateway, agents, tasks, and quality gates
- link the runbook from README documentation table
- include the local gateway URL normalization fix needed for current main test pass until #624 lands

## Verification
- pnpm typecheck
- pnpm lint (passes with existing warnings)
- GIT_AUTHOR_NAME=Bob GIT_AUTHOR_EMAIL=bob@openclaw.local GIT_COMMITTER_NAME=Bob GIT_COMMITTER_EMAIL=bob@openclaw.local pnpm test (931 passed)
- pnpm build