### PR TITLE
feat(api): add creative-CMS routes for branding, assets, and context

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "autoprefixer": "^10.4.20",
     "better-sqlite3": "^12.6.2",
     "class-variance-authority": "^0.7.1",
+    "cloudinary": "^2.5.1",
     "clsx": "^2.1.1",
     "eslint": "^9.18.0",
     "eslint-config-next": "^16.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
+      cloudinary:
+        specifier: ^2.5.1
+        version: 2.10.0
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1756,6 +1759,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unhead/vue@2.1.9':
     resolution: {integrity: sha512-7SqqDEn5zFID1PnEdjLCLa/kOhoAlzol0JdYfVr2Ejek+H4ON4s8iyExv2QQ8bReMosbXQ/Bw41j2CF1NUuGSA==}
@@ -2334,6 +2338,10 @@ packages:
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  cloudinary@2.10.0:
+    resolution: {integrity: sha512-sY09kYg7wprkndAOjZBAYqFZqwL+SxnEGcAvksOvFA+5upnFn949UjkEkHKNSwkBtW/xRDd0p6NgbSXZcxkI3w==}
+    engines: {node: '>=9'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -3536,6 +3544,9 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
@@ -4084,6 +4095,7 @@ packages:
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   prelude-ls@1.2.1:
@@ -7554,6 +7566,10 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  cloudinary@2.10.0:
+    dependencies:
+      lodash: 4.18.1
+
   clsx@2.1.1: {}
 
   color-convert@2.0.1:
@@ -8953,6 +8969,8 @@ snapshots:
       p-locate: 5.0.0
 
   lodash.merge@4.6.2: {}
+
+  lodash@4.18.1: {}
 
   longest-streak@3.1.0: {}
 

--- a/src/app/api/projects/[id]/assets/[assetId]/route.ts
+++ b/src/app/api/projects/[id]/assets/[assetId]/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getDatabase } from '@/lib/db'
+import { requireRole } from '@/lib/auth'
+import { mutationLimiter } from '@/lib/rate-limit'
+import { logger } from '@/lib/logger'
+import { ensureTenantWorkspaceAccess, ForbiddenError } from '@/lib/workspaces'
+import { findProjectInScope, parseProjectId } from '@/lib/creative-cms'
+
+/**
+ * DELETE /api/projects/[id]/assets/[assetId]
+ *
+ * Removes the asset row. Does NOT delete the file from Cloudinary — that has
+ * to happen out-of-band (or via a future webhook) so we don't accidentally
+ * orphan files that are still referenced elsewhere (e.g. by branding logos).
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; assetId: string }> }
+) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  const rateCheck = mutationLimiter(request)
+  if (rateCheck) return rateCheck
+
+  try {
+    const db = getDatabase()
+    const workspaceId = auth.user.workspace_id ?? 1
+    const tenantId = auth.user.tenant_id ?? 1
+    const forwardedFor = (request.headers.get('x-forwarded-for') || '').split(',')[0]?.trim() || null
+    ensureTenantWorkspaceAccess(db, tenantId, workspaceId, {
+      actor: auth.user.username,
+      actorId: auth.user.id,
+      route: '/api/projects/[id]/assets/[assetId]',
+      ipAddress: forwardedFor,
+      userAgent: request.headers.get('user-agent'),
+    })
+
+    const { id, assetId: assetIdRaw } = await params
+    const projectId = parseProjectId(id)
+    const assetId = Number.parseInt(assetIdRaw, 10)
+    if (Number.isNaN(projectId)) return NextResponse.json({ error: 'Invalid project ID' }, { status: 400 })
+    if (!Number.isFinite(assetId) || assetId <= 0) {
+      return NextResponse.json({ error: 'Invalid asset ID' }, { status: 400 })
+    }
+
+    const project = findProjectInScope(db, projectId, workspaceId, tenantId)
+    if (!project) return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+
+    const removed = db
+      .prepare(`DELETE FROM project_assets WHERE id = ? AND project_id = ?`)
+      .run(assetId, projectId)
+
+    if (removed.changes === 0) {
+      return NextResponse.json({ error: 'Asset not found' }, { status: 404 })
+    }
+
+    // Detach the asset if it was the active logo. Foreign-key cascade would
+    // be wrong here — the branding profile should survive losing its logo.
+    db.prepare(
+      `UPDATE project_branding SET logo_asset_id = NULL, updated_at = unixepoch() WHERE logo_asset_id = ?`
+    ).run(assetId)
+
+    return NextResponse.json({ id: assetId, deleted: true })
+  } catch (error) {
+    if (error instanceof ForbiddenError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error({ err: error }, 'DELETE /api/projects/[id]/assets/[assetId] error')
+    return NextResponse.json({ error: 'Failed to delete asset' }, { status: 500 })
+  }
+}

--- a/src/app/api/projects/[id]/assets/route.ts
+++ b/src/app/api/projects/[id]/assets/route.ts
@@ -1,0 +1,222 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getDatabase } from '@/lib/db'
+import { requireRole } from '@/lib/auth'
+import { mutationLimiter } from '@/lib/rate-limit'
+import { logger } from '@/lib/logger'
+import { ensureTenantWorkspaceAccess, ForbiddenError } from '@/lib/workspaces'
+import { CREATIVE_ASSET_TYPES, type CreativeAssetType } from '@/lib/cloudinary'
+import {
+  asStringArray,
+  findProjectInScope,
+  parseJsonColumn,
+  parseProjectId,
+  trimmedString,
+} from '@/lib/creative-cms'
+
+interface AssetRow {
+  id: number
+  project_id: number
+  workspace_id: number
+  cloudinary_public_id: string
+  cloudinary_url: string
+  asset_type: string
+  asset_category: string | null
+  original_filename: string | null
+  tags: string
+  metadata: string
+  uploaded_by: string | null
+  created_at: number
+  updated_at: number
+}
+
+function serialize(row: AssetRow) {
+  return {
+    id: row.id,
+    project_id: row.project_id,
+    workspace_id: row.workspace_id,
+    cloudinary_public_id: row.cloudinary_public_id,
+    cloudinary_url: row.cloudinary_url,
+    asset_type: row.asset_type,
+    asset_category: row.asset_category,
+    original_filename: row.original_filename,
+    tags: parseJsonColumn<string[]>(row.tags, []),
+    metadata: parseJsonColumn<Record<string, unknown>>(row.metadata, {}),
+    uploaded_by: row.uploaded_by,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  }
+}
+
+function isAssetType(value: unknown): value is CreativeAssetType {
+  return typeof value === 'string' && (CREATIVE_ASSET_TYPES as readonly string[]).includes(value)
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  try {
+    const db = getDatabase()
+    const workspaceId = auth.user.workspace_id ?? 1
+    const tenantId = auth.user.tenant_id ?? 1
+    const forwardedFor = (request.headers.get('x-forwarded-for') || '').split(',')[0]?.trim() || null
+    ensureTenantWorkspaceAccess(db, tenantId, workspaceId, {
+      actor: auth.user.username,
+      actorId: auth.user.id,
+      route: '/api/projects/[id]/assets',
+      ipAddress: forwardedFor,
+      userAgent: request.headers.get('user-agent'),
+    })
+
+    const { id } = await params
+    const projectId = parseProjectId(id)
+    if (Number.isNaN(projectId)) return NextResponse.json({ error: 'Invalid project ID' }, { status: 400 })
+
+    const project = findProjectInScope(db, projectId, workspaceId, tenantId)
+    if (!project) return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+
+    const url = new URL(request.url)
+    const assetTypeParam = url.searchParams.get('asset_type')
+    const tagParam = url.searchParams.get('tag')
+    const page = Math.max(1, Number.parseInt(url.searchParams.get('page') ?? '1', 10) || 1)
+    const pageSize = Math.min(
+      200,
+      Math.max(1, Number.parseInt(url.searchParams.get('pageSize') ?? '50', 10) || 50)
+    )
+
+    if (assetTypeParam && !isAssetType(assetTypeParam)) {
+      return NextResponse.json({ error: `Unknown asset_type: ${assetTypeParam}` }, { status: 400 })
+    }
+
+    const whereParts = ['project_id = ?']
+    const whereArgs: unknown[] = [projectId]
+    if (assetTypeParam) {
+      whereParts.push('asset_type = ?')
+      whereArgs.push(assetTypeParam)
+    }
+    const where = whereParts.join(' AND ')
+
+    const rows = db
+      .prepare(`SELECT * FROM project_assets WHERE ${where} ORDER BY created_at DESC LIMIT ? OFFSET ?`)
+      .all(...whereArgs, pageSize, (page - 1) * pageSize) as AssetRow[]
+
+    const filtered = tagParam ? rows.filter((r) => parseJsonColumn<string[]>(r.tags, []).includes(tagParam)) : rows
+
+    const totalRow = db
+      .prepare(`SELECT COUNT(*) as total FROM project_assets WHERE ${where}`)
+      .get(...whereArgs) as { total: number }
+
+    return NextResponse.json({
+      assets: filtered.map(serialize),
+      page,
+      pageSize,
+      total: totalRow.total,
+    })
+  } catch (error) {
+    if (error instanceof ForbiddenError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error({ err: error }, 'GET /api/projects/[id]/assets error')
+    return NextResponse.json({ error: 'Failed to fetch assets' }, { status: 500 })
+  }
+}
+
+/**
+ * Record an asset that was already uploaded directly to Cloudinary
+ * (e.g. via the signed-upload flow at /assets/sign).
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  const rateCheck = mutationLimiter(request)
+  if (rateCheck) return rateCheck
+
+  try {
+    const db = getDatabase()
+    const workspaceId = auth.user.workspace_id ?? 1
+    const tenantId = auth.user.tenant_id ?? 1
+    const forwardedFor = (request.headers.get('x-forwarded-for') || '').split(',')[0]?.trim() || null
+    ensureTenantWorkspaceAccess(db, tenantId, workspaceId, {
+      actor: auth.user.username,
+      actorId: auth.user.id,
+      route: '/api/projects/[id]/assets',
+      ipAddress: forwardedFor,
+      userAgent: request.headers.get('user-agent'),
+    })
+
+    const { id } = await params
+    const projectId = parseProjectId(id)
+    if (Number.isNaN(projectId)) return NextResponse.json({ error: 'Invalid project ID' }, { status: 400 })
+
+    const project = findProjectInScope(db, projectId, workspaceId, tenantId)
+    if (!project) return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+
+    const body = (await request.json().catch(() => null)) as Record<string, unknown> | null
+    if (!body) return NextResponse.json({ error: 'Request body must be JSON' }, { status: 400 })
+
+    const cloudinaryPublicId = trimmedString(body.cloudinary_public_id, 500)
+    const cloudinaryUrl = trimmedString(body.cloudinary_url, 2000)
+    if (!cloudinaryPublicId) return NextResponse.json({ error: 'cloudinary_public_id is required' }, { status: 400 })
+    if (!cloudinaryUrl) return NextResponse.json({ error: 'cloudinary_url is required' }, { status: 400 })
+    if (!isAssetType(body.asset_type)) {
+      return NextResponse.json({ error: 'asset_type must be one of the known creative-CMS types' }, { status: 400 })
+    }
+    const assetType = body.asset_type as CreativeAssetType
+
+    const existing = db
+      .prepare(`SELECT id FROM project_assets WHERE cloudinary_public_id = ?`)
+      .get(cloudinaryPublicId) as { id: number } | undefined
+    if (existing) {
+      return NextResponse.json(
+        { error: `An asset with cloudinary_public_id "${cloudinaryPublicId}" already exists` },
+        { status: 409 }
+      )
+    }
+
+    const assetCategory = trimmedString(body.asset_category, 120)
+    const originalFilename = trimmedString(body.original_filename, 255)
+    const tags = Array.isArray(body.tags) ? asStringArray(body.tags) : []
+    const metadata =
+      body.metadata && typeof body.metadata === 'object' && !Array.isArray(body.metadata)
+        ? (body.metadata as Record<string, unknown>)
+        : {}
+
+    const result = db
+      .prepare(
+        `INSERT INTO project_assets
+           (project_id, workspace_id, cloudinary_public_id, cloudinary_url, asset_type,
+            asset_category, original_filename, tags, metadata, uploaded_by)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        project.id,
+        workspaceId,
+        cloudinaryPublicId,
+        cloudinaryUrl,
+        assetType,
+        assetCategory,
+        originalFilename,
+        JSON.stringify(tags),
+        JSON.stringify(metadata),
+        auth.user.username
+      )
+
+    const created = db
+      .prepare(`SELECT * FROM project_assets WHERE id = ?`)
+      .get(Number(result.lastInsertRowid)) as AssetRow
+    return NextResponse.json({ asset: serialize(created) }, { status: 201 })
+  } catch (error) {
+    if (error instanceof ForbiddenError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error({ err: error }, 'POST /api/projects/[id]/assets error')
+    return NextResponse.json({ error: 'Failed to record asset' }, { status: 500 })
+  }
+}

--- a/src/app/api/projects/[id]/assets/sign/route.ts
+++ b/src/app/api/projects/[id]/assets/sign/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { randomBytes } from 'crypto'
+import { getDatabase } from '@/lib/db'
+import { requireRole } from '@/lib/auth'
+import { mutationLimiter } from '@/lib/rate-limit'
+import { logger } from '@/lib/logger'
+import { ensureTenantWorkspaceAccess, ForbiddenError } from '@/lib/workspaces'
+import {
+  CREATIVE_ASSET_TYPES,
+  CloudinaryNotConfiguredError,
+  type CreativeAssetType,
+  projectAssetFolder,
+  resourceTypeFor,
+  signUpload,
+} from '@/lib/cloudinary'
+import { asStringArray, findProjectInScope, parseProjectId, trimmedString } from '@/lib/creative-cms'
+
+function isAssetType(value: unknown): value is CreativeAssetType {
+  return typeof value === 'string' && (CREATIVE_ASSET_TYPES as readonly string[]).includes(value)
+}
+
+/**
+ * POST /api/projects/[id]/assets/sign
+ *
+ * Returns a signed-upload payload the frontend uses to POST a file directly
+ * to Cloudinary. The bytes never touch this server. After Cloudinary returns
+ * a `public_id` + `secure_url`, the frontend records the asset by calling
+ * POST /api/projects/[id]/assets.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  const rateCheck = mutationLimiter(request)
+  if (rateCheck) return rateCheck
+
+  try {
+    const db = getDatabase()
+    const workspaceId = auth.user.workspace_id ?? 1
+    const tenantId = auth.user.tenant_id ?? 1
+    const forwardedFor = (request.headers.get('x-forwarded-for') || '').split(',')[0]?.trim() || null
+    ensureTenantWorkspaceAccess(db, tenantId, workspaceId, {
+      actor: auth.user.username,
+      actorId: auth.user.id,
+      route: '/api/projects/[id]/assets/sign',
+      ipAddress: forwardedFor,
+      userAgent: request.headers.get('user-agent'),
+    })
+
+    const { id } = await params
+    const projectId = parseProjectId(id)
+    if (Number.isNaN(projectId)) return NextResponse.json({ error: 'Invalid project ID' }, { status: 400 })
+
+    const project = findProjectInScope(db, projectId, workspaceId, tenantId)
+    if (!project) return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+
+    const body = (await request.json().catch(() => null)) as Record<string, unknown> | null
+    if (!body) return NextResponse.json({ error: 'Request body must be JSON' }, { status: 400 })
+    if (!isAssetType(body.asset_type)) {
+      return NextResponse.json({ error: 'asset_type must be one of the known creative-CMS types' }, { status: 400 })
+    }
+    const assetType = body.asset_type as CreativeAssetType
+    const assetCategory = trimmedString(body.asset_category, 120)
+    const extraTags = Array.isArray(body.tags) ? asStringArray(body.tags) : []
+
+    const folder = projectAssetFolder(project.slug, assetType)
+    const publicId = randomBytes(12).toString('hex')
+
+    const tags = ['mission-control', project.slug, assetType, ...extraTags]
+    const context: Record<string, string> = {
+      project_id: String(project.id),
+      project_slug: project.slug,
+      asset_type: assetType,
+      asset_category: assetCategory ?? '',
+      uploaded_by: auth.user.username,
+      source: 'mission-control',
+    }
+
+    const signed = signUpload({
+      folder,
+      publicId,
+      resourceType: resourceTypeFor(assetType),
+      tags,
+      context,
+    })
+
+    return NextResponse.json({
+      cloud_name: signed.cloudName,
+      api_key: signed.apiKey,
+      resource_type: signed.resourceType,
+      upload_url: signed.uploadUrl,
+      signature: signed.signature,
+      timestamp: signed.timestamp,
+      folder: signed.folder,
+      public_id: signed.publicId,
+      tags: signed.tags,
+      context: signed.context,
+    })
+  } catch (error) {
+    if (error instanceof ForbiddenError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    if (error instanceof CloudinaryNotConfiguredError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error({ err: error }, 'POST /api/projects/[id]/assets/sign error')
+    return NextResponse.json({ error: 'Failed to sign upload' }, { status: 500 })
+  }
+}

--- a/src/app/api/projects/[id]/branding/logo/route.ts
+++ b/src/app/api/projects/[id]/branding/logo/route.ts
@@ -1,0 +1,159 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getDatabase } from '@/lib/db'
+import { requireRole } from '@/lib/auth'
+import { mutationLimiter } from '@/lib/rate-limit'
+import { logger } from '@/lib/logger'
+import { ensureTenantWorkspaceAccess, ForbiddenError } from '@/lib/workspaces'
+import {
+  CloudinaryNotConfiguredError,
+  pngHasAlpha,
+  projectBrandingFolder,
+  resourceTypeFor,
+  uploadBuffer,
+} from '@/lib/cloudinary'
+import { findProjectInScope, parseProjectId } from '@/lib/creative-cms'
+
+/**
+ * POST /api/projects/[id]/branding/logo
+ *
+ * Multipart body with a `file` field. Validates the bytes are a PNG with an
+ * alpha channel (color type 4 or 6), uploads the file to Cloudinary under
+ * `projects/{slug}/branding/`, records an asset row, and links it into the
+ * branding profile via logo_asset_id. Creates the branding profile if missing.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  const rateCheck = mutationLimiter(request)
+  if (rateCheck) return rateCheck
+
+  try {
+    const db = getDatabase()
+    const workspaceId = auth.user.workspace_id ?? 1
+    const tenantId = auth.user.tenant_id ?? 1
+    const forwardedFor = (request.headers.get('x-forwarded-for') || '').split(',')[0]?.trim() || null
+    ensureTenantWorkspaceAccess(db, tenantId, workspaceId, {
+      actor: auth.user.username,
+      actorId: auth.user.id,
+      route: '/api/projects/[id]/branding/logo',
+      ipAddress: forwardedFor,
+      userAgent: request.headers.get('user-agent'),
+    })
+
+    const { id } = await params
+    const projectId = parseProjectId(id)
+    if (Number.isNaN(projectId)) return NextResponse.json({ error: 'Invalid project ID' }, { status: 400 })
+
+    const project = findProjectInScope(db, projectId, workspaceId, tenantId)
+    if (!project) return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+
+    const contentType = request.headers.get('content-type') ?? ''
+    if (!contentType.toLowerCase().startsWith('multipart/form-data')) {
+      return NextResponse.json({ error: 'Request must be multipart/form-data' }, { status: 415 })
+    }
+
+    let formData: FormData
+    try {
+      formData = await request.formData()
+    } catch {
+      return NextResponse.json({ error: 'Failed to parse multipart body' }, { status: 400 })
+    }
+    const file = formData.get('file')
+    if (!(file instanceof File)) {
+      return NextResponse.json({ error: 'Missing "file" field' }, { status: 400 })
+    }
+
+    const buffer = Buffer.from(await file.arrayBuffer())
+    const { isPng, hasAlpha } = pngHasAlpha(buffer)
+    if (!isPng) return NextResponse.json({ error: 'Logo must be a PNG file' }, { status: 400 })
+    if (!hasAlpha) {
+      return NextResponse.json(
+        {
+          error:
+            'Logo PNG must include an alpha channel (color type 4 or 6); export with transparency preserved',
+        },
+        { status: 400 }
+      )
+    }
+
+    const folder = projectBrandingFolder(project.slug)
+    const uploaded = await uploadBuffer(buffer, {
+      folder,
+      resourceType: resourceTypeFor('image'),
+      tags: ['branding', 'logo', project.slug],
+      context: {
+        project_id: String(project.id),
+        project_slug: project.slug,
+        asset_type: 'image',
+        asset_category: 'logo',
+        uploaded_by: auth.user.username,
+        source: 'mission-control',
+      },
+    })
+
+    const insertAsset = db.prepare(
+      `INSERT INTO project_assets
+         (project_id, workspace_id, cloudinary_public_id, cloudinary_url, asset_type,
+          asset_category, original_filename, tags, metadata, uploaded_by)
+       VALUES (?, ?, ?, ?, 'image', 'logo', ?, ?, ?, ?)`
+    )
+    const assetResult = insertAsset.run(
+      project.id,
+      workspaceId,
+      uploaded.publicId,
+      uploaded.secureUrl,
+      file.name || null,
+      JSON.stringify(['branding', 'logo']),
+      JSON.stringify({ bytes: uploaded.bytes, format: uploaded.format }),
+      auth.user.username
+    )
+    const assetId = Number(assetResult.lastInsertRowid)
+
+    // Upsert branding profile and link the logo.
+    const existingBranding = db
+      .prepare(`SELECT id FROM project_branding WHERE project_id = ?`)
+      .get(project.id) as { id: number } | undefined
+
+    if (existingBranding) {
+      db.prepare(
+        `UPDATE project_branding SET logo_asset_id = ?, updated_at = unixepoch() WHERE id = ?`
+      ).run(assetId, existingBranding.id)
+    } else {
+      db.prepare(
+        `INSERT INTO project_branding (project_id, workspace_id, logo_asset_id) VALUES (?, ?, ?)`
+      ).run(project.id, workspaceId, assetId)
+    }
+
+    return NextResponse.json(
+      {
+        asset: {
+          id: assetId,
+          project_id: project.id,
+          cloudinary_public_id: uploaded.publicId,
+          cloudinary_url: uploaded.secureUrl,
+          asset_type: 'image',
+          asset_category: 'logo',
+          original_filename: file.name || null,
+        },
+        branding: {
+          project_id: project.id,
+          logo_asset_id: assetId,
+        },
+      },
+      { status: 201 }
+    )
+  } catch (error) {
+    if (error instanceof ForbiddenError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    if (error instanceof CloudinaryNotConfiguredError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error({ err: error }, 'POST /api/projects/[id]/branding/logo error')
+    return NextResponse.json({ error: 'Failed to upload logo' }, { status: 500 })
+  }
+}

--- a/src/app/api/projects/[id]/branding/route.ts
+++ b/src/app/api/projects/[id]/branding/route.ts
@@ -1,0 +1,342 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getDatabase } from '@/lib/db'
+import { requireRole } from '@/lib/auth'
+import { mutationLimiter } from '@/lib/rate-limit'
+import { logger } from '@/lib/logger'
+import { ensureTenantWorkspaceAccess, ForbiddenError } from '@/lib/workspaces'
+import {
+  asStringArray,
+  findProjectInScope,
+  isHexColor,
+  parseJsonColumn,
+  parseProjectId,
+  trimmedString,
+} from '@/lib/creative-cms'
+
+interface BrandingRow {
+  id: number
+  project_id: number
+  workspace_id: number
+  brand_name: string | null
+  primary_color: string | null
+  secondary_color: string | null
+  accent_colors: string
+  heading_font: string | null
+  body_font: string | null
+  approved_fonts: string
+  logo_asset_id: number | null
+  brand_notes: string | null
+  tone_notes: string | null
+  created_at: number
+  updated_at: number
+}
+
+function serialize(row: BrandingRow) {
+  return {
+    id: row.id,
+    project_id: row.project_id,
+    workspace_id: row.workspace_id,
+    brand_name: row.brand_name,
+    primary_color: row.primary_color,
+    secondary_color: row.secondary_color,
+    accent_colors: parseJsonColumn<string[]>(row.accent_colors, []),
+    heading_font: row.heading_font,
+    body_font: row.body_font,
+    approved_fonts: parseJsonColumn<string[]>(row.approved_fonts, []),
+    logo_asset_id: row.logo_asset_id,
+    brand_notes: row.brand_notes,
+    tone_notes: row.tone_notes,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  }
+}
+
+interface ParsedBrandingInput {
+  brand_name?: string | null
+  primary_color?: string | null
+  secondary_color?: string | null
+  accent_colors?: string[]
+  heading_font?: string | null
+  body_font?: string | null
+  approved_fonts?: string[]
+  brand_notes?: string | null
+  tone_notes?: string | null
+}
+
+function parseBrandingBody(body: unknown): { value?: ParsedBrandingInput; error?: string } {
+  if (!body || typeof body !== 'object') return { error: 'Request body must be a JSON object' }
+  const b = body as Record<string, unknown>
+  const out: ParsedBrandingInput = {}
+
+  if ('brand_name' in b) out.brand_name = trimmedString(b.brand_name, 200)
+
+  for (const colorKey of ['primary_color', 'secondary_color'] as const) {
+    if (colorKey in b) {
+      const raw = b[colorKey]
+      if (raw === null || raw === '') {
+        out[colorKey] = null
+      } else if (isHexColor(raw)) {
+        out[colorKey] = raw
+      } else {
+        return { error: `${colorKey} must be a hex color (e.g. "#0B5FFF") or null` }
+      }
+    }
+  }
+
+  if ('accent_colors' in b) {
+    if (!Array.isArray(b.accent_colors)) return { error: 'accent_colors must be an array' }
+    for (const c of b.accent_colors) {
+      if (!isHexColor(c)) return { error: `accent_colors contains an invalid hex color: ${String(c)}` }
+    }
+    out.accent_colors = b.accent_colors as string[]
+  }
+
+  if ('heading_font' in b) out.heading_font = trimmedString(b.heading_font, 120)
+  if ('body_font' in b) out.body_font = trimmedString(b.body_font, 120)
+
+  if ('approved_fonts' in b) {
+    if (!Array.isArray(b.approved_fonts)) return { error: 'approved_fonts must be an array' }
+    out.approved_fonts = asStringArray(b.approved_fonts).map((f) => f.slice(0, 120))
+  }
+
+  if ('brand_notes' in b) out.brand_notes = trimmedString(b.brand_notes, 5000)
+  if ('tone_notes' in b) out.tone_notes = trimmedString(b.tone_notes, 5000)
+
+  return { value: out }
+}
+
+function applyAudit(
+  request: NextRequest,
+  db: ReturnType<typeof getDatabase>,
+  auth: Extract<ReturnType<typeof requireRole>, { user: unknown }>,
+  routeLabel: string
+): { workspaceId: number; tenantId: number } {
+  const workspaceId = auth.user.workspace_id ?? 1
+  const tenantId = auth.user.tenant_id ?? 1
+  const forwardedFor = (request.headers.get('x-forwarded-for') || '').split(',')[0]?.trim() || null
+  ensureTenantWorkspaceAccess(db, tenantId, workspaceId, {
+    actor: auth.user.username,
+    actorId: auth.user.id,
+    route: routeLabel,
+    ipAddress: forwardedFor,
+    userAgent: request.headers.get('user-agent'),
+  })
+  return { workspaceId, tenantId }
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  try {
+    const db = getDatabase()
+    const { workspaceId, tenantId } = applyAudit(request, db, auth, '/api/projects/[id]/branding')
+
+    const { id } = await params
+    const projectId = parseProjectId(id)
+    if (Number.isNaN(projectId)) return NextResponse.json({ error: 'Invalid project ID' }, { status: 400 })
+
+    const project = findProjectInScope(db, projectId, workspaceId, tenantId)
+    if (!project) return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+
+    const row = db
+      .prepare(`SELECT * FROM project_branding WHERE project_id = ?`)
+      .get(projectId) as BrandingRow | undefined
+    if (!row) return NextResponse.json({ error: 'Branding profile not found' }, { status: 404 })
+
+    return NextResponse.json({ branding: serialize(row) })
+  } catch (error) {
+    if (error instanceof ForbiddenError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error({ err: error }, 'GET /api/projects/[id]/branding error')
+    return NextResponse.json({ error: 'Failed to fetch branding profile' }, { status: 500 })
+  }
+}
+
+/**
+ * POST upserts: creates a branding profile if none exists for the project,
+ * otherwise replaces all provided fields. Returns 200 on update, 201 on create.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  const rateCheck = mutationLimiter(request)
+  if (rateCheck) return rateCheck
+
+  try {
+    const db = getDatabase()
+    const { workspaceId, tenantId } = applyAudit(request, db, auth, '/api/projects/[id]/branding')
+
+    const { id } = await params
+    const projectId = parseProjectId(id)
+    if (Number.isNaN(projectId)) return NextResponse.json({ error: 'Invalid project ID' }, { status: 400 })
+
+    const project = findProjectInScope(db, projectId, workspaceId, tenantId)
+    if (!project) return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+
+    const body = await request.json().catch(() => null)
+    const parsed = parseBrandingBody(body)
+    if (parsed.error || !parsed.value) {
+      return NextResponse.json({ error: parsed.error ?? 'Invalid body' }, { status: 400 })
+    }
+    const v = parsed.value
+
+    const existing = db
+      .prepare(`SELECT id FROM project_branding WHERE project_id = ?`)
+      .get(projectId) as { id: number } | undefined
+
+    if (existing) {
+      db.prepare(
+        `UPDATE project_branding
+         SET brand_name = ?, primary_color = ?, secondary_color = ?, accent_colors = ?,
+             heading_font = ?, body_font = ?, approved_fonts = ?,
+             brand_notes = ?, tone_notes = ?, updated_at = unixepoch()
+         WHERE id = ?`
+      ).run(
+        v.brand_name ?? null,
+        v.primary_color ?? null,
+        v.secondary_color ?? null,
+        JSON.stringify(v.accent_colors ?? []),
+        v.heading_font ?? null,
+        v.body_font ?? null,
+        JSON.stringify(v.approved_fonts ?? []),
+        v.brand_notes ?? null,
+        v.tone_notes ?? null,
+        existing.id
+      )
+      const updated = db
+        .prepare(`SELECT * FROM project_branding WHERE id = ?`)
+        .get(existing.id) as BrandingRow
+      return NextResponse.json({ branding: serialize(updated) })
+    }
+
+    const result = db.prepare(
+      `INSERT INTO project_branding
+         (project_id, workspace_id, brand_name, primary_color, secondary_color, accent_colors,
+          heading_font, body_font, approved_fonts, brand_notes, tone_notes)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      projectId,
+      workspaceId,
+      v.brand_name ?? null,
+      v.primary_color ?? null,
+      v.secondary_color ?? null,
+      JSON.stringify(v.accent_colors ?? []),
+      v.heading_font ?? null,
+      v.body_font ?? null,
+      JSON.stringify(v.approved_fonts ?? []),
+      v.brand_notes ?? null,
+      v.tone_notes ?? null
+    )
+    const created = db
+      .prepare(`SELECT * FROM project_branding WHERE id = ?`)
+      .get(Number(result.lastInsertRowid)) as BrandingRow
+    return NextResponse.json({ branding: serialize(created) }, { status: 201 })
+  } catch (error) {
+    if (error instanceof ForbiddenError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error({ err: error }, 'POST /api/projects/[id]/branding error')
+    return NextResponse.json({ error: 'Failed to save branding profile' }, { status: 500 })
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  const rateCheck = mutationLimiter(request)
+  if (rateCheck) return rateCheck
+
+  try {
+    const db = getDatabase()
+    const { workspaceId, tenantId } = applyAudit(request, db, auth, '/api/projects/[id]/branding')
+
+    const { id } = await params
+    const projectId = parseProjectId(id)
+    if (Number.isNaN(projectId)) return NextResponse.json({ error: 'Invalid project ID' }, { status: 400 })
+
+    const project = findProjectInScope(db, projectId, workspaceId, tenantId)
+    if (!project) return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+
+    const existing = db
+      .prepare(`SELECT * FROM project_branding WHERE project_id = ?`)
+      .get(projectId) as BrandingRow | undefined
+    if (!existing) return NextResponse.json({ error: 'Branding profile not found' }, { status: 404 })
+
+    const body = await request.json().catch(() => null)
+    const parsed = parseBrandingBody(body)
+    if (parsed.error || !parsed.value) {
+      return NextResponse.json({ error: parsed.error ?? 'Invalid body' }, { status: 400 })
+    }
+    const v = parsed.value
+
+    // Build a partial update — only touch keys explicitly provided.
+    const sets: string[] = []
+    const args: unknown[] = []
+    if ('brand_name' in v) {
+      sets.push('brand_name = ?')
+      args.push(v.brand_name ?? null)
+    }
+    if ('primary_color' in v) {
+      sets.push('primary_color = ?')
+      args.push(v.primary_color ?? null)
+    }
+    if ('secondary_color' in v) {
+      sets.push('secondary_color = ?')
+      args.push(v.secondary_color ?? null)
+    }
+    if ('accent_colors' in v) {
+      sets.push('accent_colors = ?')
+      args.push(JSON.stringify(v.accent_colors ?? []))
+    }
+    if ('heading_font' in v) {
+      sets.push('heading_font = ?')
+      args.push(v.heading_font ?? null)
+    }
+    if ('body_font' in v) {
+      sets.push('body_font = ?')
+      args.push(v.body_font ?? null)
+    }
+    if ('approved_fonts' in v) {
+      sets.push('approved_fonts = ?')
+      args.push(JSON.stringify(v.approved_fonts ?? []))
+    }
+    if ('brand_notes' in v) {
+      sets.push('brand_notes = ?')
+      args.push(v.brand_notes ?? null)
+    }
+    if ('tone_notes' in v) {
+      sets.push('tone_notes = ?')
+      args.push(v.tone_notes ?? null)
+    }
+
+    if (sets.length === 0) return NextResponse.json({ error: 'No updatable fields provided' }, { status: 400 })
+
+    sets.push('updated_at = unixepoch()')
+    args.push(existing.id)
+    db.prepare(`UPDATE project_branding SET ${sets.join(', ')} WHERE id = ?`).run(...args)
+
+    const updated = db
+      .prepare(`SELECT * FROM project_branding WHERE id = ?`)
+      .get(existing.id) as BrandingRow
+    return NextResponse.json({ branding: serialize(updated) })
+  } catch (error) {
+    if (error instanceof ForbiddenError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error({ err: error }, 'PATCH /api/projects/[id]/branding error')
+    return NextResponse.json({ error: 'Failed to update branding profile' }, { status: 500 })
+  }
+}

--- a/src/app/api/projects/[id]/context/[entryId]/route.ts
+++ b/src/app/api/projects/[id]/context/[entryId]/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getDatabase } from '@/lib/db'
+import { requireRole } from '@/lib/auth'
+import { mutationLimiter } from '@/lib/rate-limit'
+import { logger } from '@/lib/logger'
+import { ensureTenantWorkspaceAccess, ForbiddenError } from '@/lib/workspaces'
+import { findProjectInScope, parseProjectId } from '@/lib/creative-cms'
+
+/**
+ * DELETE /api/projects/[id]/context/[entryId]
+ *
+ * The shared handoff contract marks context-entry deletion as "only if
+ * explicitly enabled" — the route is wired (admin role required, not just
+ * operator) but UIs that surface it should be cautious about exposing it
+ * to non-admin agents.
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; entryId: string }> }
+) {
+  const auth = requireRole(request, 'admin')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  const rateCheck = mutationLimiter(request)
+  if (rateCheck) return rateCheck
+
+  try {
+    const db = getDatabase()
+    const workspaceId = auth.user.workspace_id ?? 1
+    const tenantId = auth.user.tenant_id ?? 1
+    const forwardedFor = (request.headers.get('x-forwarded-for') || '').split(',')[0]?.trim() || null
+    ensureTenantWorkspaceAccess(db, tenantId, workspaceId, {
+      actor: auth.user.username,
+      actorId: auth.user.id,
+      route: '/api/projects/[id]/context/[entryId]',
+      ipAddress: forwardedFor,
+      userAgent: request.headers.get('user-agent'),
+    })
+
+    const { id, entryId: entryIdRaw } = await params
+    const projectId = parseProjectId(id)
+    const entryId = Number.parseInt(entryIdRaw, 10)
+    if (Number.isNaN(projectId)) return NextResponse.json({ error: 'Invalid project ID' }, { status: 400 })
+    if (!Number.isFinite(entryId) || entryId <= 0) {
+      return NextResponse.json({ error: 'Invalid entry ID' }, { status: 400 })
+    }
+
+    const project = findProjectInScope(db, projectId, workspaceId, tenantId)
+    if (!project) return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+
+    const removed = db
+      .prepare(`DELETE FROM project_context_entries WHERE id = ? AND project_id = ?`)
+      .run(entryId, projectId)
+    if (removed.changes === 0) {
+      return NextResponse.json({ error: 'Context entry not found' }, { status: 404 })
+    }
+
+    return NextResponse.json({ id: entryId, deleted: true })
+  } catch (error) {
+    if (error instanceof ForbiddenError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error({ err: error }, 'DELETE /api/projects/[id]/context/[entryId] error')
+    return NextResponse.json({ error: 'Failed to delete context entry' }, { status: 500 })
+  }
+}

--- a/src/app/api/projects/[id]/context/route.ts
+++ b/src/app/api/projects/[id]/context/route.ts
@@ -1,0 +1,207 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getDatabase } from '@/lib/db'
+import { requireRole } from '@/lib/auth'
+import { mutationLimiter } from '@/lib/rate-limit'
+import { logger } from '@/lib/logger'
+import { ensureTenantWorkspaceAccess, ForbiddenError } from '@/lib/workspaces'
+import {
+  findProjectInScope,
+  parseJsonColumn,
+  parseProjectId,
+  trimmedString,
+} from '@/lib/creative-cms'
+
+const ENTRY_TYPES = [
+  'brief',
+  'research',
+  'decision',
+  'meeting',
+  'asset_note',
+  'agent_log',
+  'client_feedback',
+  'milestone',
+  'brand_note',
+] as const
+type EntryType = (typeof ENTRY_TYPES)[number]
+
+interface ContextRow {
+  id: number
+  project_id: number
+  workspace_id: number
+  entry_type: string
+  title: string
+  content: string
+  source: string | null
+  metadata: string
+  created_by: string | null
+  created_at: number
+  updated_at: number
+}
+
+function serialize(row: ContextRow) {
+  return {
+    id: row.id,
+    project_id: row.project_id,
+    workspace_id: row.workspace_id,
+    entry_type: row.entry_type,
+    title: row.title,
+    content: row.content,
+    source: row.source,
+    metadata: parseJsonColumn<Record<string, unknown>>(row.metadata, {}),
+    created_by: row.created_by,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  }
+}
+
+function isEntryType(value: unknown): value is EntryType {
+  return typeof value === 'string' && (ENTRY_TYPES as readonly string[]).includes(value)
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  try {
+    const db = getDatabase()
+    const workspaceId = auth.user.workspace_id ?? 1
+    const tenantId = auth.user.tenant_id ?? 1
+    const forwardedFor = (request.headers.get('x-forwarded-for') || '').split(',')[0]?.trim() || null
+    ensureTenantWorkspaceAccess(db, tenantId, workspaceId, {
+      actor: auth.user.username,
+      actorId: auth.user.id,
+      route: '/api/projects/[id]/context',
+      ipAddress: forwardedFor,
+      userAgent: request.headers.get('user-agent'),
+    })
+
+    const { id } = await params
+    const projectId = parseProjectId(id)
+    if (Number.isNaN(projectId)) return NextResponse.json({ error: 'Invalid project ID' }, { status: 400 })
+
+    const project = findProjectInScope(db, projectId, workspaceId, tenantId)
+    if (!project) return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+
+    const url = new URL(request.url)
+    const entryTypeParam = url.searchParams.get('entry_type')
+    const page = Math.max(1, Number.parseInt(url.searchParams.get('page') ?? '1', 10) || 1)
+    const pageSize = Math.min(
+      200,
+      Math.max(1, Number.parseInt(url.searchParams.get('pageSize') ?? '50', 10) || 50)
+    )
+
+    if (entryTypeParam && !isEntryType(entryTypeParam)) {
+      return NextResponse.json({ error: `Unknown entry_type: ${entryTypeParam}` }, { status: 400 })
+    }
+
+    const whereParts = ['project_id = ?']
+    const whereArgs: unknown[] = [projectId]
+    if (entryTypeParam) {
+      whereParts.push('entry_type = ?')
+      whereArgs.push(entryTypeParam)
+    }
+    const where = whereParts.join(' AND ')
+
+    const rows = db
+      .prepare(
+        `SELECT * FROM project_context_entries WHERE ${where} ORDER BY created_at DESC LIMIT ? OFFSET ?`
+      )
+      .all(...whereArgs, pageSize, (page - 1) * pageSize) as ContextRow[]
+
+    const totalRow = db
+      .prepare(`SELECT COUNT(*) as total FROM project_context_entries WHERE ${where}`)
+      .get(...whereArgs) as { total: number }
+
+    return NextResponse.json({
+      entries: rows.map(serialize),
+      page,
+      pageSize,
+      total: totalRow.total,
+    })
+  } catch (error) {
+    if (error instanceof ForbiddenError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error({ err: error }, 'GET /api/projects/[id]/context error')
+    return NextResponse.json({ error: 'Failed to fetch context entries' }, { status: 500 })
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  const rateCheck = mutationLimiter(request)
+  if (rateCheck) return rateCheck
+
+  try {
+    const db = getDatabase()
+    const workspaceId = auth.user.workspace_id ?? 1
+    const tenantId = auth.user.tenant_id ?? 1
+    const forwardedFor = (request.headers.get('x-forwarded-for') || '').split(',')[0]?.trim() || null
+    ensureTenantWorkspaceAccess(db, tenantId, workspaceId, {
+      actor: auth.user.username,
+      actorId: auth.user.id,
+      route: '/api/projects/[id]/context',
+      ipAddress: forwardedFor,
+      userAgent: request.headers.get('user-agent'),
+    })
+
+    const { id } = await params
+    const projectId = parseProjectId(id)
+    if (Number.isNaN(projectId)) return NextResponse.json({ error: 'Invalid project ID' }, { status: 400 })
+
+    const project = findProjectInScope(db, projectId, workspaceId, tenantId)
+    if (!project) return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+
+    const body = (await request.json().catch(() => null)) as Record<string, unknown> | null
+    if (!body) return NextResponse.json({ error: 'Request body must be JSON' }, { status: 400 })
+
+    if (!isEntryType(body.entry_type)) {
+      return NextResponse.json({ error: 'entry_type must be one of the known context types' }, { status: 400 })
+    }
+    const title = trimmedString(body.title, 200)
+    if (!title) return NextResponse.json({ error: 'title is required' }, { status: 400 })
+
+    const content = typeof body.content === 'string' ? body.content.slice(0, 50_000) : ''
+    const source = trimmedString(body.source, 200)
+    const metadata =
+      body.metadata && typeof body.metadata === 'object' && !Array.isArray(body.metadata)
+        ? (body.metadata as Record<string, unknown>)
+        : {}
+
+    const result = db
+      .prepare(
+        `INSERT INTO project_context_entries
+           (project_id, workspace_id, entry_type, title, content, source, metadata, created_by)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        project.id,
+        workspaceId,
+        body.entry_type,
+        title,
+        content,
+        source,
+        JSON.stringify(metadata),
+        auth.user.username
+      )
+
+    const created = db
+      .prepare(`SELECT * FROM project_context_entries WHERE id = ?`)
+      .get(Number(result.lastInsertRowid)) as ContextRow
+    return NextResponse.json({ entry: serialize(created) }, { status: 201 })
+  } catch (error) {
+    if (error instanceof ForbiddenError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error({ err: error }, 'POST /api/projects/[id]/context error')
+    return NextResponse.json({ error: 'Failed to create context entry' }, { status: 500 })
+  }
+}

--- a/src/lib/cloudinary.ts
+++ b/src/lib/cloudinary.ts
@@ -1,0 +1,214 @@
+import { v2 as cloudinary } from 'cloudinary'
+
+/**
+ * Cloudinary helper for the creative-CMS routes.
+ *
+ * Credentials live in env (CLOUDINARY_CLOUD_NAME, CLOUDINARY_API_KEY,
+ * CLOUDINARY_API_SECRET). Configuration is lazy so missing creds only error
+ * when an upload route is actually called.
+ */
+
+export type CreativeAssetType =
+  | 'image'
+  | 'video'
+  | 'audio'
+  | 'document'
+  | 'raw'
+  | 'character_sheet'
+  | 'reference'
+  | 'deliverable'
+
+export const CREATIVE_ASSET_TYPES: CreativeAssetType[] = [
+  'image',
+  'video',
+  'audio',
+  'document',
+  'raw',
+  'character_sheet',
+  'reference',
+  'deliverable',
+]
+
+const ASSET_TYPE_FOLDER: Record<CreativeAssetType, string> = {
+  image: 'images',
+  video: 'videos',
+  audio: 'audio',
+  document: 'documents',
+  raw: 'raw',
+  character_sheet: 'character-sheets',
+  reference: 'raw',
+  deliverable: 'deliverables',
+}
+
+const ASSET_TYPE_RESOURCE: Record<CreativeAssetType, 'image' | 'video' | 'raw'> = {
+  image: 'image',
+  video: 'video',
+  audio: 'video', // Cloudinary serves audio under the video resource type.
+  document: 'raw',
+  raw: 'raw',
+  character_sheet: 'image',
+  reference: 'raw',
+  deliverable: 'raw',
+}
+
+export class CloudinaryNotConfiguredError extends Error {
+  status = 503
+  constructor() {
+    super(
+      'Cloudinary credentials are not set on this server. Set CLOUDINARY_CLOUD_NAME, CLOUDINARY_API_KEY, and CLOUDINARY_API_SECRET.'
+    )
+  }
+}
+
+let configured = false
+
+function ensureConfigured(): { cloudName: string; apiKey: string; apiSecret: string } {
+  const cloudName = process.env.CLOUDINARY_CLOUD_NAME
+  const apiKey = process.env.CLOUDINARY_API_KEY
+  const apiSecret = process.env.CLOUDINARY_API_SECRET
+  if (!cloudName || !apiKey || !apiSecret) throw new CloudinaryNotConfiguredError()
+  if (!configured) {
+    cloudinary.config({ cloud_name: cloudName, api_key: apiKey, api_secret: apiSecret, secure: true })
+    configured = true
+  }
+  return { cloudName, apiKey, apiSecret }
+}
+
+export function projectAssetFolder(projectSlug: string, assetType: CreativeAssetType): string {
+  return `projects/${projectSlug}/${ASSET_TYPE_FOLDER[assetType]}`
+}
+
+export function projectBrandingFolder(projectSlug: string): string {
+  return `projects/${projectSlug}/branding`
+}
+
+export function resourceTypeFor(assetType: CreativeAssetType): 'image' | 'video' | 'raw' {
+  return ASSET_TYPE_RESOURCE[assetType]
+}
+
+export interface SignUploadOptions {
+  folder: string
+  publicId: string
+  resourceType: 'image' | 'video' | 'raw'
+  tags?: string[]
+  context?: Record<string, string>
+}
+
+export interface SignedUpload {
+  cloudName: string
+  apiKey: string
+  resourceType: 'image' | 'video' | 'raw'
+  uploadUrl: string
+  signature: string
+  timestamp: number
+  folder: string
+  publicId: string
+  tags: string[]
+  context: Record<string, string>
+}
+
+/**
+ * Mints the params + signature the frontend needs to upload a file directly
+ * to Cloudinary. The VPS never sees the file bytes. Cloudinary verifies the
+ * signature against the api_secret; the secret is never sent.
+ */
+export function signUpload(opts: SignUploadOptions): SignedUpload {
+  const { cloudName, apiKey, apiSecret } = ensureConfigured()
+  const timestamp = Math.floor(Date.now() / 1000)
+  const tagsCsv = (opts.tags ?? []).join(',')
+  const contextStr = opts.context
+    ? Object.entries(opts.context)
+        .map(([k, v]) => `${k}=${v}`)
+        .join('|')
+    : ''
+
+  const toSign: Record<string, string | number> = {
+    folder: opts.folder,
+    public_id: opts.publicId,
+    timestamp,
+  }
+  if (tagsCsv) toSign.tags = tagsCsv
+  if (contextStr) toSign.context = contextStr
+
+  const signature = cloudinary.utils.api_sign_request(toSign, apiSecret)
+
+  return {
+    cloudName,
+    apiKey,
+    resourceType: opts.resourceType,
+    uploadUrl: `https://api.cloudinary.com/v1_1/${cloudName}/${opts.resourceType}/upload`,
+    signature,
+    timestamp,
+    folder: opts.folder,
+    publicId: opts.publicId,
+    tags: opts.tags ?? [],
+    context: opts.context ?? {},
+  }
+}
+
+export interface UploadedAsset {
+  publicId: string
+  secureUrl: string
+  bytes: number
+  format: string
+}
+
+/**
+ * Server-side upload for the logo flow. We want to validate the file before
+ * storing, so we proxy through the server rather than signing a direct upload.
+ */
+export async function uploadBuffer(
+  buffer: Buffer,
+  opts: {
+    folder: string
+    publicId?: string
+    resourceType?: 'image' | 'video' | 'raw'
+    tags?: string[]
+    context?: Record<string, string>
+  }
+): Promise<UploadedAsset> {
+  ensureConfigured()
+  return new Promise((resolve, reject) => {
+    const stream = cloudinary.uploader.upload_stream(
+      {
+        folder: opts.folder,
+        ...(opts.publicId && { public_id: opts.publicId }),
+        resource_type: opts.resourceType ?? 'image',
+        ...(opts.tags && { tags: opts.tags }),
+        ...(opts.context && { context: opts.context }),
+      },
+      (err, result) => {
+        if (err || !result) {
+          reject(err ?? new Error('cloudinary returned no result'))
+          return
+        }
+        resolve({
+          publicId: result.public_id,
+          secureUrl: result.secure_url,
+          bytes: result.bytes,
+          format: result.format,
+        })
+      }
+    )
+    stream.end(buffer)
+  })
+}
+
+/**
+ * PNG header inspector — checks color type for alpha channel without pulling
+ * in sharp/jimp. PNG layout:
+ *   bytes 0-7  : signature 89 50 4E 47 0D 0A 1A 0A
+ *   bytes 12-15: chunk type "IHDR"
+ *   byte 25    : color type — 4 (grayscale+alpha) or 6 (RGB+alpha) means alpha.
+ */
+export function pngHasAlpha(buffer: Buffer): { isPng: boolean; hasAlpha: boolean } {
+  if (buffer.length < 26) return { isPng: false, hasAlpha: false }
+  const sig = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
+  for (let i = 0; i < 8; i++) {
+    if (buffer[i] !== sig[i]) return { isPng: false, hasAlpha: false }
+  }
+  const ihdrType = buffer.toString('ascii', 12, 16)
+  if (ihdrType !== 'IHDR') return { isPng: true, hasAlpha: false }
+  const colorType = buffer[25]
+  return { isPng: true, hasAlpha: colorType === 4 || colorType === 6 }
+}

