### PR TITLE
feat(api): add creative-CMS routes for branding, assets, and context

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -11644,7 +11644,690 @@
           "409": { "description": "Working tree has uncommitted changes" }
         }
       }
+    },
+    "/api/projects/{id}/branding": {
+      "get": {
+        "tags": ["Projects"],
+        "summary": "Fetch a project's branding profile",
+        "operationId": "getProjectBranding",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer" },
+            "description": "Project id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Branding profile",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "branding": { "$ref": "#/components/schemas/BrandingProfile" }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "429": { "$ref": "#/components/responses/RateLimited" }
+        }
+      },
+      "post": {
+        "tags": ["Projects"],
+        "summary": "Create or replace a project's branding profile (upsert)",
+        "operationId": "upsertProjectBranding",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer" },
+            "description": "Project id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "brand_name": { "type": "string" },
+                  "primary_color": {
+                    "type": "string",
+                    "description": "Hex color (#RRGGBB / #RGB / #RRGGBBAA)"
+                  },
+                  "secondary_color": { "type": "string" },
+                  "accent_colors": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "heading_font": { "type": "string" },
+                  "body_font": { "type": "string" },
+                  "approved_fonts": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "brand_notes": { "type": "string" },
+                  "tone_notes": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Branding profile (existing, updated)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "branding": { "$ref": "#/components/schemas/BrandingProfile" }
+                  }
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Branding profile (newly created)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "branding": { "$ref": "#/components/schemas/BrandingProfile" }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "429": { "$ref": "#/components/responses/RateLimited" }
+        }
+      },
+      "patch": {
+        "tags": ["Projects"],
+        "summary": "Patch fields on an existing branding profile",
+        "operationId": "patchProjectBranding",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer" },
+            "description": "Project id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "type": "object", "additionalProperties": true }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Branding profile (patched)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "branding": { "$ref": "#/components/schemas/BrandingProfile" }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "429": { "$ref": "#/components/responses/RateLimited" }
+        }
+      }
+    },
+    "/api/projects/{id}/branding/logo": {
+      "post": {
+        "tags": ["Projects"],
+        "summary": "Upload a logo PNG (multipart). Server validates PNG alpha channel before uploading to Cloudinary.",
+        "operationId": "uploadProjectLogo",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer" },
+            "description": "Project id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": ["file"],
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "PNG file with alpha channel (color type 4 or 6)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Asset record and updated branding profile",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "asset": { "$ref": "#/components/schemas/Asset" },
+                    "branding": {
+                      "type": "object",
+                      "properties": {
+                        "project_id": { "type": "integer" },
+                        "logo_asset_id": { "type": "integer" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "415": {
+            "description": "Unsupported media type (not multipart/form-data)",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "503": {
+            "description": "Cloudinary not configured on the server",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/projects/{id}/assets": {
+      "get": {
+        "tags": ["Projects"],
+        "summary": "List a project's assets (paginated, filterable by asset_type and tag)",
+        "operationId": "listProjectAssets",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer" },
+            "description": "Project id"
+          },
+          {
+            "name": "asset_type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "image",
+                "video",
+                "audio",
+                "document",
+                "raw",
+                "character_sheet",
+                "reference",
+                "deliverable"
+              ]
+            }
+          },
+          {
+            "name": "tag",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "integer", "minimum": 1 }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "integer", "minimum": 1, "maximum": 200 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Page of assets",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "assets": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/Asset" }
+                    },
+                    "page": { "type": "integer" },
+                    "pageSize": { "type": "integer" },
+                    "total": { "type": "integer" }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "429": { "$ref": "#/components/responses/RateLimited" }
+        }
+      },
+      "post": {
+        "tags": ["Projects"],
+        "summary": "Record an asset already uploaded to Cloudinary (called after a signed-upload POST)",
+        "operationId": "recordProjectAsset",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer" },
+            "description": "Project id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["cloudinary_public_id", "cloudinary_url", "asset_type"],
+                "properties": {
+                  "cloudinary_public_id": { "type": "string" },
+                  "cloudinary_url": { "type": "string" },
+                  "asset_type": {
+                    "type": "string",
+                    "enum": [
+                      "image",
+                      "video",
+                      "audio",
+                      "document",
+                      "raw",
+                      "character_sheet",
+                      "reference",
+                      "deliverable"
+                    ]
+                  },
+                  "asset_category": { "type": "string" },
+                  "original_filename": { "type": "string" },
+                  "tags": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "metadata": { "type": "object", "additionalProperties": true }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Recorded asset",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "asset": { "$ref": "#/components/schemas/Asset" }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "409": {
+            "description": "An asset with this cloudinary_public_id already exists",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          },
+          "429": { "$ref": "#/components/responses/RateLimited" }
+        }
+      }
+    },
+    "/api/projects/{id}/assets/sign": {
+      "post": {
+        "tags": ["Projects"],
+        "summary": "Mint a signed-upload payload for direct-to-Cloudinary upload",
+        "description": "Returns the params + signature the frontend POSTs alongside the file to https://api.cloudinary.com/v1_1/{cloud_name}/{resource_type}/upload. The VPS never sees the file bytes; api_secret is never sent. After upload, the frontend records the asset via POST /api/projects/{id}/assets.",
+        "operationId": "signProjectAssetUpload",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer" },
+            "description": "Project id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["asset_type"],
+                "properties": {
+                  "asset_type": {
+                    "type": "string",
+                    "enum": [
+                      "image",
+                      "video",
+                      "audio",
+                      "document",
+                      "raw",
+                      "character_sheet",
+                      "reference",
+                      "deliverable"
+                    ]
+                  },
+                  "asset_category": { "type": "string" },
+                  "tags": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Signed upload payload",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/SignedUploadPayload" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "503": {
+            "description": "Cloudinary not configured on the server",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/projects/{id}/assets/{assetId}": {
+      "delete": {
+        "tags": ["Projects"],
+        "summary": "Delete an asset row. Also clears logo_asset_id on any branding profile that referenced it.",
+        "operationId": "deleteProjectAsset",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer" },
+            "description": "Project id"
+          },
+          {
+            "name": "assetId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Tombstone",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer" },
+                    "deleted": { "type": "boolean" }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "429": { "$ref": "#/components/responses/RateLimited" }
+        }
+      }
+    },
+    "/api/projects/{id}/context": {
+      "get": {
+        "tags": ["Projects"],
+        "summary": "List a project's context entries (paginated, filterable by entry_type)",
+        "operationId": "listProjectContext",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer" },
+            "description": "Project id"
+          },
+          {
+            "name": "entry_type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "brief",
+                "research",
+                "decision",
+                "meeting",
+                "asset_note",
+                "agent_log",
+                "client_feedback",
+                "milestone",
+                "brand_note"
+              ]
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "integer", "minimum": 1 }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "integer", "minimum": 1, "maximum": 200 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Page of context entries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "entries": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/ContextEntry" }
+                    },
+                    "page": { "type": "integer" },
+                    "pageSize": { "type": "integer" },
+                    "total": { "type": "integer" }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "429": { "$ref": "#/components/responses/RateLimited" }
+        }
+      },
+      "post": {
+        "tags": ["Projects"],
+        "summary": "Append a context entry to a project",
+        "operationId": "createProjectContextEntry",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer" },
+            "description": "Project id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["entry_type", "title"],
+                "properties": {
+                  "entry_type": {
+                    "type": "string",
+                    "enum": [
+                      "brief",
+                      "research",
+                      "decision",
+                      "meeting",
+                      "asset_note",
+                      "agent_log",
+                      "client_feedback",
+                      "milestone",
+                      "brand_note"
+                    ]
+                  },
+                  "title": { "type": "string" },
+                  "content": { "type": "string" },
+                  "source": { "type": "string" },
+                  "metadata": { "type": "object", "additionalProperties": true }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created context entry",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "entry": { "$ref": "#/components/schemas/ContextEntry" }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "429": { "$ref": "#/components/responses/RateLimited" }
+        }
+      }
+    },
+    "/api/projects/{id}/context/{entryId}": {
+      "delete": {
+        "tags": ["Projects"],
+        "summary": "Delete a context entry. Requires admin role.",
+        "operationId": "deleteProjectContextEntry",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer" },
+            "description": "Project id"
+          },
+          {
+            "name": "entryId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Tombstone",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer" },
+                    "deleted": { "type": "boolean" }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "429": { "$ref": "#/components/responses/RateLimited" }
+        }
+      }
     }
+  
   },
   "components": {
     "securitySchemes": {
@@ -12011,7 +12694,126 @@
             "type": "integer"
           }
         }
+      },
+    "BrandingProfile": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "integer" },
+        "project_id": { "type": "integer" },
+        "workspace_id": { "type": "integer" },
+        "brand_name": { "type": "string" },
+        "primary_color": { "type": "string", "description": "Hex color (#RRGGBB) or null" },
+        "secondary_color": { "type": "string", "description": "Hex color (#RRGGBB) or null" },
+        "accent_colors": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "heading_font": { "type": "string" },
+        "body_font": { "type": "string" },
+        "approved_fonts": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "logo_asset_id": { "type": "integer", "description": "project_assets.id of the active logo, or null" },
+        "brand_notes": { "type": "string" },
+        "tone_notes": { "type": "string" },
+        "created_at": { "type": "integer" },
+        "updated_at": { "type": "integer" }
       }
