### PR TITLE
refactor(github-sync-panel): migrate 10 bare fetch to apiFetch

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,37 @@ const config = [
       'react-hooks/immutability': 'off',
     },
   },
+  // P1.5 — Discourage bare `fetch('/api/...')`.
+  // The team must migrate to `apiFetch<T>()` from `@/lib/api-client` so that
+  // 401 / 403 / 5xx / network failures are handled uniformly.
+  // Phase 1 (this PR): warn level, allow incremental migration.
+  // Phase 3 (final cleanup): upgrade to error and forbid merges that introduce
+  // new bare fetch('/api/...') sites.
+  // Selector rationale:
+  //   - covers single-quoted, double-quoted, and template-literal forms
+  //   - filters by /api prefix so cross-origin / external fetches stay untouched
+  //   - exempts api-client.ts itself (the one allowed implementer)
+  {
+    files: ['src/**/*.{ts,tsx,js,jsx}'],
+    ignores: ['src/lib/api-client.ts'],
+    rules: {
+      'no-restricted-syntax': [
+        'warn',
+        {
+          selector:
+            "CallExpression[callee.name='fetch'] > Literal[value=/^\\/api\\//]",
+          message:
+            "Use apiFetch<T>() from '@/lib/api-client' instead of bare fetch('/api/...'). It handles 401 redirect, 403/5xx typed errors, and network failures uniformly. See PR-api-client.md.",
+        },
+        {
+          selector:
+            "CallExpression[callee.name='fetch'] > TemplateLiteral.arguments:first-child[quasis.0.value.raw=/^\\/api\\//]",
+          message:
+            "Use apiFetch<T>() from '@/lib/api-client' instead of bare fetch(`/api/...`). It handles 401 redirect, 403/5xx typed errors, and network failures uniformly.",
+        },
+      ],
+    },
+  },
 ]
 
 export default config

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { NextIntlClientProvider } from 'next-intl'
 import { getLocale, getMessages } from 'next-intl/server'
 import { THEME_IDS } from '@/lib/themes'
 import { ThemeBackground } from '@/components/ui/theme-background'