--- a/src/lib/creative-cms.ts
+++ b/src/lib/creative-cms.ts
@@ -1,0 +1,75 @@
+import type Database from 'better-sqlite3'
+
+/**
+ * Shared helpers for the creative-CMS route handlers
+ * (branding, assets, context). Keeps the SQL for project scope checks in
+ * one place and centralises JSON column (de)serialisation, matching the
+ * conventions used by the existing /api/projects/[id]/* routes.
+ */
+
+export function parseProjectId(raw: string): number {
+  const id = Number.parseInt(raw, 10)
+  return Number.isFinite(id) && id > 0 ? id : NaN
+}
+
+export interface ProjectScopeRow {
+  id: number
+  slug: string
+  name: string
+}
+
+/**
+ * Returns the project iff it exists AND belongs to the given workspace AND
+ * the workspace belongs to the given tenant. Returns null otherwise.
+ *
+ * The two-step check (`projects.workspace_id = ?` + `workspaces.tenant_id = ?`)
+ * mirrors the inline check used in `src/app/api/projects/[id]/agents/route.ts`.
+ */
+export function findProjectInScope(
+  db: Database.Database,
+  projectId: number,
+  workspaceId: number,
+  tenantId: number
+): ProjectScopeRow | null {
+  const row = db
+    .prepare(
+      `SELECT p.id, p.slug, p.name
+       FROM projects p
+       JOIN workspaces w ON w.id = p.workspace_id
+       WHERE p.id = ? AND p.workspace_id = ? AND w.tenant_id = ?
+       LIMIT 1`
+    )
+    .get(projectId, workspaceId, tenantId) as ProjectScopeRow | undefined
+  return row ?? null
+}
+
+/**
+ * `JSON.parse` with a fallback, for columns we store as JSON text.
+ * Returns the fallback when input is null/empty or malformed.
+ */
+export function parseJsonColumn<T>(raw: unknown, fallback: T): T {
+  if (typeof raw !== 'string' || raw.length === 0) return fallback
+  try {
+    return JSON.parse(raw) as T
+  } catch {
+    return fallback
+  }
+}
+
+export function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value.filter((v): v is string => typeof v === 'string').map((s) => s.slice(0, 200))
+}
+
+const HEX_COLOR_RE = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/
+
+export function isHexColor(value: unknown): value is string {
+  return typeof value === 'string' && HEX_COLOR_RE.test(value)
+}
+
+export function trimmedString(value: unknown, max = 5000): string | null {
+  if (typeof value !== 'string') return null
+  const t = value.trim()
+  if (t.length === 0) return null
+  return t.slice(0, max)
+}

