### PR TITLE
feat(galactus): add DW12 supervision panels

### DIFF
--- a/src/app/[[...panel]]/page.tsx
+++ b/src/app/[[...panel]]/page.tsx
@@ -38,6 +38,15 @@ import { NodesPanel } from '@/components/panels/nodes-panel'
 import { ExecApprovalPanel } from '@/components/panels/exec-approval-panel'
 import { SystemMonitorPanel } from '@/components/panels/system-monitor-panel'
 import { ChatPagePanel } from '@/components/panels/chat-page-panel'
+import { AttentionPanel } from '@/components/panels/attention-panel'
+import { RunPanel } from '@/components/panels/run-panel'
+import { VerifyPanel } from '@/components/panels/verify-panel'
+import { FleetPanel } from '@/components/panels/fleet-panel'
+import { SignalsPanel } from '@/components/panels/signals-panel'
+import { GalactusMemoryPanel } from '@/components/panels/memory-panel'
+import { ApprovalsPanel } from '@/components/panels/approvals-panel'
+import { EvidencePanel } from '@/components/panels/evidence-panel'
+import { RuntimeHealthPanel } from '@/components/panels/runtime-health-panel'
 import { ChatPanel } from '@/components/chat/chat-panel'
 import { STORAGE_GATEWAY_URL } from '@/lib/device-identity'
 import { getPluginPanel } from '@/lib/plugins'
