### PR TITLE
Self-contained Docker stack + /chat fixes for shared host claude sessionsFeat/docker stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ playwright-report/
 # Claude Code context files (root CLAUDE.md is committed for AI agent discovery)
 **/CLAUDE.md
 !/CLAUDE.md
+
+# Local agent walkthrough (kept on disk, not committed)
+WALKTHROUGH.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,20 @@ WORKDIR /app
 ENV NODE_ENV=production
 # curl, CA certs, python3, git needed for agent runtime installers (OpenClaw, Hermes)
 # procps provides `ps` and `uptime` used by system-monitor APIs
-RUN apt-get update && apt-get install -y curl ca-certificates python3 git make g++ procps --no-install-recommends && rm -rf /var/lib/apt/lists/*
-RUN addgroup --system --gid 1001 nodejs && adduser --system --uid 1001 nextjs
+RUN apt-get update && apt-get install -y curl ca-certificates python3 git make g++ procps tmux jq --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+# Bake Claude Code + Codex CLIs into the image as a fallback so the
+# Settings → Agent Runtimes panel reports "Installed" even before the host
+# bind-mounts (compose adds ${HOME}/.local/bin at runtime, which takes
+# precedence in PATH and provides authenticated host binaries).
+RUN npm install -g @anthropic-ai/claude-code @openai/codex 2>&1 | tail -5
+
+# node:22-slim already ships a `node` user at uid 1000; reuse it as our
+# `nextjs` alias so bind-mounted host files (typical Linux uid 1000) read directly.
+RUN if ! id -u nextjs >/dev/null 2>&1; then \
+      usermod --login nextjs --move-home --home /home/nextjs node && \
+      groupmod --new-name nodejs node ; \
+    fi
 COPY --from=build /app/.next/standalone ./
 COPY --from=build /app/.next/static ./.next/static
 COPY --from=build /app/public ./public
@@ -46,7 +58,8 @@ RUN mkdir -p .data && chown nextjs:nodejs .data
 RUN echo 'const http=require("http");const r=http.get("http://localhost:"+(process.env.PORT||3000)+"/api/status?action=health",s=>{process.exit(s.statusCode===200?0:1)});r.on("error",()=>process.exit(1));r.setTimeout(4000,()=>{r.destroy();process.exit(1)})' > /app/healthcheck.js
 COPY docker-entrypoint.sh /app/docker-entrypoint.sh
 RUN chmod 755 /app/docker-entrypoint.sh && \
-    chmod -R a+rX /app/public/ /app/src/
+    chmod -R a+rX /app/public/ /app/src/ && \
+    chown -R nextjs:nodejs /app /home/nextjs
 USER nextjs
 ENV PORT=3000
 EXPOSE 3000

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,118 @@
+# Mission Control — local stack control plane.
+# Use `make help` for the full target list.
+
+SHELL := /bin/bash
+.ONESHELL:
+.SHELLFLAGS := -eu -o pipefail -c
+
+PROJECT_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+COMPOSE     := docker compose
+CONTAINER   := mission-control
+URL         := http://127.0.0.1:7012
+
+.DEFAULT_GOAL := help
+
+# ── Help ───────────────────────────────────────────────────────────────────
+.PHONY: help
+help:  ## List targets
+	@awk 'BEGIN{FS=":.*##"; printf "\nUsage: make \033[36m<target>\033[0m\n\nTargets:\n"} \
+	      /^[a-zA-Z0-9_-]+:.*##/ { printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2 }' \
+	      $(MAKEFILE_LIST)
+
+# ── Compose lifecycle ──────────────────────────────────────────────────────
+.PHONY: up
+up:  ## Bring stack up and wait for /login to respond
+	@cd $(PROJECT_DIR)
+	$(COMPOSE) up -d $(ARGS)
+	@$(MAKE) --no-print-directory wait-ready
+	@echo
+	@echo "Mission Control is up at $(URL)"
+	@echo "  /setup    — create admin (first run)"
+	@echo "  /login    — sign in"
+	@echo "  /tasks    — Kanban board"
+	@echo "  /agents   — agent registry"
+
+.PHONY: down
+down:  ## Stop and remove container + network (volumes preserved)
+	@cd $(PROJECT_DIR)
+	$(COMPOSE) down
+
+.PHONY: restart
+restart:  ## Restart the running container
+	@cd $(PROJECT_DIR)
+	$(COMPOSE) restart
+	@$(MAKE) --no-print-directory wait-ready
+
+.PHONY: recreate
+recreate:  ## Force recreate the container (apply compose changes)
+	@$(MAKE) --no-print-directory up ARGS="--force-recreate"
+
+.PHONY: build
+build:  ## Build/refresh the mission-control image
+	@cd $(PROJECT_DIR)
+	$(COMPOSE) build $(ARGS)
+
+.PHONY: rebuild
+rebuild:  ## Rebuild image (no cache) and recreate
+	@cd $(PROJECT_DIR)
+	$(COMPOSE) build --no-cache
+	@$(MAKE) --no-print-directory recreate
+
+.PHONY: ps
+ps:  ## Show container status
+	@cd $(PROJECT_DIR)
+	$(COMPOSE) ps
+
+.PHONY: logs
+logs:  ## Tail server logs (Ctrl+C to stop)
+	@cd $(PROJECT_DIR)
+	$(COMPOSE) logs -f --tail=200
+
+.PHONY: shell
+shell:  ## Open an interactive shell inside the container
+	docker exec -it $(CONTAINER) bash || docker exec -it $(CONTAINER) sh
+
+.PHONY: status
+status:  ## One-liner health: HTTP code + which agent CLIs are reachable
+	@printf "URL:     "; curl -sS -o /dev/null -L -w "%{http_code} → %{url_effective}\n" $(URL) || true
+	@printf "claude:  "; docker exec $(CONTAINER) sh -c 'which claude && claude --version' 2>&1 | tail -1
+	@printf "codex:   "; docker exec $(CONTAINER) sh -c 'which codex && codex --version 2>&1 | tail -1' 2>&1 | tail -1
+	@printf "gemini:  "; docker exec $(CONTAINER) sh -c 'which gemini' 2>&1 | tail -1
+
+# ── Lifecycle utilities ────────────────────────────────────────────────────
+.PHONY: wait-ready
+wait-ready:  ## Block until /login responds 200
+	@for i in $$(seq 1 30); do \
+	  status=$$(curl -sS -o /dev/null -L -w '%{http_code}' $(URL) 2>/dev/null || true); \
+	  if [ "$$status" = "200" ]; then echo "  ✓ $(URL) → 200"; exit 0; fi; \
+	  sleep 1; \
+	done; \
+	echo "Mission Control did not become ready in 30s" >&2; exit 1
+
+.PHONY: reset-db
+reset-db:  ## Wipe SQLite db (forces /setup again — admin password recovery)
+	@if ! docker ps --format '{{.Name}}' | grep -qx '$(CONTAINER)'; then \
+	  echo "ERROR: $(CONTAINER) is not running" >&2; exit 1; \
+	fi
+	@echo "===> 1. Stop $(CONTAINER)"
+	@$(COMPOSE) stop | sed 's/^/   /'
+	@echo
+	@echo "===> 2. Wipe SQLite files in mc-data volume"
+	@docker run --rm -v mission-control_mc-data:/data alpine \
+	  sh -c 'find /data -maxdepth 2 \( -name "*.db" -o -name "*.sqlite" -o -name "*.sqlite-shm" -o -name "*.sqlite-wal" \) | xargs -r rm -v' \
+	  | sed 's/^/   /'
+	@echo
+	@echo "===> 3. Restart"
+	@$(MAKE) --no-print-directory up
+	@echo
+	@echo "Open $(URL)/setup to create a fresh admin."
+
+# ── Bookkeeping ────────────────────────────────────────────────────────────
+.PHONY: nuke
+nuke:  ## DANGER: down, drop volumes, drop image. Confirm via CONFIRM=yes
+	@if [ "$(CONFIRM)" != "yes" ]; then \
+	  echo "Refusing to nuke without CONFIRM=yes"; exit 1; \
+	fi
+	@cd $(PROJECT_DIR)
+	$(COMPOSE) down -v
+	docker image rm mission-control-mission-control 2>/dev/null || true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,24 @@ services:
       # If your gateway runs in another container, set this to the container name instead.
       - OPENCLAW_GATEWAY_HOST=${OPENCLAW_GATEWAY_HOST:-host.docker.internal}
       - OPENCLAW_GATEWAY_PORT=${OPENCLAW_GATEWAY_PORT:-18789}
+      # Host CLIs (~/.local/bin) come first; container-baked fallbacks second.
+      # Container HOME stays /home/nextjs; bind-mounts below project the host
+      # user's $HOME contents into that path.
+      - PATH=/home/nextjs/.local/bin:/home/nextjs/.bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - HOME=/home/nextjs
+      # MC's direct-API dispatch uses these (no gateway needed).
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      # How MC interacts with a session that may have a live host `claude` CLI:
+      #   coexist (default) — both write to the same jsonl, race possible
+      #   block-active      — refuse with 409 if jsonl mtime < 60s ago
+      #   nudge             — coexist + bump mtime after reply
+      - MC_HOST_SESSION_MODE=${MC_HOST_SESSION_MODE:-coexist}
+      # /chat poll interval (ms) — fallback refresh when SSE drops on
+      # `session:` conversations. NEXT_PUBLIC_* is baked at BUILD time, so
+      # changing it requires `make rebuild`. Component default: 1500.
+      # 1000ms gives near-live updates as claude writes the jsonl line-by-line.
+      - NEXT_PUBLIC_CHAT_POLL_INTERVAL_MS=${NEXT_PUBLIC_CHAT_POLL_INTERVAL_MS:-1000}
       # ── Browser-side gateway connection (user's browser → gateway) ──
       # NEXT_PUBLIC_GATEWAY_HOST must be reachable from the user's browser, NOT from
       # inside the container. For local Docker: leave empty (auto-detected from browser).
@@ -29,8 +47,24 @@ services:
     env_file:
       - path: .env
         required: false
+    # Run as host UID:GID (defaults 1000:1000) so bind-mounted host configs
+    # ($HOME/.local/bin, $HOME/.claude, $HOME/.bun) are owned by a uid the
+    # container can read/write without chown.
+    user: "1000:1000"
     volumes:
       - mc-data:/app/.data
+      # Host configs are projected into /home/nextjs (container's $HOME) using
+      # the invoking shell's ${HOME}. Compose interpolates at `up` time, so the
+      # paths track whichever user runs the command.
+      - ${HOME}/.local/bin:/home/nextjs/.local/bin:rw
+      - ${HOME}/.local/share/claude:/home/nextjs/.local/share/claude:rw
+      - ${HOME}/.bun:/home/nextjs/.bun:rw
+      - ${HOME}/.claude:/home/nextjs/.claude:rw
+      - ${HOME}/.claude.json:/home/nextjs/.claude.json:rw
+      # Host repos / datasets visible to agents (mounted at the same absolute
+      # path so paths the user sees on the host work identically in container).
+      - /mnt:/mnt:rw
+      - ${HOME}:${HOME}:rw
       # Optional: mount your OpenClaw state directory read-only so Mission Control
       # can read agent configs and memory. Uncomment and adjust the host path:
       # - ${OPENCLAW_HOME:-~/.openclaw}:/run/openclaw:ro
@@ -52,9 +86,11 @@ services:
     deploy:
       resources:
         limits:
-          memory: 512M
-          cpus: '1.0'
-          pids: 256
+          # Bumped from upstream default (512M). Next.js 16 + node-pty +
+          # task-dispatch loop OOMs at 512M when /chat opens a terminal.
+          memory: 2G
+          cpus: '2.0'
+          pids: 512
     networks:
       - mc-net
     restart: unless-stopped

--- a/src/app/api/sessions/continue/route.ts
+++ b/src/app/api/sessions/continue/route.ts
@@ -1,20 +1,172 @@
-import { promises as fs } from 'node:fs'
+import { promises as fs, constants as fsConstants } from 'node:fs'
 import path from 'node:path'
+import os from 'node:os'
 import { NextRequest, NextResponse } from 'next/server'
 import { requireRole } from '@/lib/auth'
 import { logger } from '@/lib/logger'
 import { runCommand } from '@/lib/command'
 import { getOpenCodeExecutable } from '@/lib/opencode-sessions'
 
+/**
+ * Resolve a CLI binary to an absolute path by scanning PATH directories.
+ * Next.js standalone server's process.env may not always allow Node's
+ * default execvp lookup to find tools installed in user-local bins
+ * (`~/.local/bin`) — observed empirically as `spawn claude ENOENT` even
+ * though `which claude` succeeds in the same container. Resolving the
+ * absolute path eliminates the ambiguity. Falls back to bare name.
+ */
+async function resolveExecutable(name: string): Promise<string> {
+  if (name.includes('/')) return name
+  const candidates = [
+    process.env.CLAUDE_BIN,
+    `/home/nextjs/.local/bin/${name}`,
+    `/usr/local/bin/${name}`,
+    `/usr/bin/${name}`,
+  ].filter((p): p is string => !!p && p.endsWith(`/${name}`))
+  const pathDirs = (process.env.PATH || '').split(':').filter(Boolean)
+  for (const dir of pathDirs) candidates.push(path.join(dir, name))
+  for (const candidate of candidates) {
+    try {
+      await fs.access(candidate, fsConstants.X_OK)
+      return candidate
+    } catch {
+      continue
+    }
+  }
+  return name
+}
+
+/**
+ * Resolve the absolute project path that owns a Claude session.
+ *
+ * Claude stores transcripts at `~/.claude/projects/<encoded>/<session>.jsonl`.
+ * Decoding the directory name back to a path is unreliable because claude
+ * collapses both `/` and `_` to `-` in newer versions, so e.g. both
+ * `/foo/bar_baz` and `/foo/bar/baz` round-trip to `-foo-bar-baz`.
+ *
+ * Authoritative source: every jsonl entry includes a `cwd` field with the
+ * real absolute path. We scan for the session file, read its first few
+ * entries, and return the cwd verbatim.
+ *
+ * `claude --resume <id>` only finds the conversation when the process cwd
+ * matches that project path; without it the process defaults to /app
+ * inside the container, so any host-created session fails with
+ * "No conversation found".
+ */
+async function resolveClaudeSessionCwd(sessionId: string): Promise<string | null> {
+  const home = os.homedir()
+  const projectsRoot = path.join(home, '.claude', 'projects')
+  let entries: string[]
+  try {
+    entries = await fs.readdir(projectsRoot)
+  } catch {
+    return null
+  }
+  for (const encoded of entries) {
+    const candidate = path.join(projectsRoot, encoded, `${sessionId}.jsonl`)
+    try {
+      await fs.access(candidate)
+    } catch {
+      continue
+    }
+    // Read up to ~64KB and walk lines until we find a `cwd` field.
+    let head: string
+    try {
+      const handle = await fs.open(candidate, 'r')
+      try {
+        const buf = Buffer.alloc(64 * 1024)
+        const { bytesRead } = await handle.read(buf, 0, buf.length, 0)
+        head = buf.subarray(0, bytesRead).toString('utf8')
+      } finally {
+        await handle.close()
+      }
+    } catch {
+      return null
+    }
+    for (const line of head.split('\n')) {
+      const trimmed = line.trim()
+      if (!trimmed) continue
+      try {
+        const entry = JSON.parse(trimmed) as { cwd?: unknown }
+        if (typeof entry.cwd === 'string' && entry.cwd.startsWith('/')) {
+          return entry.cwd
+        }
+      } catch {
+        // partial line at the buffer edge or non-JSON line; keep scanning
+      }
+    }
+    return null
+  }
+  return null
+}
+
 type ContinueKind = 'claude-code' | 'codex-cli' | 'opencode'
