### PR TITLE
fix: require explicit LOCAL_LLM_ENDPOINT to prevent gateway bypass

### DIFF
--- a/src/lib/__tests__/task-dispatch-reconciliation.test.ts
+++ b/src/lib/__tests__/task-dispatch-reconciliation.test.ts
@@ -92,6 +92,15 @@ vi.mock('../db', () => ({
           },
         }
       }
+      // Make isGatewayAvailable() return true so dispatchAssignedTasks() routes
+      // through the OpenClaw gateway path rather than the direct-API fallback.
+      // Without this, any API key env var in the developer's shell would silently
+      // bypass the gateway and cause gateway-dispatch tests to fail.
+      if (sql.includes('FROM gateways') && sql.includes('status IN')) {
+        return {
+          get: () => ({ c: 1 }),
+        }
+      }
       return {
         all: () => [],
         get: () => undefined,

--- a/src/lib/task-dispatch.ts
+++ b/src/lib/task-dispatch.ts
@@ -631,13 +631,15 @@ function getOpenAIApiKey(): string | null {
 }
 
 /**
- * OpenAI-compatible local endpoint. Defaults to LMStudio's stock listener on
- * the docker host (`host.docker.internal:1234/v1`). Set LOCAL_LLM_ENDPOINT to
- * point at Ollama (`http://host.docker.internal:11434/v1`), a liteLLM proxy
- * (`http://litellm:4000`), or any other OpenAI-compatible service.
+ * OpenAI-compatible local endpoint. Must be set explicitly via LOCAL_LLM_ENDPOINT.
+ * Point it at LMStudio (`http://host.docker.internal:1234/v1`), Ollama
+ * (`http://host.docker.internal:11434/v1`), a liteLLM proxy (`http://litellm:4000`),
+ * or any other OpenAI-compatible service. Returns null when unset, so that
+ * `isDirectDispatchAvailable()` only returns true when a local endpoint is
+ * intentionally configured — preventing unintended gateway bypass.
  */
 function getLocalEndpoint(): string | null {
-  return (process.env.LOCAL_LLM_ENDPOINT || 'http://host.docker.internal:1234/v1').trim() || null
+  return (process.env.LOCAL_LLM_ENDPOINT || '').trim() || null
 }
 
 function getLocalApiKey(): string | null {


### PR DESCRIPTION
## Problem

`getLocalEndpoint()` returned a hardcoded default of `http://host.docker.internal:1234/v1` even when `LOCAL_LLM_ENDPOINT` was not set. This caused `isDirectDispatchAvailable()` to always return `true`, silently routing **all new-session task dispatches** through the direct-API path instead of the OpenClaw gateway — even when a gateway was configured and running.

The gateway `else` branch in `dispatchAssignedTasks()` was effectively unreachable for any task without a `target_session`, because `useDirectApi` was always `true` in environments without a physical OpenClaw config file.

## Changes

**`src/lib/task-dispatch.ts`**
- `getLocalEndpoint()` now returns `null` when `LOCAL_LLM_ENDPOINT` is not explicitly set, matching the documented intent ("Set LOCAL_LLM_ENDPOINT to point at..."). LMStudio users who relied on the implicit default should set `LOCAL_LLM_ENDPOINT=http://host.docker.internal:1234/v1` in their environment.

**`src/lib/__tests__/task-dispatch-reconciliation.test.ts`**
- Added a DB mock entry for the `FROM gateways` count query so `isGatewayAvailable()` reliably returns `true` in the dispatch test suite. Without this, the test was environment-sensitive: any `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` set in the developer's shell would silently bypass the gateway path and fail the assertion.

## Testing

All 995 tests pass (previously 994/995 due to the pre-existing failing test fixed here).

---
*Generated with [Warp](https://app.warp.dev/conversation/a16cf43e-eded-4ed8-9a8f-cd81eed5a354)*

Co-Authored-By: Oz <oz-agent@warp.dev>
