### PR TITLE
feat(dispatch): direct multi-provider dispatch (Anthropic / OpenAI / local OpenAI-compatible)

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -76,6 +76,100 @@ What `deploy:standalone` does:
 
 ## Production (Docker)
 
+Preferred operator flow (Make controls docker compose):
+
+```bash
+# 1) choose mode in .env
+#    MC_MODE=prod   # or dev
+#    OPENCLAW_ENABLED=1   # set 0 to run MC without OpenClaw stack
+
+# 2) run universal verbs
+make up
+make restart
+make down
+make status
+```
+
+### Mode-aware Make workflow (minimal commands)
+
+For day-to-day operations, see the [Daily Ops Cheatsheet](./ops-cheatsheet.md).
+
+Use `.env` + `.env.openclaw` as the single source of truth for mode/host/port/token values.
+
+- `MC_MODE=prod` → `docker-compose.yml`
+- `MC_MODE=dev` → `docker-compose-dev.yml`
+- `OPENCLAW_ENABLED=1` → `make <verb> all` includes OpenClaw
+- `OPENCLAW_ENABLED=0` → `make <verb> all` manages MC only
+
+Command grammar:
+
+```text
+make <verb> [all|mc|openclaw] [dev|prod]
+```
+
+- `all` is default scope.
+- `dev` / `prod` override `MC_MODE` for one command invocation.
+- Why no `--dev` / `--prod`: GNU Make consumes unknown `--xxx` tokens as Make options before Makefile goals are parsed, so mode overrides use positional tokens for deterministic behavior.
+- `make restart [scope]` is deterministic and always executes `make down [scope]` followed by `make up [scope]`.
+- With default `all` scope, `OPENCLAW_ENABLED=1` includes OpenClaw in both the down and up phases; `OPENCLAW_ENABLED=0` skips OpenClaw in both phases.
+
+Primary operator commands:
+
+| Workflow | Command |
+|---|---|
+| Start selected component(s) | `make up [all|mc|openclaw]` |
+| Restart selected component(s) | `make restart [all|mc|openclaw]` |
+| Stop selected component(s) | `make down [all|mc|openclaw]` |
+| Mode + endpoint health summary | `make status [all|mc|openclaw]` |
+| Refresh source/state only | `make update [all|mc|openclaw]` |
+| Force rebuild selected component(s) | `make rebuild [all|mc|openclaw]` |
+| Full maintenance (`update` + `rebuild` + `restart`) | `make upgrade [all|mc|openclaw]` |
+
+Mode override examples:
+
+```bash
+make restart dev
+make restart mc dev
+make status openclaw
+make upgrade prod
+```
+
+### `update` vs `upgrade`
+
+- `make update [scope]`
+  - Fast-forwards the current Mission Control branch from origin.
+  - For `scope=all`, if `OPENCLAW_ENABLED=1`, also refreshes OpenClaw source state.
+  - For `scope=openclaw`, refreshes OpenClaw source state regardless of `OPENCLAW_ENABLED`.
+  - Does **not** force an MC image rebuild and does **not** force restart.
+
+- `make upgrade [scope]`
+  - Runs update + rebuild + restart for selected scope.
+  - `scope=mc`: MC-only flow.
+  - `scope=openclaw`: OpenClaw update flow (`make openclaw-update`).
+  - `scope=all`: both flows; OpenClaw path runs when `OPENCLAW_ENABLED=1`.
+
+Minimum `.env` / `.env.openclaw` keys for this flow:
+
+```env
+# .env
+MC_MODE=prod
+OPENCLAW_ENABLED=1
+MC_URL_SCHEME=http
+MC_HOST=127.0.0.1
+MC_PORT=7012
+OPENCLAW_GATEWAY_TOKEN=...
+TELEGRAM_BOT_TOKEN=...
+TELEGRAM_NUMERIC_USER_ID=123456789
+TELEGRAM_DM_POLICY=pairing
+TELEGRAM_ALLOW_FROM=
+TELEGRAM_OWNER_ALLOW_FROM=
+# .env.openclaw (or keep in .env)
+OPENCLAW_GATEWAY_PORT=18789
+OPENCLAW_CONTROL_UI_PORT=18791
+OPENCLAW_GATEWAY_INTERNAL_PORT=18789
+OPENCLAW_STATUS_HOST=127.0.0.1
+```
+
 ```bash
 docker compose up          # with gateway connectivity
 docker compose --profile standalone up   # without gateway (standalone mode)
@@ -118,6 +212,18 @@ MC inside Docker needs to reach the gateway running on the host. There are **two
 If your gateway runs in **another container**, put both on the same Docker network and set
 `OPENCLAW_GATEWAY_HOST` to the gateway container name.
 
+### Local Security Scan Expectations (HTTP dev vs HTTPS prod)
+
+For local Docker development over plain `http://`, the following defaults are expected:
+
+- Keep `MC_COOKIE_SECURE` unset
+- Keep `MC_ENABLE_HSTS` unset
+- Use `OPENCLAW_GATEWAY_HOST=host.docker.internal` when MC runs in Docker and gateway runs on host
+
+`MC_COOKIE_SECURE=1` and `MC_ENABLE_HSTS=1` are HTTPS-only hardening flags. Enabling them on plain HTTP can break login/session behavior and create misleading local warnings.
+
+Mission Control's security scan treats `host.docker.internal` as a valid local Docker topology (not a public exposure) and should not be interpreted as a production misconfiguration by itself.
+
 ### Persistent Data
 
 SQLite database is stored in `/app/.data/` inside the container. Mount a volume to persist data across restarts:
@@ -126,6 +232,81 @@ SQLite database is stored in `/app/.data/` inside the container. Mount a volume 
 docker run -v /path/to/data:/app/.data ...
 ```
 
+### Automatic backups
+
+- Set `MC_AUTO_BACKUP=1` (accepts `1`/`true`/`yes`/`on`) in your `.env` to enable automatic daily backups without toggling it in the UI.
+- The backup directory is created automatically when scheduled backups run, so the backup warning clears once the task executes.
+
+### Self-contained Operator Setup (Linux host with existing Claude Code / Codex CLIs)
+
+For an operator running MC on a Linux/Docker host who already has authenticated
+`claude` / `codex` / `opencode` CLIs in `~/.local/bin`, the default
+`docker-compose.yml` projects the host configuration into the container so MC
+can drive those same authenticated CLIs without re-login. This path runs MC
+**without** OpenClaw gateway (which is macOS-only).
+
+What the default compose does for this case:
+
+- **Image bakes `claude` and `codex` as a fallback** — if the host doesn't
+  have them in `~/.local/bin`, the container's installed copies are used.
+  The host's `~/.local/bin` comes first in `PATH`, so an authenticated host
+  install transparently shadows the baked one.
+- **Host home is bind-mounted** — `${HOME}/.local/bin`, `${HOME}/.bun`,
+  `${HOME}/.claude`, `${HOME}/.claude.json`, and `${HOME}/.local/share/claude`
+  are mounted under `/home/nextjs/...` inside the container, plus `${HOME}`
+  itself and `/mnt` are mounted at the same absolute paths so file paths the
+  user sees on the host work identically inside the container.
+- **Container runs as uid 1000** (the slim image's existing `node` user,
+  renamed `nextjs`) so bind-mounted host files (typical Linux uid 1000) are
+  read/written without `chown`.
+
+**Ports.** `docker-compose.yml` maps `${MC_PORT}` on the host to `${PORT}` in
+the container. The bundled `Makefile` computes its readiness/status URL from
+`MC_URL_SCHEME`, `MC_HOST`, and `MC_PORT` loaded from `.env`.
+
+**uid mismatch.** If your host user has uid ≠ 1000 (common on macOS, or
+multi-user Linux), edit `docker-compose.yml`:
+
+```yaml
+user: "$(id -u):$(id -g)"   # or hard-code your uid:gid
+```
+
+Otherwise bind-mounted files in `${HOME}` will be read-only inside the
+container and Claude Code will fail to write its config.
+
+**Memory.** The compose file sets `memory: 2G` deploy limit. The upstream
+default of 512M OOM-kills MC when `/chat` opens a `node-pty` terminal and the
+task-dispatch loop is running concurrently. Do not lower this limit unless
+you are sure neither feature is in use.
+
+#### Direct API dispatch (gateway-free)
+
+When OpenClaw is not present, MC dispatches tasks via direct provider APIs.
+Provider is picked by the agent's `dispatchModel` prefix:
+
+| `dispatchModel` pattern                                          | Provider           | Auth |
+|------------------------------------------------------------------|--------------------|------|
+| `claude-*`, `anthropic/*`                                        | Anthropic API      | `ANTHROPIC_API_KEY` |
+| `gpt-*`, `o1-*`, `o3-*`, `openai/*`                              | OpenAI API         | `OPENAI_API_KEY` |
+| `local/*`, `ollama/*`, `lmstudio/*`, `litellm/*`                 | OpenAI-compatible  | `LOCAL_LLM_ENDPOINT` (+ optional `LOCAL_LLM_API_KEY`) |
+
+The "local" provider speaks the OpenAI `/v1/chat/completions` REST shape, so
+LMStudio, Ollama, vLLM, and a [liteLLM](https://github.com/BerriAI/litellm)
+proxy all work behind it. For multiple local backends behind one endpoint,
+run liteLLM as a sidecar container and point `LOCAL_LLM_ENDPOINT` at it.
+
+#### Shared host Claude Code session (`MC_HOST_SESSION_MODE`)
+
+`/chat` can drive a Claude Code session that the operator has open in a host
+terminal — both processes share the same `~/.claude/projects/<encoded>/<id>.jsonl`
+transcript. Pick the policy via env:
+
+| Mode | Behaviour |
+|------|-----------|
+| `coexist` (default) | Both MC and the host CLI append to the jsonl. Each side picks up the other's writes on its next prompt. Possible interleaving on simultaneous writes — fine for a single operator switching between the two surfaces. |
+| `block-active` | Returns `409` from `/api/sessions/continue` if the jsonl was touched in the last 60s (heuristic: a live host CLI updates mtime frequently). Forces MC to act only on idle sessions. |
+| `nudge` | Same as `coexist` plus a best-effort `utimes()` on the jsonl after the reply, so a tail-watching host CLI sees a fresh mtime. |
+
 ### Production Hardening
 
 ```bash
@@ -133,6 +314,22 @@ docker compose -f docker-compose.yml -f docker-compose.hardened.yml up -d
 ```
 
 This adds: JSON logging, strict hostname allowlist, secure cookies, HSTS, internal-only network.
+
+### Host hardening (Ubuntu quick actions)
+
+- **Firewall (ufw)**: `sudo apt-get install -y ufw && sudo ufw allow OpenSSH && sudo ufw enable && sudo ufw status`
+- **Time sync (NTP)**: `timedatectl set-ntp true && timedatectl status` (ensures systemd-timesyncd is active)
+- **Automatic security updates**: `sudo apt-get install -y unattended-upgrades && sudo dpkg-reconfigure -plow unattended-upgrades && sudo unattended-upgrade -d`
+- **Brute-force protection (fail2ban)**: `sudo apt-get install -y fail2ban && sudo systemctl enable --now fail2ban` (tune `/etc/fail2ban/jail.local` as needed)
+- **/tmp noexec**: add `tmpfs /tmp tmpfs defaults,noexec,nosuid,nodev 0 0` to `/etc/fstab`, then `sudo mount -o remount /tmp`
+- **Encrypted data (LUKS)**: create/attach a LUKS volume for data (`sudo cryptsetup luksFormat /dev/sdX && sudo cryptsetup open /dev/sdX mc-data && sudo mkfs.ext4 /dev/mapper/mc-data`) and mount it for `.data/` or backups
+- **MAC framework**: keep AppArmor enabled (`sudo systemctl enable --now apparmor && sudo aa-status`); 
+  Ubuntu SELinux users can install `selinux-basics selinux-policy-default` and enable per Ubuntu guidance
+  - sudo apt update
+  - sudo apt install selinux-basics selinux-policy-default
+  - sudo selinux-activate
+  - sudo reboot
+  - sudo apt install policycoreutils; sestatus # check status
 
 ## Environment Variables
 