+    },
+    "Asset": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "integer" },
+        "project_id": { "type": "integer" },
+        "workspace_id": { "type": "integer" },
+        "cloudinary_public_id": { "type": "string" },
+        "cloudinary_url": { "type": "string" },
+        "asset_type": {
+          "type": "string",
+          "enum": [
+            "image",
+            "video",
+            "audio",
+            "document",
+            "raw",
+            "character_sheet",
+            "reference",
+            "deliverable"
+          ]
+        },
+        "asset_category": { "type": "string" },
+        "original_filename": { "type": "string" },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "metadata": { "type": "object", "additionalProperties": true },
+        "uploaded_by": {
+          "type": "string",
+          "description": "Username of the user/agent that recorded the upload"
+        },
+        "created_at": { "type": "integer" },
+        "updated_at": { "type": "integer" }
+      }
+    },
+    "ContextEntry": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "integer" },
+        "project_id": { "type": "integer" },
+        "workspace_id": { "type": "integer" },
+        "entry_type": {
+          "type": "string",
+          "enum": [
+            "brief",
+            "research",
+            "decision",
+            "meeting",
+            "asset_note",
+            "agent_log",
+            "client_feedback",
+            "milestone",
+            "brand_note"
+          ]
+        },
+        "title": { "type": "string" },
+        "content": { "type": "string" },
+        "source": { "type": "string" },
+        "metadata": { "type": "object", "additionalProperties": true },
+        "created_by": { "type": "string" },
+        "created_at": { "type": "integer" },
+        "updated_at": { "type": "integer" }
+      }
+    },
+    "SignedUploadPayload": {
+      "type": "object",
+      "properties": {
+        "cloud_name": { "type": "string" },
+        "api_key": { "type": "string" },
+        "resource_type": {
+          "type": "string",
+          "enum": ["image", "video", "raw"]
+        },
+        "upload_url": {
+          "type": "string",
+          "description": "Cloudinary endpoint to POST the file + signed params to"
+        },
+        "signature": { "type": "string" },
+        "timestamp": { "type": "integer" },
+        "folder": { "type": "string" },
+        "public_id": { "type": "string" },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "context": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      }
+    }
+  
     },
     "responses": {
       "BadRequest": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "autoprefixer": "^10.4.20",
     "better-sqlite3": "^12.6.2",
     "class-variance-authority": "^0.7.1",
+    "cloudinary": "^2.5.1",
     "clsx": "^2.1.1",
     "eslint": "^9.18.0",
     "eslint-config-next": "^16.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
+      cloudinary:
+        specifier: ^2.5.1
+        version: 2.10.0
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1756,6 +1759,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unhead/vue@2.1.9':
     resolution: {integrity: sha512-7SqqDEn5zFID1PnEdjLCLa/kOhoAlzol0JdYfVr2Ejek+H4ON4s8iyExv2QQ8bReMosbXQ/Bw41j2CF1NUuGSA==}
@@ -2334,6 +2338,10 @@ packages:
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  cloudinary@2.10.0:
+    resolution: {integrity: sha512-sY09kYg7wprkndAOjZBAYqFZqwL+SxnEGcAvksOvFA+5upnFn949UjkEkHKNSwkBtW/xRDd0p6NgbSXZcxkI3w==}
+    engines: {node: '>=9'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -3536,6 +3544,9 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
@@ -4084,6 +4095,7 @@ packages:
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   prelude-ls@1.2.1:
@@ -7554,6 +7566,10 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  cloudinary@2.10.0:
+    dependencies:
+      lodash: 4.18.1
+
   clsx@2.1.1: {}
 
   color-convert@2.0.1:
@@ -8953,6 +8969,8 @@ snapshots:
       p-locate: 5.0.0
 
   lodash.merge@4.6.2: {}
+
+  lodash@4.18.1: {}
 
   longest-streak@3.1.0: {}
 

--- a/scripts/add-creative-cms-openapi.mjs
+++ b/scripts/add-creative-cms-openapi.mjs
@@ -1,0 +1,597 @@
+#!/usr/bin/env node
+/**
+ * Adds the creative-CMS routes (branding, assets, context) to openapi.json so
+ * the contract-parity check passes and downstream codegen tools see them.
+ *
+ * Surgical: inserts new keys at the end of `paths` and `components.schemas`
+ * without re-serializing the existing file content. The diff against HEAD
+ * contains only the lines we add, not whole-file reformatting.
+ *
+ * Idempotent: if any of the new keys already exist, this overwrites just
+ * that key's block.
+ *
+ * Usage:  node scripts/add-creative-cms-openapi.mjs
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+
+const OPENAPI_PATH = path.resolve('openapi.json')
+const raw = fs.readFileSync(OPENAPI_PATH, 'utf8')
+const hadCrlf = raw.includes('\r\n')
+// Operate on LF internally; convert back at the end if the source was CRLF.
+const lf = raw.replace(/\r\n/g, '\n')
+
+// ---- Definitions ---------------------------------------------------------
+
+const ASSET_TYPE_ENUM = [
+  'image',
+  'video',
+  'audio',
+  'document',
+  'raw',
+  'character_sheet',
+  'reference',
+  'deliverable',
+]
+
+const ENTRY_TYPE_ENUM = [
+  'brief',
+  'research',
+  'decision',
+  'meeting',
+  'asset_note',
+  'agent_log',
+  'client_feedback',
+  'milestone',
+  'brand_note',
+]
+
+const newSchemas = {
+  BrandingProfile: {
+    type: 'object',
+    properties: {
+      id: { type: 'integer' },
+      project_id: { type: 'integer' },
+      workspace_id: { type: 'integer' },
+      brand_name: { type: 'string' },
+      primary_color: { type: 'string', description: 'Hex color (#RRGGBB) or null' },
+      secondary_color: { type: 'string', description: 'Hex color (#RRGGBB) or null' },
+      accent_colors: { type: 'array', items: { type: 'string' } },
+      heading_font: { type: 'string' },
+      body_font: { type: 'string' },
+      approved_fonts: { type: 'array', items: { type: 'string' } },
+      logo_asset_id: { type: 'integer', description: 'project_assets.id of the active logo, or null' },
+      brand_notes: { type: 'string' },
+      tone_notes: { type: 'string' },
+      created_at: { type: 'integer' },
+      updated_at: { type: 'integer' },
+    },
+  },
+  Asset: {
+    type: 'object',
+    properties: {
+      id: { type: 'integer' },
+      project_id: { type: 'integer' },
+      workspace_id: { type: 'integer' },
+      cloudinary_public_id: { type: 'string' },
+      cloudinary_url: { type: 'string' },
+      asset_type: { type: 'string', enum: ASSET_TYPE_ENUM },
+      asset_category: { type: 'string' },
+      original_filename: { type: 'string' },
+      tags: { type: 'array', items: { type: 'string' } },
+      metadata: { type: 'object', additionalProperties: true },
+      uploaded_by: { type: 'string', description: 'Username of the user/agent that recorded the upload' },
+      created_at: { type: 'integer' },
+      updated_at: { type: 'integer' },
+    },
+  },
+  ContextEntry: {
+    type: 'object',
+    properties: {
+      id: { type: 'integer' },
+      project_id: { type: 'integer' },
+      workspace_id: { type: 'integer' },
+      entry_type: { type: 'string', enum: ENTRY_TYPE_ENUM },
+      title: { type: 'string' },
+      content: { type: 'string' },
+      source: { type: 'string' },
+      metadata: { type: 'object', additionalProperties: true },
+      created_by: { type: 'string' },
+      created_at: { type: 'integer' },
+      updated_at: { type: 'integer' },
+    },
+  },
+  SignedUploadPayload: {
+    type: 'object',
+    properties: {
+      cloud_name: { type: 'string' },
+      api_key: { type: 'string' },
+      resource_type: { type: 'string', enum: ['image', 'video', 'raw'] },
+      upload_url: { type: 'string', description: 'Cloudinary endpoint to POST the file + signed params to' },
+      signature: { type: 'string' },
+      timestamp: { type: 'integer' },
+      folder: { type: 'string' },
+      public_id: { type: 'string' },
+      tags: { type: 'array', items: { type: 'string' } },
+      context: { type: 'object', additionalProperties: { type: 'string' } },
+    },
+  },
+}
+
+const projectIdParam = {
+  name: 'id',
+  in: 'path',
+  required: true,
+  schema: { type: 'integer' },
+  description: 'Project id',
+}
+
+const errorResponses = {
+  400: { $ref: '#/components/responses/BadRequest' },
+  401: { $ref: '#/components/responses/Unauthorized' },
+  403: { $ref: '#/components/responses/Forbidden' },
+  404: { $ref: '#/components/responses/NotFound' },
+  429: { $ref: '#/components/responses/RateLimited' },
+}
+
+function single(key, ref) {
+  return {
+    content: {
+      'application/json': {
+        schema: { type: 'object', properties: { [key]: { $ref: ref } } },
+      },
+    },
+  }
+}
+
+function paged(key, ref) {
+  return {
+    content: {
+      'application/json': {
+        schema: {
+          type: 'object',
+          properties: {
+            [key]: { type: 'array', items: { $ref: ref } },
+            page: { type: 'integer' },
+            pageSize: { type: 'integer' },
+            total: { type: 'integer' },
+          },
+        },
+      },
+    },
+  }
+}
+
+const newPaths = {
+  '/api/projects/{id}/branding': {
+    get: {
+      tags: ['Projects'],
+      summary: "Fetch a project's branding profile",
+      operationId: 'getProjectBranding',
+      parameters: [projectIdParam],
+      responses: {
+        200: { description: 'Branding profile', ...single('branding', '#/components/schemas/BrandingProfile') },
+        ...errorResponses,
+      },
+    },
+    post: {
+      tags: ['Projects'],
+      summary: "Create or replace a project's branding profile (upsert)",
+      operationId: 'upsertProjectBranding',
+      parameters: [projectIdParam],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                brand_name: { type: 'string' },
+                primary_color: { type: 'string', description: 'Hex color (#RRGGBB / #RGB / #RRGGBBAA)' },
+                secondary_color: { type: 'string' },
+                accent_colors: { type: 'array', items: { type: 'string' } },
+                heading_font: { type: 'string' },
+                body_font: { type: 'string' },
+                approved_fonts: { type: 'array', items: { type: 'string' } },
+                brand_notes: { type: 'string' },
+                tone_notes: { type: 'string' },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        200: { description: 'Branding profile (existing, updated)', ...single('branding', '#/components/schemas/BrandingProfile') },
+        201: { description: 'Branding profile (newly created)', ...single('branding', '#/components/schemas/BrandingProfile') },
+        ...errorResponses,
+      },
+    },
+    patch: {
+      tags: ['Projects'],
+      summary: 'Patch fields on an existing branding profile',
+      operationId: 'patchProjectBranding',
+      parameters: [projectIdParam],
+      requestBody: { required: true, content: { 'application/json': { schema: { type: 'object', additionalProperties: true } } } },
+      responses: {
+        200: { description: 'Branding profile (patched)', ...single('branding', '#/components/schemas/BrandingProfile') },
+        ...errorResponses,
+      },
+    },
+  },
+  '/api/projects/{id}/branding/logo': {
+    post: {
+      tags: ['Projects'],
+      summary: 'Upload a logo PNG (multipart). Server validates PNG alpha channel before uploading to Cloudinary.',
+      operationId: 'uploadProjectLogo',
+      parameters: [projectIdParam],
+      requestBody: {
+        required: true,
+        content: {
+          'multipart/form-data': {
+            schema: {
+              type: 'object',
+              required: ['file'],
+              properties: {
+                file: { type: 'string', format: 'binary', description: 'PNG file with alpha channel (color type 4 or 6)' },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        201: {
+          description: 'Asset record and updated branding profile',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  asset: { $ref: '#/components/schemas/Asset' },
+                  branding: {
+                    type: 'object',
+                    properties: {
+                      project_id: { type: 'integer' },
+                      logo_asset_id: { type: 'integer' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        ...errorResponses,
+        415: { description: 'Unsupported media type (not multipart/form-data)', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+        503: { description: 'Cloudinary not configured on the server', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+      },
+    },
+  },
+  '/api/projects/{id}/assets': {
+    get: {
+      tags: ['Projects'],
+      summary: "List a project's assets (paginated, filterable by asset_type and tag)",
+      operationId: 'listProjectAssets',
+      parameters: [
+        projectIdParam,
+        { name: 'asset_type', in: 'query', required: false, schema: { type: 'string', enum: ASSET_TYPE_ENUM } },
+        { name: 'tag', in: 'query', required: false, schema: { type: 'string' } },
+        { name: 'page', in: 'query', required: false, schema: { type: 'integer', minimum: 1 } },
+        { name: 'pageSize', in: 'query', required: false, schema: { type: 'integer', minimum: 1, maximum: 200 } },
+      ],
+      responses: {
+        200: { description: 'Page of assets', ...paged('assets', '#/components/schemas/Asset') },
+        ...errorResponses,
+      },
+    },
+    post: {
+      tags: ['Projects'],
+      summary: 'Record an asset already uploaded to Cloudinary (called after a signed-upload POST)',
+      operationId: 'recordProjectAsset',
+      parameters: [projectIdParam],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              required: ['cloudinary_public_id', 'cloudinary_url', 'asset_type'],
+              properties: {
+                cloudinary_public_id: { type: 'string' },
+                cloudinary_url: { type: 'string' },
+                asset_type: { type: 'string', enum: ASSET_TYPE_ENUM },
+                asset_category: { type: 'string' },
+                original_filename: { type: 'string' },
+                tags: { type: 'array', items: { type: 'string' } },
+                metadata: { type: 'object', additionalProperties: true },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        201: { description: 'Recorded asset', ...single('asset', '#/components/schemas/Asset') },
+        409: { description: 'An asset with this cloudinary_public_id already exists', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+        ...errorResponses,
+      },
+    },
+  },
+  '/api/projects/{id}/assets/sign': {
+    post: {
+      tags: ['Projects'],
+      summary: 'Mint a signed-upload payload for direct-to-Cloudinary upload',
+      description:
+        'Returns the params + signature the frontend POSTs alongside the file to https://api.cloudinary.com/v1_1/{cloud_name}/{resource_type}/upload. The VPS never sees the file bytes; api_secret is never sent. After upload, the frontend records the asset via POST /api/projects/{id}/assets.',
+      operationId: 'signProjectAssetUpload',
+      parameters: [projectIdParam],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              required: ['asset_type'],
+              properties: {
+                asset_type: { type: 'string', enum: ASSET_TYPE_ENUM },
+                asset_category: { type: 'string' },
+                tags: { type: 'array', items: { type: 'string' } },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        200: { description: 'Signed upload payload', content: { 'application/json': { schema: { $ref: '#/components/schemas/SignedUploadPayload' } } } },
+        503: { description: 'Cloudinary not configured on the server', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+        ...errorResponses,
+      },
+    },
+  },
+  '/api/projects/{id}/assets/{assetId}': {
+    delete: {
+      tags: ['Projects'],
+      summary: 'Delete an asset row. Also clears logo_asset_id on any branding profile that referenced it.',
+      operationId: 'deleteProjectAsset',
+      parameters: [
+        projectIdParam,
+        { name: 'assetId', in: 'path', required: true, schema: { type: 'integer' } },
+      ],
+      responses: {
+        200: {
+          description: 'Tombstone',
+          content: {
+            'application/json': {
+              schema: { type: 'object', properties: { id: { type: 'integer' }, deleted: { type: 'boolean' } } },
+            },
+          },
+        },
+        ...errorResponses,
+      },
+    },
+  },
+  '/api/projects/{id}/context': {
+    get: {
+      tags: ['Projects'],
+      summary: "List a project's context entries (paginated, filterable by entry_type)",
+      operationId: 'listProjectContext',
+      parameters: [
+        projectIdParam,
+        { name: 'entry_type', in: 'query', required: false, schema: { type: 'string', enum: ENTRY_TYPE_ENUM } },
+        { name: 'page', in: 'query', required: false, schema: { type: 'integer', minimum: 1 } },
+        { name: 'pageSize', in: 'query', required: false, schema: { type: 'integer', minimum: 1, maximum: 200 } },
+      ],
+      responses: {
+        200: { description: 'Page of context entries', ...paged('entries', '#/components/schemas/ContextEntry') },
+        ...errorResponses,
+      },
+    },
+    post: {
+      tags: ['Projects'],
+      summary: 'Append a context entry to a project',
+      operationId: 'createProjectContextEntry',
+      parameters: [projectIdParam],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              required: ['entry_type', 'title'],
+              properties: {
+                entry_type: { type: 'string', enum: ENTRY_TYPE_ENUM },
+                title: { type: 'string' },
+                content: { type: 'string' },
+                source: { type: 'string' },
+                metadata: { type: 'object', additionalProperties: true },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        201: { description: 'Created context entry', ...single('entry', '#/components/schemas/ContextEntry') },
+        ...errorResponses,
+      },
+    },
+  },
+  '/api/projects/{id}/context/{entryId}': {
+    delete: {
+      tags: ['Projects'],
+      summary: 'Delete a context entry. Requires admin role.',
+      operationId: 'deleteProjectContextEntry',
+      parameters: [
+        projectIdParam,
+        { name: 'entryId', in: 'path', required: true, schema: { type: 'integer' } },
+      ],
+      responses: {
+        200: {
+          description: 'Tombstone',
+          content: {
+            'application/json': {
+              schema: { type: 'object', properties: { id: { type: 'integer' }, deleted: { type: 'boolean' } } },
+            },
+          },
+        },
+        ...errorResponses,
+      },
+    },
+  },
+}
+
+// ---- JSON pretty-printer (only used for the new content) -----------------
+
+const MAX_INLINE = 110
+
+function fmt(value, indent = 0, prefixLen = 0) {
+  if (value === null) return 'null'
+  if (typeof value === 'boolean' || typeof value === 'number') return JSON.stringify(value)
+  if (typeof value === 'string') return JSON.stringify(value)
+
+  const pad = '  '.repeat(indent)
+  const padIn = '  '.repeat(indent + 1)
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return '[]'
+    const inline = `[${value.map(inlineOf).join(', ')}]`
+    if (prefixLen + inline.length <= MAX_INLINE) return inline
+    return `[\n${value.map((v) => padIn + fmt(v, indent + 1, padIn.length)).join(',\n')}\n${pad}]`
+  }
+
+  const keys = Object.keys(value)
+  if (keys.length === 0) return '{}'
+  const inline = `{ ${keys.map((k) => `${JSON.stringify(k)}: ${inlineOf(value[k])}`).join(', ')} }`
+  if (prefixLen + inline.length <= MAX_INLINE && depth(value) <= 1) return inline
+  const lines = keys.map((k) => {
+    const p = `${padIn}${JSON.stringify(k)}: `
+    return p + fmt(value[k], indent + 1, p.length)
+  })
+  return `{\n${lines.join(',\n')}\n${pad}}`
+}
+
+function inlineOf(value) {
+  if (value === null) return 'null'
+  if (typeof value !== 'object') return JSON.stringify(value)
+  if (Array.isArray(value)) return `[${value.map(inlineOf).join(', ')}]`
+  const keys = Object.keys(value)
+  if (keys.length === 0) return '{}'
+  return `{ ${keys.map((k) => `${JSON.stringify(k)}: ${inlineOf(value[k])}`).join(', ')} }`
+}
+
+function depth(value) {
+  if (value === null || typeof value !== 'object') return 0
+  const children = Array.isArray(value) ? value : Object.values(value)
+  let max = 0
+  for (const c of children) max = Math.max(max, depth(c))
+  return 1 + max
+}
+
+// ---- String-level surgical insertion -------------------------------------
+
+function findKeyValueRange(src, keyName, fromIdx = 0) {
+  // Locates `"keyName": {` and returns { openIdx, closeIdx } of the matching braces.
+  const needle = `"${keyName}":`
+  let i = src.indexOf(needle, fromIdx)
+  if (i === -1) return null
+  // Find the next `{` after the colon
+  while (i < src.length && src[i] !== '{') i++
+  if (i === src.length) return null
+  return { openIdx: i, closeIdx: findMatchingBrace(src, i) }
+}
+
+function findMatchingBrace(src, openIdx) {
+  let depth = 0
+  let inString = false
+  let escape = false
+  for (let i = openIdx; i < src.length; i++) {
+    const c = src[i]
+    if (escape) { escape = false; continue }
+    if (inString) {
+      if (c === '\\') escape = true
+      else if (c === '"') inString = false
+      continue
+    }
+    if (c === '"') { inString = true; continue }
+    if (c === '{') depth++
+    else if (c === '}') { depth--; if (depth === 0) return i }
+  }
+  return -1
+}
+
+function insertIntoObject(src, range, entries, indentChars) {
+  // Idempotency: strip any existing block for each new key, BUT only inside
+  // this exact object range — `findKeyValueRange` is greedy from `fromIdx`.
+  let s = src
+  for (const key of Object.keys(entries)) {
+    const innerRange = findKeyValueRange(s.slice(range.openIdx, range.closeIdx + 1), key)
+    if (!innerRange) continue
+    const absOpen = range.openIdx + innerRange.openIdx
+    const absClose = range.openIdx + innerRange.closeIdx
+    // Find the start of the key declaration line (find preceding `"key":`)
+    // and the trailing comma if any.
+    const keyDecl = s.lastIndexOf(`"${key}":`, absOpen)
+    if (keyDecl === -1 || keyDecl < range.openIdx) continue
+    // Walk back to start of the line (just past the previous newline).
+    let lineStart = s.lastIndexOf('\n', keyDecl) + 1
+    // Walk forward past closing brace + optional comma + optional trailing newline.
+    let end = absClose + 1
+    if (s[end] === ',') end++
+    if (s[end] === '\n') end++
+    // Adjust: if removing leaves a stranded leading newline, fold it.
+    s = s.slice(0, lineStart) + s.slice(end)
+    range = { openIdx: range.openIdx, closeIdx: findMatchingBrace(s, range.openIdx) }
+  }
+
+  // Render new entries with the correct indent.
+  const entryStrings = []
+  for (const [key, value] of Object.entries(entries)) {
+    const prefix = `${indentChars}${JSON.stringify(key)}: `
+    entryStrings.push(prefix + fmt(value, indentChars.length / 2, prefix.length))
+  }
+  const block = entryStrings.join(',\n')
+
+  // Insert before the closing brace. Need to decide on comma/newline placement
+  // depending on whether the existing object is empty or not.
+  const inside = s.slice(range.openIdx + 1, range.closeIdx)
+  const hasExistingContent = /[^\s]/.test(inside)
+  let insertion
+  if (hasExistingContent) {
+    // Make sure to add a leading `,\n` so we don't collide with the last entry,
+    // and trim any trailing whitespace before the closing brace.
+    let cut = range.closeIdx
+    while (cut > 0 && /\s/.test(s[cut - 1])) cut--
+    insertion = `,\n${block}\n${indentChars.slice(0, -2)}`
+    return s.slice(0, cut) + insertion + s.slice(cut)
+  } else {
+    insertion = `\n${block}\n${indentChars.slice(0, -2)}`
+    return s.slice(0, range.openIdx + 1) + insertion + s.slice(range.closeIdx)
+  }
+}
+
+// ---- Run ------------------------------------------------------------------
+
+let s = lf
+
+// 1) Insert new path keys into `paths`
+let pathsRange = findKeyValueRange(s, 'paths')
+if (!pathsRange) throw new Error('could not locate "paths" key in openapi.json')
+s = insertIntoObject(s, pathsRange, newPaths, '    ') // path entries are at indent 4
+
+// 2) Insert new schemas into `components.schemas`
+const componentsRange = findKeyValueRange(s, 'components')
+if (!componentsRange) throw new Error('could not locate "components" key in openapi.json')
+// Find the inner schemas block within components
+const componentsBlock = s.slice(componentsRange.openIdx, componentsRange.closeIdx + 1)
+const innerSchemas = findKeyValueRange(componentsBlock, 'schemas')
+if (!innerSchemas) throw new Error('could not locate "components.schemas" in openapi.json')
+const schemasRange = {
+  openIdx: componentsRange.openIdx + innerSchemas.openIdx,
+  closeIdx: componentsRange.openIdx + innerSchemas.closeIdx,
+}
+s = insertIntoObject(s, schemasRange, newSchemas, '    ') // schemas are at indent 4
+
+// Restore CRLF if the source used it
+if (hadCrlf) s = s.replace(/\r?\n/g, '\r\n')
+fs.writeFileSync(OPENAPI_PATH, s, 'utf8')
+
+process.stdout.write(`Wrote ${OPENAPI_PATH}\n`)
+process.stdout.write(`  paths added/updated:   ${Object.keys(newPaths).length}\n`)
+process.stdout.write(`  operations added:      ${Object.values(newPaths).reduce((n, ops) => n + Object.keys(ops).length, 0)}\n`)
+process.stdout.write(`  component schemas:     ${Object.keys(newSchemas).join(', ')}\n`)

--- a/src/app/api/projects/[id]/assets/[assetId]/route.ts
+++ b/src/app/api/projects/[id]/assets/[assetId]/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getDatabase } from '@/lib/db'
+import { requireRole } from '@/lib/auth'
+import { mutationLimiter } from '@/lib/rate-limit'
+import { logger } from '@/lib/logger'
+import { ensureTenantWorkspaceAccess, ForbiddenError } from '@/lib/workspaces'
+import { findProjectInScope, parseProjectId } from '@/lib/creative-cms'
+
+/**
+ * DELETE /api/projects/[id]/assets/[assetId]
+ *
+ * Removes the asset row. Does NOT delete the file from Cloudinary — that has
+ * to happen out-of-band (or via a future webhook) so we don't accidentally
+ * orphan files that are still referenced elsewhere (e.g. by branding logos).
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; assetId: string }> }
+) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  const rateCheck = mutationLimiter(request)
+  if (rateCheck) return rateCheck
+
+  try {
+    const db = getDatabase()
+    const workspaceId = auth.user.workspace_id ?? 1
+    const tenantId = auth.user.tenant_id ?? 1
+    const forwardedFor = (request.headers.get('x-forwarded-for') || '').split(',')[0]?.trim() || null
+    ensureTenantWorkspaceAccess(db, tenantId, workspaceId, {
+      actor: auth.user.username,
+      actorId: auth.user.id,
+      route: '/api/projects/[id]/assets/[assetId]',
+      ipAddress: forwardedFor,
+      userAgent: request.headers.get('user-agent'),
+    })
+
+    const { id, assetId: assetIdRaw } = await params
+    const projectId = parseProjectId(id)
+    const assetId = Number.parseInt(assetIdRaw, 10)
+    if (Number.isNaN(projectId)) return NextResponse.json({ error: 'Invalid project ID' }, { status: 400 })
+    if (!Number.isFinite(assetId) || assetId <= 0) {
+      return NextResponse.json({ error: 'Invalid asset ID' }, { status: 400 })
+    }
+
+    const project = findProjectInScope(db, projectId, workspaceId, tenantId)
+    if (!project) return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+
+    const removed = db
+      .prepare(`DELETE FROM project_assets WHERE id = ? AND project_id = ?`)
+      .run(assetId, projectId)
+
+    if (removed.changes === 0) {
+      return NextResponse.json({ error: 'Asset not found' }, { status: 404 })
+    }
+
+    // Detach the asset if it was the active logo. Foreign-key cascade would
+    // be wrong here — the branding profile should survive losing its logo.
+    db.prepare(
+      `UPDATE project_branding SET logo_asset_id = NULL, updated_at = unixepoch() WHERE logo_asset_id = ?`
+    ).run(assetId)
+
+    return NextResponse.json({ id: assetId, deleted: true })
+  } catch (error) {
+    if (error instanceof ForbiddenError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error({ err: error }, 'DELETE /api/projects/[id]/assets/[assetId] error')
+    return NextResponse.json({ error: 'Failed to delete asset' }, { status: 500 })
+  }
+}

--- a/src/app/api/projects/[id]/assets/route.ts
+++ b/src/app/api/projects/[id]/assets/route.ts
@@ -1,0 +1,222 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getDatabase } from '@/lib/db'
+import { requireRole } from '@/lib/auth'
+import { mutationLimiter } from '@/lib/rate-limit'
+import { logger } from '@/lib/logger'
+import { ensureTenantWorkspaceAccess, ForbiddenError } from '@/lib/workspaces'
+import { CREATIVE_ASSET_TYPES, type CreativeAssetType } from '@/lib/cloudinary'
+import {
+  asStringArray,
+  findProjectInScope,
+  parseJsonColumn,
+  parseProjectId,
+  trimmedString,
+} from '@/lib/creative-cms'
+
+interface AssetRow {
+  id: number
+  project_id: number
+  workspace_id: number
+  cloudinary_public_id: string
+  cloudinary_url: string
+  asset_type: string
+  asset_category: string | null
+  original_filename: string | null
+  tags: string
+  metadata: string
+  uploaded_by: string | null
+  created_at: number
+  updated_at: number
+}
+
+function serialize(row: AssetRow) {
+  return {
+    id: row.id,
+    project_id: row.project_id,
+    workspace_id: row.workspace_id,
+    cloudinary_public_id: row.cloudinary_public_id,
+    cloudinary_url: row.cloudinary_url,
+    asset_type: row.asset_type,
+    asset_category: row.asset_category,
+    original_filename: row.original_filename,
+    tags: parseJsonColumn<string[]>(row.tags, []),
+    metadata: parseJsonColumn<Record<string, unknown>>(row.metadata, {}),
+    uploaded_by: row.uploaded_by,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  }
+}
+
+function isAssetType(value: unknown): value is CreativeAssetType {
+  return typeof value === 'string' && (CREATIVE_ASSET_TYPES as readonly string[]).includes(value)
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  try {
+    const db = getDatabase()
+    const workspaceId = auth.user.workspace_id ?? 1
+    const tenantId = auth.user.tenant_id ?? 1
+    const forwardedFor = (request.headers.get('x-forwarded-for') || '').split(',')[0]?.trim() || null
+    ensureTenantWorkspaceAccess(db, tenantId, workspaceId, {
+      actor: auth.user.username,
+      actorId: auth.user.id,
+      route: '/api/projects/[id]/assets',
+      ipAddress: forwardedFor,
+      userAgent: request.headers.get('user-agent'),
+    })
+
+    const { id } = await params
+    const projectId = parseProjectId(id)
+    if (Number.isNaN(projectId)) return NextResponse.json({ error: 'Invalid project ID' }, { status: 400 })
+
+    const project = findProjectInScope(db, projectId, workspaceId, tenantId)
+    if (!project) return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+
+    const url = new URL(request.url)
+    const assetTypeParam = url.searchParams.get('asset_type')
+    const tagParam = url.searchParams.get('tag')
+    const page = Math.max(1, Number.parseInt(url.searchParams.get('page') ?? '1', 10) || 1)
+    const pageSize = Math.min(
+      200,
+      Math.max(1, Number.parseInt(url.searchParams.get('pageSize') ?? '50', 10) || 50)
+    )
+
+    if (assetTypeParam && !isAssetType(assetTypeParam)) {
+      return NextResponse.json({ error: `Unknown asset_type: ${assetTypeParam}` }, { status: 400 })
+    }
+
+    const whereParts = ['project_id = ?']
+    const whereArgs: unknown[] = [projectId]
+    if (assetTypeParam) {
+      whereParts.push('asset_type = ?')
+      whereArgs.push(assetTypeParam)
+    }
+    const where = whereParts.join(' AND ')
+
+    const rows = db
+      .prepare(`SELECT * FROM project_assets WHERE ${where} ORDER BY created_at DESC LIMIT ? OFFSET ?`)
+      .all(...whereArgs, pageSize, (page - 1) * pageSize) as AssetRow[]
+
+    const filtered = tagParam ? rows.filter((r) => parseJsonColumn<string[]>(r.tags, []).includes(tagParam)) : rows
+
+    const totalRow = db
+      .prepare(`SELECT COUNT(*) as total FROM project_assets WHERE ${where}`)
+      .get(...whereArgs) as { total: number }
+
+    return NextResponse.json({
+      assets: filtered.map(serialize),
+      page,
+      pageSize,
+      total: totalRow.total,
+    })
+  } catch (error) {
+    if (error instanceof ForbiddenError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error({ err: error }, 'GET /api/projects/[id]/assets error')
+    return NextResponse.json({ error: 'Failed to fetch assets' }, { status: 500 })
+  }
+}
+
+/**
+ * Record an asset that was already uploaded directly to Cloudinary
+ * (e.g. via the signed-upload flow at /assets/sign).
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  const rateCheck = mutationLimiter(request)
+  if (rateCheck) return rateCheck
+
+  try {
+    const db = getDatabase()
+    const workspaceId = auth.user.workspace_id ?? 1
+    const tenantId = auth.user.tenant_id ?? 1
+    const forwardedFor = (request.headers.get('x-forwarded-for') || '').split(',')[0]?.trim() || null
+    ensureTenantWorkspaceAccess(db, tenantId, workspaceId, {
+      actor: auth.user.username,
+      actorId: auth.user.id,
+      route: '/api/projects/[id]/assets',
+      ipAddress: forwardedFor,
+      userAgent: request.headers.get('user-agent'),
+    })
+
+    const { id } = await params
+    const projectId = parseProjectId(id)
+    if (Number.isNaN(projectId)) return NextResponse.json({ error: 'Invalid project ID' }, { status: 400 })
+
+    const project = findProjectInScope(db, projectId, workspaceId, tenantId)
+    if (!project) return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+
+    const body = (await request.json().catch(() => null)) as Record<string, unknown> | null
+    if (!body) return NextResponse.json({ error: 'Request body must be JSON' }, { status: 400 })
+
+    const cloudinaryPublicId = trimmedString(body.cloudinary_public_id, 500)
+    const cloudinaryUrl = trimmedString(body.cloudinary_url, 2000)
+    if (!cloudinaryPublicId) return NextResponse.json({ error: 'cloudinary_public_id is required' }, { status: 400 })
+    if (!cloudinaryUrl) return NextResponse.json({ error: 'cloudinary_url is required' }, { status: 400 })
+    if (!isAssetType(body.asset_type)) {
+      return NextResponse.json({ error: 'asset_type must be one of the known creative-CMS types' }, { status: 400 })
+    }
+    const assetType = body.asset_type as CreativeAssetType
+
+    const existing = db
+      .prepare(`SELECT id FROM project_assets WHERE cloudinary_public_id = ?`)
+      .get(cloudinaryPublicId) as { id: number } | undefined
+    if (existing) {
+      return NextResponse.json(
+        { error: `An asset with cloudinary_public_id "${cloudinaryPublicId}" already exists` },
+        { status: 409 }
+      )
+    }
+
+    const assetCategory = trimmedString(body.asset_category, 120)
+    const originalFilename = trimmedString(body.original_filename, 255)
+    const tags = Array.isArray(body.tags) ? asStringArray(body.tags) : []
+    const metadata =
+      body.metadata && typeof body.metadata === 'object' && !Array.isArray(body.metadata)
+        ? (body.metadata as Record<string, unknown>)
+        : {}
+
+    const result = db
+      .prepare(
+        `INSERT INTO project_assets
+           (project_id, workspace_id, cloudinary_public_id, cloudinary_url, asset_type,
+            asset_category, original_filename, tags, metadata, uploaded_by)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        project.id,
+        workspaceId,
+        cloudinaryPublicId,
+        cloudinaryUrl,
+        assetType,
+        assetCategory,
+        originalFilename,
+        JSON.stringify(tags),
+        JSON.stringify(metadata),
+        auth.user.username
+      )
+
+    const created = db
+      .prepare(`SELECT * FROM project_assets WHERE id = ?`)
+      .get(Number(result.lastInsertRowid)) as AssetRow
+    return NextResponse.json({ asset: serialize(created) }, { status: 201 })
+  } catch (error) {
+    if (error instanceof ForbiddenError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error({ err: error }, 'POST /api/projects/[id]/assets error')
+    return NextResponse.json({ error: 'Failed to record asset' }, { status: 500 })
+  }
+}

--- a/src/app/api/projects/[id]/assets/sign/route.ts
+++ b/src/app/api/projects/[id]/assets/sign/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { randomBytes } from 'crypto'
+import { getDatabase } from '@/lib/db'
+import { requireRole } from '@/lib/auth'
+import { mutationLimiter } from '@/lib/rate-limit'
+import { logger } from '@/lib/logger'
+import { ensureTenantWorkspaceAccess, ForbiddenError } from '@/lib/workspaces'
+import {
+  CREATIVE_ASSET_TYPES,
+  CloudinaryNotConfiguredError,
+  type CreativeAssetType,
+  projectAssetFolder,
+  resourceTypeFor,
+  signUpload,
+} from '@/lib/cloudinary'
+import { asStringArray, findProjectInScope, parseProjectId, trimmedString } from '@/lib/creative-cms'
+
+function isAssetType(value: unknown): value is CreativeAssetType {
+  return typeof value === 'string' && (CREATIVE_ASSET_TYPES as readonly string[]).includes(value)
+}
+
+/**
+ * POST /api/projects/[id]/assets/sign
+ *
+ * Returns a signed-upload payload the frontend uses to POST a file directly
+ * to Cloudinary. The bytes never touch this server. After Cloudinary returns
+ * a `public_id` + `secure_url`, the frontend records the asset by calling
+ * POST /api/projects/[id]/assets.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  const rateCheck = mutationLimiter(request)
+  if (rateCheck) return rateCheck
+
+  try {
+    const db = getDatabase()
+    const workspaceId = auth.user.workspace_id ?? 1
+    const tenantId = auth.user.tenant_id ?? 1
+    const forwardedFor = (request.headers.get('x-forwarded-for') || '').split(',')[0]?.trim() || null
+    ensureTenantWorkspaceAccess(db, tenantId, workspaceId, {
+      actor: auth.user.username,
+      actorId: auth.user.id,
+      route: '/api/projects/[id]/assets/sign',
+      ipAddress: forwardedFor,
+      userAgent: request.headers.get('user-agent'),
+    })
+
+    const { id } = await params
+    const projectId = parseProjectId(id)
+    if (Number.isNaN(projectId)) return NextResponse.json({ error: 'Invalid project ID' }, { status: 400 })
+
+    const project = findProjectInScope(db, projectId, workspaceId, tenantId)
+    if (!project) return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+
+    const body = (await request.json().catch(() => null)) as Record<string, unknown> | null
+    if (!body) return NextResponse.json({ error: 'Request body must be JSON' }, { status: 400 })
+    if (!isAssetType(body.asset_type)) {
+      return NextResponse.json({ error: 'asset_type must be one of the known creative-CMS types' }, { status: 400 })
+    }
+    const assetType = body.asset_type as CreativeAssetType
+    const assetCategory = trimmedString(body.asset_category, 120)
+    const extraTags = Array.isArray(body.tags) ? asStringArray(body.tags) : []
+
+    const folder = projectAssetFolder(project.slug, assetType)
+    const publicId = randomBytes(12).toString('hex')
+
+    const tags = ['mission-control', project.slug, assetType, ...extraTags]
+    const context: Record<string, string> = {
+      project_id: String(project.id),
+      project_slug: project.slug,
+      asset_type: assetType,
+      asset_category: assetCategory ?? '',
+      uploaded_by: auth.user.username,
+      source: 'mission-control',
+    }
+
+    const signed = signUpload({
+      folder,
+      publicId,
+      resourceType: resourceTypeFor(assetType),
+      tags,
+      context,
+    })
+
+    return NextResponse.json({
+      cloud_name: signed.cloudName,
+      api_key: signed.apiKey,
+      resource_type: signed.resourceType,
+      upload_url: signed.uploadUrl,
+      signature: signed.signature,
+      timestamp: signed.timestamp,
+      folder: signed.folder,
+      public_id: signed.publicId,
+      tags: signed.tags,
+      context: signed.context,
+    })
+  } catch (error) {
+    if (error instanceof ForbiddenError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    if (error instanceof CloudinaryNotConfiguredError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error({ err: error }, 'POST /api/projects/[id]/assets/sign error')
+    return NextResponse.json({ error: 'Failed to sign upload' }, { status: 500 })
+  }
+}

--- a/src/app/api/projects/[id]/branding/logo/route.ts
+++ b/src/app/api/projects/[id]/branding/logo/route.ts
@@ -1,0 +1,159 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getDatabase } from '@/lib/db'
+import { requireRole } from '@/lib/auth'
+import { mutationLimiter } from '@/lib/rate-limit'
+import { logger } from '@/lib/logger'
+import { ensureTenantWorkspaceAccess, ForbiddenError } from '@/lib/workspaces'
+import {
+  CloudinaryNotConfiguredError,
+  pngHasAlpha,
+  projectBrandingFolder,
+  resourceTypeFor,
+  uploadBuffer,
+} from '@/lib/cloudinary'
+import { findProjectInScope, parseProjectId } from '@/lib/creative-cms'
+
+/**
+ * POST /api/projects/[id]/branding/logo
+ *
+ * Multipart body with a `file` field. Validates the bytes are a PNG with an
+ * alpha channel (color type 4 or 6), uploads the file to Cloudinary under
+ * `projects/{slug}/branding/`, records an asset row, and links it into the
+ * branding profile via logo_asset_id. Creates the branding profile if missing.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  const rateCheck = mutationLimiter(request)
+  if (rateCheck) return rateCheck
+
+  try {
+    const db = getDatabase()
+    const workspaceId = auth.user.workspace_id ?? 1
+    const tenantId = auth.user.tenant_id ?? 1
+    const forwardedFor = (request.headers.get('x-forwarded-for') || '').split(',')[0]?.trim() || null
+    ensureTenantWorkspaceAccess(db, tenantId, workspaceId, {
+      actor: auth.user.username,
+      actorId: auth.user.id,
+      route: '/api/projects/[id]/branding/logo',
+      ipAddress: forwardedFor,
+      userAgent: request.headers.get('user-agent'),
+    })
+
+    const { id } = await params
+    const projectId = parseProjectId(id)
+    if (Number.isNaN(projectId)) return NextResponse.json({ error: 'Invalid project ID' }, { status: 400 })
+
+    const project = findProjectInScope(db, projectId, workspaceId, tenantId)
+    if (!project) return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+
+    const contentType = request.headers.get('content-type') ?? ''
+    if (!contentType.toLowerCase().startsWith('multipart/form-data')) {
+      return NextResponse.json({ error: 'Request must be multipart/form-data' }, { status: 415 })
+    }
+
+    let formData: FormData
+    try {
+      formData = await request.formData()
+    } catch {
+      return NextResponse.json({ error: 'Failed to parse multipart body' }, { status: 400 })
+    }
+    const file = formData.get('file')
+    if (!(file instanceof File)) {
+      return NextResponse.json({ error: 'Missing "file" field' }, { status: 400 })
+    }
+
+    const buffer = Buffer.from(await file.arrayBuffer())
+    const { isPng, hasAlpha } = pngHasAlpha(buffer)
+    if (!isPng) return NextResponse.json({ error: 'Logo must be a PNG file' }, { status: 400 })
+    if (!hasAlpha) {
+      return NextResponse.json(
+        {
+          error:
+            'Logo PNG must include an alpha channel (color type 4 or 6); export with transparency preserved',
+        },
+        { status: 400 }
+      )
+    }
+
+    const folder = projectBrandingFolder(project.slug)
+    const uploaded = await uploadBuffer(buffer, {
+      folder,
+      resourceType: resourceTypeFor('image'),
+      tags: ['branding', 'logo', project.slug],
+      context: {
+        project_id: String(project.id),
+        project_slug: project.slug,
+        asset_type: 'image',
+        asset_category: 'logo',
+        uploaded_by: auth.user.username,
+        source: 'mission-control',
+      },
+    })
+
+    const insertAsset = db.prepare(
+      `INSERT INTO project_assets
+         (project_id, workspace_id, cloudinary_public_id, cloudinary_url, asset_type,
+          asset_category, original_filename, tags, metadata, uploaded_by)
+       VALUES (?, ?, ?, ?, 'image', 'logo', ?, ?, ?, ?)`
+    )
+    const assetResult = insertAsset.run(
+      project.id,
+      workspaceId,
+      uploaded.publicId,
+      uploaded.secureUrl,
+      file.name || null,
+      JSON.stringify(['branding', 'logo']),
+      JSON.stringify({ bytes: uploaded.bytes, format: uploaded.format }),
+      auth.user.username
+    )
+    const assetId = Number(assetResult.lastInsertRowid)
+
+    // Upsert branding profile and link the logo.
+    const existingBranding = db
+      .prepare(`SELECT id FROM project_branding WHERE project_id = ?`)
+      .get(project.id) as { id: number } | undefined
+
+    if (existingBranding) {
+      db.prepare(
+        `UPDATE project_branding SET logo_asset_id = ?, updated_at = unixepoch() WHERE id = ?`
+      ).run(assetId, existingBranding.id)
+    } else {
+      db.prepare(
+        `INSERT INTO project_branding (project_id, workspace_id, logo_asset_id) VALUES (?, ?, ?)`
+      ).run(project.id, workspaceId, assetId)
+    }
+
+    return NextResponse.json(
+      {
+        asset: {
+          id: assetId,
+          project_id: project.id,
+          cloudinary_public_id: uploaded.publicId,
+          cloudinary_url: uploaded.secureUrl,
+          asset_type: 'image',
+          asset_category: 'logo',
+          original_filename: file.name || null,
+        },
+        branding: {
+          project_id: project.id,
+          logo_asset_id: assetId,
+        },
+      },
+      { status: 201 }
+    )
+  } catch (error) {
+    if (error instanceof ForbiddenError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    if (error instanceof CloudinaryNotConfiguredError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error({ err: error }, 'POST /api/projects/[id]/branding/logo error')
+    return NextResponse.json({ error: 'Failed to upload logo' }, { status: 500 })
+  }
+}

--- a/src/app/api/projects/[id]/branding/route.ts
+++ b/src/app/api/projects/[id]/branding/route.ts
@@ -1,0 +1,342 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getDatabase } from '@/lib/db'
+import { requireRole } from '@/lib/auth'
+import { mutationLimiter } from '@/lib/rate-limit'
+import { logger } from '@/lib/logger'
+import { ensureTenantWorkspaceAccess, ForbiddenError } from '@/lib/workspaces'
+import {
+  asStringArray,
+  findProjectInScope,
+  isHexColor,
+  parseJsonColumn,
+  parseProjectId,
+  trimmedString,
+} from '@/lib/creative-cms'
+
+interface BrandingRow {
+  id: number
+  project_id: number
+  workspace_id: number
+  brand_name: string | null
+  primary_color: string | null
+  secondary_color: string | null
+  accent_colors: string
+  heading_font: string | null
+  body_font: string | null
+  approved_fonts: string
+  logo_asset_id: number | null
+  brand_notes: string | null
+  tone_notes: string | null
+  created_at: number
+  updated_at: number
+}
+
+function serialize(row: BrandingRow) {
+  return {
+    id: row.id,
+    project_id: row.project_id,
+    workspace_id: row.workspace_id,
+    brand_name: row.brand_name,
+    primary_color: row.primary_color,
+    secondary_color: row.secondary_color,
+    accent_colors: parseJsonColumn<string[]>(row.accent_colors, []),
+    heading_font: row.heading_font,
+    body_font: row.body_font,
+    approved_fonts: parseJsonColumn<string[]>(row.approved_fonts, []),
+    logo_asset_id: row.logo_asset_id,
+    brand_notes: row.brand_notes,
+    tone_notes: row.tone_notes,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  }
+}
+
+interface ParsedBrandingInput {
+  brand_name?: string | null
+  primary_color?: string | null
+  secondary_color?: string | null
+  accent_colors?: string[]
+  heading_font?: string | null
+  body_font?: string | null
+  approved_fonts?: string[]
+  brand_notes?: string | null
+  tone_notes?: string | null
+}
+
+function parseBrandingBody(body: unknown): { value?: ParsedBrandingInput; error?: string } {
+  if (!body || typeof body !== 'object') return { error: 'Request body must be a JSON object' }
+  const b = body as Record<string, unknown>
+  const out: ParsedBrandingInput = {}
+
+  if ('brand_name' in b) out.brand_name = trimmedString(b.brand_name, 200)
+
+  for (const colorKey of ['primary_color', 'secondary_color'] as const) {
+    if (colorKey in b) {
+      const raw = b[colorKey]
+      if (raw === null || raw === '') {
+        out[colorKey] = null
+      } else if (isHexColor(raw)) {
+        out[colorKey] = raw
+      } else {
+        return { error: `${colorKey} must be a hex color (e.g. "#0B5FFF") or null` }
+      }
+    }
+  }
+
+  if ('accent_colors' in b) {
+    if (!Array.isArray(b.accent_colors)) return { error: 'accent_colors must be an array' }
+    for (const c of b.accent_colors) {
+      if (!isHexColor(c)) return { error: `accent_colors contains an invalid hex color: ${String(c)}` }
+    }
+    out.accent_colors = b.accent_colors as string[]
+  }
+
+  if ('heading_font' in b) out.heading_font = trimmedString(b.heading_font, 120)
+  if ('body_font' in b) out.body_font = trimmedString(b.body_font, 120)
+
+  if ('approved_fonts' in b) {
+    if (!Array.isArray(b.approved_fonts)) return { error: 'approved_fonts must be an array' }
+    out.approved_fonts = asStringArray(b.approved_fonts).map((f) => f.slice(0, 120))
+  }
+
+  if ('brand_notes' in b) out.brand_notes = trimmedString(b.brand_notes, 5000)
+  if ('tone_notes' in b) out.tone_notes = trimmedString(b.tone_notes, 5000)
+
+  return { value: out }
+}
+
+function applyAudit(
+  request: NextRequest,
+  db: ReturnType<typeof getDatabase>,
+  auth: Extract<ReturnType<typeof requireRole>, { user: unknown }>,
+  routeLabel: string
+): { workspaceId: number; tenantId: number } {
+  const workspaceId = auth.user.workspace_id ?? 1
+  const tenantId = auth.user.tenant_id ?? 1
+  const forwardedFor = (request.headers.get('x-forwarded-for') || '').split(',')[0]?.trim() || null
+  ensureTenantWorkspaceAccess(db, tenantId, workspaceId, {
+    actor: auth.user.username,
+    actorId: auth.user.id,
+    route: routeLabel,
+    ipAddress: forwardedFor,
+    userAgent: request.headers.get('user-agent'),
+  })
+  return { workspaceId, tenantId }
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  try {
+    const db = getDatabase()
+    const { workspaceId, tenantId } = applyAudit(request, db, auth, '/api/projects/[id]/branding')
+
+    const { id } = await params
+    const projectId = parseProjectId(id)
+    if (Number.isNaN(projectId)) return NextResponse.json({ error: 'Invalid project ID' }, { status: 400 })
+
+    const project = findProjectInScope(db, projectId, workspaceId, tenantId)
+    if (!project) return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+
+    const row = db
+      .prepare(`SELECT * FROM project_branding WHERE project_id = ?`)
+      .get(projectId) as BrandingRow | undefined
+    if (!row) return NextResponse.json({ error: 'Branding profile not found' }, { status: 404 })
+
+    return NextResponse.json({ branding: serialize(row) })
+  } catch (error) {
+    if (error instanceof ForbiddenError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error({ err: error }, 'GET /api/projects/[id]/branding error')
+    return NextResponse.json({ error: 'Failed to fetch branding profile' }, { status: 500 })
+  }
+}
+
+/**
+ * POST upserts: creates a branding profile if none exists for the project,
+ * otherwise replaces all provided fields. Returns 200 on update, 201 on create.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  const rateCheck = mutationLimiter(request)
+  if (rateCheck) return rateCheck
+
+  try {
+    const db = getDatabase()
+    const { workspaceId, tenantId } = applyAudit(request, db, auth, '/api/projects/[id]/branding')
+
+    const { id } = await params
+    const projectId = parseProjectId(id)
+    if (Number.isNaN(projectId)) return NextResponse.json({ error: 'Invalid project ID' }, { status: 400 })
+
+    const project = findProjectInScope(db, projectId, workspaceId, tenantId)
+    if (!project) return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+
+    const body = await request.json().catch(() => null)
+    const parsed = parseBrandingBody(body)
+    if (parsed.error || !parsed.value) {
+      return NextResponse.json({ error: parsed.error ?? 'Invalid body' }, { status: 400 })
+    }
+    const v = parsed.value
+
+    const existing = db
+      .prepare(`SELECT id FROM project_branding WHERE project_id = ?`)
+      .get(projectId) as { id: number } | undefined
+
+    if (existing) {
+      db.prepare(
+        `UPDATE project_branding
+         SET brand_name = ?, primary_color = ?, secondary_color = ?, accent_colors = ?,
+             heading_font = ?, body_font = ?, approved_fonts = ?,
+             brand_notes = ?, tone_notes = ?, updated_at = unixepoch()
+         WHERE id = ?`
+      ).run(
+        v.brand_name ?? null,
+        v.primary_color ?? null,
+        v.secondary_color ?? null,
+        JSON.stringify(v.accent_colors ?? []),
+        v.heading_font ?? null,
+        v.body_font ?? null,
+        JSON.stringify(v.approved_fonts ?? []),
+        v.brand_notes ?? null,
+        v.tone_notes ?? null,
+        existing.id
+      )
+      const updated = db
+        .prepare(`SELECT * FROM project_branding WHERE id = ?`)
+        .get(existing.id) as BrandingRow
+      return NextResponse.json({ branding: serialize(updated) })
+    }
+
+    const result = db.prepare(
+      `INSERT INTO project_branding
+         (project_id, workspace_id, brand_name, primary_color, secondary_color, accent_colors,
+          heading_font, body_font, approved_fonts, brand_notes, tone_notes)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      projectId,
+      workspaceId,
+      v.brand_name ?? null,
+      v.primary_color ?? null,
+      v.secondary_color ?? null,
+      JSON.stringify(v.accent_colors ?? []),
+      v.heading_font ?? null,
+      v.body_font ?? null,
+      JSON.stringify(v.approved_fonts ?? []),
+      v.brand_notes ?? null,
+      v.tone_notes ?? null
+    )
+    const created = db
+      .prepare(`SELECT * FROM project_branding WHERE id = ?`)
+      .get(Number(result.lastInsertRowid)) as BrandingRow
+    return NextResponse.json({ branding: serialize(created) }, { status: 201 })
+  } catch (error) {
+    if (error instanceof ForbiddenError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error({ err: error }, 'POST /api/projects/[id]/branding error')
+    return NextResponse.json({ error: 'Failed to save branding profile' }, { status: 500 })
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  const rateCheck = mutationLimiter(request)
+  if (rateCheck) return rateCheck
+
+  try {
+    const db = getDatabase()
+    const { workspaceId, tenantId } = applyAudit(request, db, auth, '/api/projects/[id]/branding')
+
+    const { id } = await params
+    const projectId = parseProjectId(id)
+    if (Number.isNaN(projectId)) return NextResponse.json({ error: 'Invalid project ID' }, { status: 400 })
+
+    const project = findProjectInScope(db, projectId, workspaceId, tenantId)
+    if (!project) return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+
+    const existing = db
+      .prepare(`SELECT * FROM project_branding WHERE project_id = ?`)
+      .get(projectId) as BrandingRow | undefined
+    if (!existing) return NextResponse.json({ error: 'Branding profile not found' }, { status: 404 })
+
+    const body = await request.json().catch(() => null)
+    const parsed = parseBrandingBody(body)
+    if (parsed.error || !parsed.value) {
+      return NextResponse.json({ error: parsed.error ?? 'Invalid body' }, { status: 400 })
+    }
+    const v = parsed.value
+
+    // Build a partial update — only touch keys explicitly provided.
+    const sets: string[] = []
+    const args: unknown[] = []
+    if ('brand_name' in v) {
+      sets.push('brand_name = ?')
+      args.push(v.brand_name ?? null)
+    }
+    if ('primary_color' in v) {
+      sets.push('primary_color = ?')
+      args.push(v.primary_color ?? null)
+    }
+    if ('secondary_color' in v) {
+      sets.push('secondary_color = ?')
+      args.push(v.secondary_color ?? null)
+    }
+    if ('accent_colors' in v) {
+      sets.push('accent_colors = ?')
+      args.push(JSON.stringify(v.accent_colors ?? []))
+    }
+    if ('heading_font' in v) {
+      sets.push('heading_font = ?')
+      args.push(v.heading_font ?? null)
+    }
+    if ('body_font' in v) {
+      sets.push('body_font = ?')
+      args.push(v.body_font ?? null)
+    }
+    if ('approved_fonts' in v) {
+      sets.push('approved_fonts = ?')
+      args.push(JSON.stringify(v.approved_fonts ?? []))
+    }
+    if ('brand_notes' in v) {
+      sets.push('brand_notes = ?')
+      args.push(v.brand_notes ?? null)
+    }
+    if ('tone_notes' in v) {
+      sets.push('tone_notes = ?')
+      args.push(v.tone_notes ?? null)
+    }
+
+    if (sets.length === 0) return NextResponse.json({ error: 'No updatable fields provided' }, { status: 400 })
+
+    sets.push('updated_at = unixepoch()')
+    args.push(existing.id)
+    db.prepare(`UPDATE project_branding SET ${sets.join(', ')} WHERE id = ?`).run(...args)
+
+    const updated = db
+      .prepare(`SELECT * FROM project_branding WHERE id = ?`)
+      .get(existing.id) as BrandingRow
+    return NextResponse.json({ branding: serialize(updated) })
+  } catch (error) {
+    if (error instanceof ForbiddenError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error({ err: error }, 'PATCH /api/projects/[id]/branding error')
+    return NextResponse.json({ error: 'Failed to update branding profile' }, { status: 500 })
+  }
+}

--- a/src/app/api/projects/[id]/context/[entryId]/route.ts
+++ b/src/app/api/projects/[id]/context/[entryId]/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getDatabase } from '@/lib/db'
+import { requireRole } from '@/lib/auth'
+import { mutationLimiter } from '@/lib/rate-limit'
+import { logger } from '@/lib/logger'
+import { ensureTenantWorkspaceAccess, ForbiddenError } from '@/lib/workspaces'
+import { findProjectInScope, parseProjectId } from '@/lib/creative-cms'
+
+/**
+ * DELETE /api/projects/[id]/context/[entryId]
+ *
+ * The shared handoff contract marks context-entry deletion as "only if
+ * explicitly enabled" — the route is wired (admin role required, not just
+ * operator) but UIs that surface it should be cautious about exposing it
+ * to non-admin agents.
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; entryId: string }> }
+) {
+  const auth = requireRole(request, 'admin')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  const rateCheck = mutationLimiter(request)
+  if (rateCheck) return rateCheck
+
+  try {
+    const db = getDatabase()
+    const workspaceId = auth.user.workspace_id ?? 1
+    const tenantId = auth.user.tenant_id ?? 1
+    const forwardedFor = (request.headers.get('x-forwarded-for') || '').split(',')[0]?.trim() || null
+    ensureTenantWorkspaceAccess(db, tenantId, workspaceId, {
+      actor: auth.user.username,
+      actorId: auth.user.id,
+      route: '/api/projects/[id]/context/[entryId]',
+      ipAddress: forwardedFor,
+      userAgent: request.headers.get('user-agent'),
+    })
+
+    const { id, entryId: entryIdRaw } = await params
+    const projectId = parseProjectId(id)
+    const entryId = Number.parseInt(entryIdRaw, 10)
+    if (Number.isNaN(projectId)) return NextResponse.json({ error: 'Invalid project ID' }, { status: 400 })
+    if (!Number.isFinite(entryId) || entryId <= 0) {
+      return NextResponse.json({ error: 'Invalid entry ID' }, { status: 400 })
+    }
+
+    const project = findProjectInScope(db, projectId, workspaceId, tenantId)
+    if (!project) return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+
+    const removed = db
+      .prepare(`DELETE FROM project_context_entries WHERE id = ? AND project_id = ?`)
+      .run(entryId, projectId)
+    if (removed.changes === 0) {
+      return NextResponse.json({ error: 'Context entry not found' }, { status: 404 })
+    }
+
+    return NextResponse.json({ id: entryId, deleted: true })
+  } catch (error) {
+    if (error instanceof ForbiddenError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error({ err: error }, 'DELETE /api/projects/[id]/context/[entryId] error')
+    return NextResponse.json({ error: 'Failed to delete context entry' }, { status: 500 })
+  }
+}

--- a/src/app/api/projects/[id]/context/route.ts
+++ b/src/app/api/projects/[id]/context/route.ts
@@ -1,0 +1,207 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getDatabase } from '@/lib/db'
+import { requireRole } from '@/lib/auth'
+import { mutationLimiter } from '@/lib/rate-limit'
+import { logger } from '@/lib/logger'
+import { ensureTenantWorkspaceAccess, ForbiddenError } from '@/lib/workspaces'
+import {
+  findProjectInScope,
+  parseJsonColumn,
+  parseProjectId,
+  trimmedString,
+} from '@/lib/creative-cms'
+
+const ENTRY_TYPES = [
+  'brief',
+  'research',
+  'decision',
+  'meeting',
+  'asset_note',
+  'agent_log',
+  'client_feedback',
+  'milestone',
+  'brand_note',
+] as const
+type EntryType = (typeof ENTRY_TYPES)[number]
+
+interface ContextRow {
+  id: number
+  project_id: number
+  workspace_id: number
+  entry_type: string
+  title: string
+  content: string
+  source: string | null
+  metadata: string
+  created_by: string | null
+  created_at: number
+  updated_at: number
+}
+
+function serialize(row: ContextRow) {
+  return {
+    id: row.id,
+    project_id: row.project_id,
+    workspace_id: row.workspace_id,
+    entry_type: row.entry_type,
+    title: row.title,
+    content: row.content,
+    source: row.source,
+    metadata: parseJsonColumn<Record<string, unknown>>(row.metadata, {}),
+    created_by: row.created_by,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  }
+}
+
+function isEntryType(value: unknown): value is EntryType {
+  return typeof value === 'string' && (ENTRY_TYPES as readonly string[]).includes(value)
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  try {
+    const db = getDatabase()
+    const workspaceId = auth.user.workspace_id ?? 1
+    const tenantId = auth.user.tenant_id ?? 1
+    const forwardedFor = (request.headers.get('x-forwarded-for') || '').split(',')[0]?.trim() || null
+    ensureTenantWorkspaceAccess(db, tenantId, workspaceId, {
+      actor: auth.user.username,
+      actorId: auth.user.id,
+      route: '/api/projects/[id]/context',
+      ipAddress: forwardedFor,
+      userAgent: request.headers.get('user-agent'),
+    })
+
+    const { id } = await params
+    const projectId = parseProjectId(id)
+    if (Number.isNaN(projectId)) return NextResponse.json({ error: 'Invalid project ID' }, { status: 400 })
+
+    const project = findProjectInScope(db, projectId, workspaceId, tenantId)
+    if (!project) return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+
+    const url = new URL(request.url)
+    const entryTypeParam = url.searchParams.get('entry_type')
+    const page = Math.max(1, Number.parseInt(url.searchParams.get('page') ?? '1', 10) || 1)
+    const pageSize = Math.min(
+      200,
+      Math.max(1, Number.parseInt(url.searchParams.get('pageSize') ?? '50', 10) || 50)
+    )
+
+    if (entryTypeParam && !isEntryType(entryTypeParam)) {
+      return NextResponse.json({ error: `Unknown entry_type: ${entryTypeParam}` }, { status: 400 })
+    }
+
+    const whereParts = ['project_id = ?']
+    const whereArgs: unknown[] = [projectId]
+    if (entryTypeParam) {
+      whereParts.push('entry_type = ?')
+      whereArgs.push(entryTypeParam)
+    }
+    const where = whereParts.join(' AND ')
+
+    const rows = db
+      .prepare(
+        `SELECT * FROM project_context_entries WHERE ${where} ORDER BY created_at DESC LIMIT ? OFFSET ?`
+      )
+      .all(...whereArgs, pageSize, (page - 1) * pageSize) as ContextRow[]
+
+    const totalRow = db
+      .prepare(`SELECT COUNT(*) as total FROM project_context_entries WHERE ${where}`)
+      .get(...whereArgs) as { total: number }
+
+    return NextResponse.json({
+      entries: rows.map(serialize),
+      page,
+      pageSize,
+      total: totalRow.total,
+    })
+  } catch (error) {
+    if (error instanceof ForbiddenError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error({ err: error }, 'GET /api/projects/[id]/context error')
+    return NextResponse.json({ error: 'Failed to fetch context entries' }, { status: 500 })
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  const rateCheck = mutationLimiter(request)
+  if (rateCheck) return rateCheck
+
+  try {
+    const db = getDatabase()
+    const workspaceId = auth.user.workspace_id ?? 1
+    const tenantId = auth.user.tenant_id ?? 1
+    const forwardedFor = (request.headers.get('x-forwarded-for') || '').split(',')[0]?.trim() || null
+    ensureTenantWorkspaceAccess(db, tenantId, workspaceId, {
+      actor: auth.user.username,
+      actorId: auth.user.id,
+      route: '/api/projects/[id]/context',
+      ipAddress: forwardedFor,
+      userAgent: request.headers.get('user-agent'),
+    })
+
+    const { id } = await params
+    const projectId = parseProjectId(id)
+    if (Number.isNaN(projectId)) return NextResponse.json({ error: 'Invalid project ID' }, { status: 400 })
+
+    const project = findProjectInScope(db, projectId, workspaceId, tenantId)
+    if (!project) return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+
+    const body = (await request.json().catch(() => null)) as Record<string, unknown> | null
+    if (!body) return NextResponse.json({ error: 'Request body must be JSON' }, { status: 400 })
+
+    if (!isEntryType(body.entry_type)) {
+      return NextResponse.json({ error: 'entry_type must be one of the known context types' }, { status: 400 })
+    }
+    const title = trimmedString(body.title, 200)
+    if (!title) return NextResponse.json({ error: 'title is required' }, { status: 400 })
+
+    const content = typeof body.content === 'string' ? body.content.slice(0, 50_000) : ''
+    const source = trimmedString(body.source, 200)
+    const metadata =
+      body.metadata && typeof body.metadata === 'object' && !Array.isArray(body.metadata)
+        ? (body.metadata as Record<string, unknown>)
+        : {}
+
+    const result = db
+      .prepare(
+        `INSERT INTO project_context_entries
+           (project_id, workspace_id, entry_type, title, content, source, metadata, created_by)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        project.id,
+        workspaceId,
+        body.entry_type,
+        title,
+        content,
+        source,
+        JSON.stringify(metadata),
+        auth.user.username
+      )
+
+    const created = db
+      .prepare(`SELECT * FROM project_context_entries WHERE id = ?`)
+      .get(Number(result.lastInsertRowid)) as ContextRow
+    return NextResponse.json({ entry: serialize(created) }, { status: 201 })
+  } catch (error) {
+    if (error instanceof ForbiddenError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
+    logger.error({ err: error }, 'POST /api/projects/[id]/context error')
+    return NextResponse.json({ error: 'Failed to create context entry' }, { status: 500 })
+  }
+}

--- a/src/lib/cloudinary.ts
+++ b/src/lib/cloudinary.ts
@@ -1,0 +1,214 @@
+import { v2 as cloudinary } from 'cloudinary'
+
+/**
+ * Cloudinary helper for the creative-CMS routes.
+ *
+ * Credentials live in env (CLOUDINARY_CLOUD_NAME, CLOUDINARY_API_KEY,
+ * CLOUDINARY_API_SECRET). Configuration is lazy so missing creds only error
+ * when an upload route is actually called.
+ */
+
+export type CreativeAssetType =
+  | 'image'
+  | 'video'
+  | 'audio'
+  | 'document'
+  | 'raw'
+  | 'character_sheet'
+  | 'reference'
+  | 'deliverable'
+
+export const CREATIVE_ASSET_TYPES: CreativeAssetType[] = [
+  'image',
+  'video',
+  'audio',
+  'document',
+  'raw',
+  'character_sheet',
+  'reference',
+  'deliverable',
+]
+
+const ASSET_TYPE_FOLDER: Record<CreativeAssetType, string> = {
+  image: 'images',
+  video: 'videos',
+  audio: 'audio',
+  document: 'documents',
+  raw: 'raw',
+  character_sheet: 'character-sheets',
+  reference: 'raw',
+  deliverable: 'deliverables',
+}
+
+const ASSET_TYPE_RESOURCE: Record<CreativeAssetType, 'image' | 'video' | 'raw'> = {
+  image: 'image',
+  video: 'video',
+  audio: 'video', // Cloudinary serves audio under the video resource type.
+  document: 'raw',
+  raw: 'raw',
+  character_sheet: 'image',
+  reference: 'raw',
+  deliverable: 'raw',
+}
+
+export class CloudinaryNotConfiguredError extends Error {
+  status = 503
+  constructor() {
+    super(
+      'Cloudinary credentials are not set on this server. Set CLOUDINARY_CLOUD_NAME, CLOUDINARY_API_KEY, and CLOUDINARY_API_SECRET.'
+    )
+  }
+}
+
+let configured = false
+
+function ensureConfigured(): { cloudName: string; apiKey: string; apiSecret: string } {
+  const cloudName = process.env.CLOUDINARY_CLOUD_NAME
+  const apiKey = process.env.CLOUDINARY_API_KEY
+  const apiSecret = process.env.CLOUDINARY_API_SECRET
+  if (!cloudName || !apiKey || !apiSecret) throw new CloudinaryNotConfiguredError()
+  if (!configured) {
+    cloudinary.config({ cloud_name: cloudName, api_key: apiKey, api_secret: apiSecret, secure: true })
+    configured = true
+  }
+  return { cloudName, apiKey, apiSecret }
+}
+
+export function projectAssetFolder(projectSlug: string, assetType: CreativeAssetType): string {
+  return `projects/${projectSlug}/${ASSET_TYPE_FOLDER[assetType]}`
+}
+
+export function projectBrandingFolder(projectSlug: string): string {
+  return `projects/${projectSlug}/branding`
+}
+
+export function resourceTypeFor(assetType: CreativeAssetType): 'image' | 'video' | 'raw' {
+  return ASSET_TYPE_RESOURCE[assetType]
+}
+
+export interface SignUploadOptions {
+  folder: string
+  publicId: string
+  resourceType: 'image' | 'video' | 'raw'
+  tags?: string[]
+  context?: Record<string, string>
+}
+
+export interface SignedUpload {
+  cloudName: string
+  apiKey: string
+  resourceType: 'image' | 'video' | 'raw'
+  uploadUrl: string
+  signature: string
+  timestamp: number
+  folder: string
+  publicId: string
+  tags: string[]
+  context: Record<string, string>
+}
+
+/**
+ * Mints the params + signature the frontend needs to upload a file directly
+ * to Cloudinary. The VPS never sees the file bytes. Cloudinary verifies the
+ * signature against the api_secret; the secret is never sent.
+ */
+export function signUpload(opts: SignUploadOptions): SignedUpload {
+  const { cloudName, apiKey, apiSecret } = ensureConfigured()
+  const timestamp = Math.floor(Date.now() / 1000)
+  const tagsCsv = (opts.tags ?? []).join(',')
+  const contextStr = opts.context
+    ? Object.entries(opts.context)
+        .map(([k, v]) => `${k}=${v}`)
+        .join('|')
+    : ''
+
+  const toSign: Record<string, string | number> = {
+    folder: opts.folder,
+    public_id: opts.publicId,
+    timestamp,
+  }
+  if (tagsCsv) toSign.tags = tagsCsv
+  if (contextStr) toSign.context = contextStr
+
+  const signature = cloudinary.utils.api_sign_request(toSign, apiSecret)
+
+  return {
+    cloudName,
+    apiKey,
+    resourceType: opts.resourceType,
+    uploadUrl: `https://api.cloudinary.com/v1_1/${cloudName}/${opts.resourceType}/upload`,
+    signature,
+    timestamp,
+    folder: opts.folder,
+    publicId: opts.publicId,
+    tags: opts.tags ?? [],
+    context: opts.context ?? {},
+  }
+}
+
+export interface UploadedAsset {
+  publicId: string
+  secureUrl: string
+  bytes: number
+  format: string
+}
+
+/**
+ * Server-side upload for the logo flow. We want to validate the file before
+ * storing, so we proxy through the server rather than signing a direct upload.
+ */
+export async function uploadBuffer(
+  buffer: Buffer,
+  opts: {
+    folder: string
+    publicId?: string
+    resourceType?: 'image' | 'video' | 'raw'
+    tags?: string[]
+    context?: Record<string, string>
+  }
+): Promise<UploadedAsset> {
+  ensureConfigured()
+  return new Promise((resolve, reject) => {
+    const stream = cloudinary.uploader.upload_stream(
+      {
+        folder: opts.folder,
+        ...(opts.publicId && { public_id: opts.publicId }),
+        resource_type: opts.resourceType ?? 'image',
+        ...(opts.tags && { tags: opts.tags }),
+        ...(opts.context && { context: opts.context }),
+      },
+      (err, result) => {
+        if (err || !result) {
+          reject(err ?? new Error('cloudinary returned no result'))
+          return
+        }
+        resolve({
+          publicId: result.public_id,
+          secureUrl: result.secure_url,
+          bytes: result.bytes,
+          format: result.format,
+        })
+      }
+    )
+    stream.end(buffer)
+  })
+}
+
+/**
+ * PNG header inspector — checks color type for alpha channel without pulling
+ * in sharp/jimp. PNG layout:
+ *   bytes 0-7  : signature 89 50 4E 47 0D 0A 1A 0A
+ *   bytes 12-15: chunk type "IHDR"
+ *   byte 25    : color type — 4 (grayscale+alpha) or 6 (RGB+alpha) means alpha.
+ */
+export function pngHasAlpha(buffer: Buffer): { isPng: boolean; hasAlpha: boolean } {
+  if (buffer.length < 26) return { isPng: false, hasAlpha: false }
+  const sig = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
+  for (let i = 0; i < 8; i++) {
+    if (buffer[i] !== sig[i]) return { isPng: false, hasAlpha: false }
+  }
+  const ihdrType = buffer.toString('ascii', 12, 16)
+  if (ihdrType !== 'IHDR') return { isPng: true, hasAlpha: false }
+  const colorType = buffer[25]
+  return { isPng: true, hasAlpha: colorType === 4 || colorType === 6 }
+}

--- a/src/lib/creative-cms.ts
+++ b/src/lib/creative-cms.ts
@@ -1,0 +1,75 @@
+import type Database from 'better-sqlite3'
+
+/**
+ * Shared helpers for the creative-CMS route handlers
+ * (branding, assets, context). Keeps the SQL for project scope checks in
+ * one place and centralises JSON column (de)serialisation, matching the
+ * conventions used by the existing /api/projects/[id]/* routes.
+ */
+
+export function parseProjectId(raw: string): number {
+  const id = Number.parseInt(raw, 10)
+  return Number.isFinite(id) && id > 0 ? id : NaN
+}
+
+export interface ProjectScopeRow {
+  id: number
+  slug: string
+  name: string
+}
+
+/**
+ * Returns the project iff it exists AND belongs to the given workspace AND
+ * the workspace belongs to the given tenant. Returns null otherwise.
+ *
+ * The two-step check (`projects.workspace_id = ?` + `workspaces.tenant_id = ?`)
+ * mirrors the inline check used in `src/app/api/projects/[id]/agents/route.ts`.
+ */
+export function findProjectInScope(
+  db: Database.Database,
+  projectId: number,
+  workspaceId: number,
+  tenantId: number
+): ProjectScopeRow | null {
+  const row = db
+    .prepare(
+      `SELECT p.id, p.slug, p.name
+       FROM projects p
+       JOIN workspaces w ON w.id = p.workspace_id
+       WHERE p.id = ? AND p.workspace_id = ? AND w.tenant_id = ?
+       LIMIT 1`
+    )
+    .get(projectId, workspaceId, tenantId) as ProjectScopeRow | undefined
+  return row ?? null
+}
+
+/**
+ * `JSON.parse` with a fallback, for columns we store as JSON text.
+ * Returns the fallback when input is null/empty or malformed.
+ */
+export function parseJsonColumn<T>(raw: unknown, fallback: T): T {
+  if (typeof raw !== 'string' || raw.length === 0) return fallback
+  try {
+    return JSON.parse(raw) as T
+  } catch {
+    return fallback
+  }
+}
+
+export function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value.filter((v): v is string => typeof v === 'string').map((s) => s.slice(0, 200))
+}
+
+const HEX_COLOR_RE = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/
+
+export function isHexColor(value: unknown): value is string {
+  return typeof value === 'string' && HEX_COLOR_RE.test(value)
+}
+
+export function trimmedString(value: unknown, max = 5000): string | null {
+  if (typeof value !== 'string') return null
+  const t = value.trim()
+  if (t.length === 0) return null
+  return t.slice(0, max)
+}

--- a/src/lib/migrations.ts
+++ b/src/lib/migrations.ts
@@ -1428,6 +1428,78 @@ const migrations: Migration[] = [
       db.exec(`ALTER TABLE mcp_call_log ADD COLUMN signature TEXT DEFAULT NULL`)
       db.exec(`ALTER TABLE mcp_call_log ADD COLUMN public_key TEXT DEFAULT NULL`)
     }
+  },
+  {
+    id: '051_creative_cms',
+    up(db: Database.Database) {
+      // Creative-CMS tables: per-project branding profile, asset library, and
+      // project-scoped context entries. Mirrors the contract surface the Vercel
+      // frontend (Deep Vibe) consumes. Existing /api/memory/context is
+      // agent/session-scoped and remains untouched.
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS project_branding (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          project_id INTEGER NOT NULL UNIQUE,
+          workspace_id INTEGER NOT NULL,
+          brand_name TEXT,
+          primary_color TEXT,
+          secondary_color TEXT,
+          accent_colors TEXT NOT NULL DEFAULT '[]',
+          heading_font TEXT,
+          body_font TEXT,
+          approved_fonts TEXT NOT NULL DEFAULT '[]',
+          logo_asset_id INTEGER,
+          brand_notes TEXT,
+          tone_notes TEXT,
+          created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+          updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+          FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
+        )
+      `)
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_project_branding_workspace ON project_branding(workspace_id)`)
+
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS project_assets (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          project_id INTEGER NOT NULL,
+          workspace_id INTEGER NOT NULL,
+          cloudinary_public_id TEXT NOT NULL UNIQUE,
+          cloudinary_url TEXT NOT NULL,
+          asset_type TEXT NOT NULL,
+          asset_category TEXT,
+          original_filename TEXT,
+          tags TEXT NOT NULL DEFAULT '[]',
+          metadata TEXT NOT NULL DEFAULT '{}',
+          uploaded_by TEXT,
+          created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+          updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+          FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
+        )
+      `)
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_project_assets_project ON project_assets(project_id)`)
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_project_assets_workspace ON project_assets(workspace_id)`)
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_project_assets_type ON project_assets(project_id, asset_type)`)
+
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS project_context_entries (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          project_id INTEGER NOT NULL,
+          workspace_id INTEGER NOT NULL,
+          entry_type TEXT NOT NULL,
+          title TEXT NOT NULL,
+          content TEXT NOT NULL DEFAULT '',
+          source TEXT,
+          metadata TEXT NOT NULL DEFAULT '{}',
+          created_by TEXT,
+          created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+          updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+          FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
+        )
+      `)
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_project_context_project ON project_context_entries(project_id)`)
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_project_context_workspace ON project_context_entries(workspace_id)`)
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_project_context_type ON project_context_entries(project_id, entry_type)`)
+    }
   }
 ]
 