@@ -604,6 +613,24 @@ function ContentRouter({ tab }: { tab: string }) {
       return <ExecApprovalPanel />
     case 'chat':
       return <ChatPagePanel />
+    case 'galactus-attention':
+      return <AttentionPanel />
+    case 'galactus-run':
+      return <RunPanel />
+    case 'galactus-verify':
+      return <VerifyPanel />
+    case 'galactus-fleet':
+      return <FleetPanel />
+    case 'galactus-signals':
+      return <SignalsPanel />
+    case 'galactus-memory':
+      return <GalactusMemoryPanel />
+    case 'galactus-approvals':
+      return <ApprovalsPanel />
+    case 'galactus-evidence':
+      return <EvidencePanel />
+    case 'galactus-runtime-health':
+      return <RuntimeHealthPanel />
     default: {
       return renderPluginPanel(tab)
     }

--- a/src/components/panels/approvals-panel.tsx
+++ b/src/components/panels/approvals-panel.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { GalactusPanelCore } from '@/components/panels/galactus-panel-core'
+
+export function ApprovalsPanel() {
+  return <GalactusPanelCore kind="approvals" />
+}

--- a/src/components/panels/attention-panel.tsx
+++ b/src/components/panels/attention-panel.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { GalactusPanelCore } from '@/components/panels/galactus-panel-core'
+
+export function AttentionPanel() {
+  return <GalactusPanelCore kind="attention" />
+}

--- a/src/components/panels/evidence-panel.tsx
+++ b/src/components/panels/evidence-panel.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { GalactusPanelCore } from '@/components/panels/galactus-panel-core'
+
+export function EvidencePanel() {
+  return <GalactusPanelCore kind="evidence" />
+}

--- a/src/components/panels/fleet-panel.tsx
+++ b/src/components/panels/fleet-panel.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { GalactusPanelCore } from '@/components/panels/galactus-panel-core'
+
+export function FleetPanel() {
+  return <GalactusPanelCore kind="fleet" />
+}

--- a/src/components/panels/galactus-panel-core.tsx
+++ b/src/components/panels/galactus-panel-core.tsx
@@ -1,0 +1,478 @@
+'use client'
+
+import { useCallback, useMemo, useState } from 'react'
+import { useSmartPoll } from '@/lib/use-smart-poll'
+import {
+  fetchGalactus,
+  readGalactusClientConfig,
+  saveGalactusToken,
+  type ApprovalQueueItem,
+  type AttentionResponse,
+  type EvidenceReview,
+  type FleetResponse,
+  type MemoryResponse,
+  type RunDetail,
+  type RuntimeHealthResponse,
+  type SignalsResponse,
+} from '@/lib/galactus-api'
+
+type PanelKind =
+  | 'attention'
+  | 'run'
+  | 'verify'
+  | 'fleet'
+  | 'signals'
+  | 'memory'
+  | 'approvals'
+  | 'evidence'
+  | 'runtime-health'
+
+interface PanelState {
+  attention: AttentionResponse | null
+  fleet: FleetResponse | null
+  signals: SignalsResponse | null
+  memory: MemoryResponse | null
+  approvals: ApprovalQueueItem[] | null
+  runtimeHealth: RuntimeHealthResponse | null
+  runDetail: RunDetail | null
+  evidence: EvidenceReview | null
+}
+
+const emptyState: PanelState = {
+  attention: null,
+  fleet: null,
+  signals: null,
+  memory: null,
+  approvals: null,
+  runtimeHealth: null,
+  runDetail: null,
+  evidence: null,
+}
+
+const toneClasses = {
+  healthy: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-100',
+  warning: 'border-amber-500/30 bg-amber-500/10 text-amber-100',
+  critical: 'border-rose-500/30 bg-rose-500/10 text-rose-100',
+  muted: 'border-slate-700 bg-slate-900/70 text-slate-300',
+}
+
+const severityTone = {
+  critical: toneClasses.critical,
+  high: toneClasses.warning,
+  medium: 'border-sky-500/30 bg-sky-500/10 text-sky-100',
+  low: toneClasses.healthy,
+}
+
+function formatAge(minutes: number | null | undefined): string {
+  if (minutes === null || minutes === undefined) return 'No event clock'
+  if (minutes < 60) return `${minutes}m`
+  return `${Math.floor(minutes / 60)}h ${minutes % 60}m`
+}
+
+function formatTime(value: string | null | undefined): string {
+  if (!value) return 'Unavailable'
+  return new Date(value).toLocaleString()
+}
+
+function selectedRunId(fleet: FleetResponse | null): string | null {
+  return fleet?.runs[0]?.run.run_id ?? null
+}
+
+async function fetchPanelState(kind: PanelKind): Promise<PanelState> {
+  const next: PanelState = { ...emptyState }
+  if (kind === 'attention') {
+    next.attention = await fetchGalactus<AttentionResponse>('/api/mission-control/attention')
+    return next
+  }
+  if (kind === 'fleet' || kind === 'run' || kind === 'verify' || kind === 'evidence') {
+    next.fleet = await fetchGalactus<FleetResponse>('/api/mission-control/fleet')
+    const runId = selectedRunId(next.fleet)
+    if (runId && (kind === 'run' || kind === 'verify')) {
+      next.runDetail = await fetchGalactus<RunDetail>(`/api/runs/control-plane/${runId}`)
+    }
+    if (runId && (kind === 'verify' || kind === 'evidence')) {
+      next.evidence = await fetchGalactus<EvidenceReview>(
+        `/api/runs/control-plane/${runId}/evidence`
+      )
+    }
+    return next
+  }
+  if (kind === 'signals') {
+    next.signals = await fetchGalactus<SignalsResponse>('/api/mission-control/signals')
+    return next
+  }
+  if (kind === 'memory') {
+    next.memory = await fetchGalactus<MemoryResponse>('/api/mission-control/memory')
+    return next
+  }
+  if (kind === 'approvals') {
+    next.approvals = await fetchGalactus<ApprovalQueueItem[]>(
+      '/api/runs/control-plane/approvals?stream_id=galactus'
+    )
+    return next
+  }
+  next.runtimeHealth = await fetchGalactus<RuntimeHealthResponse>(
+    '/api/mission-control/runtime-health'
+  )
+  return next
+}
+
+function TokenSetup({ onSaved }: { onSaved: () => void }) {
+  const config = readGalactusClientConfig()
+  const [token, setToken] = useState(config.token)
+  return (
+    <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-4">
+      <p className="text-xs font-semibold uppercase tracking-wider text-amber-100">
+        TTM connection
+      </p>
+      <div className="mt-3 flex flex-col gap-2 sm:flex-row">
+        <input
+          value={token}
+          onChange={event => setToken(event.target.value)}
+          className="min-h-10 flex-1 rounded-md border border-border bg-background px-3 text-sm text-foreground outline-none focus:border-primary"
+          placeholder="Bearer token"
+          type="password"
+        />
+        <button
+          className="min-h-10 rounded-md border border-amber-300/30 px-4 text-sm font-semibold text-amber-100 hover:bg-amber-400/10"
+          type="button"
+          onClick={() => {
+            saveGalactusToken(token)
+            onSaved()
+          }}
+        >
+          Save
+        </button>
+      </div>
+      <p className="mt-2 text-xs text-amber-50/75">
+        API base: {config.apiBase}
+      </p>
+    </div>
+  )
+}
+
+function Shell({
+  title,
+  eyebrow,
+  children,
+  error,
+  loading,
+  onRetry,
+}: {
+  title: string
+  eyebrow: string
+  children: React.ReactNode
+  error: string | null
+  loading: boolean
+  onRetry: () => void
+}) {
+  return (
+    <div className="m-4 space-y-4">
+      <section className="rounded-lg border border-border bg-card p-5">
+        <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              {eyebrow}
+            </p>
+            <h1 className="mt-1 text-xl font-semibold tracking-tight text-foreground">
+              {title}
+            </h1>
+          </div>
+          <button
+            className="min-h-9 rounded-md border border-border px-3 text-sm text-muted-foreground hover:text-foreground"
+            type="button"
+            onClick={onRetry}
+          >
+            Refresh
+          </button>
+        </div>
+        {loading && <p className="mt-3 text-sm text-muted-foreground">Loading live TTM data...</p>}
+        {error && <div className="mt-4"><TokenSetup onSaved={onRetry} /></div>}
+      </section>
+      {error && (
+        <div className="rounded-lg border border-rose-500/30 bg-rose-500/10 p-4 text-sm text-rose-100">
+          {error}
+        </div>
+      )}
+      {children}
+    </div>
+  )
+}
+
+function EmptyPanel({ label }: { label: string }) {
+  return (
+    <section className="rounded-lg border border-border bg-card p-5 text-sm text-muted-foreground">
+      No {label} data is available from TTM.
+    </section>
+  )
+}
+
+function AttentionPanel({ data }: { data: AttentionResponse | null }) {
+  if (!data) return <EmptyPanel label="attention" />
+  return (
+    <section className="grid gap-3 xl:grid-cols-2">
+      {data.items.map(item => (
+        <article key={item.id} className={`rounded-lg border p-4 ${severityTone[item.severity]}`}>
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wider text-current/70">
+                {item.kind.replace(/_/g, ' ')}
+              </p>
+              <h2 className="mt-1 text-base font-semibold text-current">{item.title}</h2>
+            </div>
+            <span className="rounded-full border border-current/25 px-2 py-1 text-xs uppercase">
+              {item.severity}
+            </span>
+          </div>
+          <p className="mt-3 text-sm text-current/80">{item.reason}</p>
+          <dl className="mt-4 grid grid-cols-2 gap-2 text-xs text-current/75">
+            <div><dt>Run</dt><dd className="font-mono">{item.run_id.slice(0, 8)}</dd></div>
+            <div><dt>Clock</dt><dd>{formatAge(item.time_since_last_event_minutes)}</dd></div>
+          </dl>
+        </article>
+      ))}
+      {data.items.length === 0 && <EmptyPanel label="attention" />}
+    </section>
+  )
+}
+
+function FleetPanel({ data }: { data: FleetResponse | null }) {
+  if (!data) return <EmptyPanel label="fleet" />
+  return (
+    <section className="rounded-lg border border-border bg-card p-5">
+      <div className="grid gap-3">
+        {data.runs.map(row => (
+          <article key={row.run.run_id} className="rounded-lg border border-border bg-background/40 p-4">
+            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+              <div>
+                <h2 className="text-base font-semibold text-foreground">{row.run.title}</h2>
+                <p className="mt-1 text-sm text-muted-foreground">{row.run.objective}</p>
+              </div>
+              <span className="rounded-full border border-border px-3 py-1 text-xs uppercase text-muted-foreground">
+                {row.run.status}
+              </span>
+            </div>
+            <dl className="mt-4 grid gap-3 text-sm sm:grid-cols-4">
+              <Metric label="Burn rate" value={`$${(row.cost_burn_rate ?? 0).toFixed(4)}/min`} />
+              <Metric label="Last event" value={formatAge(row.time_since_last_event_minutes)} />
+              <Metric label="Runtime" value={`${row.run.runtime_id}:${row.run.runtime_status}`} />
+              <Metric label="Cost" value={`$${(row.run.run_usage?.cost_usd ?? 0).toFixed(2)}`} />
+            </dl>
+          </article>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-xs uppercase tracking-wider text-muted-foreground">{label}</dt>
+      <dd className="mt-1 font-mono text-sm text-foreground">{value}</dd>
+    </div>
+  )
+}
+
+function SignalsPanel({ data }: { data: SignalsResponse | null }) {
+  if (!data) return <EmptyPanel label="signals" />
+  return (
+    <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+      {data.items.map(item => (
+        <article key={item.label} className={`rounded-lg border p-4 ${toneClasses[item.tone]}`}>
+          <p className="text-xs font-semibold uppercase tracking-wider text-current/70">
+            {item.label}
+          </p>
+          <p className="mt-2 text-2xl font-semibold text-current">{item.value}</p>
+          <p className="mt-2 text-xs text-current/60">Source: {item.provenance}</p>
+        </article>
+      ))}
+    </section>
+  )
+}
+
+function MemoryPanel({ data }: { data: MemoryResponse | null }) {
+  if (!data) return <EmptyPanel label="memory" />
+  return (
+    <section className="grid gap-3 md:grid-cols-2">
+      {data.runbooks.map(item => (
+        <article key={item.label} className="rounded-lg border border-border bg-card p-5">
+          <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            {item.status}
+          </p>
+          <h2 className="mt-1 text-base font-semibold text-foreground">{item.label}</h2>
+          <p className="mt-2 text-sm text-muted-foreground">{item.detail}</p>
+          <p className="mt-3 text-xs text-muted-foreground">Source: {item.provenance}</p>
+        </article>
+      ))}
+    </section>
+  )
+}
+
+function ApprovalsPanel({ data }: { data: ApprovalQueueItem[] | null }) {
+  if (!data) return <EmptyPanel label="approvals" />
+  return (
+    <section className="rounded-lg border border-border bg-card p-5">
+      <div className="space-y-3">
+        {data.map(item => (
+          <article key={`${item.run_id}:${item.approval_id ?? item.approval_type}`} className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-4 text-amber-100">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <h2 className="text-base font-semibold">{item.title}</h2>
+                <p className="mt-1 text-sm text-amber-50/75">{item.approval_type}</p>
+              </div>
+              <span className="rounded-full border border-current/25 px-2 py-1 text-xs uppercase">
+                {item.status}
+              </span>
+            </div>
+          </article>
+        ))}
+        {data.length === 0 && <p className="text-sm text-muted-foreground">No pending approvals.</p>}
+      </div>
+    </section>
+  )
+}
+
+function RunPanel({ data }: { data: RunDetail | null; fleet: FleetResponse | null }) {
+  if (!data) return <EmptyPanel label="run" />
+  return (
+    <section className="rounded-lg border border-border bg-card p-5">
+      <h2 className="text-lg font-semibold text-foreground">{data.title}</h2>
+      <p className="mt-2 text-sm text-muted-foreground">{data.objective}</p>
+      <dl className="mt-5 grid gap-3 sm:grid-cols-3">
+        <Metric label="Status" value={data.status} />
+        <Metric label="Runtime" value={`${data.runtime_id}:${data.runtime_status}`} />
+        <Metric label="Events" value={String(data.event_count)} />
+      </dl>
+      <div className="mt-5 space-y-2">
+        {(data.recent_events ?? []).slice(0, 5).map(event => (
+          <div key={event.event_id} className="rounded-md border border-border bg-background/40 p-3">
+            <p className="text-sm text-foreground">{event.summary}</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {event.event_type} · {formatTime(event.occurred_at)}
+            </p>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function EvidencePanel({ data }: { data: EvidenceReview | null; verify?: boolean }) {
+  if (!data) return <EmptyPanel label="evidence" />
+  return (
+    <section className="rounded-lg border border-border bg-card p-5">
+      <div className="grid gap-3 sm:grid-cols-3">
+        <Metric label="Current" value={String(data.rollup.current)} />
+        <Metric label="Stale" value={String(data.rollup.stale)} />
+        <Metric label="Total" value={String(data.rollup.total)} />
+      </div>
+      <div className="mt-5 space-y-3">
+        {data.items.map(item => (
+          <article key={item.evidence_id} className={`rounded-lg border p-4 ${item.is_current_scope ? toneClasses.healthy : toneClasses.warning}`}>
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wider text-current/70">
+                  {item.kind} · {item.verdict}
+                </p>
+                <h2 className="mt-1 text-sm font-semibold text-current">{item.subject}</h2>
+              </div>
+              <span className="rounded-full border border-current/25 px-2 py-1 text-xs uppercase">
+                {item.is_current_scope ? 'fresh' : 'stale'}
+              </span>
+            </div>
+            <p className="mt-2 text-xs text-current/70">{formatTime(item.produced_at)}</p>
+          </article>
+        ))}
+        {data.items.length === 0 && <p className="text-sm text-muted-foreground">No evidence items.</p>}
+      </div>
+    </section>
+  )
+}
+
+function RuntimeHealthPanel({ data }: { data: RuntimeHealthResponse | null }) {
+  if (!data) return <EmptyPanel label="runtime health" />
+  return (
+    <section className="grid gap-3 md:grid-cols-2">
+      {data.runtimes.map(runtime => {
+        const tone = runtime.status === 'ok' ? toneClasses.healthy : runtime.status === 'degraded' ? toneClasses.warning : toneClasses.muted
+        return (
+          <article key={runtime.runtime_id} className={`rounded-lg border p-5 ${tone}`}>
+            <p className="text-xs font-semibold uppercase tracking-wider text-current/70">
+              {runtime.runtime_id}
+            </p>
+            <h2 className="mt-2 text-2xl font-semibold text-current">{runtime.status}</h2>
+            <p className="mt-2 text-sm text-current/75">{runtime.reason ?? runtime.producer}</p>
+            <p className="mt-3 text-xs text-current/60">{formatTime(runtime.last_checked)}</p>
+          </article>
+        )
+      })}
+    </section>
+  )
+}
+
+const titles: Record<PanelKind, string> = {
+  attention: 'Galactus Attention',
+  run: 'Galactus Run',
+  verify: 'Galactus Verify',
+  fleet: 'Galactus Fleet',
+  signals: 'Galactus Signals',
+  memory: 'Galactus Memory',
+  approvals: 'Galactus Approvals',
+  evidence: 'Galactus Evidence',
+  'runtime-health': 'Galactus Runtime Health',
+}
+
+export function GalactusPanelCore({ kind }: { kind: PanelKind }) {
+  const [state, setState] = useState<PanelState>(emptyState)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      setState(await fetchPanelState(kind))
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load TTM data')
+    } finally {
+      setLoading(false)
+    }
+  }, [kind])
+
+  useSmartPoll(load, 15_000)
+
+  const body = useMemo(() => {
+    switch (kind) {
+      case 'attention':
+        return <AttentionPanel data={state.attention} />
+      case 'fleet':
+        return <FleetPanel data={state.fleet} />
+      case 'signals':
+        return <SignalsPanel data={state.signals} />
+      case 'memory':
+        return <MemoryPanel data={state.memory} />
+      case 'approvals':
+        return <ApprovalsPanel data={state.approvals} />
+      case 'run':
+        return <RunPanel data={state.runDetail} fleet={state.fleet} />
+      case 'verify':
+      case 'evidence':
+        return <EvidencePanel data={state.evidence} verify={kind === 'verify'} />
+      case 'runtime-health':
+        return <RuntimeHealthPanel data={state.runtimeHealth} />
+    }
+  }, [kind, state])
+
+  return (
+    <Shell
+      title={titles[kind]}
+      eyebrow="GSJ DW12 / Read-only supervision"
+      error={error}
+      loading={loading}
+      onRetry={load}
+    >
+      {body}
+    </Shell>
+  )
+}

--- a/src/components/panels/memory-panel.tsx
+++ b/src/components/panels/memory-panel.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { GalactusPanelCore } from '@/components/panels/galactus-panel-core'
+
+export function GalactusMemoryPanel() {
+  return <GalactusPanelCore kind="memory" />
+}

--- a/src/components/panels/run-panel.tsx
+++ b/src/components/panels/run-panel.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { GalactusPanelCore } from '@/components/panels/galactus-panel-core'
+
+export function RunPanel() {
+  return <GalactusPanelCore kind="run" />
+}

--- a/src/components/panels/runtime-health-panel.tsx
+++ b/src/components/panels/runtime-health-panel.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { GalactusPanelCore } from '@/components/panels/galactus-panel-core'
+
+export function RuntimeHealthPanel() {
+  return <GalactusPanelCore kind="runtime-health" />
+}

--- a/src/components/panels/signals-panel.tsx
+++ b/src/components/panels/signals-panel.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { GalactusPanelCore } from '@/components/panels/galactus-panel-core'
+
+export function SignalsPanel() {
+  return <GalactusPanelCore kind="signals" />
+}

--- a/src/components/panels/verify-panel.tsx
+++ b/src/components/panels/verify-panel.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { GalactusPanelCore } from '@/components/panels/galactus-panel-core'
+
+export function VerifyPanel() {
+  return <GalactusPanelCore kind="verify" />
+}

--- a/src/lib/galactus-api.ts
+++ b/src/lib/galactus-api.ts
@@ -1,0 +1,191 @@
+'use client'
+
+const DEFAULT_TTM_API_URL = 'http://localhost:8100'
+const TOKEN_STORAGE_KEY = 'ttm_access_token'
+
+export interface RunUsage {
+  tokens_used: number
+  cost_usd: number
+  cost_burn_rate: number | null
+  budget_threshold_status: 'ok' | 'warn' | 'critical'
+}
+
+export interface ControlPlaneRunSummary {
+  run_id: string
+  stream_id: string
+  stream_version: string
+  title: string
+  objective: string
+  status: string
+  risk_level: string
+  runtime_id: string
+  runtime_status: string
+  event_count: number
+  last_event_at: string | null
+  run_usage: RunUsage | null
+  created_at: string
+  updated_at: string
+}
+
+export interface ApprovalQueueItem {
+  approval_id: string | null
+  run_id: string
+  stream_id: string
+  stream_version: string
+  title: string
+  objective: string
+  approval_type: string
+  decision: string
+  scope_epoch: number
+  status: string
+  run_status: string
+  risk_level: string
+  runtime_status: string
+  created_at: string
+  updated_at: string
+}
+
+export interface AttentionItem {
+  id: string
+  kind: 'approval' | 'stuck_run' | 'blocked_run' | 'degraded_runtime'
+  severity: 'critical' | 'high' | 'medium' | 'low'
+  title: string
+  reason: string
+  run_id: string
+  stream_id: string
+  run_status: string
+  runtime_status: string | null
+  time_since_last_event_minutes: number | null
+  approval: ApprovalQueueItem | null
+}
+
+export interface AttentionResponse {
+  generated_at: string
+  stream_id: string
+  stale_threshold_minutes: number
+  items: AttentionItem[]
+}
+
+export interface FleetRun {
+  run: ControlPlaneRunSummary
+  time_since_last_event_minutes: number | null
+  is_stuck: boolean
+  has_open_approval: boolean
+  cost_burn_rate: number | null
+}
+
+export interface FleetResponse {
+  generated_at: string
+  stream_id: string
+  runs: FleetRun[]
+}
+
+export interface SignalItem {
+  label: string
+  value: string
+  tone: 'healthy' | 'warning' | 'critical' | 'muted'
+  provenance: string
+}
+
+export interface SignalsResponse {
+  generated_at: string
+  stream_id: string
+  freshness: string
+  authority: string
+  items: SignalItem[]
+}
+
+export interface MemoryResponse {
+  generated_at: string
+  freshness: string
+  authority: string
+  runbooks: Array<{
+    label: string
+    status: 'available' | 'stub'
+    provenance: string
+    detail: string
+  }>
+}
+
+export interface RuntimeHealthResponse {
+  generated_at: string
+  runtimes: Array<{
+    runtime_id: string
+    status: string
+    freshness: string
+    last_checked: string
+    reason: string | null
+    producer: string
+  }>
+}
+
+export interface EvidenceReview {
+  run_id: string
+  stream_id: string
+  stream_version: string
+  scope_epoch: number
+  items: Array<{
+    evidence_id: string
+    kind: string
+    subject: string
+    produced_at: string
+    verdict: string
+    verification_status: string
+    is_current_scope: boolean
+    stale_reason: string | null
+  }>
+  rollup: {
+    total: number
+    current: number
+    stale: number
+    by_verdict: Record<string, number>
+    by_kind: Record<string, number>
+  }
+}
+
+export interface RunDetail extends ControlPlaneRunSummary {
+  recent_events?: Array<{
+    event_id: string
+    event_type: string
+    occurred_at: string
+    summary: string
+  }>
+  approvals?: ApprovalQueueItem[]
+  evidence_items?: EvidenceReview['items']
+}
+
+export interface GalactusClientConfig {
+  apiBase: string
+  token: string
+}
+
+export function readGalactusClientConfig(): GalactusClientConfig {
+  const apiBase =
+    process.env.NEXT_PUBLIC_TTM_API_URL ||
+    process.env.NEXT_PUBLIC_API_URL ||
+    DEFAULT_TTM_API_URL
+  let token = process.env.NEXT_PUBLIC_TTM_ACCESS_TOKEN || ''
+  if (typeof window !== 'undefined') {
+    token = window.localStorage.getItem(TOKEN_STORAGE_KEY) || token
+  }
+  return { apiBase: apiBase.replace(/\/$/, ''), token }
+}
+
+export function saveGalactusToken(token: string) {
+  if (typeof window !== 'undefined') {
+    window.localStorage.setItem(TOKEN_STORAGE_KEY, token.trim())
+  }
+}
+
+export async function fetchGalactus<T>(
+  path: string,
+  config = readGalactusClientConfig()
+): Promise<T> {
+  const headers: Record<string, string> = { Accept: 'application/json' }
+  if (config.token) headers.Authorization = `Bearer ${config.token}`
+  const response = await fetch(`${config.apiBase}${path}`, { headers })
+  if (!response.ok) {
+    throw new Error(`TTM ${response.status}: ${await response.text()}`)
+  }
+  return response.json() as Promise<T>
+}

--- a/src/nav-rail.tsx
+++ b/src/nav-rail.tsx
@@ -39,6 +39,21 @@ const navGroups: NavGroup[] = [
     ],
   },
   {
+    id: 'galactus',
+    label: 'GALACTUS',
+    items: [
+      { id: 'galactus-attention', label: 'Attention', icon: <AlertIcon />, priority: false },
+      { id: 'galactus-run', label: 'Run', icon: <ActivityIcon />, priority: false },
+      { id: 'galactus-verify', label: 'Verify', icon: <AuditIcon />, priority: false },
+      { id: 'galactus-fleet', label: 'Fleet', icon: <AgentsIcon />, priority: false },
+      { id: 'galactus-signals', label: 'Signals', icon: <TokensIcon />, priority: false },
+      { id: 'galactus-memory', label: 'Memory', icon: <MemoryIcon />, priority: false },
+      { id: 'galactus-approvals', label: 'Approvals', icon: <UsersIcon />, priority: false },
+      { id: 'galactus-evidence', label: 'Evidence', icon: <HistoryIcon />, priority: false },
+      { id: 'galactus-runtime-health', label: 'Runtime', icon: <GatewaysIcon />, priority: false },
+    ],
+  },
+  {
     id: 'automate',
     label: 'AUTOMATE',
     items: [


### PR DESCRIPTION
## Summary
- Add nine read-only GSJ DW12 Galactus supervision panels to Mission Control.
- Add a TTM API client for `/api/mission-control/*` and existing `/api/runs/control-plane/*` data.
- Register Galactus panel routes and navigation entries.

## Evidence
- Paired TTM evidence: `docs/galactus/waves/GSJ-v1.0/context/reviews/DW12-evidence.md` in `you-kol/ttm` PR #684.
- Screenshots captured in paired TTM PR under `docs/galactus/waves/GSJ-v1.0/context/screenshots/DW12-mc-{view}.png`.

## Validation
- `pnpm typecheck`
- `pnpm lint` (passed with existing non-DW12 hook dependency warnings)
- Live Playwright browser proof across all 9 Galactus panels with no failed Galactus API requests.

## Coordination
Paired TTM PR: https://github.com/you-kol/ttm/pull/684