@@ -147,8 +344,25 @@ See `.env.example` for the full list. Key variables:
 | `PORT` | No | `3005` (direct) / `3000` (Docker) | Server port |
 | `OPENCLAW_HOME` | No | - | Legacy: parent home directory containing `.openclaw/`. Use `OPENCLAW_STATE_DIR` instead (see note below) |
 | `OPENCLAW_STATE_DIR` | No | `~/.openclaw` | Exact path to the OpenClaw state directory. Preferred over `OPENCLAW_HOME` — avoids double-nesting when the path already ends in `.openclaw` |
+| `OPENCLAW_TOOLS_PROFILE` | No | `coding` | Tool profile projected into OpenClaw config when the env var is present (compose injects the default) |
+| `OPENCLAW_SECURITY_WORKSPACE_ONLY` | No | `1` | Restrict filesystem tools to the workspace when set (env-driven) |
+| `OPENCLAW_SECURITY_DENY_AUTOMATION` | No | `1` | Deny automation tool group via env-driven bootstrap |
+| `OPENCLAW_SECURITY_DENY_RUNTIME` | No | `1` | Deny runtime tool group via env-driven bootstrap |
+| `OPENCLAW_SECURITY_DENY_FS` | No | `0` | Deny filesystem tool group (opt-in; can block file workflows) |
+| `OPENCLAW_SECURITY_SANDBOX_ALL` | No | `1` | Force `agents.defaults.sandbox.mode="all"` when set (env-driven) |
 | `MISSION_CONTROL_DATA_DIR` | No | `.data/` | Directory for all Mission Control data files (DB, tokens, etc.). Use an absolute path with the standalone server to survive rebuilds. |
 | `MC_ALLOWED_HOSTS` | No | `localhost,127.0.0.1` | Allowed hosts in production |
+| `MC_PORT` | No | `3000` | Host-side port that the bundled `docker-compose.yml` publishes the container's `PORT` on. The bundled `Makefile` expects `7012`. |
+| `ANTHROPIC_API_KEY` | No (Yes for direct dispatch) | - | Used when `dispatchModel` matches `claude-*` / `anthropic/*` and no gateway is available. |
+| `OPENAI_API_KEY` | No | - | Used when `dispatchModel` matches `gpt-*` / `o1-*` / `o3-*` / `openai/*`. |
+| `LOCAL_LLM_ENDPOINT` | No | `http://host.docker.internal:1234/v1` | OpenAI-compatible base URL (LMStudio default shown). Override for Ollama (`:11434/v1`) or a liteLLM proxy. |
+| `LOCAL_LLM_API_KEY` | No | - | Bearer token sent to `LOCAL_LLM_ENDPOINT`. Only needed for proxies that require auth (e.g. liteLLM with master key). |
+| `MC_HOST_SESSION_MODE` | No | `coexist` | Policy when MC `--resumes` a host Claude Code session that may have a live CLI attached. One of `coexist`, `block-active`, `nudge`. |
+| `NEXT_PUBLIC_CHAT_POLL_INTERVAL_MS` | No | `1500` (code) / `1000` (docker-compose) | `/chat` transcript poll cadence (ms) when the SSE channel drops. **Baked at build time**, so changing it requires `make rebuild`. |
+
+> **Sandbox runtime requirement**
+> 
+> Enabling sandbox mode via `OPENCLAW_SECURITY_SANDBOX_ALL=1` requires Docker access. Ensure the `mc-openclaw-gateway` service bind-mounts the host Docker socket (`/var/run/docker.sock`) as shown in `docker-compose-openclaw.yml`.
 
 > **Note — `OPENCLAW_HOME` vs `OPENCLAW_STATE_DIR`**
 >