--- a/src/lib/migrations.ts
+++ b/src/lib/migrations.ts
@@ -1428,6 +1428,78 @@ const migrations: Migration[] = [
       db.exec(`ALTER TABLE mcp_call_log ADD COLUMN signature TEXT DEFAULT NULL`)
       db.exec(`ALTER TABLE mcp_call_log ADD COLUMN public_key TEXT DEFAULT NULL`)
     }
+  },
+  {
+    id: '051_creative_cms',
+    up(db: Database.Database) {
+      // Creative-CMS tables: per-project branding profile, asset library, and
+      // project-scoped context entries. Mirrors the contract surface the Vercel
+      // frontend (Deep Vibe) consumes. Existing /api/memory/context is
+      // agent/session-scoped and remains untouched.
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS project_branding (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          project_id INTEGER NOT NULL UNIQUE,
+          workspace_id INTEGER NOT NULL,
+          brand_name TEXT,
+          primary_color TEXT,
+          secondary_color TEXT,
+          accent_colors TEXT NOT NULL DEFAULT '[]',
+          heading_font TEXT,
+          body_font TEXT,
+          approved_fonts TEXT NOT NULL DEFAULT '[]',
+          logo_asset_id INTEGER,
+          brand_notes TEXT,
+          tone_notes TEXT,
+          created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+          updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+          FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
+        )
+      `)
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_project_branding_workspace ON project_branding(workspace_id)`)
+
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS project_assets (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          project_id INTEGER NOT NULL,
+          workspace_id INTEGER NOT NULL,
+          cloudinary_public_id TEXT NOT NULL UNIQUE,
+          cloudinary_url TEXT NOT NULL,
+          asset_type TEXT NOT NULL,
+          asset_category TEXT,
+          original_filename TEXT,
+          tags TEXT NOT NULL DEFAULT '[]',
+          metadata TEXT NOT NULL DEFAULT '{}',
+          uploaded_by TEXT,
+          created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+          updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+          FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
+        )
+      `)
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_project_assets_project ON project_assets(project_id)`)
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_project_assets_workspace ON project_assets(workspace_id)`)
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_project_assets_type ON project_assets(project_id, asset_type)`)
+
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS project_context_entries (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          project_id INTEGER NOT NULL,
+          workspace_id INTEGER NOT NULL,
+          entry_type TEXT NOT NULL,
+          title TEXT NOT NULL,
+          content TEXT NOT NULL DEFAULT '',
+          source TEXT,
+          metadata TEXT NOT NULL DEFAULT '{}',
+          created_by TEXT,
+          created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+          updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+          FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
+        )
+      `)
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_project_context_project ON project_context_entries(project_id)`)
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_project_context_workspace ON project_context_entries(workspace_id)`)
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_project_context_type ON project_context_entries(project_id, entry_type)`)
+    }
   }
 ]
 


