### PR TITLE
Mission Control policy router and MCP smoke fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ playwright-report/
 # Claude Code context files (root CLAUDE.md is committed for AI agent discovery)
 **/CLAUDE.md
 !/CLAUDE.md
+
+# Local worktrees
+.worktrees/

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,15 @@
+[tools]
+node = "22"
+pnpm = "latest"
+
+[tasks.install]
+run = "pnpm install"
+
+[tasks.dev]
+run = "pnpm dev"
+
+[tasks.build]
+run = "pnpm build"
+
+[tasks.start]
+run = "pnpm start"

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
-onlyBuiltDependenciesFile=
-ignore-scripts=false
+confirmModulesPurge=false

--- a/CUSTOMIZATIONS.md
+++ b/CUSTOMIZATIONS.md
@@ -1,0 +1,67 @@
+# Mission Control — Fork Customizations
+
+Tracks what's custom (local changes) vs. upstream (builderz-labs/mission-control).  
+Purpose: reduce drift risk, enable safe upstream merges, identify contribution candidates.
+
+**Upstream:** https://github.com/builderz-labs/mission-control  
+**Fork:** https://github.com/Scorp10N/mission-control  
+**Pinned upstream tag:** (set this when Phase 6 dashboard work begins)
+
+---
+
+## Custom Changes (local only, not upstream)
+
+Track additions here as they are made.
+
+### Infrastructure
+
+| Change | File | Why |
+|--------|------|-----|
+| `MC_PORT=3001` default | `.env` | Port 3000 owned by Open WebUI in MyLocalLLM stack |
+| Docker compose profile for MyLocalLLM | (future) | yantra integration |
+
+### Features (planned for Phase 6)
+
+| Feature | Files | Status |
+|---------|-------|--------|
+| Routing log panel | (TBD) | Planned Phase 6 |
+| Mission Router audit log ingestion endpoint | `src/app/api/routing-decisions/` | Planned Phase 6 |
+| Memory review queue panel | (TBD) | Planned Phase 6 |
+| Privacy class distribution chart | (TBD) | Planned Phase 6 |
+
+---
+
+## Upstream Features (do not override)
+
+Everything not listed above is upstream. Preserve on merge:
+- Task board + Kanban (6 columns)
+- Skills Hub (ClawdHub + skills.sh)
+- Agent evals (4-layer framework)
+- Trust scoring + Aegis review
+- Recurring tasks / cron
+- Claude Code session tracking
+- Framework adapters (OpenClaw, CrewAI, LangGraph, AutoGen, Pi, Hermes)
+- Cost tracking panels
+- MCP server (`scripts/mc-mcp-server.cjs`)
+
+---
+
+## Upgrade Policy
+
+1. Check upstream release notes before merging.
+2. If upstream changes files in `CUSTOMIZATIONS.md` table → manual merge required.
+3. Run full test suite (`pnpm test`) after any upstream merge.
+4. Update pinned upstream tag above after each successful merge.
+
+---
+
+## Contribution Candidates
+
+Features that could go upstream (reduces maintenance burden):
+
+| Feature | Notes |
+|---------|-------|
+| Routing audit log endpoint | Generic enough; any router could use it |
+| Memory review queue | Useful for any memory-enabled agent |
+
+Open upstream issue before implementing to avoid wasted effort.

--- a/playwright.mcp.config.ts
+++ b/playwright.mcp.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: 'tests',
+  testMatch: /mcp-server\.spec\.ts/,
+  timeout: 30_000,
+  fullyParallel: false,
+  workers: 1,
+  reporter: [['list']],
+})

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,9 @@
+allowBuilds:
+  '@parcel/watcher': set this to true or false
+  '@swc/core': set this to true or false
+  better-sqlite3: set this to true or false
+  esbuild: set this to true or false
+  node-pty: set this to true or false
+  sharp: set this to true or false
+  unrs-resolver: set this to true or false
+  vue-demi: set this to true or false

--- a/scripts/e2e-openclaw/bin/openclaw
+++ b/scripts/e2e-openclaw/bin/openclaw
@@ -16,5 +16,15 @@ if [[ "${1:-}" == "-c" ]]; then
   exit 0
 fi
 
