### PR TITLE
fix: send user id in DELETE request body

### DIFF
--- a/src/components/panels/user-management-panel.tsx
+++ b/src/components/panels/user-management-panel.tsx
@@ -164,7 +164,11 @@ export function UserManagementPanel() {
   const handleDelete = async (u: UserRecord) => {
     if (u.id === currentUser?.id) return
     try {
-      const res = await fetch(`/api/auth/users?id=${u.id}`, { method: 'DELETE' })
+      const res = await fetch('/api/auth/users', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: u.id }),
+      })
       const data = await res.json().catch(() => ({}))
       if (res.ok) {
         showFeedback(true, t('deletedUser', { username: u.username }))


### PR DESCRIPTION
## Fixes #614

Delete user from UI fails with 'Request body required'

**Root cause**: `handleDelete` sent user ID as query param (`?id=xxx`) but the backend API route requires it in the request body.

**Change**: Move `id` from query parameter to JSON body.