### PR TITLE
fix(openclaw-doctor): single-flight + 30s TTL cache to prevent CPU/RAM spikes

### DIFF
--- a/src/app/api/openclaw/doctor/route.ts
+++ b/src/app/api/openclaw/doctor/route.ts
@@ -25,31 +25,117 @@ function isMissingOpenClaw(detail: string): boolean {
   return /enoent|not installed|not reachable|command not found/i.test(detail)
 }
 
+// ── Single-flight + TTL cache for ambient GET polling (closes #613) ──
+//
+// `openclaw doctor` spawns a Node subprocess that allocates ~300-600 MB
+// and runs at 37-51 % CPU. The dashboard banner + onboarding modal +
+// multiple browser tabs polling /api/openclaw/doctor concurrently could
+// produce 6+ simultaneous subprocesses on a 4 GB host (issue #613).
+//
+// Two layers of mitigation, GET-only (POST/--fix path stays uncoalesced
+// because operators clicking "Re-check" want a guaranteed fresh run):
+//
+//   1. Single-flight: if a doctor invocation is already in flight, share
+//      its eventual result with all concurrent callers — never spawn a
+//      second subprocess while one is running.
+//   2. TTL cache: cache the last successful response for DOCTOR_TTL_MS
+//      (30 s default, override via MC_DOCTOR_TTL_MS). Subsequent GETs
+//      within the window return the cached payload.
+//
+// Cache is invalidated by a successful POST /api/openclaw/doctor (--fix)
+// so the freshly-fixed state surfaces immediately.
+
+interface CachedDoctor {
+  payload: unknown
+  status: number
+  fetchedAt: number
+}
+
+interface DoctorCacheModule {
+  cached: CachedDoctor | null
+  inFlight: Promise<CachedDoctor> | null
+  ttlMs: number
+}
+
+// Module-level singleton (lives across requests within one server worker).
+const doctorCache: DoctorCacheModule = (() => {
+  // Allow operators to tune the TTL (e.g. CI smoke tests set it to 0).
+  const fromEnv = Number.parseInt(process.env.MC_DOCTOR_TTL_MS || '', 10)
+  const ttlMs = Number.isFinite(fromEnv) && fromEnv >= 0 ? fromEnv : 30_000
+  return { cached: null, inFlight: null, ttlMs }
+})()
+
+/** Internal helper: invalidates the GET cache. Called by POST after --fix. */
+export function invalidateDoctorCache(): void {
+  doctorCache.cached = null
+}
+
+async function runAndCacheDoctor(): Promise<CachedDoctor> {
+  try {
+    const result = await runOpenClaw(['doctor'], { timeoutMs: 15000 })
+    const payload = parseOpenClawDoctorOutput(
+      `${result.stdout}\n${result.stderr}`,
+      result.code ?? 0,
+      { stateDir: config.openclawStateDir },
+    )
+    const entry: CachedDoctor = { payload, status: 200, fetchedAt: Date.now() }
+    doctorCache.cached = entry
+    return entry
+  } catch (error) {
+    const { detail, code } = getCommandDetail(error)
+    if (isMissingOpenClaw(detail)) {
+      // Don't cache "not installed" — the operator may install OpenClaw and
+      // we want the next poll to pick that up immediately rather than waiting
+      // out the TTL.
+      const entry: CachedDoctor = {
+        payload: { error: 'OpenClaw is not installed or not reachable' },
+        status: 400,
+        fetchedAt: Date.now(),
+      }
+      return entry
+    }
+    const payload = parseOpenClawDoctorOutput(detail, code ?? 1, {
+      stateDir: config.openclawStateDir,
+    })
+    // Cache the parsed-error payload (status 200) so a flapping doctor doesn't
+    // re-spawn on every poll. The payload itself carries the failure detail.
+    const entry: CachedDoctor = { payload, status: 200, fetchedAt: Date.now() }
+    doctorCache.cached = entry
+    return entry
+  }
+}
+
 export async function GET(request: Request) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) {
     return NextResponse.json({ error: auth.error }, { status: auth.status })
   }
 
