### PR TITLE
fix: preserve gateway auth for saved urls

### DIFF
--- a/scripts/start-standalone.sh
+++ b/scripts/start-standalone.sh
@@ -40,6 +40,8 @@ if [[ -f "$PROJECT_ROOT/.env" ]]; then
   set +a
 fi
 
+export MISSION_CONTROL_DATA_DIR="${MISSION_CONTROL_DATA_DIR:-$PROJECT_ROOT/.data}"
+
 # Next.js standalone server reads HOSTNAME to decide bind address.
 # Default to 0.0.0.0 so the server is accessible from outside the host.
 export HOSTNAME="${HOSTNAME:-0.0.0.0}"

--- a/src/app/[[...panel]]/page.tsx
+++ b/src/app/[[...panel]]/page.tsx
@@ -193,7 +193,7 @@ export default function Home() {
       connect(wsUrl)
     }
 
-    const connectWithPrimaryGateway = async (): Promise<{ attempted: boolean; connected: boolean }> => {
+    const connectWithPrimaryGateway = async (preferredWsUrl?: string | null): Promise<{ attempted: boolean; connected: boolean }> => {
       try {
         const gatewaysRes = await fetch('/api/gateways')
         if (!gatewaysRes.ok) return { attempted: false, connected: false }
@@ -212,7 +212,8 @@ export default function Home() {
         if (!connectRes.ok) return { attempted: true, connected: false }
 
         const payload = await connectRes.json().catch(() => ({}))
-        const wsUrl = typeof payload?.ws_url === 'string' ? payload.ws_url : ''
+        const resolvedWsUrl = typeof payload?.ws_url === 'string' ? payload.ws_url : ''
+        const wsUrl = preferredWsUrl?.trim() || resolvedWsUrl
         const wsToken = typeof payload?.token === 'string' ? payload.token : ''
         if (!wsUrl) return { attempted: true, connected: false }
 
@@ -294,7 +295,10 @@ export default function Home() {
           }
           setCapabilitiesChecked(true)
           markStep('capabilities')
-          connect(localGatewayUrl)
+          const primaryConnect = await connectWithPrimaryGateway(localGatewayUrl)
+          if (!primaryConnect.connected) {
+            connect(localGatewayUrl)
+          }
           markStep('connect')
           return
         }


### PR DESCRIPTION
## Summary\n- keep saved browser gateway URLs on the server-token connect path instead of connecting without auth\n- set standalone runtime data dir to the repo .data directory so production uses the real gateway DB\n\n## Verification\n- pnpm build\n- systemctl restart mission-control.service\n- /api/gateways/connect returns wss://gw.doremon.app with token_set=true\n- https://mc.doremon.app/login returns 200\n