### PR TITLE
fix(build): unblock docker rebuild on hosts where corepack resolves pnpm@10+

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
   "engines": {
     "node": ">=22"
   },
+  "packageManager": "pnpm@9.15.4",
   "keywords": [
     "openclaw",
     "agent",
@@ -95,8 +96,14 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
+      "@parcel/watcher",
+      "@swc/core",
       "better-sqlite3",
-      "node-pty"
+      "esbuild",
+      "node-pty",
+      "sharp",
+      "unrs-resolver",
+      "vue-demi"
     ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,23 @@
+# pnpm settings — pnpm 10+ moved configuration out of `package.json#pnpm`
+# (warned in build output as "the pnpm field in package.json is no longer
+# read by pnpm"). For non-workspace projects, this file is still read for
+# settings even without a `packages:` field.
+#
+# `package.json#pnpm.onlyBuiltDependencies` is kept in sync below for pnpm 9
+# (pinned via `package.json#packageManager`) — if/when corepack runtime
+# resolves to pnpm 10+, this file takes over.
+#
+# `packages: ['.']` is required even for a single-package repo: without it,
+# `pnpm build` errors with "packages field missing or empty" when this
+# file is present. The dot tells pnpm this directory IS the workspace.
+packages:
+  - '.'
+onlyBuiltDependencies:
+  - '@parcel/watcher'
+  - '@swc/core'
+  - 'better-sqlite3'
+  - 'esbuild'
+  - 'node-pty'
+  - 'sharp'
+  - 'unrs-resolver'
+  - 'vue-demi'


### PR DESCRIPTION
## Summary

`docker compose build mission-control` and the corresponding dev compose path fail on a clean host with:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts:
  @parcel/watcher, @swc/core, better-sqlite3, esbuild,
  node-pty, sharp, unrs-resolver, vue-demi
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.

$ node -e "require('better-sqlite3')"
⚠  better-sqlite3 compiled for wrong Node version. Run: pnpm rebuild better-sqlite3
ERROR  process "/bin/sh -c if [ -f pnpm-lock.yaml ]; then pnpm install --frozen-lockfile; …" did not complete successfully: exit code 1
```

Root cause: pnpm 10+ no longer reads `package.json#pnpm.onlyBuiltDependencies` (the build log warns _"the `pnpm` field in package.json is no longer read by pnpm"_). Native install scripts are silently skipped, the postinstall `require('better-sqlite3')` check fails, install exits 1. Corepack auto-resolves the latest pnpm at runtime (currently 11.1.3) regardless of what the contributor has locally, so this happens on every fresh-host docker build.

## What changes

1. **Add `packageManager: \"pnpm@9.15.4\"` to package.json** — the standardized field corepack reads to pin the version. pnpm 9 still honours the legacy `pnpm.onlyBuiltDependencies` location, so contributors with corepack experience no behaviour change locally.

2. **Add `pnpm-workspace.yaml`** with the same `onlyBuiltDependencies` list and `packages: ['.']`. Forward-compat: if a future pnpm release ever ignores `package.json#pnpm` even with v9 corepack pinning, this file is the read location. The single-entry `packages: ['.']` is required — without it, pnpm 10+ errors with _\"packages field missing or empty\"_ when this file is present.

3. **Extend `onlyBuiltDependencies`** from 2 → 8 entries. Newer transitive deps that ship binary install scripts and need explicit approval:

   ```diff
   + @parcel/watcher       (next 16 file watcher)
   + @swc/core             (next 16 swc transformer)
   + esbuild               (next 16 bundler)
   + sharp                 (image processing)
   + unrs-resolver         (rust-based module resolver)
   + vue-demi              (peer of one of the chart deps)
   ```

## Verification

On a clean Linux host where corepack resolves pnpm 11.1.3 (today's default):

| Command | Before | After |
|---|---|---|
| `docker compose build mission-control` | exit 1 | Image Built ✓ |
| `docker compose -f docker-compose-dev.yml build mission-control-dev` | exit 1 | Image Built ✓ |
| Runtime container starts | n/a | healthy ✓ |
| `/app/.next/server/chunks/src_lib_task-dispatch_ts_*.js` contains `pickProvider(\"local/\")` | n/a (no build) | present ✓ — PR #648's multi-provider dispatch is in the bundle again |

## No source changes

This is a build-system fix only. No source code, no API changes, no peer-dep changes. The pinned `pnpm@9.15.4` is the latest pnpm 9 release; pnpm 10/11 users can still develop locally because the same settings are mirrored in both `package.json` and `pnpm-workspace.yaml`.

## Test plan
- [x] Fresh-host `docker compose build mission-control` succeeds
- [x] Fresh-host `docker compose -f docker-compose-dev.yml build mission-control-dev` succeeds
- [x] Container boots, health probe passes
- [x] Task dispatch routes through `pickProvider`/`callLocalDirectly` as designed in #648