+import { AuthExpiredListener } from '@/components/auth-expired-listener'
 import './globals.css'
 
 const inter = Inter({
@@ -114,6 +115,7 @@ export default async function RootLayout({
             disableTransitionOnChange
           >
             <ThemeBackground />
+            <AuthExpiredListener />
             <div className="h-screen overflow-hidden bg-background text-foreground">
               {children}
             </div>

--- a/src/components/auth-expired-listener.tsx
+++ b/src/components/auth-expired-listener.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useEffect } from 'react'
+
+/**
+ * Listens for `mc:auth-expired` CustomEvent dispatched by `apiFetch()` when the
+ * server returns 401. The redirect to `/login?from=...` is already handled inside
+ * `apiFetch`; this listener exists so we have a single observability hook the
+ * team can extend (toast, telemetry, Sentry).
+ *
+ * Mounted once at the root layout. SSR-safe (effect runs only on the client).
+ *
+ * Why a separate component?
+ *   - layout.tsx is a server component (uses `await headers()`); we cannot
+ *     attach window listeners there directly.
+ *   - Co-locating the listener with the api-client keeps the auth-failure
+ *     contract in one place.
+ */
+export function AuthExpiredListener(): null {
+  useEffect(() => {
+    const onExpired = (e: Event) => {
+      const detail = (e as CustomEvent<{ path: string; status: number }>).detail
+      // No toast lib installed yet — log for now. Replace with sonner in next PR.
+      console.warn(
+        `[mc] session expired on ${detail?.path ?? 'unknown'} (status=${detail?.status ?? 401}), redirecting to /login`
+      )
+    }
+    window.addEventListener('mc:auth-expired', onExpired)
+    return () => window.removeEventListener('mc:auth-expired', onExpired)
+  }, [])
+
+  return null
+}

--- a/src/components/panels/github-sync-panel.tsx
+++ b/src/components/panels/github-sync-panel.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useTranslations } from 'next-intl'
 import { Button } from '@/components/ui/button'
+import { apiFetch } from '@/lib/api-client'
 
 interface GitHubLabel {
   name: string
@@ -91,11 +92,12 @@ export function GitHubSyncPanel() {
   // Check GitHub token status
   const checkToken = useCallback(async () => {
     try {
-      const res = await fetch('/api/integrations', {
+      const res = await apiFetch<Response>('/api/integrations', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action: 'test', integrationId: 'github' }),
         signal: AbortSignal.timeout(8000),
+        raw: true,
       })
       const data = await res.json()
       setTokenStatus({
@@ -110,11 +112,12 @@ export function GitHubSyncPanel() {
   // Fetch sync history
   const fetchSyncHistory = useCallback(async () => {
     try {
-      const res = await fetch('/api/github', {
+      const res = await apiFetch<Response>('/api/github', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action: 'status' }),
         signal: AbortSignal.timeout(8000),
+        raw: true,
       })
       if (res.ok) {
         const data = await res.json()
@@ -126,7 +129,7 @@ export function GitHubSyncPanel() {
   // Fetch linked tasks
   const fetchLinkedTasks = useCallback(async () => {
     try {
-      const res = await fetch('/api/tasks?limit=200', { signal: AbortSignal.timeout(8000) })
+      const res = await apiFetch<Response>('/api/tasks?limit=200', { signal: AbortSignal.timeout(8000), raw: true })
       if (res.ok) {
         const data = await res.json()
         const linked = (data.tasks || []).filter(
@@ -140,7 +143,7 @@ export function GitHubSyncPanel() {
   // Fetch projects for two-way sync
   const fetchProjects = useCallback(async () => {
     try {
-      const res = await fetch('/api/projects', { signal: AbortSignal.timeout(8000) })
+      const res = await apiFetch<Response>('/api/projects', { signal: AbortSignal.timeout(8000), raw: true })
       if (res.ok) {
         const data = await res.json()
         setProjects(data.projects || [])
@@ -151,7 +154,7 @@ export function GitHubSyncPanel() {
   // Fetch agents for assign dropdown
   const fetchAgents = useCallback(async () => {
     try {
-      const res = await fetch('/api/agents', { signal: AbortSignal.timeout(8000) })
+      const res = await apiFetch<Response>('/api/agents', { signal: AbortSignal.timeout(8000), raw: true })
       if (res.ok) {
         const data = await res.json()
         setAgents((data.agents || []).map((a: any) => ({ name: a.name })))
@@ -176,7 +179,7 @@ export function GitHubSyncPanel() {
     try {
       const params = new URLSearchParams({ action: 'issues', repo, state: stateFilter })
       if (labelFilter) params.set('labels', labelFilter)
-      const res = await fetch(`/api/github?${params}`)
+      const res = await apiFetch<Response>(`/api/github?${params}`, { raw: true })
       const data = await res.json()
       if (res.ok) {
         setPreviewIssues(data.issues || [])
@@ -197,7 +200,7 @@ export function GitHubSyncPanel() {
     setSyncing(true)
     setSyncResult(null)
     try {
-      const res = await fetch('/api/github', {
+      const res = await apiFetch<Response>('/api/github', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -207,6 +210,7 @@ export function GitHubSyncPanel() {
           state: stateFilter,
           assignAgent: assignAgent || undefined,
         }),
+        raw: true,
       })
       const data = await res.json()
       if (res.ok) {
@@ -228,10 +232,11 @@ export function GitHubSyncPanel() {
   // Two-way sync handlers
   const handleToggleSync = async (project: typeof projects[number]) => {
     try {
-      const res = await fetch(`/api/projects/${project.id}`, {
+      const res = await apiFetch<Response>(`/api/projects/${project.id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ github_sync_enabled: !project.github_sync_enabled }),
+        raw: true,
       })
       if (res.ok) {
         await fetchProjects()
@@ -248,10 +253,11 @@ export function GitHubSyncPanel() {
   const handleSyncProject = async (projectId: number) => {
     setSyncingProjectId(projectId)
     try {
-      const res = await fetch('/api/github/sync', {
+      const res = await apiFetch<Response>('/api/github/sync', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action: 'trigger', project_id: projectId }),
+        raw: true,
       })
       const data = await res.json()
       if (res.ok) {
@@ -270,10 +276,11 @@ export function GitHubSyncPanel() {
   const handleSyncAll = async () => {
     setSyncingProjectId(-1)
     try {
-      const res = await fetch('/api/github/sync', {
+      const res = await apiFetch<Response>('/api/github/sync', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action: 'trigger-all' }),
+        raw: true,
       })
       const data = await res.json()
       if (res.ok) {

--- a/src/lib/__tests__/api-client.test.ts
+++ b/src/lib/__tests__/api-client.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { apiFetch, ApiError } from '../api-client'
+
+const realFetch = global.fetch
+const realLocation = window.location
+
+function mockResponse(status: number, body: unknown = {}, opts: { json?: boolean } = { json: true }) {
+  return new Response(opts.json ? JSON.stringify(body) : String(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('apiFetch — global 401 / 403 / 5xx / network handling', () => {
+  let dispatched: CustomEvent[] = []
+  let originalHref = ''
+  let authExpiredListener: ((e: Event) => void) | null = null
+
+  beforeEach(() => {
+    dispatched = []
+    authExpiredListener = (e) => dispatched.push(e as CustomEvent)
+    window.addEventListener('mc:auth-expired', authExpiredListener)
+
+    // Stub location so redirect-to-login is observable
+    originalHref = window.location.href
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: {
+        ...realLocation,
+        pathname: '/cost-tracker',
+        search: '',
+        href: 'http://127.0.0.1:3000/cost-tracker',
+      },
+    })
+  })
+
+  afterEach(() => {
+    if (authExpiredListener) {
+      window.removeEventListener('mc:auth-expired', authExpiredListener)
+      authExpiredListener = null
+    }
+    global.fetch = realFetch
+    Object.defineProperty(window, 'location', { writable: true, value: realLocation })
+    window.location.href = originalHref
+    vi.restoreAllMocks()
+  })
+
+  it('returns parsed JSON on 200', async () => {
+    global.fetch = vi.fn().mockResolvedValue(mockResponse(200, { ok: true, count: 42 }))
+    const data = await apiFetch<{ ok: boolean; count: number }>('/api/tokens')
+    expect(data).toEqual({ ok: true, count: 42 })
+  })
+
+  it('emits mc:auth-expired and redirects to /login on 401', async () => {
+    global.fetch = vi.fn().mockResolvedValue(mockResponse(401, { error: 'Authentication required' }))
+    await expect(apiFetch('/api/tokens')).rejects.toMatchObject({
+      code: 'UNAUTHENTICATED',
+      status: 401,
+    })
+    expect(dispatched).toHaveLength(1)
+    expect(dispatched[0].detail).toMatchObject({ path: '/api/tokens', status: 401 })
+    expect(window.location.href).toContain('/login?from=%2Fcost-tracker')
+  })
+
+  it('does NOT redirect when redirectOnUnauthenticated=false', async () => {
+    global.fetch = vi.fn().mockResolvedValue(mockResponse(401, { error: 'Authentication required' }))
+    await expect(
+      apiFetch('/api/tokens', { redirectOnUnauthenticated: false })
+    ).rejects.toThrow(ApiError)
+    expect(window.location.href).toBe('http://127.0.0.1:3000/cost-tracker')
+  })
+
+  it('throws FORBIDDEN on 403 without redirecting', async () => {
+    global.fetch = vi.fn().mockResolvedValue(mockResponse(403, { error: 'Requires admin role' }))
+    await expect(apiFetch('/api/tokens')).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      status: 403,
+    })
+    expect(window.location.href).toBe('http://127.0.0.1:3000/cost-tracker')
+  })
+
+  it('throws SERVER_ERROR on 500 with upstream message', async () => {
+    global.fetch = vi.fn().mockResolvedValue(mockResponse(500, { error: 'database is locked' }))
+    await expect(apiFetch('/api/tokens')).rejects.toMatchObject({
+      code: 'SERVER_ERROR',
+      status: 500,
+      message: 'database is locked',
+    })
+  })
+
+  it('throws NETWORK_ERROR when fetch rejects', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'))
+    await expect(apiFetch('/api/tokens')).rejects.toMatchObject({
+      code: 'NETWORK_ERROR',
+      status: 0,
+    })
+  })
+
+  it('does not redirect when already on /login (avoid infinite loop)', async () => {
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { ...realLocation, pathname: '/login', search: '', href: 'http://127.0.0.1:3000/login' },
+    })
+    global.fetch = vi.fn().mockResolvedValue(mockResponse(401))
+    await expect(apiFetch('/api/auth/login', { method: 'POST' })).rejects.toThrow(ApiError)
+    expect(window.location.href).toBe('http://127.0.0.1:3000/login')
+  })
+
+  it('returns undefined for 204 No Content', async () => {
+    global.fetch = vi.fn().mockResolvedValue(new Response(null, { status: 204 }))
+    const data = await apiFetch('/api/sessions/123', { method: 'DELETE' })
+    expect(data).toBeUndefined()
+  })
+})

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,0 +1,145 @@
+/**
+ * API client with global 401 / 403 / network handling.
+ *
+ * Why this exists
+ * ---------------
+ * Mission Control had no global auth-failure handler. When a session expired,
+ * `fetch('/api/...')` returned 401 silently and panels (cost-tracker, dashboard,
+ * activities) stuck on loading skeletons forever — users perceived "the service
+ * died" but the backend was healthy. Root cause logged in:
+ *   src/lib/auth.ts:629  requireRole()
+ *
+ * Contract
+ * --------
+ *   apiFetch<T>(path, init?) -> Promise<T>
+ *
+ *   - Always sends cookies (credentials: 'include')
+ *   - On 401: emits an `mc:auth-expired` CustomEvent, redirects to /login?from=…
+ *   - On 403: throws ApiError with code='FORBIDDEN'
+ *   - On 5xx: throws ApiError with code='SERVER_ERROR' and the upstream message
+ *   - On network failure: throws ApiError with code='NETWORK_ERROR'
+ *
+ * Listen once at app root:
+ *   window.addEventListener('mc:auth-expired', () => showToast('Session expired'))
+ */
+
+export type ApiErrorCode =
+  | 'UNAUTHENTICATED'
+  | 'FORBIDDEN'
+  | 'NOT_FOUND'
+  | 'SERVER_ERROR'
+  | 'NETWORK_ERROR'
+  | 'PARSE_ERROR'
+
+export class ApiError extends Error {
+  readonly code: ApiErrorCode
+  readonly status: number
+  readonly payload: unknown
+
+  constructor(code: ApiErrorCode, status: number, message: string, payload?: unknown) {
+    super(message)
+    this.name = 'ApiError'
+    this.code = code
+    this.status = status
+    this.payload = payload
+  }
+}
+
+// Browser-only redirect to /login. SSR / unit tests skip it.
+function redirectToLogin(): void {
+  if (typeof window === 'undefined') return
+  const from = window.location.pathname + window.location.search
+  // Avoid redirect loops if user is already on /login
+  if (window.location.pathname === '/login') return
+  window.location.href = `/login?from=${encodeURIComponent(from)}`
+}
+
+function emitAuthExpired(detail: { path: string; status: number }): void {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(new CustomEvent('mc:auth-expired', { detail }))
+}
+export interface ApiFetchOptions extends RequestInit {
+  /** When true (default) and the response is 401, redirect to /login. */
+  redirectOnUnauthenticated?: boolean
+  /** When true, return raw Response instead of parsed JSON. */
+  raw?: boolean
+}
+
+export async function apiFetch<T = unknown>(
+  path: string,
+  options: ApiFetchOptions = {}
+): Promise<T> {
+  const {
+    redirectOnUnauthenticated = true,
+    raw = false,
+    headers,
+    ...rest
+  } = options
+
+  let response: Response
+  try {
+    response = await fetch(path, {
+      credentials: 'include',
+      headers: {
+        Accept: 'application/json',
+        ...(rest.body && !(rest.body instanceof FormData)
+          ? { 'Content-Type': 'application/json' }
+          : {}),
+        ...headers,
+      },
+      ...rest,
+    })
+  } catch (err) {
+    throw new ApiError(
+      'NETWORK_ERROR',
+      0,
+      err instanceof Error ? err.message : 'Network request failed'
+    )
+  }
+
+  // 401 — emit event, optionally redirect, always throw
+  if (response.status === 401) {
+    emitAuthExpired({ path, status: 401 })
+    if (redirectOnUnauthenticated) redirectToLogin()
+    throw new ApiError('UNAUTHENTICATED', 401, 'Authentication required')
+  }
+
+  // 403 — throw, do NOT redirect (user is logged in but lacks role)
+  if (response.status === 403) {
+    const payload = await safeParseJson(response)
+    throw new ApiError('FORBIDDEN', 403, 'Insufficient permissions', payload)
+  }
+
+  if (response.status === 404) {
+    throw new ApiError('NOT_FOUND', 404, `Not found: ${path}`)
+  }
+
+  if (response.status >= 500) {
+    const payload = await safeParseJson(response)
+    const msg =
+      (typeof payload === 'object' && payload !== null && 'error' in payload &&
+        typeof (payload as { error: unknown }).error === 'string'
+        ? (payload as { error: string }).error
+        : null) || `Server error ${response.status}`
+    throw new ApiError('SERVER_ERROR', response.status, msg, payload)
+  }
+
+  if (raw) return response as unknown as T
+
+  if (response.status === 204) return undefined as T
+
+  try {
+    return (await response.json()) as T
+  } catch {
+    throw new ApiError('PARSE_ERROR', response.status, 'Response was not valid JSON')
+  }
+}
+
+async function safeParseJson(res: Response): Promise<unknown> {
+  try {
+    return await res.json()
+  } catch {
+    return null
+  }
+}
+


### PR DESCRIPTION
## Summary
Migrate 10 bare fetch calls in `github-sync-panel.tsx` to `apiFetch`.

## Changes
- Token check, sync history, linked tasks, projects, agents, preview/import, two-way sync
- Uses `{ raw: true }` to preserve `res.ok` and `AbortSignal.timeout(8000)`
- 401 redirects to /login, 403/5xx surfaces typed errors

## Validation
- typecheck: 0 errors
- lint: 0 errors (file-level)
