### PR TITLE
fix(recurring-tasks): include HH:MM in child title for sub-daily crons

### DIFF
--- a/src/lib/__tests__/recurring-tasks.test.ts
+++ b/src/lib/__tests__/recurring-tasks.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { isSubDailyCron, formatDateSuffix } from '@/lib/recurring-tasks'
+
+describe('isSubDailyCron', () => {
+  it('flags hourly crons (`0 * * * *`)', () => {
+    expect(isSubDailyCron('0 * * * *')).toBe(true)
+  })
+
+  it('flags every-5-min crons (`*/5 * * * *`)', () => {
+    expect(isSubDailyCron('*/5 * * * *')).toBe(true)
+  })
+
+  it('flags every-minute crons (`* * * * *`)', () => {
+    expect(isSubDailyCron('* * * * *')).toBe(true)
+  })
+
+  it('flags ranged-minute crons (`0,30 * * * *`)', () => {
+    expect(isSubDailyCron('0,30 * * * *')).toBe(true)
+  })
+
+  it('treats daily-at-09:00 as not sub-daily', () => {
+    expect(isSubDailyCron('0 9 * * *')).toBe(false)
+  })
+
+  it('treats weekly Mon-09:00 as not sub-daily', () => {
+    expect(isSubDailyCron('0 9 * * 1')).toBe(false)
+  })
+
+  it('returns false for malformed expressions (defensive)', () => {
+    expect(isSubDailyCron('not-a-cron')).toBe(false)
+    expect(isSubDailyCron('')).toBe(false)
+    expect(isSubDailyCron('0 9 *')).toBe(false)
+  })
+})
+
+describe('formatDateSuffix', () => {
+  // Pin a known date so test output is deterministic across machines/timezones
+  // we run the test in. We use a Date constructed via individual setters so
+  // local-time interpretation matches what the suffix uses.
+  const fixedDate = new Date(2026, 3, 24, 13, 35) // 2026-04-24 13:35 local
+
+  it('returns MMM DD for daily/weekly/monthly crons', () => {
+    expect(formatDateSuffix(fixedDate, false)).toBe('Apr 24')
+  })
+
+  it('returns MMM DD, HH:MM for sub-daily crons', () => {
+    expect(formatDateSuffix(fixedDate, true)).toBe('Apr 24, 13:35')
+  })
+
+  it('zero-pads day-of-month', () => {
+    const earlyMonth = new Date(2026, 0, 3, 9, 5) // Jan 3, 09:05
+    expect(formatDateSuffix(earlyMonth, false)).toBe('Jan 03')
+    expect(formatDateSuffix(earlyMonth, true)).toBe('Jan 03, 09:05')
+  })
+
+  it('regression #616: two hourly spawns on the same day produce different titles', () => {
+    const at13 = new Date(2026, 3, 24, 13, 0)
+    const at14 = new Date(2026, 3, 24, 14, 0)
+    const t13 = `Memory Consolidation - ${formatDateSuffix(at13, true)}`
+    const t14 = `Memory Consolidation - ${formatDateSuffix(at14, true)}`
+    // Before the fix both would have been "Memory Consolidation - Apr 24"
+    // and the second spawn would have been silently skipped.
+    expect(t13).not.toBe(t14)
+  })
+
+  it('regression #616: every-5-min spawns within an hour produce different titles', () => {
+    const at1300 = new Date(2026, 3, 24, 13, 0)
+    const at1305 = new Date(2026, 3, 24, 13, 5)
+    expect(formatDateSuffix(at1300, true)).not.toBe(formatDateSuffix(at1305, true))
+  })
+
+  it('daily cron preserves historical "MMM DD" shape (no churn for existing operators)', () => {
+    const morningSpawn = new Date(2026, 3, 24, 9, 0)
+    const lateAfternoonSpawn = new Date(2026, 3, 24, 17, 0)
+    // Both spawns produce the same suffix when the cron is daily — that's
+    // intentional because a daily cron only fires once per calendar day, so
+    // the dedup correctly skips a duplicate within the same day.
+    expect(formatDateSuffix(morningSpawn, false)).toBe(formatDateSuffix(lateAfternoonSpawn, false))
+  })
+})

--- a/src/lib/recurring-tasks.ts
+++ b/src/lib/recurring-tasks.ts
@@ -20,10 +20,35 @@ export interface RecurrenceMetadata {
   parent_task_id: null
 }
 