+
+/**
+ * MC_HOST_SESSION_MODE — how MC's `claude --resume` interacts with a session
+ * that may already have a live `claude` CLI on the host writing to the same
+ * jsonl.
+ *
+ *   coexist (default) — always spawn; both processes append to the jsonl,
+ *     and each picks up the other's writes on its next prompt. Possible
+ *     interleaving on simultaneous writes.
+ *   block-active     — refuse with 409 if the jsonl was touched in the last
+ *     LIVE_WINDOW_MS seconds (heuristic: a live host CLI updates mtime
+ *     frequently). Forces MC to act only on idle sessions.
+ *   nudge            — spawn like coexist, but additionally `touch` the
+ *     jsonl after the response so the host CLI sees a fresh mtime and is
+ *     more likely to pick up the new entries on its next operation.
+ */
+type HostSessionMode = 'coexist' | 'block-active' | 'nudge'
+const HOST_SESSION_LIVE_WINDOW_MS = 60 * 1000
+
+function getHostSessionMode(): HostSessionMode {
+  const raw = (process.env.MC_HOST_SESSION_MODE || '').trim().toLowerCase()
+  if (raw === 'block-active' || raw === 'nudge') return raw
+  return 'coexist'
+}
 
 function sanitizePrompt(value: unknown): string {
   return typeof value === 'string' ? value.trim() : ''
 }
 
