### PR TITLE
fix(deps): extend pnpm.onlyBuiltDependencies for pnpm@11 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,8 +95,13 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
+      "@parcel/watcher",
+      "@swc/core",
       "better-sqlite3",
-      "node-pty"
+      "esbuild",
+      "node-pty",
+      "sharp",
+      "unrs-resolver"
     ]
   }
 }


### PR DESCRIPTION
Fixes #702.

## Summary

Extends `pnpm.onlyBuiltDependencies` in `package.json` from 2 to 7 entries so fresh Docker installs work cleanly against pnpm 11.

The current allowlist (`better-sqlite3`, `node-pty`) was correct for pnpm 10's permissive default but is incomplete now that pnpm 11 blocks unlisted native build scripts. Five additional packages in the lockfile legitimately need their install/postinstall to run:

| Package | Why it needs build scripts |
|---|---|
| `@parcel/watcher` | Native compile via `node scripts/build-from-source.js` |
| `@swc/core` | WASM/platform-binary fetch via `node postinstall.js` |
| `esbuild` | Platform-binary fetch via `node install.js` |
| `sharp` | Platform-binary fetch (or build from source fallback) |
| `unrs-resolver` | NAPI native via `napi-postinstall ... check` |

`vue-demi` appears in the warning but is intentionally omitted — its postinstall is a no-op try/catch shim with no side effects, so allowlisting it would add noise.

## Test plan

- [x] `bash install.sh --docker` from a fresh checkout against pnpm 11.1.3 — completes with no `ERR_PNPM_IGNORED_BUILDS` warnings.
- [x] Container starts healthy: `GET /api/status?action=health` returns `{"status":"healthy"}`.
- [x] `/setup` flow + admin creation work end-to-end.
- [x] `pnpm install` (host-side, without Docker) also clean.

## Notes

- This is the minimal fix. A reasonable follow-up — not included here to keep the PR scoped — is pinning the Dockerfile to a tested pnpm major (`corepack prepare pnpm@11 --activate`) so the next major bump doesn't silently break installs again.
- See #702 for full root cause + repro details.