### PR TITLE
fix: prevent @mention dropdown arrow-key selection reset

### DIFF
--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -144,9 +144,12 @@ export function ChatInput({ onSend, onAbort, disabled, agents = [], isGenerating
     const atMatch = textBeforeCursor.match(/@(\w*)$/)
 
     if (atMatch) {
-      setMentionFilter(atMatch[1])
+      const newFilter = atMatch[1]
+      if (newFilter !== mentionFilter) {
+        setMentionIndex(0)
+      }
+      setMentionFilter(newFilter)
       setShowMentions(true)
-      setMentionIndex(0)
     } else {
       setShowMentions(false)
     }


### PR DESCRIPTION
Fixes #661

The mention dropdown index was reset to 0 on every input change, making arrow-key navigation impossible. Now only resets when the filter text changes.