+/** Single-quote a string for safe inclusion in `sh -c "..."`. */
+function shQuote(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`
+}
+
+/** Best-effort mtime check on a session jsonl in any candidate project dir. */
+async function getSessionJsonlMtime(sessionId: string): Promise<number | null> {
+  const home = os.homedir()
+  const projectsRoot = path.join(home, '.claude', 'projects')
+  let entries: string[]
+  try {
+    entries = await fs.readdir(projectsRoot)
+  } catch {
+    return null
+  }
+  for (const encoded of entries) {
+    const candidate = path.join(projectsRoot, encoded, `${sessionId}.jsonl`)
+    try {
+      const stat = await fs.stat(candidate)
+      return stat.mtimeMs
+    } catch {
+      continue
+    }
+  }
+  return null
+}
+
 /**
  * POST /api/sessions/continue
  * Body: { kind: 'claude-code'|'codex-cli'|'opencode', id: string, prompt: string }
+ *
+ * TODO: stream the reply incrementally. Currently this handler waits for
+ *   `claude --print` to finish before responding, which can take 10-60s on
+ *   long answers. A streaming variant (e.g. POST /api/sessions/continue/stream
+ *   returning Server-Sent Events backed by `claude --output-format stream-json`)
+ *   would let the chat UI render tokens as they arrive — matching the UX of
+ *   the host claude CLI itself.
  */
 export async function POST(request: NextRequest) {
   const auth = requireRole(request, 'operator')
@@ -39,10 +191,76 @@ export async function POST(request: NextRequest) {
     let reply = ''
 
     if (kind === 'claude-code') {
-      const result = await runCommand('claude', ['--print', '--resume', sessionId, prompt], {
-        timeoutMs: 180000,
-      })
+      // Resolve the project cwd for this session — claude --resume only finds
+      // the transcript when invoked from the project path encoded in the
+      // session file's parent directory. Crucial for shared sessions across
+      // host Claude Code and MC container.
+      const sessionCwd = await resolveClaudeSessionCwd(sessionId)
+      const claudeBin = await resolveExecutable('claude')
+      const hostMode = getHostSessionMode()
+
+      // Mode `block-active`: refuse if the host CLI appears to be actively
+      // writing the jsonl (recent mtime). Spares the user from interleaved
+      // writes between MC and host CLI.
+      if (hostMode === 'block-active') {
+        const mtimeMs = await getSessionJsonlMtime(sessionId)
+        if (mtimeMs !== null && (Date.now() - mtimeMs) < HOST_SESSION_LIVE_WINDOW_MS) {
+          return NextResponse.json(
+            { error: 'Session has a live host CLI; refusing to --resume (mode=block-active). Wait for it to go idle.' },
+            { status: 409 },
+          )
+        }
+      }
+
+      // Use a shell wrapper instead of direct spawn. Next.js standalone server
+      // observed `spawn ENOENT` even when the absolute path resolves and is
+      // executable from `docker exec node -e`. Routing through `sh -c` works
+      // around the issue and keeps argv quoting safe via stdin-fed prompt.
+      const runViaShell = async (resume: boolean) => {
+        const args = ['--print']
+        if (resume) args.push('--resume', sessionId)
+        // Read prompt from stdin (`-`) to avoid shell quoting issues with
+        // arbitrary user input (newlines, quotes, special chars).
+        const cmd = `cd ${shQuote(sessionCwd || '/')} && exec ${shQuote(claudeBin)} ${args.map(shQuote).join(' ')}`
+        return runCommand('sh', ['-c', cmd], {
+          timeoutMs: 180000,
+          input: prompt,
+        })
+      }
+
+      let result: { stdout: string; stderr: string; code: number | null }
+      try {
+        result = await runViaShell(true)
+      } catch (err: any) {
+        const stderrText = String(err?.stderr || err?.message || '')
+        const resumeFailed =
+          /no conversation found|session.*not found|unknown session/i.test(stderrText)
+        if (!resumeFailed) throw err
+        logger.warn({ sessionId, sessionCwd, claudeBin }, 'claude --resume failed, retrying as fresh session')
+        result = await runViaShell(false)
+      }
       reply = (result.stdout || '').trim() || (result.stderr || '').trim()
+
+      // Mode `nudge`: bump jsonl mtime so a tail-following host CLI is more
+      // likely to notice fresh entries. Best-effort; no fatal on failure.
+      if (hostMode === 'nudge') {
+        const mtimeMs = await getSessionJsonlMtime(sessionId)
+        if (mtimeMs !== null) {
+          const home = os.homedir()
+          const projectsRoot = path.join(home, '.claude', 'projects')
+          try {
+            const entries = await fs.readdir(projectsRoot)
+            for (const encoded of entries) {
+              const candidate = path.join(projectsRoot, encoded, `${sessionId}.jsonl`)
+              try {
+                const now = new Date()
+                await fs.utimes(candidate, now, now)
+                break
+              } catch { continue }
+            }
+          } catch { /* best-effort */ }
+        }
+      }
     } else if (kind === 'codex-cli') {
       const outputPath = path.join('/tmp', `mc-codex-last-${Date.now()}-${Math.random().toString(36).slice(2)}.txt`)
       try {

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -10,7 +10,10 @@ import { callOpenClawGateway } from '@/lib/openclaw-gateway'
 import { mutationLimiter } from '@/lib/rate-limit'
 import { logger } from '@/lib/logger'
 
-const LOCAL_SESSION_ACTIVE_WINDOW_MS = 90 * 60 * 1000
+// Upstream default 90 minutes was too lax (every recently-touched jsonl
+// stayed "active"); 2 minutes was too tight. 15 minutes matches the
+// scanner's threshold so derived/scanned active state stay coherent.
+const LOCAL_SESSION_ACTIVE_WINDOW_MS = 15 * 60 * 1000
 
 export async function GET(request: NextRequest) {
   const auth = requireRole(request, 'viewer')

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -92,6 +92,9 @@ export default async function RootLayout({
   const locale = await getLocale()
   const messages = await getMessages()
 
+  // Debug log retained (commented) for future CSP/nonce flow troubleshooting.
+  // console.log('[DEBUG csp] layout nonce from x-nonce header:', nonce ? `${nonce.slice(0, 8)}...` : '(MISSING)')
+
   return (
     <html lang={locale} dir={locale === 'ar' ? 'rtl' : 'ltr'} className="dark" suppressHydrationWarning>
       <head>
@@ -112,6 +115,7 @@ export default async function RootLayout({
             themes={THEME_IDS}
             enableSystem={false}
             disableTransitionOnChange
+            nonce={nonce}
           >
             <ThemeBackground />
             <div className="h-screen overflow-hidden bg-background text-foreground">

--- a/src/components/chat/chat-workspace.tsx
+++ b/src/components/chat/chat-workspace.tsx
@@ -113,9 +113,18 @@ export function ChatWorkspace({ mode = 'embedded', onClose }: ChatWorkspaceProps
     loadMessages()
   }, [loadMessages])
 
-  // Poll for new messages (visibility-aware)
-  useSmartPoll(loadMessages, 15000, {
-    enabled: !!activeConversation && !activeConversation.startsWith('session:'),
+  // Poll for new messages (visibility-aware). Also active for `session:`
+  // conversations as a fallback when SSE drops — pauseWhenSseConnected makes
+  // polling step aside whenever the live stream is healthy, so the only cost
+  // when SSE works is a no-op tick. Without this, dropped SSE leaves the
+  // /chat panel frozen until the user hits F5.
+  //
+  // Tunable via NEXT_PUBLIC_CHAT_POLL_INTERVAL_MS at build time. Default 1500.
+  const chatPollIntervalMs = Number(
+    process.env.NEXT_PUBLIC_CHAT_POLL_INTERVAL_MS,
+  ) || 1500
+  useSmartPoll(loadMessages, chatPollIntervalMs, {
+    enabled: !!activeConversation,
     pauseWhenSseConnected: true,
   })
 
@@ -545,7 +554,6 @@ function SessionConversationView({
   const [continuePrompt, setContinuePrompt] = useState('')
   const [continueBusy, setContinueBusy] = useState(false)
   const [continueError, setContinueError] = useState<string | null>(null)
-  const [lastReply, setLastReply] = useState<string | null>(null)
   const [nameDraft, setNameDraft] = useState(session.displayName || '')
   const [colorDraft, setColorDraft] = useState(session.colorTag || '')
   const [prefBusy, setPrefBusy] = useState(false)
@@ -567,14 +575,13 @@ function SessionConversationView({
     setColorDraft(session.colorTag || '')
     setPrefError(null)
     setContinueError(null)
-    setLastReply(null)
   }, [session.prefKey, session.displayName, session.colorTag])
 
   useEffect(() => {
     const container = transcriptScrollRef.current
     if (!container) return
     container.scrollTop = container.scrollHeight
-  }, [messages, loading, lastReply])
+  }, [messages, loading])
 
   const handleContinueSession = async () => {
     const prompt = continuePrompt.trim()
@@ -582,7 +589,6 @@ function SessionConversationView({
 
     setContinueBusy(true)
     setContinueError(null)
-    setLastReply(null)
     try {
       if (isGatewaySession) {
         // Gateway sessions: forward message to the agent via chat messages API
@@ -612,6 +618,9 @@ function SessionConversationView({
         // Refresh transcript after a short delay to capture the response
         setTimeout(() => onRefreshTranscript(), 2000)
       } else {
+        // Debug logs retained (commented) for future troubleshooting of the
+        // /chat → MC → host claude session pipeline.
+        // console.log('[DEBUG chat] sending continue request', { kind: session.sessionKind, id: session.sessionId, promptLength: prompt.length })
         const res = await fetch('/api/sessions/continue', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -621,14 +630,16 @@ function SessionConversationView({
             prompt,
           }),
         })
+        // console.log('[DEBUG chat] continue response status:', res.status)
         const data = await res.json().catch(() => ({}))
         if (!res.ok) {
           throw new Error(data?.error || 'Failed to continue session')
         }
         setContinuePrompt('')
-        if (typeof data?.reply === 'string' && data.reply.trim()) {
-          setLastReply(data.reply.trim())
-        }
+        // The reply from `data.reply` is intentionally not surfaced inline here:
+        // claude has already written both the user prompt and the assistant
+        // reply to the host session jsonl, and onRefreshTranscript() pulls them
+        // into the transcript so the message stream stays in one place.
         onRefreshTranscript()
       }
     } catch (err) {
@@ -790,8 +801,11 @@ function SessionConversationView({
         </div>
       )}
 
-      {/* Continue session input */}
+      {/* Continue session input — reply is appended to the transcript above
+          via onRefreshTranscript(); only show transient errors here so the
+          input row stays anchored to the bottom regardless of reply size. */}
       <div className="border-t border-border/50 px-4 py-2">
+        {continueError && <div className="mb-1 text-xs text-red-400">{continueError}</div>}
         <div className="flex items-center gap-2">
           <span className={`font-mono-tight text-xs ${isGatewaySession ? 'text-cyan-400/60' : 'text-green-400/60'}`}>{isGatewaySession ? '>' : '$'}</span>
           <input
@@ -816,12 +830,6 @@ function SessionConversationView({
             {continueBusy ? '...' : 'Send'}
           </Button>
         </div>
-        {continueError && <div className="mt-1 text-xs text-red-400">{continueError}</div>}
-        {lastReply && (
-          <div className="mt-2 border-l-2 border-primary/30 pl-3">
-            <div className="font-mono-tight text-xs leading-relaxed text-foreground whitespace-pre-wrap">{lastReply}</div>
-          </div>
-        )}
       </div>
     </div>
   )

--- a/src/lib/claude-sessions.ts
+++ b/src/lib/claude-sessions.ts
@@ -31,9 +31,11 @@ const MODEL_PRICING: Record<string, { input: number; output: number }> = {
 
 const DEFAULT_PRICING = { input: 3 / 1_000_000, output: 15 / 1_000_000 }
 
-// Session is "active" if last activity was within this window.
-// Local CLI sessions can remain interactive without emitting frequent logs.
-const ACTIVE_THRESHOLD_MS = 90 * 60 * 1000
+// "Active" window. Upstream default was 90 minutes which surfaced too many
+// stale jsonls; 2 minutes was too tight (any pause >2 min in an active host
+// CLI dropped the session out of "active"). 15 minutes covers normal think
+// time between user prompts in a live `claude` session.
+const ACTIVE_THRESHOLD_MS = 15 * 60 * 1000
 const FUTURE_TOLERANCE_MS = 60 * 1000
 
 interface SessionStats {
@@ -312,6 +314,7 @@ export async function syncClaudeSessions(force = false): Promise<{ ok: boolean; 
     `)
 
     let upserted = 0