@@ -179,7 +393,7 @@ When running Mission Control alongside a gateway as containers in the same pod (
 │  │ :3000   │     │   :18789      │  │
 │  └─────────┘     └───────────────┘  │
 │       ▲                  ▲          │
-│       │ localhost         │          │
+│       │ localhost        │          │
 │       └──────────────────┘          │
 └─────────────────────────────────────┘
 ```

--- a/examples/MULTI-PROVIDER-DEMO.md
+++ b/examples/MULTI-PROVIDER-DEMO.md
@@ -1,0 +1,747 @@
+# Образцовый пример: команда из 3 провайдеров (Claude + OpenAI + Local) в Mission Control
+
+Демо-сценарий для оператора. Поднимает 4 агентов на трёх провайдерах, прогоняет одну master-задачу через декомпозицию → реализацию → линт → ревью.
+
+> **Все названия кнопок, поля форм и значения — копировать-вставлять.** Если что-то в UI у тебя называется иначе — отметь в разделе 13, обновлю.
+
+---
+
+## 0. Подготовка
+
+### 0.1. `.env` в корне проекта
+
+Создай (или допиши) файл `beads/discovered/mission-control/.env`:
+
+```dotenv
+# Порт для Makefile (по умолчанию 7012)
+MC_PORT=7012
+
+# Anthropic — для architect и aegis
+ANTHROPIC_API_KEY=sk-ant-api03-...
+
+# OpenAI — для implementor (dev)
+OPENAI_API_KEY=sk-...
+
+# Local LLM (LMStudio дефолт). Замени на свою модель.
+LOCAL_LLM_ENDPOINT=http://host.docker.internal:1234/v1
+LOCAL_LLM_API_KEY=
+
+# Race policy для shared host claude sessions
+MC_HOST_SESSION_MODE=coexist
+
+# Админ — заполни если хочешь сразу зайти без /setup
+AUTH_USER=admin
+AUTH_PASS=admin123
+```
+
+### 0.2. LMStudio — поднять на хосте
+
+1. Запусти LMStudio на хосте.
+2. Загрузи модель — рекомендую `qwen2.5-coder-7b-instruct` или `qwen2.5-7b-instruct` (помещаются в 16GB RAM).
+3. Перейди на вкладку **Server** (значок 🖥 слева в LMStudio).
+4. Нажми **Start Server** — порт 1234 по умолчанию.
+5. **Запиши точный API Identifier** загруженной модели — его видно в верхней строке Server tab (например `qwen2.5-coder-7b-instruct`). Этот id пойдёт в config агента.
+
+Проверь что MC видит LMStudio:
+
+```bash
+docker exec mission-control sh -c 'curl -sS http://host.docker.internal:1234/v1/models'
+```
+
+Если возвращает JSON с твоей моделью — всё ок.
+
+### 0.3. Поднять MC
+
+```bash
+cd beads/discovered/mission-control
+make recreate     # пересоздаст контейнер с новым .env
+```
+
+Дождись `✓ http://127.0.0.1:7012 → 200`.
+
+### 0.4. Войти
+
+1. Открой **http://127.0.0.1:7012/setup** — если сюда редиректнуло, создай админа (или используй `AUTH_USER`/`AUTH_PASS` из `.env`).
+2. После логина окажешься на дашборде (`/overview`).
+
+---
+
+## 1. Workspace — рекомендация: пропустить, использовать `default`
+
+> **Важно.** На странице `/super-admin` форма `Create New Workspace` использует OpenClaw template provisioning через env `MC_SUPER_TEMPLATE_OPENCLAW_JSON`. На Linux без OpenClaw создание нового workspace **зависнет в `Pending`** или упадёт с ошибкой:
+> `Missing OpenClaw template config. Set MC_SUPER_TEMPLATE_OPENCLAW_JSON to an openclaw.json to seed new tenants.`
+>
+> Поскольку у нас direct-API path (без OpenClaw), **проще оставаться в дефолтном workspace** — он уже видим как `Active Orgs: 1` на той же странице. Все шаги ниже (project, agents, task) работают в нём.
+>
+> Если всё-таки хочешь создать отдельный workspace — см. **раздел 1.A** в конце.
+
+Чтобы убедиться что используется default:
+
+1. В верхнем правом углу (header-bar) — селектор текущего workspace. Если там одно значение или ничего — ты уже в дефолтном.
+2. Перейти в `/super-admin` → блок Active Orgs покажет «1». Это и есть наш default.
+
+Можешь сразу перейти к **разделу 2 (Project)**.
+
+### 1.A. Создание нового workspace (если есть OpenClaw template)
+
+Только если ты собираешься заполнить `MC_SUPER_TEMPLATE_OPENCLAW_JSON` — иначе **этот блок пропустить**.
+
+1. Сайдбар → иконка super-admin → `/super-admin`.
+2. Сверху справа — кнопка **`+ Add Workspace`**. Кликни — раскроется форма `Create New Workspace`.
+3. Реальные поля формы (8 шт):
+
+| #  | Поле (placeholder)         | Тип       | Что вводить                                              |
+|----|----------------------------|-----------|----------------------------------------------------------|
+| 1  | (slug)                     | text      | `multi-provider-demo` — URL-safe идентификатор           |
+| 2  | (display name)             | text      | `Multi-Provider Demo` — человеко-читаемое имя            |
+| 3  | (linux user)               | text      | `uadmin` — твой хост-юзер (на скриншоте именно `uadmin`) |
+| 4  | Owner Gateway              | dropdown  | `primary (primary)` — единственный pre-seeded gateway    |
+| 5  | (tier / profile)           | dropdown  | `Standard`                                               |
+| 6  | Gateway port               | text      | оставь пустым (auto)                                     |
+| 7  | Dashboard port             | text      | оставь пустым (auto)                                     |
+| 8  | Dry-run                    | checkbox  | ☐ снять (если включить — provisioning не выполнится)     |
+
+4. Кнопка **`Create + Queue`** (не просто `Create`!). Она поставит provisioning в очередь.
+5. **Только если** `MC_SUPER_TEMPLATE_OPENCLAW_JSON` указывает на валидный openclaw.json — статус новой строки в `Pending / In Progress` сменится на `Active`. Иначе застрянет.
+
+> Для этого demo **не делай** этот шаг. Default workspace покрывает все нужды.
+
+---
+
+## 2. Project (для тикет-префикса и группировки задач)
+
+1. В левом сайдбаре кликни иконку **Tasks** — откроется `/tasks` Kanban.
+2. В верхней панели Tasks найди кнопку **`Projects`** (outline-вариант). Кликни.
+3. Откроется модальное окно **`Project Management`** (× в правом верхнем углу для закрытия).
+
+### 2.1. Создать проект — top-bar форма
+
+В самом верху модала **3 поля + 1 кнопка** в одну строку:
+
+| #   | Поле                | Тип    | Значение                            |
+|-----|---------------------|--------|-------------------------------------|
+| 1   | (project name)      | text   | `Refactor Login Flow`               |
+| 2   | (ticket prefix)     | text   | `LOGIN`                             |
+| 3   | (—)                 | button | **`Add Project`**                   |
+
+Под этой строкой — **отдельное поле Description** (textarea на всю ширину):
+
+```
+Migrate session-cookie auth to JWT. Demo project for multi-provider team.
+```
+
+Нажми **`Add Project`**.
+
+### 2.2. После создания — раскрыть и доконфигурить (опционально)
+
+Под top-bar формой в этом же модале — **список существующих проектов**. После клика `Add Project` твой `Refactor Login Flow` появится там как карточка с заголовком `Refactor Login Flow` (1 tasks) → `LOGIN · <slug> · active`.
+
+Кликни на карточку — раскроется блок с дополнительными полями:
+
+| Поле                | Тип            | Что вводить                                                    |
+|---------------------|----------------|----------------------------------------------------------------|
+| Description         | textarea       | (уже сохранено из шага 2.1, при желании можно отредактировать) |
+| GitHub Repo         | text `owner/repo` | оставь пустым или впиши `nnnet/mission-control` если работаешь с реальным репо |
+| Deadline            | date `mm/dd/yyyy` | оставь пустым                                                |
+| Color               | 8 цветных точек | выбери любой (например синий — для UI-маркера)                |
+| Assigned Agents     | chip selector  | пока не трогай — назначим агентов в шаге 7 на уровне задачи    |
+
+Нажми **`Save`**. (Или `Cancel` если ничего не менял.)
+
+### 2.3. Закрой модал
+
+Кликни **`×`** в правом верхнем углу или нажми Esc. Возвращаешься на `/tasks`.
+
+---
+
+## 3. Агент №1 — Architect (Claude Opus)
+
+### 3.1. Открыть форму создания
+
+1. В левом сайдбаре кликни иконку **Agents** — откроется `/agents` (`Agent Squad`).
+2. Найди кнопку **`+ Create Agent`** (или просто `Create Agent`) — обычно в верхней строке панели.
+3. Откроется **трёхшаговый wizard** `Create New Agent`.
+
+### 3.2. Step 1 — Template (выбор шаблона)
+
+В верхнем прогресс-баре wizard'а: `1 Template` → `2 Configure` → `3 Review`.
+
+Покажет 7 карточек:
+
+| Шаблон             | Emoji | Tier   | Tools | Theme |
+|--------------------|-------|--------|-------|-------|
+| Orchestrator       | 🧭    | Opus   | 23    | operator strategist |
+| Developer          | 🛠️   | Sonnet | 21    | builder engineer |
+| Specialist Dev     | ⚙️    | Sonnet | 15    | specialist developer |
+| Reviewer / QA      | 🔬    | Haiku  | 7     | quality reviewer |
+| **Researcher**     | 🔍    | Sonnet | 8     | research analyst |
+| Content Creator    | ✏️    | Haiku  | 9     | content creator |
+| Security Auditor   | 🛡️   | Sonnet | 10    | security auditor |
+
+Выбери **`Researcher`**. Wizard перейдёт на Step 2 «Configure».
+
+### 3.3. Step 2 — Configure (точные названия полей и опций)
+
+В форме сверху вниз:
+
+| Лейбл (как в UI)         | Тип       | Значение для architect                               | Опции / placeholder |
+|--------------------------|-----------|------------------------------------------------------|---------------------|
+| Display Name (или Name)  | text      | `Architect (Claude Opus)`                            | поле сверху wizard'а; ID автоматически сгенерится из этого как `architect-claude-opus` (kebab-case) |
+| **Role Theme**           | text      | `architect`                                          | placeholder `builder engineer` |
+| **Emoji**                | text      | `🏛️`                                                 | placeholder `e.g. 🛠️` |
+| **Tier**                 | 3-button toggle | **`Opus $$$`** (нажми кнопку — подсветится) | другие: `Sonnet $$`, `Haiku $` |
+| **Primary Model**        | text input + autocomplete | `anthropic/claude-opus-4-5`            | автозаполнится при выборе Tier; можно править вручную |
+| **Workspace** *(dropdown)* | select    | `None`                                               | другие: `Read & Write`, `Read-only` |
+| **Sandbox** *(dropdown)*   | select    | `Non-main sessions`                                  | другие: `All sessions` |
+| **Network** *(dropdown)*   | select    | `Isolated`                                           | другие: `Bridge` |
+| **Session Key (Optional)** | text     | (оставь пустым)                                      | placeholder `e.g. agent:my-agent:main` |
+
+Нажми **`Next`** (внизу справа, между `Back` и `Cancel`).
+
+### 3.4. Step 3 — Review
+
+Wizard показывает сводку карточкой: emoji иконка, заголовок (`Architect (Claude Opus)`), Role (`architect`), и блок свойств:
+
+```
+ID: architect-claude-opus    Template: Researcher
+Model: Opus $$$              Tools: 8
+Primary Model: anthropic/claude-opus-4-5
+Workspace: none              Sandbox: non-main
+Network: none
+```
+
+Под сводкой — **2 чекбокса** (точные названия с UI):
+
+| Чекбокс              | Состояние   | Почему                              |
+|----------------------|-------------|-------------------------------------|
+| `Add to gateway`     | ☐ снять     | у нас нет OpenClaw gateway          |
+| `Provision Workspace`| ☐ снять     | то же самое                         |
+
+Нажми **`Create Agent`** (cyan-кнопка между `Back` и `Cancel`).
+
+Wizard закрывается, агент появляется в списке `/agents`.
+
+### 3.5. После создания — задать Soul
+
+1. В списке агентов (`/agents`) найди `architect-claude`. Кликни на карточку.
+2. Откроется детальная страница агента с вкладками. Найди вкладку **`Soul`** (рядом с Overview/Activity/Config/...).
+3. В текстовом поле **вставь полный текст** (копируй блок ниже целиком):
+
+```
+You are an experienced software architect. Your job is to break a single
+high-level task into 3-7 atomic implementation tasks.
+
+For each subtask output exactly:
+  TITLE: <one-line title>
+  DESCRIPTION: <what to do, 2-4 sentences>
+  ACCEPTANCE: <how to verify, 1-2 bullets>
+  ESTIMATE: <hours, integer>
+
+Do not write code. Do not explain your approach. Only the structured list.
+Number subtasks 1, 2, 3, ...
+```
+
+4. Нажми **`Save Soul`** (или просто `Save` если кнопка одна).
+
+### 3.6. dispatchModel НЕ нужен для Anthropic
+
+Шаблон уже задал `model.primary = anthropic/claude-opus-4-5`. Anthropic — дефолтный путь, дополнительный override не требуется. **Пропусти Config tab edit.**
+
+---
+
+## 4. Агент №2 — Implementor (OpenAI gpt-4o-mini)
+
+### 4.1. Step 1 — Template
+
+`/agents` → **`+ Create Agent`** → выбери **`Developer`** (🛠️, theme `builder engineer`, Sonnet, 21 tools).
+
+### 4.2. Step 2 — Configure
+
+| Лейбл                    | Значение                              |
+|--------------------------|---------------------------------------|
+| Display Name             | `Dev (OpenAI)`                        |
+| Role Theme               | `developer`                           |
+| Emoji                    | `⚙️`                                  |
+| Tier                     | `Sonnet $$` (override на OpenAI зададим потом через Config tab) |
+| Primary Model            | `anthropic/claude-sonnet-4-20250514` (оставь как есть) |
+| Workspace                | `Read & Write`                        |
+| Sandbox                  | `All sessions`                        |
+| Network                  | `Bridge` (dev может качать deps)      |
+| Session Key (Optional)   | (пусто)                               |
+
+`Next`. На Step 3 Review:
+
+| Чекбокс              | Состояние |
+|----------------------|-----------|
+| `Add to gateway`     | ☐         |
+| `Provision Workspace`| ☐         |
+
+`Create Agent`.
+
+Step 3 → **Create**.
+
+### 4.3. Soul
+
+Кликни на агента → tab **`Soul`** → вставь:
+
+```
+You implement code changes. Reply with file paths and unified diffs only.
+No prose. No explanations. No "here is the code" preamble.
+
+Format:
+  --- a/<path> ---
+  <full file content if new>
+
+  *** edit a/<path> ***
+  <unified diff with @@ markers>
+
+If the task is unclear, reply with one line:
+  CLARIFY: <single specific question>
+```
+
+Save.
+
+### 4.4. ⚠ Важно — задать `dispatchModel = openai/gpt-4o-mini`
+
+Шаблон Developer проставляет Anthropic-модель. Чтобы маршрутизация пошла в OpenAI — нужно переопределить через `dispatchModel` поле в config агента.
+
+#### Вариант A: через UI (Config tab)
+
+> Если Config tab падает с ошибкой `Something went wrong / React error #31` — это известный баг рендеринга в детальной карточке (см. ниже Вариант B). Используй API-путь.
+
+1. На странице агента → tab **`Config`**.
+2. Кнопка **`JSON`** в правом верхнем углу карточки — переключает режим в JSON-редактор.
+3. Нажми **`Edit`**. JSON станет редактируемым.
+4. **Добавь** поле `dispatchModel` в корень объекта (рядом с `model`, `sandbox`, `tools`):
+
+```json
+{
+  "model": {
+    "primary": "anthropic/claude-sonnet-4-20250514",
+    "fallbacks": [...]
+  },
+  "sandbox": { "mode": "all", "workspaceAccess": "rw", "docker": { "network": "bridge" } },
+  "tools": { "allow": [...], "deny": [...] },
+  "dispatchModel": "openai/gpt-4o-mini"
+}
+```
+
+(остальные поля **не трогать** — только добавить `dispatchModel`).
+
+5. **`Save`**.
+6. Префикс `openai/` обязателен — он триггерит маршрутизацию на `OPENAI_API_KEY` в `task-dispatch.ts`.
+
+#### Вариант B: через API (если UI падает)
+
+Получи API key в `/settings` → `API Keys` → `+ Generate Key`. Затем:
+
+```bash
+# 1. Найди id агента
+curl -sS http://127.0.0.1:7012/api/agents \
+  -H "x-api-key: $MC_API_KEY" | jq '.agents[] | select(.name=="Dev (OpenAI)") | {id, name, config}'
+
+# 2. Получи текущий config (для merge)
+curl -sS http://127.0.0.1:7012/api/agents/<AGENT_ID> \
+  -H "x-api-key: $MC_API_KEY" | jq '.agent.config'
+
+# 3. PATCH/PUT config с новым dispatchModel (точный endpoint смотри в /docs)
+curl -X PATCH http://127.0.0.1:7012/api/agents/<AGENT_ID> \
+  -H "x-api-key: $MC_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"config":{"dispatchModel":"openai/gpt-4o-mini","model":{"primary":"anthropic/claude-sonnet-4-20250514"},"sandbox":{"mode":"all","workspaceAccess":"rw","docker":{"network":"bridge"}}}}'
+```
+
+Проверь:
+
+```bash
+curl -sS http://127.0.0.1:7012/api/agents/<AGENT_ID> \
+  -H "x-api-key: $MC_API_KEY" | jq '.agent.config.dispatchModel'
+# должно вернуть: "openai/gpt-4o-mini"
+```
+
+#### Что должно произойти
+
+При следующем dispatch'е задачи на этого агента — в `make logs` появится `Dispatching task via direct openai`, и в `/cost-tracker` модель будет `gpt-4o-mini`.
+
+---
+
+## 5. Агент №3 — Linter (Local LMStudio)
+
+### 5.1. Step 1 — Template
+
+`/agents` → **`+ Create Agent`** → выбери **`Reviewer / QA`** (🔬, theme `quality reviewer`, Haiku, 7 tools, read-only).
+
+### 5.2. Step 2 — Configure
+
+| Лейбл                    | Значение                              |
+|--------------------------|---------------------------------------|
+| Display Name             | `Linter (Local LLM)`                  |
+| Role Theme               | `linter`                              |
+| Emoji                    | `✨`                                  |
+| Tier                     | `Haiku $`                             |
+| Primary Model            | (оставь дефолт `anthropic/claude-haiku-4-5` — override через Config tab) |
+| Workspace                | `Read-only`                           |
+| Sandbox                  | `All sessions`                        |
+| Network                  | `Isolated`                            |
+| Session Key (Optional)   | (пусто)                               |
+
+`Next` → Review → оба чекбокса ☐ → **`Create Agent`**.
+
+Step 3 → **Create**.
+
+### 5.3. Soul
+
+```
+You only suggest lint/format/style fixes. Skip semantic changes.
+Reply with bullet list of fixes:
+  - <file>:<line> — <fix description>
+
+If nothing to fix, reply:
+  CLEAN
+```
+
+Save.
+
+### 5.4. dispatchModel — указать LMStudio модель
+
+Аналогично 4.4 (через UI или API):
+
+```json
+{
+  "dispatchModel": "local/qwen2.5-coder-7b-instruct"
+}
+```
+
+> Замени `qwen2.5-coder-7b-instruct` на **точный API Identifier** из LMStudio Server tab (см. шаг 0.2 пункт 5).
+
+Префикс `local/` (или `lmstudio/`/`ollama/`/`litellm/`) триггерит маршрутизацию на `LOCAL_LLM_ENDPOINT`.
+
+---
+
+## 6. Агент №4 — Aegis (Claude Sonnet, reviewer)
+
+> Aegis может уже быть создан системой автоматически (имя `aegis` в default workspace). Проверь в `/agents`. Если есть — открой его, обнови Soul по шаблону ниже и пропусти создание. Если нет — создавай.
+
+### 6.1. Создание (если нет)
+
+`/agents` → **`+ Create Agent`** → Step 1 Template: **`Reviewer / QA`** (🔬).
+
+Step 2 Configure:
+
+| Лейбл                    | Значение                              |
+|--------------------------|---------------------------------------|
+| Display Name             | `Aegis`                               |
+| Role Theme               | `reviewer`                            |
+| Emoji                    | `🛡️`                                  |
+| Tier                     | `Sonnet $$` (переопредели если шаблон поставил Haiku) |
+| Primary Model            | `anthropic/claude-sonnet-4-20250514`  |
+| Workspace                | `Read-only`                           |
+| Sandbox                  | `Non-main sessions`                   |
+| Network                  | `Isolated`                            |
+| Session Key (Optional)   | (пусто)                               |
+
+`Next` → Review → оба чекбокса ☐ → **`Create Agent`**.
+
+### 6.2. Soul (формат строгий — MC парсит ответ)
+
+```
+You are Aegis, the quality reviewer.
+
+Evaluate the agent's resolution against the acceptance criteria.
+
+Reply with EXACTLY one of these two formats:
+
+If acceptable:
+VERDICT: APPROVED
+NOTES: <one-line summary>
+
+If needs fix:
+VERDICT: REJECTED
+NOTES: <specific issues to fix>
+```
+
+Save.
+
+### 6.3. dispatchModel — оставь Anthropic (нужен дефолт)
+
+Sonnet shaблon уже даёт `anthropic/claude-sonnet-4-20250514`. Anthropic — дефолтный путь. **Config edit не нужен.**
+
+---
+
+## 7. Master-задача
+
+1. В левом сайдбаре кликни **Tasks** (📋) — `/tasks`.
+2. В верхней панели Kanban-доски кнопка **`+ New Task`** (или `Add Task`) — кликни.
+3. Откроется форма создания задачи. Заполни:
+
+| Поле               | Значение                                                                    |
+|--------------------|-----------------------------------------------------------------------------|
+| `Title`            | `Migrate /api/auth/login from session cookies to JWT`                       |
+| `Project`          | (dropdown) `Refactor Login Flow (LOGIN)`                                    |
+| `Assigned To`      | (dropdown) `architect-claude`                                               |
+| `Priority`         | `high`                                                                      |
+| `Estimated Hours`  | `8`                                                                         |
+| `Tags`             | `auth, refactor, jwt`                                                       |
+| `Status`           | `backlog` (оставь по умолчанию)                                             |
+| `Description`      | (см. блок ниже)                                                             |
+
+Description — копируй полный текст:
+
+```
+Replace cookie-based session auth with JWT in the /api/auth/login endpoint.
+
+Current state:
+- /api/auth/login sets a session cookie via NextResponse.cookies.set('session', token)
+- Server reads this cookie to authenticate subsequent /api/* requests
+- Cookie is httpOnly + Secure + SameSite=Lax
+- Session token is stored in `sessions` table, looked up by id
+
+Goal:
+- /api/auth/login returns { token: string, expiresAt: number } in the JSON body
+- Token is a signed JWT (use existing AUTH_SECRET as HS256 signing key)
+- Subsequent requests authenticate via Authorization: Bearer <token> header
+- Drop the `sessions` table dependency entirely
+- Keep /api/auth/logout working (now stateless: client just discards the token)
+
+Constraints:
+- All existing E2E tests must still pass after refactor
+- Backward compatibility for ONE release: accept BOTH cookie and Bearer header
+  during the deprecation window
+- Document the migration in CHANGELOG.md
+
+Decompose into 3-7 atomic subtasks. For each, give acceptance criteria
+the implementor agent can verify locally before marking done.
+```
+
+Кнопка **`Create`** (или `Save`).
+
+---
+
+## 7.A. Про "Owner" и колонку "Awaiting Owner"
+
+В MC у задачи **нет отдельного поля Owner** в форме создания/редактирования. Есть только `Assigned To` — агент-исполнитель (ты выбрал `architect-claude`).
+
+Колонка **`Awaiting Owner`** в Task Board — это автоматический статус для задач, требующих **человеческого вмешательства** (PM, оператор). MC выставляет его в трёх случаях:
+
+- **Aegis reject** — рецензент отклонил resolution → задача ждёт что человек разберётся и решит дальше делать.
+- **Метки/теги** в title или description (`owner action`, `human required`, `blocked on owner`, `awaiting human`, `needs owner`) — детектится в `detectAwaitingOwner()`.
+- **Manual drag** — ты сам перетаскиваешь карточку в колонку `Awaiting Owner`. Status станет `awaiting_owner`.
+
+**Что это значит на практике для нашего демо:**
+- На старте все задачи в `Backlog`. После назначения агенту → `Assigned`.
+- При drag в `In Progress` агент работает. При rejection от Aegis (или ручном drag в `Awaiting Owner`) — задача ожидает тебя.
+- Когда ты сам обработал и хочешь вернуть в работу — drag из `Awaiting Owner` обратно в `In Progress` или `Backlog`.
+
+**Если нужен полноценный «owner» как отдельное поле** (например, в виде «менеджер этой задачи = vasya, исполнитель = agent-X»), это потребует апстрим-доработки MC: добавить колонку `owner` в schema + поле в task form. На этой ветке этого нет.
+
+## 8. Запустить конвейер
+
+### 8.1. Architect декомпозирует
+
+1. На `/tasks` Kanban найди карточку `Migrate /api/auth/login...` в колонке **`Backlog`**.
+2. **Перетащи мышью** в колонку **`In Progress`**. (Или открой карточку → Status dropdown → `in_progress`.)
+3. Через ~30-90с (Opus думает) карточка обновится. Кликни на неё.
+4. В детальном виде поле **`Resolution`** будет содержать список из 3-7 пронумерованных пунктов в формате TITLE/DESCRIPTION/ACCEPTANCE/ESTIMATE.
+
+**Где смотреть прогресс:**
+- Карточка задачи (live-обновляется через polling/SSE).
+- В терминале: `make logs | grep -i dispatch` — увидишь `Dispatching task via direct anthropic`.
+- `/cost-tracker` (левый сайдбар) — строка с `claude-opus-4-5` и потраченными токенами.
+
+### 8.2. Раскладка подзадач (вручную, ~3 мин)
+
+Открой `Resolution` master-задачи. Для **каждой** подзадачи:
+
+1. `/tasks` → **`+ New Task`**.
+2. Поля:
+   - `Title`: `LOGIN-N: <TITLE из resolution>` (например `LOGIN-1: Add JWT sign helper`)
+   - `Project`: `Refactor Login Flow (LOGIN)`
+   - `Assigned To`: `dev-openai`
+   - `Priority`: `medium` (или `high` если ESTIMATE > 4h)
+   - `Tags`: `auth, jwt, subtask`
+   - `Description`: **скопируй блок DESCRIPTION + ACCEPTANCE из вывода architect**
+3. `Create`.
+
+> Если есть желание — автоматизировать через CLI: `node scripts/mc-cli.cjs tasks create ...` (см. `docs/cli-agent-control.md`).
+
+### 8.3. Dev пишет код
+
+Перетащи каждую `LOGIN-N` подзадачу из `Backlog` → `In Progress`.
+- Implementor (gpt-4o-mini) обработает за ~10-30с/задачу.
+- Resolution каждой подзадачи: список файлов + unified diff'ы.
+- В `/cost-tracker`: модель `gpt-4o-mini`.
+- В `make logs`: `Dispatching task via direct openai`.
+
+### 8.4. Linter (опционально, показывает работу local LLM)
+
+Для каждой готовой dev-задачи создай **linter-задачу**:
+
+1. `+ New Task`:
+   - `Title`: `Lint LOGIN-N output`
+   - `Assigned To`: `linter-local`
+   - `Description`: вставь diff из `LOGIN-N` resolution + строка `Suggest only style/lint fixes.`
+2. Перетащи в `In Progress`.
+3. **Открой LMStudio Server tab** → должна появиться запись запроса в Server logs.
+4. Resolution = bullet list или `CLEAN`.
+
+### 8.5. Aegis ревью
+
+> Aegis запускается **автоматически** каждые 60с по задачам в статусе `review` (см. `runAegisReviews` в `src/lib/task-dispatch.ts`).
+
+Перетащи каждую dev-задачу из `In Progress` → **`Review`**.
+
+В течение 60с:
+- Aegis получит задачу, прочитает `description` (acceptance criteria) и `resolution`, вернёт `VERDICT: APPROVED` или `VERDICT: REJECTED`.
+- **Если APPROVED** → задача → `Done`.
+- **Если REJECTED** → задача → обратно в `In Progress`, `error_message` содержит NOTES от Aegis.
+
+`/cost-tracker`: модель `claude-sonnet-4-20250514`.
+
+---
+
+## 9. Чек-лист приёмки
+
+После 5-15 минут активной работы конвейера:
+
+| Проверка                         | Где                          | Ожидание                                                                 |
+|----------------------------------|------------------------------|--------------------------------------------------------------------------|
+| 4 агента онлайн                  | `/agents`                    | 4 строки, last_seen свежий                                                |
+| Master декомпозирована           | `/tasks/<master-id>`         | Resolution содержит 3-7 пронумерованных TITLE/DESCRIPTION/ACCEPTANCE/ESTIMATE |
+| Подзадачи созданы                | `/tasks` Kanban              | Колонки заполнены, все assigned `dev-openai`                              |
+| Dev-задачи имеют diff            | `/tasks/<id>`                | Resolution содержит unified diff                                          |
+| Linter работает                  | LMStudio Server tab → Logs    | Хотя бы 1 POST `/v1/chat/completions`                                     |
+| Aegis verdicts                   | `/tasks/<id>`                | Resolution или комментарий: `VERDICT: APPROVED` или `REJECTED`            |
+| Cost tracker — три провайдера    | `/cost-tracker`              | Anthropic + OpenAI (+ local = $0)                                         |
+| Логи dispatch                    | `make logs`                  | Есть строки `direct anthropic`, `direct openai`, `direct local`           |
+
+---
+
+## 10. Troubleshooting
+
+### LMStudio не отвечает / `local API 404`
+
+```bash
+docker exec mission-control sh -c 'curl -sS http://host.docker.internal:1234/v1/models | head'
+```
+
+- 404 → LMStudio не на 1234.
+- timeout → LMStudio не запущена / firewall.
+- пустой `data` → загрузи модель в LMStudio Server tab.
+
+### `OPENAI_API_KEY not set` в логах
+
+`.env` не подхватился. Сделай **`make recreate`** (не просто `restart`).
+
+### Aegis не запускается
+
+Aegis сканирует задачи в `review` каждые 60с. Подожди или жми `make logs | grep -i aegis`. Если совсем тишина — проверь что у агента `aegis` есть Soul и `dispatchModel` (или Anthropic дефолт).
+
+### Architect отвечает обычным текстом, не структурированно
+
+Soul слишком "softный". Усиль: добавь в начало `OUTPUT EXACTLY THIS FORMAT, NO PROSE`. Понизь temperature через JSON Config.
+
+### dispatchModel `local/...` падает с timeout
+
+LMStudio долго грузит модель в память на первом запросе (5-30с). Сделай warmup: пинг через curl или просто запрос-другой через LMStudio chat.
+
+### Не знаю свой LMStudio model id
+
+```bash
+docker exec mission-control sh -c 'curl -sS http://host.docker.internal:1234/v1/models' | python3 -c 'import json,sys;[print(m["id"]) for m in json.load(sys.stdin)["data"]]'
+```
+
+Покажет точные id всех моделей. Используй один из них (с префиксом `local/`).
+
+### Кнопки `+ Create Agent` нет
+
+Проверь что текущий workspace выбран (header-bar). Если ты в `read-only` workspace — переключись на свой.
+
+### Кнопки `Projects` нет на /tasks
+
+Возможно UI обновился. Проверь правый верхний угол панели Tasks. Также форма создания проектов может быть в `/super-admin` → секция `Projects`.
+
+---
+
+## 11. Что менять для своего сценария
+
+**Ollama вместо LMStudio:**
+```dotenv
+LOCAL_LLM_ENDPOINT=http://host.docker.internal:11434/v1
+```
+Префикс агента `ollama/<model>` или `local/<model>`.
+
+**liteLLM proxy для нескольких backend'ов:**
+```yaml
+# docker-compose.yml — добавь сервис litellm рядом с mission-control
+litellm:
+  image: ghcr.io/berriai/litellm:main-latest
+  ports: ["4000:4000"]
+  environment:
+    - LITELLM_MASTER_KEY=sk-litellm-master-key
+  volumes:
+    - ./litellm-config.yaml:/app/config.yaml
+```
+
+В `.env`:
+```dotenv
+LOCAL_LLM_ENDPOINT=http://litellm:4000
+LOCAL_LLM_API_KEY=sk-litellm-master-key
+```
+
+В Config агента `dispatchModel = litellm/<routing-name>`.
+
+**Только Anthropic + OpenAI (без local):**
+Не задавай `LOCAL_LLM_ENDPOINT`, не используй `local/*` префиксы. Удали агент `linter-local`.
+
+**Только Anthropic:**
+Не задавай `OPENAI_API_KEY`. Удали `dev-openai`. Замени роль на `dev-claude` с шаблоном Developer и Sonnet.
+
+---
+
+## 12. Полезные команды
+
+```bash
+# Полный лог сервера
+make logs
+
+# Только dispatch события
+make logs | grep -i "Dispatching task"
+
+# Перезапуск с применением .env
+make recreate
+
+# Сбросить БД и начать с нуля (внимание: удалит всех агентов и задачи)
+make reset-db
+
+# Проверить статус контейнера
+make status
+
+# Войти в shell контейнера
+make shell
+
+# Внутри контейнера: проверить env vars
+env | grep -E "ANTHROPIC|OPENAI|LOCAL_LLM|MC_HOST"
+
+# Внутри контейнера: проверить что claude binary на месте
+which claude && claude --version
+```
+
+---
+
+## 13. Открытые вопросы (отметь если что-то не сошлось)
+
+Подтверждённые (исправлено в файле):
+- [x] Workspace форма — кнопка `Create + Queue`, 8 полей (см. раздел 1).
+- [x] Project — кнопка `Add Project` + раскрывающаяся карточка для GitHub/Color/Deadline (см. раздел 2).
+- [x] Agent wizard — 3 шага: Template / Configure / Review. Поля Step 2: Display Name, Role Theme, Emoji, Tier (3-button), Primary Model, Workspace (None/RW/RO), Sandbox (All/Non-main sessions), Network (Isolated/Bridge), Session Key. Step 3: Add to gateway / Provision Workspace + кнопка `Create Agent`.
+
+Ещё открыто:
+- [ ] Tab `Soul` — точно так называется в детальном виде агента? Или `Personality`/`Identity`?
+- [ ] Tab `Config` с JSON editor — существует, и формат как в моём шаблоне?
+- [ ] `Add Project` → раскрытие карточки existing project — кликом по карточке или иначе?
+- [ ] LMStudio model id в моей системе: ___________
+- [ ] При drag в `Review` колонку — Aegis действительно срабатывает в течение 60с?
+- [ ] `dispatchModel` в JSON config сохраняется после reload агента?
+- [ ] Workspace селектор в header-bar — есть или MC работает только с одним workspace?
+
+Если что-то не совпадает — пометь, обновлю файл.

--- a/src/app/api/agents/[id]/route.ts
+++ b/src/app/api/agents/[id]/route.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs'
 import { NextRequest, NextResponse } from 'next/server'
 import { getDatabase, db_helpers, logAuditEvent } from '@/lib/db'
 import { requireRole } from '@/lib/auth'
@@ -5,6 +6,7 @@ import { writeAgentToConfig, enrichAgentConfigFromWorkspace, removeAgentFromConf
 import { eventBus } from '@/lib/event-bus'
 import { logger } from '@/lib/logger'
 import { runOpenClaw } from '@/lib/command'
+import { config as appConfig } from '@/lib/config'
 
 /**
  * GET /api/agents/[id] - Get a single agent by ID or name
@@ -87,10 +89,24 @@ export async function PUT(
       newConfig = { ...existingConfig, ...gateway_config }
     }
 
+    // Skip gateway-config write-back when no openclaw.json exists on disk —
+    // this happens on Linux operator setups that drive agents via direct API
+    // dispatch (no OpenClaw install). Without this guard the route DB-saves
+    // the new config, then immediately reverts it because the file open fails
+    // with ENOENT, leaving the user with a misleading "Save failed".
+    const openclawConfigPath = appConfig.openclawConfigPath
+    const openclawConfigPresent = !!openclawConfigPath && existsSync(openclawConfigPath)
     const shouldWriteToGateway = Boolean(
       gateway_config &&
+      openclawConfigPresent &&
       (write_to_gateway === undefined || write_to_gateway === null || write_to_gateway === true)
     )
+    if (gateway_config && !openclawConfigPresent && (write_to_gateway === true)) {
+      logger.warn(
+        { agent: agent.name, openclawConfigPath },
+        'write_to_gateway requested but openclaw.json is absent — DB save only, gateway write skipped',
+      )
+    }
     const openclawId = existingConfig.openclawId || agent.name.toLowerCase().replace(/\s+/g, '-')
     const getWriteBackPayload = (source: Record<string, any>) => {
       const writeBack: any = { id: openclawId }

--- a/src/components/panels/agent-detail-tabs.tsx
+++ b/src/components/panels/agent-detail-tabs.tsx
@@ -214,7 +214,16 @@ export function OverviewTab({
                 </select>
               ) : (
                 <span className="text-foreground font-mono text-xs">
-                  {(() => { const p = (agent as any).config?.model?.primary; const m = (agent as any).model; const v = typeof p === 'string' ? p : p?.primary; return v || (typeof m === 'string' ? m : m?.primary) || t('default') })()}
+                  {(() => {
+                    const toStr = (x: unknown): string => {
+                      if (typeof x === 'string') return x
+                      if (x && typeof x === 'object' && typeof (x as any).primary === 'string') return (x as any).primary
+                      return ''
+                    }
+                    const p = (agent as any).config?.model?.primary
+                    const m = (agent as any).model
+                    return toStr(p) || toStr(m) || t('default')
+                  })()}
                 </span>
               )}
             </div>
@@ -1572,7 +1581,18 @@ export function ConfigTab({
   const toolAllow = Array.isArray(tools.allow) ? tools.allow : []
   const toolDeny = Array.isArray(tools.deny) ? tools.deny : []
   const toolRawPreview = typeof tools.raw === 'string' ? tools.raw : ''
-  const modelPrimary = model.primary || ''
+  // Defense: agent config may have been written with model.primary as an
+  // object (some templates / migrations end up with `{primary: "name"}`
+  // wrapped twice). Always coerce to a renderable string so this tab never
+  // crashes with React error #31 ("objects are not valid as a React child").
+  const modelPrimaryRaw: unknown = (model as any)?.primary
+  const modelPrimary = typeof modelPrimaryRaw === 'string'
+    ? modelPrimaryRaw
+    : (modelPrimaryRaw && typeof modelPrimaryRaw === 'object'
+        ? (typeof (modelPrimaryRaw as any).primary === 'string'
+            ? (modelPrimaryRaw as any).primary
+            : JSON.stringify(modelPrimaryRaw))
+        : '')
   const modelFallbacks = Array.isArray(model.fallbacks) ? model.fallbacks : []
 
   return (
@@ -2101,7 +2121,12 @@ export function ConfigTab({
                       ))}
                     </div>
                     {subagents.model && (
-                      <div className="text-xs text-muted-foreground mt-1">{t('modelLabel')}: {subagents.model}</div>
+                      <div className="text-xs text-muted-foreground mt-1">
+                        {t('modelLabel')}:{' '}
+                        {typeof subagents.model === 'string'
+                          ? subagents.model
+                          : (subagents.model?.primary || JSON.stringify(subagents.model))}
+                      </div>
                     )}
                   </>
                 ) : (
@@ -2767,8 +2792,17 @@ export function ModelsTab({ agent }: { agent: Agent }) {
   const t = useTranslations('agentDetail')
   const agentConfig = (agent as any).config || {}
   const modelCfg = agentConfig.model || {}
-  const modelPrimary = typeof modelCfg === 'string' ? modelCfg : (modelCfg.primary || '')
-  const modelFallbacks: string[] = Array.isArray(modelCfg.fallbacks) ? modelCfg.fallbacks : []
+  // Same defensive coercion as ConfigTab: `model.primary` may be an object
+  // in some legacy/imported configs. Always end up with a string.
+  const _primaryRaw: unknown = typeof modelCfg === 'string' ? modelCfg : (modelCfg as any)?.primary
+  const modelPrimary = typeof _primaryRaw === 'string'
+    ? _primaryRaw
+    : (_primaryRaw && typeof _primaryRaw === 'object'
+        ? (typeof (_primaryRaw as any).primary === 'string'
+            ? (_primaryRaw as any).primary
+            : JSON.stringify(_primaryRaw))
+        : '')
+  const modelFallbacks: string[] = Array.isArray((modelCfg as any).fallbacks) ? (modelCfg as any).fallbacks : []
 
   const [primary, setPrimary] = useState(modelPrimary)
   const [fallbacks, setFallbacks] = useState<string[]>(modelFallbacks)

--- a/src/lib/task-dispatch.ts
+++ b/src/lib/task-dispatch.ts
@@ -1,3 +1,5 @@
+import { existsSync } from 'node:fs'
+import { spawn } from 'node:child_process'
 import { getDatabase, db_helpers } from './db'
 import { runOpenClaw } from './command'
 import { callOpenClawGateway } from './openclaw-gateway'
@@ -149,11 +151,25 @@ function getAnthropicApiKey(): string | null {
 }
 
 function isGatewayAvailable(): boolean {
-  // Gateway is available if OpenClaw is installed OR a gateway is registered in the DB
-  if (config.openclawHome) return true
+  // `config.openclawHome` defaults to `~/.openclaw` even when OpenClaw is not
+  // installed, so a truthy path string alone is not evidence that a gateway
+  // can actually be invoked. Require physical evidence:
+  //   - a real `openclaw.json` on disk (= an installed OpenClaw config), OR
+  //   - a registered gateway row whose status is healthy. We explicitly
+  //     reject `status = 'unknown'` because the onboarding flow seeds a
+  //     `primary` row pointing at `host.docker.internal:18789` regardless
+  //     of whether OpenClaw is actually running. Treating that seed row as
+  //     proof of availability would route every dispatch through
+  //     `runOpenClaw` and fail with `spawn openclaw ENOENT` on hosts that
+  //     don't have the binary. Require the row to have been pinged
+  //     successfully at least once (status in healthy set) before we trust
+  //     the gateway path.
+  if (config.openclawConfigPath && existsSync(config.openclawConfigPath)) return true
   try {
     const db = getDatabase()
-    const row = db.prepare('SELECT COUNT(*) as c FROM gateways').get() as { c: number } | undefined
+    const row = db.prepare(
+      "SELECT COUNT(*) as c FROM gateways WHERE status IN ('online', 'healthy', 'ready')"
+    ).get() as { c: number } | undefined
     return (row?.c ?? 0) > 0
   } catch {
     return false
@@ -293,6 +309,244 @@ async function callClaudeDirectly(
   return { text, sessionId: null }
 }
 
+// ---------------------------------------------------------------------------
+// Direct OpenAI / OpenAI-compatible local dispatch — also gateway-free.
+//
+// The "local" provider path is intentionally generic: it speaks the OpenAI
+// `/v1/chat/completions` REST shape, which is what LMStudio, Ollama, vLLM and
+// liteLLM proxies all expose. Operators who run multiple local backends
+// behind a single liteLLM endpoint can point LOCAL_LLM_ENDPOINT at it and
+// route every "local model" request through one process.
+//
+// Model routing is done by prefix on the agent's `dispatchModel`:
+//   "openai/gpt-4o-mini", "gpt-4.1-mini", "o1-*", "o3-*"  → OpenAI cloud
+//   "local/<model>", "ollama/<model>", "lmstudio/<model>" → LOCAL_LLM_ENDPOINT
+//   anything else (incl. "claude-*")                      → Anthropic
+// ---------------------------------------------------------------------------
+
+type DirectProvider = 'anthropic' | 'openai' | 'local'
+
+function getOpenAIApiKey(): string | null {
+  return (process.env.OPENAI_API_KEY || '').trim() || null
+}
+
+/**
+ * OpenAI-compatible local endpoint. Defaults to LMStudio's stock listener on
+ * the docker host (`host.docker.internal:1234/v1`). Set LOCAL_LLM_ENDPOINT to
+ * point at Ollama (`http://host.docker.internal:11434/v1`), a liteLLM proxy
+ * (`http://litellm:4000`), or any other OpenAI-compatible service.
+ */
+function getLocalEndpoint(): string | null {
+  return (process.env.LOCAL_LLM_ENDPOINT || 'http://host.docker.internal:1234/v1').trim() || null
+}
+
+function getLocalApiKey(): string | null {
+  // Some liteLLM/proxy setups require a master key even for local routing.
+  return (process.env.LOCAL_LLM_API_KEY || '').trim() || null
+}
+
+function pickProvider(model: string): DirectProvider {
+  const m = model.toLowerCase()
+  if (m.startsWith('openai/') || m.startsWith('gpt-') || m.startsWith('o1-') || m.startsWith('o3-')) return 'openai'
+  if (m.startsWith('local/') || m.startsWith('ollama/') || m.startsWith('lmstudio/') || m.startsWith('litellm/')) return 'local'
+  return 'anthropic'
+}
+
+function stripProviderPrefix(model: string): string {
+  return model.replace(/^(openai|local|ollama|lmstudio|litellm|anthropic)\//, '')
+}
+
+/**
+ * The Claude Code CLI on the container's PATH (mounted from the host's
+ * `~/.local/bin`). When present and authenticated (host's `~/.claude.json`
+ * is bind-mounted in), we prefer it over the raw Anthropic API: it inherits
+ * the operator's existing login, plan, and rate limits without requiring
+ * an `ANTHROPIC_API_KEY` to be exported into the container.
+ */
+function isClaudeCliAvailable(): boolean {
+  try {
+    return existsSync('/home/nextjs/.local/bin/claude')
+      || existsSync('/usr/local/bin/claude')
+      || existsSync('/usr/bin/claude')
+  } catch { return false }
+}
+
+function isDirectDispatchAvailable(provider?: DirectProvider): boolean {
+  if (provider === 'anthropic') return !!getAnthropicApiKey() || isClaudeCliAvailable()
+  if (provider === 'openai') return !!getOpenAIApiKey()
+  if (provider === 'local') return !!getLocalEndpoint()
+  return !!getAnthropicApiKey() || !!getOpenAIApiKey() || !!getLocalEndpoint() || isClaudeCliAvailable()
+}
+
+/**
+ * Dispatch via the host-mounted Claude Code CLI, using the operator's existing
+ * login (no API key required). Reads the prompt over stdin and asks for a
+ * machine-readable result via `--output-format json`.
+ *
+ * The CLI accepts model aliases ("opus" / "sonnet" / "haiku") and the long
+ * `claude-...` IDs. We try the bare ID first (already produced by
+ * `classifyDirectModel`), and fall back to the alias derived from the family
+ * keyword so a stale `claude-opus-4-5` mapping still routes correctly.
+ */
+async function callClaudeViaCli(
+  task: DispatchableTask,
+  prompt: string,
+  model: string,
+): Promise<AgentResponseParsed> {
+  const soul = getAgentSoulContent(task)
+  const args = ['--print', '--output-format', 'json', '--model', model]
+  if (soul) args.push('--append-system-prompt', soul)
+
+  logger.info({ taskId: task.id, model, agent: task.agent_name }, 'Dispatching task via Claude CLI')
+
+  return await new Promise<AgentResponseParsed>((resolve, reject) => {
+    const proc = spawn('claude', args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, CI: '1' },
+    })
+    let stdout = ''
+    let stderr = ''
+    const timeoutMs = 180_000
+    const timer = setTimeout(() => {
+      proc.kill('SIGTERM')
+      reject(new Error(`Claude CLI timed out after ${timeoutMs / 1000}s`))
+    }, timeoutMs)
+
+    proc.stdout.on('data', (d) => { stdout += d.toString() })
+    proc.stderr.on('data', (d) => { stderr += d.toString() })
+    proc.on('error', (err) => { clearTimeout(timer); reject(err) })
+    proc.on('close', (code) => {
+      clearTimeout(timer)
+      if (code !== 0) {
+        return reject(new Error(`claude CLI exited ${code}: ${stderr.slice(0, 500) || stdout.slice(0, 500)}`))
+      }
+      try {
+        const parsed = JSON.parse(stdout)
+        const text: string | null = (typeof parsed?.result === 'string' && parsed.result)
+          || (typeof parsed?.output === 'string' && parsed.output)
+          || (typeof parsed?.text === 'string' && parsed.text)
+          || stdout.trim()
+          || null
+        const sessionId: string | null = (typeof parsed?.session_id === 'string' && parsed.session_id)
+          || (typeof parsed?.sessionId === 'string' && parsed.sessionId)
+          || null
+
+        // Record token usage if reported.
+        if (parsed?.usage && (parsed.usage.input_tokens || parsed.usage.output_tokens)) {
+          try {
+            const db = getDatabase()
+            const now = Math.floor(Date.now() / 1000)
+            db.prepare(`
+              INSERT INTO token_usage (model, session_id, input_tokens, output_tokens, total_tokens, cost, created_at, workspace_id)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            `).run(
+              model,
+              sessionId || `task-${task.id}`,
+              parsed.usage.input_tokens || 0,
+              parsed.usage.output_tokens || 0,
+              (parsed.usage.input_tokens || 0) + (parsed.usage.output_tokens || 0),
+              0,
+              now,
+              task.workspace_id,
+            )
+          } catch { /* non-fatal */ }
+        }
+
+        resolve({ text, sessionId })
+      } catch {
+        resolve({ text: stdout.trim() || null, sessionId: null })
+      }
+    })
+
+    proc.stdin.write(prompt)
+    proc.stdin.end()
+  })
+}
+
+async function callOpenAICompatible(
+  task: DispatchableTask,
+  prompt: string,
+  endpoint: string,
+  apiKey: string | null,
+  model: string,
+  providerLabel: DirectProvider,
+): Promise<AgentResponseParsed> {
+  const soul = getAgentSoulContent(task)
+  const messages: Array<{ role: string; content: string }> = []
+  if (soul) messages.push({ role: 'system', content: soul })
+  messages.push({ role: 'user', content: prompt })
+
+  const body = { model, messages, max_tokens: 4096 }
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`
+
+  logger.info({ taskId: task.id, model, agent: task.agent_name, provider: providerLabel },
+    `Dispatching task via direct ${providerLabel} API`)
+
+  const res = await fetch(`${endpoint.replace(/\/$/, '')}/chat/completions`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  })
+
+  if (!res.ok) {
+    const errorBody = await res.text().catch(() => '')
+    throw new Error(`${providerLabel} API ${res.status}: ${errorBody.substring(0, 500)}`)
+  }
+
+  const data = await res.json() as {
+    choices?: Array<{ message?: { content?: string } }>
+    usage?: { prompt_tokens?: number; completion_tokens?: number }
+  }
+  const text = data.choices?.[0]?.message?.content?.trim() || null
+
+  if (data.usage) {
+    try {
+      const db = getDatabase()
+      const now = Math.floor(Date.now() / 1000)
+      db.prepare(`
+        INSERT INTO token_usage (model, session_id, input_tokens, output_tokens, total_tokens, cost, created_at, workspace_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        model,
+        `task-${task.id}`,
+        data.usage.prompt_tokens || 0,
+        data.usage.completion_tokens || 0,
+        (data.usage.prompt_tokens || 0) + (data.usage.completion_tokens || 0),
+        0,
+        now,
+        task.workspace_id,
+      )
+    } catch { /* non-fatal */ }
+  }
+
+  return { text, sessionId: null }
+}
+
+async function callOpenAIDirectly(task: DispatchableTask, prompt: string, model: string): Promise<AgentResponseParsed> {
+  const apiKey = getOpenAIApiKey()
+  if (!apiKey) throw new Error('OPENAI_API_KEY not set — cannot dispatch to OpenAI without gateway')
+  return callOpenAICompatible(task, prompt, 'https://api.openai.com/v1', apiKey, stripProviderPrefix(model), 'openai')
+}
+
+async function callLocalDirectly(task: DispatchableTask, prompt: string, model: string): Promise<AgentResponseParsed> {
+  const endpoint = getLocalEndpoint()
+  if (!endpoint) throw new Error('LOCAL_LLM_ENDPOINT not set — cannot dispatch to local model')
+  return callOpenAICompatible(task, prompt, endpoint, getLocalApiKey(), stripProviderPrefix(model), 'local')
+}
+
+async function callDirectly(task: DispatchableTask, prompt: string): Promise<AgentResponseParsed> {
+  const model = classifyDirectModel(task)
+  const provider = pickProvider(model)
+  if (provider === 'openai') return callOpenAIDirectly(task, prompt, model)
+  if (provider === 'local') return callLocalDirectly(task, prompt, model)
+  // Anthropic: prefer the host Claude Code CLI when available — it uses the
+  // operator's existing login, no API key needed. Fall back to the API key
+  // path only if the CLI isn't installed.
+  if (isClaudeCliAvailable()) return callClaudeViaCli(task, prompt, stripProviderPrefix(model))
+  return callClaudeDirectly(task, prompt)
+}
+
 interface ReviewableTask {
   id: number
   title: string
@@ -403,16 +657,18 @@ export async function runAegisReviews(): Promise<{ ok: boolean; message: string 
       const prompt = buildReviewPrompt(task)
       let agentResponse: AgentResponseParsed
 
-      if (!isGatewayAvailable() && getAnthropicApiKey()) {
-        // Direct Claude API review — no gateway needed
+      if (!isGatewayAvailable() && isDirectDispatchAvailable()) {
+        // Direct API review — no gateway needed (Anthropic / OpenAI / local).
+        // Pass through agent_config so Aegis honors per-agent dispatchModel
+        // overrides and routes to the matching provider.
         const reviewTask: DispatchableTask = {
           id: task.id, title: task.title, description: task.description,
           status: 'quality_review', priority: 'high', assigned_to: 'aegis',
           workspace_id: task.workspace_id, agent_name: 'aegis', agent_id: 0,
-          agent_config: null, ticket_prefix: task.ticket_prefix,
+          agent_config: task.agent_config, ticket_prefix: task.ticket_prefix,
           project_ticket_no: task.project_ticket_no, project_id: null,
         }
-        agentResponse = await callClaudeDirectly(reviewTask, prompt)
+        agentResponse = await callDirectly(reviewTask, prompt)
       } else {
         // Resolve the gateway agent ID from config, falling back to assigned_to or default
         const reviewAgent = resolveGatewayAgentIdForReview(task)
@@ -567,7 +823,15 @@ export async function requeueStaleTasks(): Promise<{ ok: boolean; message: strin
   let requeued = 0
   let failed = 0
 
+  // When MC runs in direct-API mode (no gateway), the agent has no heartbeat
+  // and stays "offline" by design — but tasks still get dispatched via the
+  // direct provider (Anthropic/OpenAI/local). Skip the offline-stale check
+  // entirely in that mode, otherwise every task is failed after 5 cycles
+  // before any direct-API dispatch can run.
+  const directApiSkipsStaleCheck = !isGatewayAvailable() && isDirectDispatchAvailable()
+
   for (const task of staleTasks) {
+    if (directApiSkipsStaleCheck) continue
     // Only requeue if the agent is offline or unknown
     const agentOffline = !task.agent_status || task.agent_status === 'offline'
     if (!agentOffline) continue
@@ -695,11 +959,12 @@ export async function dispatchAssignedTasks(): Promise<{ ok: boolean; message: s
         : null
 
       let agentResponse: AgentResponseParsed
-      const useDirectApi = !isGatewayAvailable() && getAnthropicApiKey()
+      const useDirectApi = !isGatewayAvailable() && isDirectDispatchAvailable()
 
       if (useDirectApi && !targetSession) {
-        // Direct Claude API dispatch — no gateway needed
-        agentResponse = await callClaudeDirectly(task, prompt)
+        // Direct API dispatch — provider chosen by `dispatchModel` prefix
+        // (Anthropic / OpenAI / OpenAI-compatible local). No gateway needed.
+        agentResponse = await callDirectly(task, prompt)
       } else if (targetSession) {
         // Dispatch to a specific existing session via chat.send
         logger.info({ taskId: task.id, targetSession, agent: task.agent_name }, 'Dispatching task to targeted session')
@@ -899,8 +1164,11 @@ function scoreAgentForTask(
   agent: { name: string; role: string; status: string; config: string | null },
   taskText: string,
 ): number {
-  // Offline agents can't take work
-  if (agent.status === 'offline' || agent.status === 'error' || agent.status === 'sleeping') return -1
+  // Offline agents can't take work — unless we're in direct-API mode where
+  // the agent has no heartbeat by design and the dispatcher invokes the
+  // provider HTTP API directly (no live agent process required).
+  const directApiOk = !isGatewayAvailable() && isDirectDispatchAvailable()
+  if (!directApiOk && (agent.status === 'offline' || agent.status === 'error' || agent.status === 'sleeping')) return -1
 
   const text = taskText.toLowerCase()
   const keywords = ROLE_AFFINITY[agent.role] || []


### PR DESCRIPTION
## Summary

Adds a direct-dispatch path for tasks so MC no longer requires the OpenClaw gateway to reach LLMs. When the gateway isn't available — most commonly on Linux deployments where the macOS-native gateway can't be installed — MC now calls provider HTTP APIs itself.

### Supported direct providers

| Provider | Env variable | Notes |
|---|---|---|
| **Anthropic** | `ANTHROPIC_API_KEY` | Smart Opus/Sonnet/Haiku selection via `classifyDirectModel()` heuristics. |
| **OpenAI** | `OPENAI_API_KEY` | Models like `openai/gpt-4o-mini`, `openai/gpt-5-nano` selectable per-agent. |
| **Any OpenAI-compatible local** | `LOCAL_LLM_ENDPOINT`, optional `LOCAL_LLM_API_KEY` | LMStudio, Ollama, vLLM — anything serving `/v1/chat/completions`. |

Each agent's `agent_config.dispatchModel` overrides the heuristics (e.g. set `openai/gpt-4o-mini` to lock that agent to OpenAI).

### Hardened gateway-availability check

`isGatewayAvailable()` previously returned `true` whenever `~/.openclaw` was a non-empty path string — which is the **default** even when OpenClaw isn't installed. On Linux this caused `useDirectApi = !true && … = false`, so MC fell through to `runOpenClaw(...)` and crashed with `spawn openclaw ENOENT`.

The check now requires physical evidence:
- A real `openclaw.json` exists at `config.openclawConfigPath`, **or**
- A `gateways` row whose status is in `{online, healthy, ready}` (the seed `unknown` row planted by onboarding doesn't count).

## Why this is useful upstream

Dropping the macOS-only constraint is the single biggest barrier to running MC in cloud / Linux dev environments. With this change, an operator can `git clone`, set `ANTHROPIC_API_KEY`, and dispatch tasks immediately — no gateway, no Mac, no extra processes.

## Walkthrough

`examples/MULTI-PROVIDER-DEMO.md` is a field-by-field walkthrough that builds a three-agent team using all three direct providers (Anthropic for the lead, OpenAI for the worker, local LMStudio for the reviewer) and runs an end-to-end task.

## Test plan

- Run on a Linux host with no OpenClaw installed; confirm `/agents` shows "No gateways installed" and dispatch still works.
- Set only `ANTHROPIC_API_KEY` and dispatch a task — logs show "Dispatching task via direct Claude API".
- Set only `OPENAI_API_KEY`, set agent `dispatchModel: openai/gpt-4o-mini`, dispatch — logs show OpenAI direct.
- Bring up LMStudio at `127.0.0.1:1234`, set `LOCAL_LLM_ENDPOINT=http://host.docker.internal:1234/v1`, dispatch with `dispatchModel: local/<your-model>` — logs show local direct.
- With OpenClaw running and a healthy `gateways` row, dispatch — `useDirectApi=false`, gateway path used as before. Backwards-compatible.

## Provenance

Squashes:
- `70328ad feat(dispatch): direct OpenAI + OpenAI-compatible local providers`
- `762ed51 fix(dispatch): make MC self-sufficient without OpenClaw gateway`
- `8def310 docs(deployment): document host-config projection, direct providers, host session modes`
- `bdd86ea docs(examples): add multi-provider team walkthrough`
- `c7627c7 docs(examples): expand multi-provider demo into a field-by-field walkthrough`