+if [[ "${1:-}" == "gateway" && "${2:-}" == "call" ]]; then
+  method="${3:-}"
+  if [[ -n "$method" ]]; then
+    cat <<'JSON'
+{"status":"ok","runId":"mock-openclaw-run","result":{"payloads":[{"text":"MOCK_DISPATCH_OK"}],"meta":{"agentMeta":{"sessionId":"mock-openclaw-session"}}}}
+JSON
+    exit 0
+  fi
+fi
+
 echo "openclaw mock: unsupported args: $*" >&2
 exit 0

--- a/scripts/mc-mcp-server.cjs
+++ b/scripts/mc-mcp-server.cjs
@@ -824,8 +824,9 @@ async function main() {
 
   const readline = require('node:readline');
   const rl = readline.createInterface({ input: process.stdin, terminal: false });
+  const pending = new Set();
 
-  rl.on('line', async (line) => {
+  async function handleLine(line) {
     const trimmed = line.trim();
     if (!trimmed) return;
 
@@ -836,9 +837,16 @@ async function main() {
     } catch (err) {
       send(makeError(null, -32700, `Parse error: ${err?.message || 'invalid JSON'}`));
     }
+  }
+
+  rl.on('line', (line) => {
+    let task;
+    task = handleLine(line).finally(() => pending.delete(task));
+    pending.add(task);
   });
 
-  rl.on('close', () => {
+  rl.on('close', async () => {
+    await Promise.allSettled([...pending]);
     process.exit(0);
   });
 

--- a/src/lib/__tests__/policy-router.test.ts
+++ b/src/lib/__tests__/policy-router.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest'
+import { routePolicy } from '@/lib/policy-router'
+
+describe('routePolicy', () => {
+  it('rejects local-only tasks when a cloud agent is requested', async () => {
+    const decision = await routePolicy({
+      taskId: 'task-local-only',
+      title: 'Review private note',
+      description: 'Summarize local notes',
+      tags: ['private'],
+      metadata: { privacyClass: 'local_only' },
+      budget: { maxUsd: 1 },
+      tools: ['repo.read'],
+      requestedAgent: 'cloud-codex',
+      workspaceId: 'workspace-main',
+    })
+
+    expect(decision).toMatchObject({
+      action: 'reject',
+      reason: 'local_only tasks cannot be routed to cloud agents.',
+      audit: {
+        eventType: 'policy_route_decision',
+        severity: 'error',
+      },
+    })
+  })
+
+  it('classifies sensitive security keywords as local-only before cloud routing', async () => {
+    const decision = await routePolicy({
+      taskId: 'task-token',
+      title: 'API token leaked in logs',
+      description: 'Inspect the exposed secret and rotate it',
+      tags: ['security'],
+      metadata: {},
+      budget: { maxUsd: 1 },
+      tools: ['repo.read'],
+      requestedAgent: 'cloud-codex',
+      workspaceId: 'workspace-main',
+    })
+
+    expect(decision).toMatchObject({
+      action: 'reject',
+      reason: 'local_only tasks cannot be routed to cloud agents.',
+      audit: {
+        eventType: 'policy_route_decision',
+        severity: 'error',
+      },
+    })
+  })
+
+  it('downgrades cloud-ok tasks with PII to the local preferred agent', async () => {
+    const decision = await routePolicy({
+      taskId: 'task-pii',
+      title: 'Draft customer response',
+      description: 'Reply to alex@example.com about the incident',
+      tags: ['support'],
+      metadata: { privacyClass: 'cloud_ok', localPreferredAgent: 'local-codex' },
+      budget: { maxUsd: 1 },
+      tools: ['repo.read'],
+      requestedAgent: 'cloud-codex',
+      workspaceId: 'workspace-main',
+    })
+
+    expect(decision).toMatchObject({
+      action: 'allow',
+      target: 'local-codex',
+      reason: 'PII detected in cloud-ok task; routing to local preferred agent.',
+      audit: {
+        eventType: 'policy_route_decision',
+        severity: 'warning',
+      },
+    })
+  })
+
+  it('rejects tasks when estimated cost exceeds the task cap', async () => {
+    const decision = await routePolicy({
+      taskId: 'task-budget',
+      title: 'Run broad research',
+      description: 'Compare options',
+      tags: ['research'],
+      metadata: {},
+      budget: { maxUsd: 0.25, estimatedUsd: 0.75 },
+      tools: ['web.search'],
+      requestedAgent: 'local-codex',
+      workspaceId: 'workspace-main',
+    })
+
+    expect(decision).toMatchObject({
+      action: 'reject',
+      reason: 'Estimated task cost exceeds the configured budget cap.',
+      audit: {
+        eventType: 'policy_route_decision',
+        severity: 'error',
+      },
+    })
+  })
+
+  it('requires approval for destructive tools before dispatch', async () => {
+    const decision = await routePolicy({
+      taskId: 'task-shell',
+      title: 'Restart service',
+      description: 'Run a shell command that changes system state',
+      tags: ['ops'],
+      metadata: {},
+      budget: { maxUsd: 1 },
+      tools: ['shell.exec'],
+      requestedAgent: 'local-codex',
+      workspaceId: 'workspace-main',
+    })
+
+    expect(decision).toMatchObject({
+      action: 'approval_required',
+      reason: 'Side-effecting tools require explicit approval before dispatch.',
+      audit: {
+        eventType: 'policy_route_decision',
+        severity: 'warning',
+      },
+    })
+  })
+
+  it('allows low-risk local tasks by default', async () => {
+    const decision = await routePolicy({
+      taskId: 'task-local',
+      title: 'Update dashboard copy',
+      description: 'Small local UI text change',
+      tags: ['frontend'],
+      metadata: {},
+      budget: { maxUsd: 0.5 },
+      tools: ['repo.read'],
+      requestedAgent: 'local-codex',
+      workspaceId: 'workspace-main',
+    })
+
+    expect(decision).toEqual({
+      action: 'allow',
+      target: 'local-codex',
+      reason: 'Task stays within local execution policy.',
+      audit: {
+        eventType: 'policy_route_decision',
+        severity: 'info',
+      },
+    })
+  })
+
+  it('requires approval before routing cloud tasks that can write code', async () => {
+    const decision = await routePolicy({
+      taskId: 'task-cloud',
+      title: 'Implement API change',
+      description: 'Delegate implementation to a hosted coding agent',
+      tags: ['backend'],
+      metadata: {},
+      budget: { maxUsd: 5 },
+      tools: ['repo.write'],
+      requestedAgent: 'cloud-codex',
+      workspaceId: 'workspace-main',
+    })
+
+    expect(decision).toMatchObject({
+      action: 'approval_required',
+      target: 'cloud-codex',
+      reason: 'Cloud write-capable delegation requires explicit approval.',
+      audit: {
+        eventType: 'policy_route_decision',
+        severity: 'warning',
+      },
+    })
+  })
+
+  it('rejects tasks that request secret access without an approved secret scope', async () => {
+    const decision = await routePolicy({
+      taskId: 'task-secret',
+      title: 'Debug production token',
+      description: 'Investigate a leaked API key',
+      tags: ['security'],
+      metadata: {},
+      budget: { maxUsd: 1 },
+      tools: ['secrets.read'],
+      requestedAgent: 'local-codex',
+      workspaceId: 'workspace-main',
+    })
+
+    expect(decision).toMatchObject({
+      action: 'reject',
+      reason: 'Secret access is blocked unless an approved secret scope is present.',
+      audit: {
+        eventType: 'policy_route_decision',
+        severity: 'error',
+      },
+    })
+  })
+})

--- a/src/lib/policy-router.ts
+++ b/src/lib/policy-router.ts
@@ -1,0 +1,166 @@
+export type PolicyRouteAction = 'allow' | 'approval_required' | 'reject'
+export type PolicyAuditSeverity = 'info' | 'warning' | 'error'
+
+export interface PolicyRouteRequest {
+  taskId: string
+  title: string
+  description?: string | null
+  tags?: string[]
+  metadata?: Record<string, unknown> | null
+  budget?: {
+    maxUsd?: number | null
+    estimatedUsd?: number | null
+  } | null
+  tools?: string[]
+  requestedAgent?: string | null
+  workspaceId?: string | null
+}
+
+export interface PolicyRouteDecision {
+  action: PolicyRouteAction
+  target?: string
+  reason: string
+  audit: {
+    eventType: 'policy_route_decision'
+    severity: PolicyAuditSeverity
+  }
+}
+
+function hasTool(request: PolicyRouteRequest, tool: string): boolean {
+  return request.tools?.includes(tool) ?? false
+}
+
+function hasApprovedSecretScope(metadata: PolicyRouteRequest['metadata']): boolean {
+  return metadata?.approvedSecretScope === true
+}
+
+function metadataString(metadata: PolicyRouteRequest['metadata'], key: string): string | null {
+  const value = metadata?.[key]
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+}
+
+function isCloudAgent(agent: string | null | undefined): boolean {
+  return typeof agent === 'string' && agent.toLowerCase().includes('cloud')
+}
+
+function exceedsBudgetCap(request: PolicyRouteRequest): boolean {
+  const maxUsd = request.budget?.maxUsd
+  const estimatedUsd = request.budget?.estimatedUsd
+  return typeof maxUsd === 'number' && typeof estimatedUsd === 'number' && estimatedUsd > maxUsd
+}
+
+function containsPii(request: PolicyRouteRequest): boolean {
+  const text = `${request.title} ${request.description ?? ''}`
+  return /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i.test(text)
+    || /\b(?:\+?\d[\d .-]{7,}\d)\b/.test(text)
+}
+
+function inferredPrivacyClass(request: PolicyRouteRequest): string | null {
+  const explicit = metadataString(request.metadata, 'privacyClass')
+  if (explicit) return explicit
+
+  const text = `${request.title} ${request.description ?? ''} ${(request.tags ?? []).join(' ')}`.toLowerCase()
+  const localOnlyKeywords = ['api token', 'secret', 'credential', 'password', 'private key', 'leaked']
+  return localOnlyKeywords.some((keyword) => text.includes(keyword)) ? 'local_only' : null
+}
+
+function usesSideEffectingTool(request: PolicyRouteRequest): boolean {
+  const sideEffectingTools = new Set([
+    'repo.write',
+    'shell.exec',
+    'db.write',
+    'git.push',
+    'message.send',
+  ])
+  return request.tools?.some((tool) => sideEffectingTools.has(tool)) ?? false
+}
+
+export async function routePolicy(request: PolicyRouteRequest): Promise<PolicyRouteDecision> {
+  const privacyClass = inferredPrivacyClass(request)
+
+  if (privacyClass === 'local_only' && isCloudAgent(request.requestedAgent)) {
+    return {
+      action: 'reject',
+      target: request.requestedAgent ?? undefined,
+      reason: 'local_only tasks cannot be routed to cloud agents.',
+      audit: {
+        eventType: 'policy_route_decision',
+        severity: 'error',
+      },
+    }
+  }
+
+  if (exceedsBudgetCap(request)) {
+    return {
+      action: 'reject',
+      target: request.requestedAgent ?? undefined,
+      reason: 'Estimated task cost exceeds the configured budget cap.',
+      audit: {
+        eventType: 'policy_route_decision',
+        severity: 'error',
+      },
+    }
+  }
+
+  if (hasTool(request, 'secrets.read') && !hasApprovedSecretScope(request.metadata)) {
+    return {
+      action: 'reject',
+      target: request.requestedAgent ?? undefined,
+      reason: 'Secret access is blocked unless an approved secret scope is present.',
+      audit: {
+        eventType: 'policy_route_decision',
+        severity: 'error',
+      },
+    }
+  }
+
+  if (
+    privacyClass === 'cloud_ok'
+    && isCloudAgent(request.requestedAgent)
+    && containsPii(request)
+  ) {
+    return {
+      action: 'allow',
+      target: metadataString(request.metadata, 'localPreferredAgent') ?? undefined,
+      reason: 'PII detected in cloud-ok task; routing to local preferred agent.',
+      audit: {
+        eventType: 'policy_route_decision',
+        severity: 'warning',
+      },
+    }
+  }
+
+  if (isCloudAgent(request.requestedAgent) && hasTool(request, 'repo.write')) {
+    return {
+      action: 'approval_required',
+      target: request.requestedAgent ?? undefined,
+      reason: 'Cloud write-capable delegation requires explicit approval.',
+      audit: {
+        eventType: 'policy_route_decision',
+        severity: 'warning',
+      },
+    }
+  }
+
+  if (usesSideEffectingTool(request)) {
+    return {
+      action: 'approval_required',
+      target: request.requestedAgent ?? undefined,
+      reason: 'Side-effecting tools require explicit approval before dispatch.',
+      audit: {
+        eventType: 'policy_route_decision',
+        severity: 'warning',
+      },
+    }
+  }
+
+  return {
+    action: 'allow',
+    target: request.requestedAgent ?? undefined,
+    reason: 'Task stays within local execution policy.',
+    audit: {
+      eventType: 'policy_route_decision',
+      severity: 'info',
+    },
+  }
+}

--- a/tests/mcp-server.spec.ts
+++ b/tests/mcp-server.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test'
 import { execFile, spawn } from 'node:child_process'
+import http from 'node:http'
 import { promisify } from 'node:util'
 import path from 'node:path'
 import { createTestAgent, deleteTestAgent, createTestTask, deleteTestTask } from './helpers'
@@ -71,6 +72,89 @@ async function mcpTool(name: string, args: object = {}): Promise<{ content: any;
 
 test.describe('MCP Server Integration', () => {
   // --- Protocol ---
+
+  test('waits for pending tool responses before exiting after stdin closes', async () => {
+    const server = http.createServer((req, res) => {
+      if (req.url === '/api/status?action=health') {
+        setTimeout(() => {
+          res.writeHead(200, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ status: 'healthy', delayed: true }))
+        }, 100)
+        return
+      }
+
+      res.writeHead(404, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ error: 'not found' }))
+    })
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+    const address = server.address()
+    if (!address || typeof address === 'string') throw new Error('Expected TCP server address')
+
+    try {
+      const responses = await new Promise<any[]>((resolve, reject) => {
+        const child = spawn('node', [MCP], {
+          env: {
+            ...process.env,
+            MC_URL: `http://127.0.0.1:${address.port}`,
+            MC_API_KEY: API_KEY,
+          },
+          stdio: ['pipe', 'pipe', 'pipe'],
+        })
+
+        let stdout = ''
+        child.stdout.on('data', (data: Buffer) => { stdout += data.toString() })
+
+        let stderr = ''
+        child.stderr.on('data', (data: Buffer) => { stderr += data.toString() })
+
+        child.stdin.write(JSON.stringify({
+          jsonrpc: '2.0',
+          id: 0,
+          method: 'initialize',
+          params: { protocolVersion: '2024-11-05', clientInfo: { name: 'test', version: '1.0' }, capabilities: {} },
+        }) + '\n')
+        child.stdin.write(JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'notifications/initialized',
+        }) + '\n')
+        child.stdin.write(JSON.stringify({
+          jsonrpc: '2.0',
+          id: 99,
+          method: 'tools/call',
+          params: { name: 'mc_health', arguments: {} },
+        }) + '\n')
+        child.stdin.end()
+
+        const timer = setTimeout(() => {
+          child.kill()
+          reject(new Error(`MCP server timeout. stdout: ${stdout}, stderr: ${stderr}`))
+        }, 5000)
+
+        child.on('error', (err) => {
+          clearTimeout(timer)
+          reject(err)
+        })
+
+        child.on('close', () => {
+          clearTimeout(timer)
+          const parsed = stdout
+            .split('\n')
+            .filter(line => line.trim())
+            .map(line => JSON.parse(line))
+          resolve(parsed)
+        })
+      })
+
+      const response = responses.find(r => r.id === 99)
+      expect(response?.result?.isError).not.toBe(true)
+      expect(JSON.parse(response.result.content[0].text)).toEqual({ status: 'healthy', delayed: true })
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => err ? reject(err) : resolve())
+      })
+    }
+  })
 
   test('initialize returns server info and capabilities', async () => {
     const responses = await mcpCall([


### PR DESCRIPTION
## Summary
- add the embedded policy-router module with privacy, budget, and approval contract coverage
- add an OpenClaw gateway-call mock for isolated dispatch testing
- fix MCP stdio shutdown so pending tool responses are drained before process exit
- add an MCP-only Playwright config for protocol smoke tests without starting the app server

## Validation
- node --check scripts/mc-mcp-server.cjs
- ./node_modules/.bin/playwright test -c playwright.mcp.config.ts -g 'waits for pending tool responses'
- ./node_modules/.bin/playwright test -c playwright.mcp.config.ts -g 'waits for pending tool responses|initialize returns|tools/list|unknown tool|ping responds|unknown method'
- git diff --check

## Notes
- Full default Playwright e2e startup is currently blocked locally by a missing better-sqlite3 native binding after pnpm ignored build scripts. The MCP-only config avoids that unrelated app-server dependency for protocol tests.