+    let removed = 0
     db.transaction(() => {
       // Mark all sessions inactive before scanning
       db.prepare('UPDATE claude_sessions SET is_active = 0').run()
@@ -326,11 +329,28 @@ export async function syncClaudeSessions(force = false): Promise<{ ok: boolean; 
         )
         upserted++
       }
+
+      // Delete rows whose jsonl no longer exists on disk. Without this, removed
+      // session files (manual cleanup, project rename, claude --resume that
+      // creates a new id) leave phantom rows that the API still surfaces as
+      // "Active" via the derivedActive mtime fallback.
+      const liveIds = new Set(sessions.map(s => s.sessionId))
+      const allRows = db.prepare('SELECT session_id FROM claude_sessions').all() as Array<{ session_id: string }>
+      const del = db.prepare('DELETE FROM claude_sessions WHERE session_id = ?')
+      for (const row of allRows) {
+        if (!liveIds.has(row.session_id)) {
+          del.run(row.session_id)
+          removed++
+        }
+      }
     })()
 
     const active = sessions.filter(s => s.isActive).length
     lastSyncAt = Date.now()
-    lastSyncResult = { ok: true, message: `Scanned ${upserted} session(s), ${active} active` }
+    lastSyncResult = {
+      ok: true,
+      message: `Scanned ${upserted} session(s), ${active} active${removed ? `, removed ${removed} orphan(s)` : ''}`,
+    }
     return lastSyncResult
   } catch (err: any) {
     logger.error({ err }, 'Claude session sync failed')

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -97,6 +97,8 @@ function nextResponseWithNonce(request: NextRequest): { response: NextResponse; 
       headers: requestHeaders,
     },
   })