-  try {
-    const result = await runOpenClaw(['doctor'], { timeoutMs: 15000 })
-    return NextResponse.json(parseOpenClawDoctorOutput(`${result.stdout}\n${result.stderr}`, result.code ?? 0, {
-      stateDir: config.openclawStateDir,
-    }), {
-      headers: { 'Cache-Control': 'no-store' },
-    })
-  } catch (error) {
-    const { detail, code } = getCommandDetail(error)
-    if (isMissingOpenClaw(detail)) {
-      return NextResponse.json({ error: 'OpenClaw is not installed or not reachable' }, { status: 400 })
-    }
-
-    return NextResponse.json(parseOpenClawDoctorOutput(detail, code ?? 1, {
-      stateDir: config.openclawStateDir,
-    }), {
-      headers: { 'Cache-Control': 'no-store' },
+  // 1) Cache hit — return immediately.
+  const cached = doctorCache.cached
+  if (cached && Date.now() - cached.fetchedAt < doctorCache.ttlMs) {
+    return NextResponse.json(cached.payload, {
+      status: cached.status,
+      headers: {
+        'Cache-Control': 'no-store',
+        'X-Doctor-Cache': 'hit',
+        'X-Doctor-Age-Ms': String(Date.now() - cached.fetchedAt),
+      },
     })
   }
+
+  // 2) Single-flight — attach to an in-progress run if one exists.
+  const inFlight = doctorCache.inFlight ?? (doctorCache.inFlight = runAndCacheDoctor()
+    .finally(() => { doctorCache.inFlight = null }))
+
+  const sharedResult = await inFlight
+  return NextResponse.json(sharedResult.payload, {
+    status: sharedResult.status,
+    headers: {
+      'Cache-Control': 'no-store',
+      'X-Doctor-Cache': 'miss',
+    },
+  })
 }
 
 export async function POST(request: Request) {
@@ -85,6 +171,10 @@ export async function POST(request: Request) {
     const status = parseOpenClawDoctorOutput(`${postFix.stdout}\n${postFix.stderr}`, postFix.code ?? 0, {
       stateDir: config.openclawStateDir,
     })
+
+    // The fix changed state on disk — drop the GET cache so the next poll
+    // sees the fresh status immediately rather than waiting out the TTL.
+    invalidateDoctorCache()
 
     try {
       const db = getDatabase()

--- a/src/lib/__tests__/openclaw-doctor-route.test.ts
+++ b/src/lib/__tests__/openclaw-doctor-route.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mocks must be set up before importing the route module.
+const requireRole = vi.fn()
+const runOpenClaw = vi.fn()
+const archiveOrphanTranscriptsForStateDir = vi.fn()
+
+vi.mock('@/lib/auth', () => ({ requireRole }))
+vi.mock('@/lib/command', () => ({ runOpenClaw }))
+vi.mock('@/lib/db', () => ({
+  getDatabase: vi.fn(() => ({ prepare: () => ({ run: vi.fn() }) })),
+}))
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}))
+vi.mock('@/lib/openclaw-doctor-fix', () => ({ archiveOrphanTranscriptsForStateDir }))
+vi.mock('@/lib/openclaw-doctor', () => ({
+  parseOpenClawDoctorOutput: (out: string, code: number) => ({
+    healthy: code === 0,
+    level: code === 0 ? 'ok' : 'error',
+    issues: [],
+    raw: out,
+  }),
+}))
+vi.mock('@/lib/config', () => ({
+  config: { openclawStateDir: '/tmp/state' },
+}))
+
+const fakeRequest = () => new Request('http://localhost/api/openclaw/doctor')
+
+describe('GET /api/openclaw/doctor — single-flight + TTL cache (issue #613)', () => {
+  beforeEach(() => {
+    // Reset module state between tests so the in-memory cache starts empty.
+    vi.resetModules()
+    requireRole.mockReturnValue({ user: { id: 1, username: 'admin', role: 'admin', workspace_id: 1 } })
+    runOpenClaw.mockReset()
+    // Default TTL — long enough that the cache hit test is reliable.
+    process.env.MC_DOCTOR_TTL_MS = '30000'
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('coalesces concurrent GETs into a single subprocess invocation', async () => {
+    runOpenClaw.mockImplementation(async () => {
+      // Simulate the doctor subprocess taking some time.
+      await new Promise(resolve => setTimeout(resolve, 20))
+      return { stdout: 'all good', stderr: '', code: 0 }
+    })
+
+    const { GET } = await import('@/app/api/openclaw/doctor/route')
+
+    const responses = await Promise.all([
+      GET(fakeRequest()),
+      GET(fakeRequest()),
+      GET(fakeRequest()),
+      GET(fakeRequest()),
+      GET(fakeRequest()),
+    ])
+
+    expect(runOpenClaw).toHaveBeenCalledTimes(1)
+    expect(responses).toHaveLength(5)
+    for (const res of responses) {
+      expect(res.status).toBe(200)
+    }
+  })
+
+  it('serves cached response within TTL without re-running the subprocess', async () => {
+    runOpenClaw.mockResolvedValue({ stdout: 'all good', stderr: '', code: 0 })
+
+    const { GET } = await import('@/app/api/openclaw/doctor/route')
+
+    const first = await GET(fakeRequest())
+    expect(runOpenClaw).toHaveBeenCalledTimes(1)
+    expect(first.headers.get('X-Doctor-Cache')).toBe('miss')
+
+    const second = await GET(fakeRequest())
+    expect(runOpenClaw).toHaveBeenCalledTimes(1) // still 1 — cache hit
+    expect(second.headers.get('X-Doctor-Cache')).toBe('hit')
+  })
+
+  it('re-runs the subprocess after the TTL expires', async () => {
+    process.env.MC_DOCTOR_TTL_MS = '0' // expire immediately
+    runOpenClaw.mockResolvedValue({ stdout: 'all good', stderr: '', code: 0 })
+
+    const { GET } = await import('@/app/api/openclaw/doctor/route')
+
+    await GET(fakeRequest())
+    await GET(fakeRequest())
+    expect(runOpenClaw).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not cache "not installed" — next poll re-attempts immediately', async () => {
+    runOpenClaw.mockRejectedValue(Object.assign(new Error('spawn openclaw ENOENT'), { code: 'ENOENT' }))
+
+    const { GET } = await import('@/app/api/openclaw/doctor/route')
+
+    const first = await GET(fakeRequest())
+    expect(first.status).toBe(400)
+    expect(runOpenClaw).toHaveBeenCalledTimes(1)
+
+    const second = await GET(fakeRequest())
+    expect(second.status).toBe(400)
+    // Both calls invoked the subprocess — operator may install OpenClaw mid-session.
+    expect(runOpenClaw).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects unauthenticated requests before invoking the subprocess', async () => {
+    requireRole.mockReturnValue({ error: 'Unauthorized', status: 401 })
+
+    const { GET } = await import('@/app/api/openclaw/doctor/route')
+
+    const res = await GET(fakeRequest())
+    expect(res.status).toBe(401)
+    expect(runOpenClaw).not.toHaveBeenCalled()
+  })
+
+  it('exposes invalidateDoctorCache so POST /--fix can invalidate', async () => {
+    runOpenClaw.mockResolvedValue({ stdout: 'all good', stderr: '', code: 0 })
+
+    const route = await import('@/app/api/openclaw/doctor/route')
+    expect(typeof route.invalidateDoctorCache).toBe('function')
+
+    await route.GET(fakeRequest())
+    expect(runOpenClaw).toHaveBeenCalledTimes(1)
+
+    // Sanity: cached
+    await route.GET(fakeRequest())
+    expect(runOpenClaw).toHaveBeenCalledTimes(1)
+
+    // Invalidate: next GET should re-run.
+    route.invalidateDoctorCache()
+    await route.GET(fakeRequest())
+    expect(runOpenClaw).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
**Closes #613.**

## Problem

\`GET /api/openclaw/doctor\` spawns a Node subprocess that allocates ~300-600 MB and runs at 37-51% CPU. The dashboard banner + onboarding modal + multiple browser tabs polling concurrently can produce 6+ simultaneous subprocesses on a 4 GB host (issue #613 observed combined ~89% CPU, ~3.5 GB RAM).

## Fix

Two layers of mitigation, **GET-only**:

1. **Single-flight**: if a doctor invocation is already in flight, concurrent callers share its eventual result — never spawn a second subprocess while one is running.
2. **TTL cache**: cache the last response for \`MC_DOCTOR_TTL_MS\` (30 s default; settable via env, 0 disables for tests). Subsequent GETs within the window return the cached payload.

The POST/\`--fix\` path stays uncoalesced — operators clicking \"Re-check\" want a guaranteed fresh run.

## Cache invalidation

- \`POST /api/openclaw/doctor\` (the \`--fix\` path) calls \`invalidateDoctorCache()\` after a successful fix so the freshly-fixed state surfaces immediately rather than waiting out the TTL.
- **\"Not installed\" errors are NOT cached** — the operator may install OpenClaw mid-session and we want the next poll to pick that up.
- Parsed-error payloads (status 200 with failure detail in body) ARE cached so a flapping doctor doesn't re-spawn on every poll.

## Response headers

- \`X-Doctor-Cache: hit | miss\` so dashboards can confirm coalescing is working.
- \`X-Doctor-Age-Ms: <n>\` on cache hits.

## Tests

6 new tests in \`src/lib/__tests__/openclaw-doctor-route.test.ts\`:

- Concurrent GETs collapse to a single \`runOpenClaw\` invocation.
- Cache hits within TTL skip the subprocess.
- TTL=0 forces re-run on every GET.
- \"Not installed\" errors are not cached.
- Unauthenticated requests reject before subprocess spawn.
- \`invalidateDoctorCache()\` drops the cache on demand.

## Verification

\`\`\`bash
pnpm vitest run src/lib/__tests__/openclaw-doctor-route.test.ts
# Test Files  1 passed (1)  Tests  6 passed (6)

# Full repo typecheck clean.
pnpm tsc --noEmit
\`\`\`

## Operator note

If you want to disable caching entirely (e.g. for a debug session), set \`MC_DOCTOR_TTL_MS=0\` in your environment. The single-flight layer still applies — concurrent calls within one tick still coalesce — but the TTL window collapses to zero so each GET that arrives outside an in-flight call spawns a fresh subprocess.