### PR TITLE
fix(security-scan): handle SecretRef gateway auth credentials

### DIFF
--- a/src/lib/security-scan.ts
+++ b/src/lib/security-scan.ts
@@ -309,8 +309,16 @@ function scanOpenClaw(): Category {
   } catch { /* skip */ }
 
   const gwAuth = ocConfig?.gateway?.auth
-  const tokenOk = gwAuth?.mode === 'token' && (gwAuth?.token ?? '').trim().length > 0
-  const passwordOk = gwAuth?.mode === 'password' && (gwAuth?.password ?? '').trim().length > 0
+  // gateway.auth.token / .password may be a plain string OR a SecretRef object
+  // (e.g. {source:"vault", ref:"op://..."} or {source:"file", path:"..."}).
+  // Calling .trim() on the object crashes. Treat any non-null value as
+  // "credential configured" — the resolved value is checked at runtime by OpenClaw.
+  const hasCredential = (value: unknown): boolean => {
+    if (typeof value === 'string') return value.trim().length > 0
+    return value != null
+  }
+  const tokenOk = gwAuth?.mode === 'token' && hasCredential(gwAuth?.token)
+  const passwordOk = gwAuth?.mode === 'password' && hasCredential(gwAuth?.password)
   const authOk = tokenOk || passwordOk
   checks.push({
     id: 'gateway_auth',


### PR DESCRIPTION
## Summary

Fixes a crash in `runSecurityScan` when `gateway.auth.token` or `gateway.auth.password` is a SecretRef object (e.g. `{ source: 'vault', ref: 'op://...' }`, `{ source: 'file', path: '/path/to/token' }`) rather than a plain string. The current code calls `.trim()` directly on these values, which throws:

```
TypeError: ((intermediate value) ?? "").trim is not a function
    at runSecurityScan (src/lib/security-scan.ts:312)
```

This makes both `GET /api/security-audit` and `POST /api/security-scan` return HTTP 500 for any install using SecretRef-based gateway auth — a common pattern with vault integrations on OpenClaw 2026.5+. The /debug page surfaces it as "Security scan error" in the logs, and the Settings panel's "Run security scan" button silently fails.

## Repro

`~/.openclaw/openclaw.json` snippet that triggers it:

```jsonc
{
  "gateway": {
    "auth": {
      "mode": "token",
      "token": { "source": "file", "path": "/Users/me/.openclaw/secrets/gateway-token" }
    }
  }
}
```

Click "Run security scan" in Settings → 500. Server logs show the TypeError above.

## Fix

Introduces a small `hasCredential()` helper in the `gateway_auth` check that treats:
- **string** → trim and check length (original behavior, no change)
- **non-null object** (SecretRef) → credential is configured; actual resolution happens at runtime by OpenClaw

If both branches fail (undefined / null), behavior is identical to before.

```ts
const hasCredential = (value: unknown): boolean => {
  if (typeof value === 'string') return value.trim().length > 0
  return value != null
}
const tokenOk = gwAuth?.mode === 'token' && hasCredential(gwAuth?.token)
const passwordOk = gwAuth?.mode === 'password' && hasCredential(gwAuth?.password)
```

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm vitest run src/lib/__tests__/security-scan` — 4/4 pass (existing tests still green; no behavior change for the string path they cover)
- [x] Manual: with SecretRef-typed `gateway.auth.token`, `GET /api/security-audit` now returns 200 with `gateway_auth: pass` instead of 500
- [x] Manual: with plain-string `gateway.auth.token`, scan still returns the same pass/fail as before
- [x] Manual: with `gateway.auth.token = ''`, scan still returns `gateway_auth: fail` as before
- [x] Manual: with no `gateway.auth` at all, scan still returns `gateway_auth: fail` as before

## Notes

- This does not validate that the SecretRef itself resolves to a non-empty string — that check would require live resolution and belongs in a separate runtime check. The intent of the `gateway_auth` security item is "is auth configured at all", which a SecretRef satisfies.
- I'm happy to add a dedicated unit test for the gateway_auth check covering string / SecretRef / undefined / empty string cases if preferred — let me know.