### PR DESCRIPTION
## Summary

Adds the project-scoped creative-CMS surface (branding profile, asset library, context entries) that the Deep Vibe Vercel frontend needs. Matches the existing route conventions exactly: `requireRole` + `ensureTenantWorkspaceAccess` + `mutationLimiter`, integer IDs, `unixepoch()` timestamps, workspace-scoped tables, bare JSON responses.

Migration `051_creative_cms` creates `project_branding`, `project_assets`, `project_context_entries` (each FK to `projects(id)` ON DELETE CASCADE). New helper modules `src/lib/cloudinary.ts` (signed-upload, PNG-alpha inspector) and `src/lib/creative-cms.ts` (shared validators + project-scope lookup). Adds `cloudinary@^2.5.1`.

Endpoints added:
- `GET/POST/PATCH /api/projects/[id]/branding` (upsert; 200 update / 201 create)
- `POST /api/projects/[id]/branding/logo` — multipart, PNG-alpha-validated, server-side Cloudinary upload, auto-links into branding profile
- `GET/POST /api/projects/[id]/assets` (filter by `asset_type`, `tag`; paginated)
- `POST /api/projects/[id]/assets/sign` — direct-to-Cloudinary signed-upload payload
- `DELETE /api/projects/[id]/assets/[assetId]` — detaches logo refs in branding
- `GET/POST /api/projects/[id]/context` (filter by `entry_type`; paginated)
- `DELETE /api/projects/[id]/context/[entryId]` — admin-role-gated

