### PR TITLE
Run ANALYZE in auto_cleanup + make claude-session scan interval configurable

### DIFF
--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -51,6 +51,14 @@ function getSettingNumber(key: string, defaultValue: number): number {
   }
 }
 
+function getEnvNumber(key: string, defaultValue: number): number {
+  const raw = process.env[key]
+  if (!raw) return defaultValue
+
+  const value = Number.parseInt(raw, 10)
+  return Number.isFinite(value) && value > 0 ? value : defaultValue
+}
+
 /** Run a database backup */
 async function runBackup(): Promise<{ ok: boolean; message: string }> {
   ensureDirExists(BACKUP_DIR)
@@ -141,15 +149,23 @@ async function runCleanup(): Promise<{ ok: boolean; message: string }> {
       totalDeleted += sessionCleanup.deleted
     }
 
+    let analyzed = false
+    try {
+      db.prepare('ANALYZE').run()
+      analyzed = true
+    } catch (err) {
+      logger.warn({ err }, 'Database ANALYZE failed during cleanup')
+    }
+
     if (totalDeleted > 0) {
       logAuditEvent({
         action: 'auto_cleanup',
         actor: 'scheduler',
-        detail: { total_deleted: totalDeleted },
+        detail: { total_deleted: totalDeleted, analyzed },
       })
     }
 
-    return { ok: true, message: `Cleaned ${totalDeleted} stale record${totalDeleted === 1 ? '' : 's'}` }
+    return { ok: true, message: `Cleaned ${totalDeleted} stale record${totalDeleted === 1 ? '' : 's'}${analyzed ? ' and updated query planner statistics' : ''}` }
   } catch (err: any) {
     return { ok: false, message: `Cleanup failed: ${err.message}` }
   }
@@ -328,7 +344,7 @@ export function initScheduler() {
 
   tasks.set('claude_session_scan', {
     name: 'Claude Session Scan',
-    intervalMs: TICK_MS, // Every 60s — lightweight file stat checks
+    intervalMs: getEnvNumber('MC_CLAUDE_SCAN_INTERVAL_MS', TICK_MS), // Default: every 60s; tune for large ~/.claude/projects trees
     lastRun: null,
     nextRun: now + 5_000, // First scan 5s after startup
     enabled: true,


### PR DESCRIPTION
## Problem
After a SQLite maintenance/recover pass, stale planner statistics can make the query planner pick a poor index, spiking CPU on the tasks read path. Separately, the claude-session scan interval (TICK_MS) is hardcoded, so operators must fork to tune it.

## Change
- Add `ANALYZE` to the daily `auto_cleanup` scheduled task so planner stats stay fresh.
- Read the claude-session scan interval from `MC_CLAUDE_SCAN_INTERVAL_MS` (falling back to the current default) so it is tunable without a fork.

Low-risk maintenance/configurability hygiene; no schema or API changes.