### PR DESCRIPTION
# Summary

Adds the project-scoped creative-CMS surface (branding profile, asset
library, context entries) requested by the Deep Vibe Vercel frontend.
Matches existing `/api/projects/[id]/*` route conventions exactly:
`requireRole` + `ensureTenantWorkspaceAccess` + `mutationLimiter`,
integer IDs, `unixepoch()` timestamps, workspace-scoped tables, bare
JSON responses (`{branding}`, `{assets}`, `{entry}`).

Migration `051_creative_cms` creates `project_branding`,
`project_assets`, `project_context_entries`, each FK to `projects(id)`
ON DELETE CASCADE. New helper modules `src/lib/cloudinary.ts`
(signed-upload, server-side upload, PNG-alpha inspector) and
`src/lib/creative-cms.ts` (shared validators + project-scope lookup).
Adds `cloudinary@^2.5.1`.

Endpoints added:
- `GET/POST/PATCH /api/projects/[id]/branding` (POST upserts; 200/201)
- `POST /api/projects/[id]/branding/logo` — multipart, PNG-alpha-validated, server-side Cloudinary upload, auto-links into branding
- `GET/POST /api/projects/[id]/assets` (filter `asset_type`, `tag`; paginated)
- `POST /api/projects/[id]/assets/sign` — signed-upload payload for direct-to-Cloudinary uploads
- `DELETE /api/projects/[id]/assets/[assetId]` — also nulls `logo_asset_id` if it referenced this asset
- `GET/POST /api/projects/[id]/context` (filter `entry_type`; paginated)
- `DELETE /api/projects/[id]/context/[entryId]` — `admin` role required