Resolves open questions 1, 2, 4 in `docs/vercel_frontend_brief.md` (companion repo).

## Test plan

- [x] `tsc --noEmit` clean across the codebase
- [x] Migration `051_creative_cms` runs on first startup; idempotent on re-run via `schema_migrations`
- [ ] Smoke test on staging after merge:
  - `POST /api/agents/login` → grab Bearer
  - `POST /api/projects` → get project id
  - `POST /api/projects/{id}/branding` `{primary_color:"#0B5FFF"}` → 201
  - `POST /api/projects/{id}/assets/sign` `{asset_type:"image"}` → signed payload
  - Upload a file to the signed URL → Cloudinary returns `public_id`
  - `POST /api/projects/{id}/assets` `{cloudinary_public_id,cloudinary_url,asset_type:"image"}` → 201
  - `POST /api/projects/{id}/context` `{entry_type:"decision",title:"x"}` → 201
- [ ] Verify pre-existing vitest failures on main are unchanged (22 failures in `config.test.ts`, `paths.test.ts`, `opencode-sessions.test.ts`, etc. — all Windows/runtime-environment unrelated to this PR)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


Problem
-------

Mission Control ships an agent-orchestration surface but no per-project creative-CMS endpoints. The Deep Vibe Vercel frontend needs branding profiles, an asset library backed by Cloudinary, and project-scoped context entries — none of which existed. The brief at docs/vercel_frontend_brief.md flagged seven missing endpoints as open questions; this PR resolves them.