-function formatDateSuffix(): string {
-  const now = new Date()
-  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-  return `${months[now.getMonth()]} ${String(now.getDate()).padStart(2, '0')}`
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+
+/**
+ * Detect whether a 5-field cron expression fires more than once per day.
+ * Returns true when the minute or hour field is anything other than a
+ * single concrete number (i.e. wildcard, list, range, or step).
+ */
+export function isSubDailyCron(cronExpr: string): boolean {
+  const parts = cronExpr.split(/\s+/)
+  if (parts.length !== 5) return false
+  const [minExpr, hourExpr] = parts
+  const isConcrete = (s: string) => /^\d+$/.test(s)
+  return !isConcrete(minExpr) || !isConcrete(hourExpr)
+}
+
+/**
+ * Title suffix for a child spawn. Daily/weekly/monthly crons use the
+ * historical `MMM DD` shape so existing operator workflows don't see
+ * title churn. Sub-daily crons (e.g. hourly, every-5-min) include
+ * `HH:MM` so two spawns on the same calendar day don't collapse
+ * to the same title and trip the duplicate-prevention guard (#616).
+ */
+export function formatDateSuffix(now: Date = new Date(), subDaily = false): string {
+  const month = MONTHS[now.getMonth()]
+  const day = String(now.getDate()).padStart(2, '0')
+  if (!subDaily) return `${month} ${day}`
+  const hh = String(now.getHours()).padStart(2, '0')
+  const mm = String(now.getMinutes()).padStart(2, '0')
+  return `${month} ${day}, ${hh}:${mm}`
 }
 
 export async function spawnRecurringTasks(): Promise<{ ok: boolean; message: string }> {
@@ -68,10 +93,17 @@ export async function spawnRecurringTasks(): Promise<{ ok: boolean; message: str
 
       if (!isCronDue(recurrence.cron_expr, nowMs, lastSpawnedAtMs)) continue
 
-      const dateSuffix = formatDateSuffix()
+      // Sub-daily crons need hour:minute granularity in the title; otherwise
+      // two spawns on the same calendar day collapse to the same title and
+      // get silently skipped by the duplicate-prevention guard below (#616).
+      const subDaily = isSubDailyCron(recurrence.cron_expr)
+      const dateSuffix = formatDateSuffix(new Date(nowMs), subDaily)
       const childTitle = `${template.title} - ${dateSuffix}`
 
-      // Duplicate prevention: check if a child with this exact title already exists in the same project
+      // Duplicate prevention: check if a child with this exact title already
+      // exists in the same project. With the sub-daily suffix in place, the
+      // dedup correctly fires only when two spawns land in the same minute
+      // (which `isCronDue` already guards against via lastSpawnedAtMs).
       const existing = db.prepare(`
         SELECT id FROM tasks
         WHERE title = ? AND workspace_id = ? AND project_id = ?


### PR DESCRIPTION
**Closes #616.**

## Problem

Recurring tasks with sub-daily cron schedules (e.g. \`0 * * * *\` hourly, \`*/5 * * * *\` every-5-min) only spawned once per calendar day. All subsequent spawns within the same day were silently skipped.

Root cause: \`spawnRecurringTasks\` derives child titles from \`formatDateSuffix()\` which only emitted day-level granularity (\`MMM DD\`). The duplicate-prevention guard at \`recurring-tasks.ts:75-79\` then matches on \`(title, workspace_id, project_id)\`, finds the previous spawn from earlier the same day, and returns early.

## Fix

1. New \`isSubDailyCron(cronExpr)\` helper returns true when the minute or hour field is anything other than a single concrete number (covers wildcards, ranges, lists, steps).
2. \`formatDateSuffix(now, subDaily)\` now takes an explicit \`now\` and a \`subDaily\` flag:

   | Cron shape | Suffix |
   |---|---|
   | Daily / weekly / monthly | \`Apr 24\` (unchanged) |
   | Sub-daily | \`Apr 24, 13:35\` |

   Same-day spawns at 13:00 and 14:00 now produce different titles, and the duplicate-guard correctly admits both.
3. Daily/weekly/monthly title format is preserved so existing operator workflows don't see a title-churn migration.

## Compatibility

- \`isCronDue()\` already prevents same-minute double-spawns via the \`lastSpawnedAtMs\` check, so this PR doesn't loosen the dedup — it just stops the dedup from firing on the *wrong* layer.
- The \`formatDateSuffix\` signature now takes optional arguments with sane defaults; existing call sites still work.

## Tests

13 new tests in \`src/lib/__tests__/recurring-tasks.test.ts\`:

- \`isSubDailyCron\` recognizes hourly / every-5-min / every-minute / ranged-minute crons; rejects daily/weekly; defensive on malformed.
- \`formatDateSuffix\` returns \`MMM DD\` (daily) and \`MMM DD, HH:MM\` (sub-daily); zero-pads day-of-month.
- **Regression**: two hourly spawns on the same day produce different titles.
- **Regression**: every-5-min spawns within the same hour produce different titles.
- Daily cron preserves historical \`MMM DD\` shape.

## Verification

\`\`\`bash
pnpm vitest run src/lib/__tests__/recurring-tasks.test.ts
# Test Files  1 passed (1)  Tests  13 passed (13)

pnpm tsc --noEmit
# (clean)
\`\`\`

## Note on the existing test failure

While running the full suite I noticed \`src/lib/__tests__/task-dispatch-reconciliation.test.ts\` has one pre-existing failing assertion on \`main\` that's unrelated to this PR (the test from PR #655's file expects \`callOpenClawGateway\` to be called once but gets zero calls). This PR does not touch \`task-dispatch.ts\` and the failure reproduces without my changes. Worth a separate look.