# Risk Level

Medium — pure-additive surface (no existing endpoints touched, no
existing tables touched), but introduces a new external integration
(Cloudinary HTTP API). The Cloudinary client is lazy: missing creds
raise `503 cloudinary_not_configured` only on first call to the
signed-upload or logo routes, so unrelated routes are unaffected.

# Tests

- `tsc --noEmit`: clean across full codebase
- `vitest run`: 22 failures, all pre-existing on `main` (Windows path
  resolution + OpenCode runtime tests requiring fixture files);
  unchanged by this PR. Confirmed by running the suite on both
  branches.
- No new unit tests in this PR — happy to add `__tests__/` coverage
  for the new helpers + routes in a follow-up if you want it gated
  on this.
- Manual smoke test against a fresh sqlite recommended: create
  project → POST branding → POST assets/sign → POST assets →
  POST context entry. The PR description on the Vercel-side brief
  (linked below) describes the full happy path.

# Contribution Checklist

- [ ] Tests added/updated for behavior changes — _new helpers/routes
      have no `__tests__/` yet; can add if requested_
- [x] Lint/typecheck/build passing — typecheck clean; lint not run
      from contributor's local clone (no `pnpm` on Windows path);
      CI will validate
- [ ] Security review done if auth/data/crypto touched — auth
      surfaces re-use `requireRole` + `ensureTenantWorkspaceAccess`
      verbatim; no new crypto introduced; Cloudinary signing uses
      their official `cloudinary` package's `api_sign_request`
- [x] DB migration tested if schema changed — `051_creative_cms` is
      idempotent (CREATE TABLE IF NOT EXISTS, CREATE INDEX IF NOT
      EXISTS), runs via `runMigrations()` on app start, applied
      cleanly on a fresh sqlite during contributor's local test

# Notes

- Companion brief for the Vercel frontend coder lives at
  https://github.com/RaSDrEaDAI/RasDashboard (post-merge, the
  brief's `vercel_frontend_brief.md` will mark these endpoints as
  available rather than open questions).
- `/api/health`, `/api/me`, `/api/schema/version` were considered
  but skipped — the existing `/api/status` and `/api/auth/me` cover
  the same ground; adding aliases would be redundant.
- The Vercel coder's BFF pattern is: signed-upload payload from
  `/assets/sign` → frontend POSTs file straight to Cloudinary →
  frontend POSTs `{cloudinary_public_id, cloudinary_url, ...}` to
  `/assets`. The VPS never sees the file bytes (except for logo,
  which is server-side proxied so PNG-alpha can be enforced).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
