### PR TITLE
chore(security): enable supply-chain cooldown (Dependabot + pnpm)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+# Dependabot config — Mission Control
+# Supply chain hardening: 7-day cooldown contra Mini Shai-Hulud (Mai 2026)
+# Ref: ~/CLAUDE.md > Package Cooldown 7-Day Rule
+# Stack: pnpm (root) + GitHub Actions
+version: 2
+updates:
+  - package-ecosystem: "npm"  # cobre pnpm-lock.yaml também
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    cooldown:
+      default-days: 7
+    groups:
+      js-deps:
+        patterns: ["*"]
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    cooldown:
+      default-days: 7

--- a/package.json
+++ b/package.json
@@ -97,6 +97,8 @@
     "onlyBuiltDependencies": [
       "better-sqlite3",
       "node-pty"
-    ]
+    ],
+    "minimumReleaseAge": 10080,
+    "minimumReleaseAgeExclude": []
   }
 }


### PR DESCRIPTION
Supply chain hardening contra Mini Shai-Hulud worm (Mar-Mai/2026) que comprometeu TanStack (42 pkgs), Mistral AI, UiPath (65 pkgs), Bitwarden CLI, Aqua Trivy, Guardrails AI.

- `.github/dependabot.yml`: 7-day cooldown para npm/pnpm, github-actions, docker
- `package.json`: `pnpm.minimumReleaseAge=10080` (minutos = 7d) + `minimumReleaseAgeExclude` (allow-list vazia, pronta pra customizar)

**Por que 7 dias**: análise Woodruff/PyPI mostra que 8/10 ataques recentes têm janela de exploração < 1 semana. TanStack foi detectado em ~25min mas só yanked horas depois.

**Defesa em camadas**: bunfig/pnpm config impede install local de pacotes recém-publicados; dependabot.yml bloqueia bumps via PR. Ambos trabalham juntos.

Refs:
- Sintaxe oficial Dependabot: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
- TanStack postmortem: https://tanstack.com/blog/npm-supply-chain-compromise-postmortem