Fix
---

New migration 051_creative_cms creates three workspace-scoped tables:

  - project_branding         (one row per project, UNIQUE(project_id))
  - project_assets           (n per project, indexed by type)
  - project_context_entries  (n per project, indexed by entry_type)

Each FKs to projects(id) with ON DELETE CASCADE. Timestamps use unixepoch(); JSON columns (tags, metadata, accent_colors, etc.) are stored as TEXT and (de)serialized at the route layer.

Routes follow the same conventions as src/app/api/projects/[id]/agents:

  - requireRole('viewer') for GETs, 'operator' for mutations, 'admin' for context-entry delete (which the contract marks "only if explicitly enabled")
  - ensureTenantWorkspaceAccess + the projects/workspaces/tenant join on every request
  - mutationLimiter on mutations
  - logger.error({err}) + ForbiddenError special-case in catch blocks
  - Bare JSON responses ({branding}, {assets}, {entry}, {error}), no new envelope shape introduced

Endpoint surface added:

  GET   /api/projects/[id]/branding                (404 if not set)
  POST  /api/projects/[id]/branding                (upsert; 200/201)
  PATCH /api/projects/[id]/branding                (partial update)
  POST  /api/projects/[id]/branding/logo           (multipart; PNG+alpha
                                                    validated server-side,
                                                    uploaded to Cloudinary,
                                                    linked into branding)
  GET   /api/projects/[id]/assets                  (filter by asset_type,
                                                    tag; paginated)
  POST  /api/projects/[id]/assets/sign             (mints signed-upload
                                                    payload for direct
                                                    Cloudinary upload)
  POST  /api/projects/[id]/assets                  (records the asset row
                                                    after Cloudinary returns)
  DELETE /api/projects/[id]/assets/[assetId]       (detaches logo refs)
  GET   /api/projects/[id]/context                 (filter by entry_type;
                                                    paginated)
  POST  /api/projects/[id]/context                 (append; 201)
  DELETE /api/projects/[id]/context/[entryId]      (admin only)