+  // Debug log retained (commented) for future CSP/nonce flow troubleshooting.
+  // console.log(`[DEBUG csp] proxy generated nonce for ${request.nextUrl.pathname}: ${nonce.slice(0, 8)}...`)
   return { response, nonce }
 }
 


### PR DESCRIPTION
## Summary

Makes Mission Control runnable as a single self-contained Docker container that drives the operator's host-installed Claude Code / Codex / OpenCode CLIs without requiring re-authentication inside the container, and without an OpenClaw gateway (which is macOS-only and not available on Linux hosts). Along the way, fixes a CSP/hydration regression that broke `/chat`, and several issues in the local-Claude-sessions pipeline.

This is a focused contribution on the **operator path** (single user running MC locally on a Linux/Docker host alongside their own claude CLI) — not on the multi-tenant or production deployment story.

## Why

I wanted to use the existing `/chat` page to drive the same Claude Code session I have open in a host terminal, while running MC itself in Docker. That setup hits a few rough edges:

- The CLI binaries need to come from the host (the operator is already authenticated), but the container needs to be able to spawn them.
- `/chat` was not interactive in my browser — strict CSP blocked hydration entirely.
- `claude --resume <id>` from inside the container couldn't find any session, even though it could see the jsonl files from the bind-mounted host `~/.claude`.
- The "Active" session list kept growing forever and surfacing dead jsonls as live.

