### PR TITLE
fix(gateway-url): downgrade http(s)://localhost inputs to ws:// for the gateway WebSocket

### DIFF
--- a/src/lib/__tests__/gateway-url.test.ts
+++ b/src/lib/__tests__/gateway-url.test.ts
@@ -42,6 +42,22 @@ describe('buildGatewayWebSocketUrl', () => {
     })).toBe('ws://127.0.0.1:18789')
   })
 
+  it('downgrades http://localhost to ws://', () => {
+    expect(buildGatewayWebSocketUrl({
+      host: 'http://localhost:18789',
+      port: 18789,
+      browserProtocol: 'http:',
+    })).toBe('ws://localhost:18789')
+  })
+
+  it('preserves explicit wss:// on localhost (reverse-proxy TLS opt-in)', () => {
+    expect(buildGatewayWebSocketUrl({
+      host: 'wss://127.0.0.1:18789',
+      port: 18789,
+      browserProtocol: 'https:',
+    })).toBe('wss://127.0.0.1:18789')
+  })
+
   it('omits 18789 for remote hosts on https browser context', () => {
     expect(buildGatewayWebSocketUrl({
       host: 'node-01.tailnet123.ts.net',

--- a/src/lib/gateway-url.ts
+++ b/src/lib/gateway-url.ts
@@ -97,12 +97,16 @@ export function buildGatewayWebSocketUrl(input: {
   if (prefixed) {
     try {
       const parsed = new URL(prefixed)
-      // Local hosts use plain ws:// unless the URL was explicitly set to wss://
-      // (e.g. wss://127.0.0.1 via reverse proxy that terminates TLS).
-      if (!isLocalHost(parsed.hostname)) {
+      // Local hosts use plain ws:// unless the URL was explicitly wss://
+      // (i.e. a reverse proxy is terminating TLS in front of the gateway).
+      // http://, https://, and ws:// all collapse to ws:// for localhost since
+      // the gateway itself does not speak TLS. Only wss:// is preserved as the
+      // operator's explicit opt-in.
+      if (isLocalHost(parsed.hostname)) {
+        parsed.protocol = parsed.protocol === 'wss:' ? 'wss:' : 'ws:'
+      } else {
         parsed.protocol = normalizeProtocol(parsed.protocol)
       }
-      // else: preserve the protocol the user explicitly set (ws:// or wss://)
       // Keep explicit proxy paths (e.g. /gw), but collapse known dashboard/session routes to root.
       parsed.pathname = normalizeGatewayPath(parsed.pathname)
       preserveTokenQuery(parsed)


### PR DESCRIPTION
## Problem

`buildGatewayWebSocketUrl` preserved any user-set protocol on localhost inputs — including `http://` and `https://`, which are not valid WebSocket schemes. Passing `host='https://127.0.0.1:18789'` returned `https://127.0.0.1:18789` verbatim instead of the expected `ws://127.0.0.1:18789`.

## Why now

Additive tightening on top of @0xnykcd's a020d1b — that change already routes the `NEXT_PUBLIC_GATEWAY_REVERSE_PROXY=1` path to `wss://` when the browser is on HTTPS, and that behavior is preserved here. The only new constraint is: for localhost, `http://` and `https://` (and bare `ws://`) collapse to `ws://`; `wss://` stays `wss://` as the operator's explicit TLS-terminator opt-in.

## Changes

- `src/lib/gateway-url.ts`: tighten the prefixed-URL localhost branch (line 97-118) — collapse non-`wss` protocols to `ws:`, leave `wss:` untouched. Bare-host path (line 124-125) and no-host path (line 85) continue to honor `NEXT_PUBLIC_GATEWAY_REVERSE_PROXY`.
- `src/lib/__tests__/gateway-url.test.ts`: 2 new cases pin the `http://localhost → ws://` and `wss://127.0.0.1 (preserved)` invariants.

Diff: +24 / −4 across 2 files.

## Tests

- New: \`downgrades http://localhost to ws://\` (http://localhost:18789 → ws://localhost:18789)
- New: \`preserves explicit wss:// on localhost (reverse-proxy TLS opt-in)\` (wss://127.0.0.1:18789 unchanged)
- Pre-existing: \`downgrades https://127.0.0.1 to ws:// when no reverse proxy is configured\` continues to assert the https://localhost path.

## Validation

- \`npx vitest run src/lib/__tests__/gateway-url.test.ts\` → 17/17 ✅
- \`npx vitest run\` → 82 files / 933 tests ✅
- \`npx tsc --noEmit\` → clean ✅

## Related

Aware of #623 (broader gateway WebSocket autodetect refactor). This PR is intentionally narrower — a one-function tightening — and is additive on top of a020d1b. If #623 lands first I'm happy to rebase or close.