### PR TITLE
Pin pnpm to v10 in Dockerfile (fixes Docker build broken by pnpm 11 ERR_PNPM_IGNORED_BUILDS)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM node:22.22.0-slim AS base
-RUN corepack enable && corepack prepare pnpm@latest --activate
+# Pin to pnpm 10 — matches what .github/workflows uses for CI. pnpm 11+
+# introduced stricter ERR_PNPM_IGNORED_BUILDS behavior that fails the
+# Docker install step even with onlyBuiltDependencies set in package.json.
+# Until upstream pins this themselves, we carry this patch locally.
+RUN corepack enable && corepack prepare pnpm@10 --activate
 WORKDIR /app
 
 FROM base AS deps


### PR DESCRIPTION
## Problem

`Dockerfile` line 2 uses `corepack prepare pnpm@latest --activate` which currently pulls **pnpm 11.2.2**. pnpm 11 changed `ERR_PNPM_IGNORED_BUILDS` from a warning into a non-zero exit, even when `package.json#pnpm.onlyBuiltDependencies` is set (the allowed package's scripts DO run, but the other packages' ignored builds are still treated as errors).

A fresh `docker build .` against current `main` fails with:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @parcel/watcher@2.5.6, @swc/core@1.15.18, better-sqlite3@12.6.2, esbuild@0.21.5, sharp@0.34.5, unrs-resolver@1.11.1, vue-demi@0.14.10

Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.

ERROR: process "/bin/sh -c if [ -f pnpm-lock.yaml ]; then pnpm install --frozen-lockfile; ..." did not complete successfully: exit code: 1
```

## Fix

Pin pnpm in the Dockerfile to `pnpm@10`. The repo's own CI (`.github/workflows/`) already pins to pnpm 10 via `pnpm/action-setup@v4 with: version: 10`, so this just aligns the docker path with CI.

## Repro

```bash
git clone https://github.com/builderz-labs/mission-control
cd mission-control
git checkout v2.0.1
docker build .   # fails as above
```

With the patch applied: builds cleanly.

## Tested on

- Ubuntu 24.04 host, Docker engine 28.x
- `node:22.22.0-slim` base image
- corepack 0.34.x pulling `pnpm@latest` (currently 11.2.2)

## Notes

Found while deploying MC v2.0.1 in Docker on a VPS. Happy to make this a `pnpm@10.x.y` strict pin if you'd prefer to lock the patch level; left it as `pnpm@10` to track 10's minor updates the same way CI does.