This PR addresses each of those.

## What's in here (per-commit walkthrough)

### 1. `feat(docker): self-contained docker stack with host config projection`

- `Dockerfile`: bake `claude` and `codex` into the image as a fallback (host's `~/.local/bin` still wins via `PATH` order); add `tmux` and `jq` (required by `/chat` PTY view and runtime probes); reuse the slim image's existing uid 1000 user as `nextjs` so bind-mounted host files (typical Linux uid 1000) are read/written without chown.
- `docker-compose.yml`: run as `1000:1000`; project the host user's `\$HOME` (`.local/bin`, `.bun`, `.claude`, `.claude.json`, `.local/share/claude`) into the container; bind-mount `/mnt` and `\${HOME}` at the same absolute path so paths are identical inside and outside; bump memory limit to 2G (Next.js 16 + node-pty + the task-dispatch loop OOM at the upstream 512M when `/chat` opens a terminal); pass `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` from `.env` so direct-API dispatch works without a gateway; add `MC_HOST_SESSION_MODE` env (see commit 3).
- `Makefile` (new): single entrypoint for the operator — `up`, `down`, `restart`, `recreate`, `build`, `rebuild` (no-cache), `ps`, `logs`, `shell`, `status`, `wait-ready`, `reset-db`, `nuke`. URL fixed to `http://127.0.0.1:7012`.
- `.gitignore`: ignore `WALKTHROUGH.md` (operator-local notes file kept on disk, never committed).

### 2. `fix(csp): pass nonce to next-themes ThemeProvider so hydration works`

The strict CSP set in `src/proxy.ts` uses `script-src 'nonce-X' 'strict-dynamic'` which blocks every inline `<script>` that does not carry the matching nonce. `next-themes` injects an inline anti-FOUC script at render time; without an explicit `nonce` prop it ships that script with no nonce attribute, so the browser blocks it. With `strict-dynamic`, that boot script is the trust root for everything else: when the browser blocks it, **no further scripts can load**, so React never hydrates. Symptoms: chat input has no working Send button, fetch from client code throws `TypeError: Failed to fetch`, etc.

Fix: pass the per-request nonce (already available in layout via the `x-nonce` request header that `proxy.ts` sets) into `<ThemeProvider nonce={nonce} ...>`. `next-themes >= 0.4` propagates this to its inline tag.

I also left two `console.log('[DEBUG csp] ...')` lines commented out in `proxy.ts` and `layout.tsx` — useful for the next person who has to debug nonce flow end-to-end. Happy to remove them entirely if reviewers prefer.

### 3. `fix(chat): /api/sessions/continue works on shared host claude sessions`

Four sub-issues collapsed into this commit:

- **Wrong cwd**: `claude --resume <id>` only finds the transcript if process `cwd` matches the project path encoded in `~/.claude/projects/<encoded>/`. MC's `runCommand` defaulted to `/app`, so resume silently picked up no conversation.
- **Lossy decoding**: claude collapses both `/` and `_` to `-` in the encoded directory name, so `/foo/bar_baz` and `/foo/bar/baz` both round-trip to `-foo-bar-baz`. Naive decoding produced wrong cwds → `cd` failed → claude never ran. The fix reads the authoritative `cwd` field directly from the first JSON line of the session jsonl.
- **`spawn claude ENOENT` under Next 16 standalone**: a direct `child_process.spawn('claude', ...)` from the Next.js standalone server consistently produced `ENOENT` even though the binary was reachable via `which claude` and via `node -e 'spawn(...)'` in the same container with the same env. The exact root cause was not pinned down; I worked around it by resolving the absolute path to `claude` via `fs.access(X_OK)` over `PATH`, and then spawning through `sh -c \"cd <cwd> && exec <bin> --print --resume <id>\"` instead of direct execvp. `shQuote()` keeps both paths safe.
- **Race policy**: when MC `--resume`s a session that already has a live host CLI, both processes append to the same jsonl. Added env `MC_HOST_SESSION_MODE`:
  - `coexist` (default) — both write, each picks up the other's writes on its next prompt.
  - `block-active` — return 409 if jsonl mtime < 60s ago (the host CLI looks live).
  - `nudge` — coexist + best-effort \`utimes()\` after the reply.

A `TODO` marker is added for the proper UX-level fix to the long Send→reply latency: replace the blocking `claude --print` with an SSE endpoint backed by `--output-format stream-json` so the chat UI can render tokens incrementally. Out of scope for this PR.

### 4. `fix(chat): tighter active-session window + remove orphan rows`

Two related issues caused the `/chat` session list to drift from reality:

- The 90-minute "active" window flagged any jsonl touched in the last hour and a half as live. For an operator with several claude sessions across projects this surfaced almost everything as active, including ones they had finished with hours of think-time ago. Tightened to 15 minutes in both the scanner-side (`ACTIVE_THRESHOLD_MS`) and the API-side derived recovery (`LOCAL_SESSION_ACTIVE_WINDOW_MS`) so they stay coherent.
- Rows in `claude_sessions` lived forever even after the underlying jsonl was deleted (manual cleanup, project rename, or `claude --resume` that creates a new id). The API still surfaced those orphans as "active" off the stale `last_message_at`. Now, after a scan cycle, the scanner also `DELETE`s rows whose `session_id` is not in the freshly-scanned set, and reports `removed N orphan(s)` when this happens.

### 5. `fix(chat): keep input anchored, reply renders into transcript`

- Stop excluding `session:*` conversations from the polling fallback — without this, `/chat` would freeze until the operator hit F5 every time SSE dropped. Cadence is now parameterized via `NEXT_PUBLIC_CHAT_POLL_INTERVAL_MS` (1500ms component default; 1000ms in docker-compose) so it can be tuned without code changes.
- Drop the standalone `lastReply` panel that used to show the most recent assistant message above the input. It duplicated the transcript and, on long replies, pushed the input field below the viewport. The reply now lands in the transcript via `onRefreshTranscript()` — same `SessionMessage` rendering, same formatting, same scroll behaviour as the rest of the conversation. The prompt input row stays anchored to the bottom regardless of reply size, matching how the host claude CLI itself displays things.

## What I deliberately did **not** change

- The OpenClaw gateway path. macOS-only OpenClaw is untouched; this PR only adds a parallel direct-API dispatch path that already existed in the codebase (`callClaudeDirectly`) — it doesn't modify it.
- Multi-provider direct dispatch (OpenAI, local LMStudio). I prototyped this on a separate branch but pulled it back out of this PR — it's a separate feature and should be its own review.
- Streaming reply (SSE / `--output-format stream-json`). Marked as `TODO` in `route.ts`. Worth a follow-up; the current 1000ms polling is a workable but not great UX for long replies.

## Test plan

- [ ] `make up` brings the container up and reaches HTTP 200 at `http://127.0.0.1:7012/login` within 30s.
- [ ] `/setup` creates an admin and `/login` works.
- [ ] `/chat` loads without CSP errors in DevTools Console; the Send button is interactive.
- [ ] In `/chat`, sending a prompt to a host-created Claude Code session:
  - returns 200 from `POST /api/sessions/continue`
  - the user prompt and the assistant reply both appear in the host session jsonl
  - both also appear in the MC transcript view (via the polling refresh)
  - the input row stays anchored to the bottom, regardless of reply size
- [ ] Setting `MC_HOST_SESSION_MODE=block-active` in `.env` and pinging an actively-written jsonl returns HTTP 409 with the "Wait for it to go idle" message.
- [ ] After deleting some jsonls under `~/.claude/projects/<some-dir>/`, the next sync removes the corresponding rows from `claude_sessions` and the `/chat` Active list shrinks accordingly.