### PR TITLE
feat(docker): expose NEXT_PUBLIC_* as build args for browser-side gateway config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,33 @@ RUN if [ -f pnpm-lock.yaml ]; then \
 FROM base AS build
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+
+# ─── PR-CANDIDATE: NEXT_PUBLIC_* baked into client bundle ──────────────────
+# Next.js inlines NEXT_PUBLIC_* into the client JS at build time. Without
+# these ARG/ENV pairs, downstream operators (Docker / CI / k8s) cannot
+# configure the gateway URL for the browser without a custom image build.
+# Discovered via Project EIGHTBALL deployment with separate subdomain for
+# the gateway (openclaw-mac.example.io) vs dashboard (mc-mac.example.io).
+ARG NEXT_PUBLIC_GATEWAY_URL=
+ARG NEXT_PUBLIC_GATEWAY_HOST=
+ARG NEXT_PUBLIC_GATEWAY_PORT=
+ARG NEXT_PUBLIC_GATEWAY_PROTOCOL=
+ARG NEXT_PUBLIC_GATEWAY_REVERSE_PROXY=
+ARG NEXT_PUBLIC_GATEWAY_CLIENT_ID=
+ARG NEXT_PUBLIC_GATEWAY_OPTIONAL=
+ARG NEXT_PUBLIC_COORDINATOR_AGENT=
+ARG NEXT_PUBLIC_GOOGLE_CLIENT_ID=
+ENV NEXT_PUBLIC_GATEWAY_URL=${NEXT_PUBLIC_GATEWAY_URL}
+ENV NEXT_PUBLIC_GATEWAY_HOST=${NEXT_PUBLIC_GATEWAY_HOST}
+ENV NEXT_PUBLIC_GATEWAY_PORT=${NEXT_PUBLIC_GATEWAY_PORT}
+ENV NEXT_PUBLIC_GATEWAY_PROTOCOL=${NEXT_PUBLIC_GATEWAY_PROTOCOL}
+ENV NEXT_PUBLIC_GATEWAY_REVERSE_PROXY=${NEXT_PUBLIC_GATEWAY_REVERSE_PROXY}
+ENV NEXT_PUBLIC_GATEWAY_CLIENT_ID=${NEXT_PUBLIC_GATEWAY_CLIENT_ID}
+ENV NEXT_PUBLIC_GATEWAY_OPTIONAL=${NEXT_PUBLIC_GATEWAY_OPTIONAL}
+ENV NEXT_PUBLIC_COORDINATOR_AGENT=${NEXT_PUBLIC_COORDINATOR_AGENT}
+ENV NEXT_PUBLIC_GOOGLE_CLIENT_ID=${NEXT_PUBLIC_GOOGLE_CLIENT_ID}
+# ────────────────────────────────────────────────────────────────────────────
+
 RUN pnpm build
 
 FROM node:22.22.0-slim AS runtime


### PR DESCRIPTION
## Problem

When deploying Mission Control via Docker behind a reverse proxy (e.g. nginx-proxy-manager / Caddy / Traefik) where the OpenClaw gateway is exposed on a **different subdomain or hostname** than the dashboard itself, there is currently no way to configure the browser-side WebSocket URL without forking and rebuilding the image manually.

## Root Cause

`src/app/[[...panel]]/page.tsx:182-190` reads:

```ts
const explicitWsUrl = localGatewayUrl || process.env.NEXT_PUBLIC_GATEWAY_URL || ''
const gatewayPort   = process.env.NEXT_PUBLIC_GATEWAY_PORT || '18789'
const gatewayHost   = process.env.NEXT_PUBLIC_GATEWAY_HOST || window.location.hostname
const protocol      = process.env.NEXT_PUBLIC_GATEWAY_PROTOCOL || ...
```

These `NEXT_PUBLIC_*` variables are baked into the client bundle at **build time** (`pnpm build`). However the published `Dockerfile` does not declare them as `ARG`s in the `build` stage, so passing `--build-arg NEXT_PUBLIC_GATEWAY_URL=...` to `docker build` (or via `args:` in `compose.yml`) has no effect — the bundle is always built with defaults, and the browser falls back to `wss://${window.location.hostname}:18789/gateway-ws`.

For deployments where the dashboard sits at e.g. `https://mc.example.com` and the gateway sits at `https://openclaw.example.com` (proxied by nginx to `127.0.0.1:18789` with WS upgrade), this default is unreachable from the browser.

The `.env.example` already documents these variables clearly, but operators have no clean path to inject them into the build.

## Fix

Add `ARG` and `ENV` declarations for all browser-facing `NEXT_PUBLIC_*` variables in the `build` stage of the `Dockerfile`, immediately before `RUN pnpm build`. This is a backward-compatible change — the defaults remain empty so behaviour is identical when no build args are passed, but operators can now configure the build via:

```yaml
# compose.yml
services:
  mission-control:
    build:
      context: .
      args:
        NEXT_PUBLIC_GATEWAY_URL: wss://openclaw.example.com
        NEXT_PUBLIC_GATEWAY_CLIENT_ID: openclaw-control-ui
```

Variables added (matching `.env.example`):

- `NEXT_PUBLIC_GATEWAY_URL`
- `NEXT_PUBLIC_GATEWAY_HOST`
- `NEXT_PUBLIC_GATEWAY_PORT`
- `NEXT_PUBLIC_GATEWAY_PROTOCOL`
- `NEXT_PUBLIC_GATEWAY_REVERSE_PROXY`
- `NEXT_PUBLIC_GATEWAY_CLIENT_ID`
- `NEXT_PUBLIC_GATEWAY_OPTIONAL`
- `NEXT_PUBLIC_COORDINATOR_AGENT`
- `NEXT_PUBLIC_GOOGLE_CLIENT_ID`

## Test Plan

1. Build with: `docker build --build-arg NEXT_PUBLIC_GATEWAY_URL=wss://example.com .`
2. Run image, open dashboard in browser
3. DevTools → Network → WS → confirm WS connects to `wss://example.com/gateway-ws` (instead of `wss://${page-host}:18789/gateway-ws`)
4. Build without build args → unchanged behaviour (defaults to current logic)

## Discovered via

Project EIGHTBALL — multi-agent self-hosted deployment on Mac mini M4 with separate subdomains for gateway (`openclaw.example.io`) and dashboard (`mc.example.io`), both behind nginx-proxy-manager with Let's Encrypt SSL.

## Backwards Compatibility

100% backward compatible. No defaults change. Operators who don't pass build args get exactly the current behaviour.

## Optional Follow-up

Could add a `Deployment Modes / Reverse Proxy` section to README pointing to this approach, since `.env.example` already covers the variable semantics but doesn't mention the build-arg path.