Cloudinary helper (src/lib/cloudinary.ts) provides:

  - Lazy config loader (raises 503 CloudinaryNotConfiguredError until creds are set so missing creds don't break unrelated routes)
  - signUpload() — SHA-1 signature minted with api_secret server-side
  - uploadBuffer() — server-side upload for the logo flow
  - pngHasAlpha() — PNG header inspector (no sharp/jimp dependency)
  - folder convention: projects/{slug}/{images|videos|audio|documents| raw|character-sheets|deliverables} + projects/{slug}/branding for the logo

Shared route helpers (src/lib/creative-cms.ts):

  - parseProjectId       — Number.parseInt with NaN guard
  - findProjectInScope   — single SELECT joining workspaces, returns
                           {id, slug, name} or null
  - parseJsonColumn      — JSON.parse with fallback for JSON-as-TEXT cols
  - isHexColor / asStringArray / trimmedString — input validators

Adds the `cloudinary` package (^2.5.1).

Skipped intentionally
---------------------

  - /api/health, /api/me, /api/schema/version — superseded by the existing /api/status and /api/auth/me; Vercel BFF can use those.
  - Tasks model rewrite — MC already has a richer tasks impl with the 'inbox' / 'quality_review' workflow; the brief recommends BFF translation rather than displacing it.
  - Agent/Membership model — MC's project_agent_assignments stays.

Tests
-----

tsc --noEmit passes against the whole codebase including new routes. The vitest suite has 22 pre-existing failures on main (Windows path resolution, OpenCode runtime tests requiring runtime side-state) — unchanged by this PR. No new unit tests added in this PR; happy to add a dedicated route-test file in a follow-up if useful.

# Summary
Describe what changed and why.

# Risk Level
Low / Medium / High (pick one)

# Tests
List commands run and results.

# Contribution Checklist
- [ ] Tests added/updated for behavior changes
- [ ] Lint/typecheck/build passing
- [ ] Security review done if auth/data/crypto touched
- [ ] DB migration tested if schema changed

# Notes
Anything reviewers should know.
