### PR TITLE
feat: align Mission Control with Hermes OS

### DIFF
--- a/docs/CITARA-BUILDERZ-PARITY.md
+++ b/docs/CITARA-BUILDERZ-PARITY.md
@@ -1,0 +1,48 @@
+# Cítara Builderz Parity
+
+Este documento registra a decisão de manter o `builderz-labs/mission-control` como base do cockpit e adaptar tudo que for útil para o Mission Control Cítara/Hermes.
+
+Referência completa no Cítara Brain:
+
+- `/Users/phfer/hermes-workspaces/citara-tech-brain/docs/mission-control-builderz-feature-parity-2026-05-26.md`
+
+## Prioridade P0
+
+- Agentes + heartbeat + API keys por agente.
+- Task board + fila segura `awaiting_owner` para Hermes Adapter.
+- CLI + MCP server.
+- Sessões/transcripts/continue para Hermes.
+- Segurança: RBAC, CSRF, CSP, scan, secret scanner, injection guard, exec approvals.
+- Activity/logs/eventos/custos.
+
+## Prioridade P1
+
+- Memory browser/knowledge graph.
+- Skills Hub + scanner.
+- Cron/scheduler/painel de recorrência.
+- Webhooks + alerts.
+
+## Prioridade P2
+
+- Multi-gateway como arquitetura, não acoplamento a OpenClaw.
+- Terminal/PTTY somente com hardening.
+- Multi-tenant/provisioning depois do core Cítara estável.
+
+## Regras Cítara
+
+- Hermes é o runtime/motor.
+- Mission Control é o cockpit.
+- Hermes Adapter/Fleet Runner é a ponte.
+- Tasks Hermes-owned entram por `awaiting_owner`, não `assigned`.
+- Sucesso do Adapter vai para `quality_review`.
+- Falha vai para `failed`.
+- Langfuse entra depois.
+- n8n entra depois como automação linear.
+
+## Gaps imediatos
+
+- Registrar rotas Cítara/Hermes em OpenAPI/API index.
+- Adicionar testes para `/api/citara/*` e `/api/hermes/fleet-runner`.
+- Parametrizar paths absolutos do Fleet Runner.
+- Criar painel dedicado `Cítara Command Center`.
+- Versionar adapter sem segredos, logs ou runtime.

--- a/messages/en.json
+++ b/messages/en.json
@@ -482,8 +482,8 @@
   "memoryGraph": {
     "loading": "Loading graph...",
     "retry": "Retry",
-    "noMemoryDatabases": "No memory databases found",
-    "noMemoryDatabasesHint": "OpenClaw memory SQLite files not detected",
+    "noMemoryDatabases": "No Hermes memory found",
+    "noMemoryDatabasesHint": "Hermes memory/session files not detected under ~/.hermes",
     "allAgents": "all agents",
     "filterFiles": "filter files...",
     "statAgents": "agents",

--- a/messages/en.json
+++ b/messages/en.json
@@ -79,6 +79,7 @@
   },
   "nav": {
     "overview": "Overview",
+    "citaraCommand": "Cítara",
     "agents": "Agents",
     "tasks": "Tasks",
     "chat": "Chat",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -79,6 +79,7 @@
   },
   "nav": {
     "overview": "Visão geral",
+    "citaraCommand": "Cítara",
     "agents": "Agentes",
     "tasks": "Tarefas",
     "chat": "Chat",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -482,8 +482,8 @@
   "memoryGraph": {
     "loading": "Carregando grafo...",
     "retry": "Tentar novamente",
-    "noMemoryDatabases": "Nenhum banco de dados de memória encontrado",
-    "noMemoryDatabasesHint": "Arquivos SQLite de memória OpenClaw não detectados",
+    "noMemoryDatabases": "Nenhuma memória Hermes encontrada",
+    "noMemoryDatabasesHint": "Arquivos de memória/sessões Hermes não detectados em ~/.hermes",
     "allAgents": "todos os agentes",
     "filterFiles": "filtrar arquivos...",
     "statAgents": "agentes",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,9 @@
+allowBuilds:
+  '@parcel/watcher': true
+  '@swc/core': true
+  better-sqlite3: true
+  esbuild: true
+  node-pty: true
+  sharp: true
+  unrs-resolver: true
+  vue-demi: true

--- a/src/app/[[...panel]]/page.tsx
+++ b/src/app/[[...panel]]/page.tsx
@@ -38,6 +38,7 @@ import { NodesPanel } from '@/components/panels/nodes-panel'
 import { ExecApprovalPanel } from '@/components/panels/exec-approval-panel'
 import { SystemMonitorPanel } from '@/components/panels/system-monitor-panel'
 import { ChatPagePanel } from '@/components/panels/chat-page-panel'
+import { CitaraCommandCenterPanel } from '@/components/panels/citara-command-center-panel'
 import { ChatPanel } from '@/components/chat/chat-panel'
 import { STORAGE_GATEWAY_URL } from '@/lib/device-identity'
 import { getPluginPanel } from '@/lib/plugins'
@@ -538,6 +539,8 @@ function ContentRouter({ tab }: { tab: string }) {
       )
     case 'tasks':
       return <TaskBoardPanel />
+    case 'citara-command':
+      return <CitaraCommandCenterPanel />
     case 'agents':
       return (
         <>

--- a/src/app/[[...panel]]/page.tsx
+++ b/src/app/[[...panel]]/page.tsx
@@ -11,6 +11,7 @@ import { CronManagementPanel } from '@/components/panels/cron-management-panel'
 import { MemoryBrowserPanel } from '@/components/panels/memory-browser-panel'
 import { CostTrackerPanel } from '@/components/panels/cost-tracker-panel'
 import { TaskBoardPanel } from '@/components/panels/task-board-panel'
+import { ProjectOSPanel } from '@/components/panels/project-os-panel'
 import { ActivityFeedPanel } from '@/components/panels/activity-feed-panel'
 import { AgentSquadPanelPhase3 } from '@/components/panels/agent-squad-panel-phase3'
 import { AgentCommsPanel } from '@/components/panels/agent-comms-panel'
@@ -502,7 +503,7 @@ export default function Home() {
 }
 
 const ESSENTIAL_PANELS = new Set([
-  'overview', 'agents', 'tasks', 'chat', 'activity', 'logs', 'settings',
+  'overview', 'citara-command', 'project-os', 'agents', 'tasks', 'chat', 'activity', 'logs', 'settings',
 ])
 
 function ContentRouter({ tab }: { tab: string }) {
@@ -556,6 +557,8 @@ function ContentRouter({ tab }: { tab: string }) {
       )
     case 'tasks':
       return <TaskBoardPanel />
+    case 'project-os':
+      return <ProjectOSPanel />
     case 'citara-command':
       return <CitaraCommandCenterPanel />
     case 'agents':

--- a/src/app/[[...panel]]/page.tsx
+++ b/src/app/[[...panel]]/page.tsx
@@ -66,6 +66,19 @@ interface GatewaySummary {
   is_primary: number
 }
 
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '::1'])
+
+function isLoopbackGatewayUrlForRemoteBrowser(url: string | null): boolean {
+  if (!url || typeof window === 'undefined') return false
+  try {
+    const gatewayHost = new URL(url, window.location.origin).hostname.toLowerCase()
+    const browserHost = window.location.hostname.toLowerCase()
+    return LOOPBACK_HOSTS.has(gatewayHost) && !LOOPBACK_HOSTS.has(browserHost)
+  } catch {
+    return false
+  }
+}
+
 const STEP_KEYS = ['auth', 'capabilities', 'config', 'connect', 'agents', 'sessions', 'projects', 'memory', 'skills'] as const
 
 const bootLabelKeys: Record<string, string> = {
@@ -273,7 +286,11 @@ export default function Home() {
     fetch('/api/status?action=capabilities')
       .then(res => res.ok ? res.json() : null)
       .then(async data => {
-        const localGatewayUrl = localStorage.getItem(STORAGE_GATEWAY_URL)
+        let localGatewayUrl = localStorage.getItem(STORAGE_GATEWAY_URL)
+        if (isLoopbackGatewayUrlForRemoteBrowser(localGatewayUrl)) {
+          localStorage.removeItem(STORAGE_GATEWAY_URL)
+          localGatewayUrl = null
+        }
 
         if (data?.subscription) {
           setSubscription(data.subscription)

--- a/src/app/api/agents/[id]/route.ts
+++ b/src/app/api/agents/[id]/route.ts
@@ -34,9 +34,18 @@ export async function GET(
       return NextResponse.json({ error: 'Agent not found' }, { status: 404 })
     }
 
+    const parsedConfig = enrichAgentConfigFromWorkspace((agent as any).config ? JSON.parse((agent as any).config) : {})
+    const isHermesAdapterAgent =
+      parsedConfig?.runtime === 'hermes' &&
+      parsedConfig?.adapter === 'citara-hermes-adapter' &&
+      parsedConfig?.queue_status === 'awaiting_owner'
     const parsed = {
       ...(agent as any),
-      config: enrichAgentConfigFromWorkspace((agent as any).config ? JSON.parse((agent as any).config) : {}),
+      status: isHermesAdapterAgent && (agent as any).status === 'offline' ? 'idle' : (agent as any).status,
+      last_activity: isHermesAdapterAgent && (agent as any).status === 'offline'
+        ? 'Hermes Adapter queue-ready'
+        : (agent as any).last_activity,
+      config: parsedConfig,
     }
 
     return NextResponse.json({ agent: parsed })

--- a/src/app/api/agents/route.ts
+++ b/src/app/api/agents/route.ts
@@ -58,10 +58,26 @@ export async function GET(request: NextRequest) {
     const agents = stmt.all(...params) as Agent[];
     
     // Parse JSON config field
-    const agentsWithParsedData = agents.map(agent => ({
-      ...agent,
-      config: enrichAgentConfigFromWorkspace(agent.config ? JSON.parse(agent.config) : {})
-    }));
+    const agentsWithParsedData = agents.map(agent => {
+      const parsedConfig = enrichAgentConfigFromWorkspace(agent.config ? JSON.parse(agent.config) : {})
+      const isHermesAdapterAgent =
+        parsedConfig?.runtime === 'hermes' &&
+        parsedConfig?.adapter === 'citara-hermes-adapter' &&
+        parsedConfig?.queue_status === 'awaiting_owner'
+
+      return {
+        ...agent,
+        // Hermes Adapter agents are queue-backed, not always-on socket sessions.
+        // If no native OpenClaw/Claude heartbeat exists, Mission Control may store
+        // them as offline; present them as idle/queue-ready so Paulo sees the
+        // adapter fleet as available without handing control to the native scheduler.
+        status: isHermesAdapterAgent && agent.status === 'offline' ? 'idle' : agent.status,
+        last_activity: isHermesAdapterAgent && agent.status === 'offline'
+          ? 'Hermes Adapter queue-ready'
+          : agent.last_activity,
+        config: parsedConfig
+      }
+    });
     
     // Get task counts for all listed agents in one query (avoids N+1 queries)
     const agentNames = agentsWithParsedData.map(agent => agent.name).filter(Boolean)

--- a/src/app/api/citara/approval/route.ts
+++ b/src/app/api/citara/approval/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { getDatabase, db_helpers } from '@/lib/db'
+import { logger } from '@/lib/logger'
+
+type ApprovalAction = 'approve' | 'request_changes' | 'reject'
+
+function normalizeAction(value: unknown): ApprovalAction | null {
+  if (value === 'approve' || value === 'request_changes' || value === 'reject') return value
+  return null
+}
+
+export async function POST(request: NextRequest) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  try {
+    const body = await request.json().catch(() => ({}))
+    const taskId = Number(body.task_id)
+    const action = normalizeAction(body.action)
+    const note = typeof body.note === 'string' ? body.note.trim() : ''
+    const workspaceId = auth.user.workspace_id ?? 1
+    const actor = auth.user.display_name || auth.user.username || 'operator'
+
+    if (!Number.isInteger(taskId) || taskId <= 0) {
+      return NextResponse.json({ error: 'task_id inválido' }, { status: 400 })
+    }
+    if (!action) {
+      return NextResponse.json({ error: 'action deve ser approve, request_changes ou reject' }, { status: 400 })
+    }
+
+    const db = getDatabase()
+    const task = db.prepare('SELECT * FROM tasks WHERE id = ? AND workspace_id = ?').get(taskId, workspaceId) as any
+    if (!task) return NextResponse.json({ error: 'Task não encontrada' }, { status: 404 })
+
+    const now = Math.floor(Date.now() / 1000)
+    const comment = [
+      action === 'approve' ? '✅ Aprovado pelo operador.' : action === 'request_changes' ? '🟡 Ajustes solicitados pelo operador.' : '❌ Reprovado pelo operador.',
+      note ? `\n${note}` : '',
+    ].join('')
+
+    db.prepare(`
+      INSERT INTO comments (task_id, author, content, created_at, parent_id, mentions, workspace_id)
+      VALUES (?, ?, ?, ?, NULL, NULL, ?)
+    `).run(taskId, actor, comment, now, workspaceId)
+
+    if (action === 'approve') {
+      db.prepare(`
+        UPDATE tasks
+        SET status = 'done', outcome = COALESCE(outcome, 'success'), completed_at = COALESCE(completed_at, ?), updated_at = ?, feedback_notes = ?
+        WHERE id = ? AND workspace_id = ?
+      `).run(now, now, note || 'Aprovado no painel Mission Control.', taskId, workspaceId)
+    } else if (action === 'request_changes') {
+      db.prepare(`
+        UPDATE tasks
+        SET status = 'awaiting_owner', outcome = 'partial', updated_at = ?, feedback_notes = ?
+        WHERE id = ? AND workspace_id = ?
+      `).run(now, note || 'Ajustes solicitados no painel Mission Control.', taskId, workspaceId)
+    } else {
+      db.prepare(`
+        UPDATE tasks
+        SET status = 'failed', outcome = 'failed', updated_at = ?, error_message = ?
+        WHERE id = ? AND workspace_id = ?
+      `).run(now, note || 'Reprovado no painel Mission Control.', taskId, workspaceId)
+    }
+
+    db_helpers.logActivity(
+      'task_approval',
+      'task',
+      taskId,
+      actor,
+      `Approval action "${action}" on task: ${task.title}`,
+      { action, note },
+      workspaceId
+    )
+
+    const updated = db.prepare('SELECT id, title, status, outcome, updated_at, completed_at, feedback_notes, error_message FROM tasks WHERE id = ? AND workspace_id = ?').get(taskId, workspaceId)
+    return NextResponse.json({ ok: true, action, task: updated })
+  } catch (error) {
+    logger.error({ err: error }, 'POST /api/citara/approval error')
+    return NextResponse.json({ error: 'Falha ao aplicar aprovação' }, { status: 500 })
+  }
+}

--- a/src/app/api/citara/clickup/sync/route.ts
+++ b/src/app/api/citara/clickup/sync/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { getDatabase } from '@/lib/db'
+import { logger } from '@/lib/logger'
+
+const CLICKUP_API = 'https://api.clickup.com/api/v2'
+
+function getClickUpConfig() {
+  return {
+    token: process.env.CLICKUP_API_TOKEN || process.env.CLICKUP_TOKEN || '',
+    listId: process.env.CLICKUP_LIST_ID || process.env.CITARA_CLICKUP_LIST_ID || '',
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const cfg = getClickUpConfig()
+  return NextResponse.json({
+    ok: true,
+    configured: Boolean(cfg.token && cfg.listId),
+    has_token: Boolean(cfg.token),
+    list_id: cfg.listId || null,
+    mode: cfg.token && cfg.listId ? 'ready' : 'needs_env',
+    required_env: ['CLICKUP_API_TOKEN', 'CLICKUP_LIST_ID'],
+  })
+}
+
+export async function POST(request: NextRequest) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  try {
+    const cfg = getClickUpConfig()
+    if (!cfg.token || !cfg.listId) {
+      return NextResponse.json({
+        error: 'ClickUp não configurado',
+        required_env: ['CLICKUP_API_TOKEN', 'CLICKUP_LIST_ID'],
+      }, { status: 400 })
+    }
+
+    const body = await request.json().catch(() => ({}))
+    const taskId = Number(body.task_id)
+    if (!Number.isInteger(taskId) || taskId <= 0) {
+      return NextResponse.json({ error: 'task_id inválido' }, { status: 400 })
+    }
+
+    const workspaceId = auth.user.workspace_id ?? 1
+    const db = getDatabase()
+    const task = db.prepare(`
+      SELECT t.*, p.name AS project_name
+      FROM tasks t
+      LEFT JOIN projects p ON p.id = t.project_id AND p.workspace_id = t.workspace_id
+      WHERE t.id = ? AND t.workspace_id = ?
+    `).get(taskId, workspaceId) as any
+    if (!task) return NextResponse.json({ error: 'Task não encontrada' }, { status: 404 })
+
+    const metadata = task.metadata ? JSON.parse(task.metadata) : {}
+    const client = metadata.client || metadata.cliente || task.project_name || 'Cítara / Interno'
+    const description = [
+      task.description || '',
+      '',
+      `Origem: Mission Control`,
+      `Cliente: ${client}`,
+      `Agente: ${task.assigned_to || 'não definido'}`,
+      `Status MC: ${task.status}`,
+      task.resolution ? `\nResultado:\n${task.resolution}` : '',
+      task.error_message ? `\nErro:\n${task.error_message}` : '',
+    ].filter(Boolean).join('\n')
+
+    const res = await fetch(`${CLICKUP_API}/list/${cfg.listId}/task`, {
+      method: 'POST',
+      headers: {
+        Authorization: cfg.token,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: task.title,
+        description,
+        tags: ['mission-control', 'citara', ...(task.tags ? JSON.parse(task.tags) : [])].slice(0, 20),
+        priority: task.priority === 'critical' || task.priority === 'urgent' ? 1 : task.priority === 'high' ? 2 : task.priority === 'medium' ? 3 : 4,
+      }),
+    })
+
+    const text = await res.text()
+    let payload: any = text
+    try { payload = JSON.parse(text) } catch {}
+
+    if (!res.ok) {
+      return NextResponse.json({ error: 'ClickUp API falhou', status: res.status, payload }, { status: 502 })
+    }
+
+    const clickupId = payload?.id
+    const now = Math.floor(Date.now() / 1000)
+    const nextMetadata = { ...metadata, clickup_task_id: clickupId, clickup_synced_at: now }
+    db.prepare('UPDATE tasks SET metadata = ?, updated_at = ? WHERE id = ? AND workspace_id = ?')
+      .run(JSON.stringify(nextMetadata), now, taskId, workspaceId)
+
+    return NextResponse.json({ ok: true, clickup_task_id: clickupId, clickup_url: payload?.url || null, payload })
+  } catch (error) {
+    logger.error({ err: error }, 'POST /api/citara/clickup/sync error')
+    return NextResponse.json({ error: 'Falha no sync ClickUp' }, { status: 500 })
+  }
+}

--- a/src/app/api/citara/general-report/route.ts
+++ b/src/app/api/citara/general-report/route.ts
@@ -1,0 +1,136 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { getDatabase } from '@/lib/db'
+import { logger } from '@/lib/logger'
+
+type CountRow = { status: string; count: number }
+type AgentRow = { name: string; role: string; status: string; total: number; active: number; review: number; done: number; failed: number }
+type TaskRow = { id: number; title: string; status: string; priority: string; assigned_to: string | null; updated_at: number; resolution: string | null; error_message: string | null }
+
+const TOPIC_BY_AGENT: Record<string, string> = {
+  'Cítara Comando Nexus': 'Comando Nexus',
+  'Cítara Inteligência': 'Inteligência',
+  'Cítara Laboratório': 'Laboratório',
+  'Cítara Crescimento': 'Crescimento',
+  'Cítara Orgânico': 'Orgânico',
+  'Cítara Web': 'Web',
+  'Cítara Busca': 'Busca',
+  'Cítara Comercial': 'Comercial',
+  'Cítara Operações': 'Operações',
+}
+
+const CANONICAL_CITARA_AGENTS = Object.keys(TOPIC_BY_AGENT)
+
+function parseLimit(request: NextRequest): number {
+  const raw = request.nextUrl.searchParams.get('limit')
+  const n = raw ? Number(raw) : 10
+  if (!Number.isFinite(n)) return 10
+  return Math.max(1, Math.min(50, Math.floor(n)))
+}
+
+function buildExecutiveSummary(counts: Record<string, number>, agents: AgentRow[]): string[] {
+  const queue = counts.awaiting_owner || 0
+  const running = counts.in_progress || 0
+  const review = counts.quality_review || 0
+  const failed = counts.failed || 0
+  const done = counts.done || 0
+  const adapterReady = agents.filter(a => CANONICAL_CITARA_AGENTS.includes(a.name)).length
+
+  const lines = [
+    `Agentes Cítara prontos: ${adapterReady}/9`,
+    `Fila aguardando Hermes Adapter: ${queue}`,
+    `Em execução: ${running}`,
+    `Aguardando revisão humana: ${review}`,
+    `Concluídas: ${done}`,
+  ]
+  if (failed > 0) lines.push(`Atenção: ${failed} task(s) com falha`)
+  if (queue === 0 && running === 0 && review === 0 && failed === 0) {
+    lines.push('Operação limpa: sem fila, sem revisão pendente e sem falhas abertas.')
+  }
+  return lines
+}
+
+export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  try {
+    const db = getDatabase()
+    const workspaceId = auth.user.workspace_id ?? 1
+    const limit = parseLimit(request)
+
+    const countRows = db.prepare(`
+      SELECT status, COUNT(*) as count
+      FROM tasks
+      WHERE workspace_id = ?
+      GROUP BY status
+      ORDER BY status
+    `).all(workspaceId) as CountRow[]
+    const counts = Object.fromEntries(countRows.map(row => [row.status, row.count])) as Record<string, number>
+
+    const agents = db.prepare(`
+      SELECT
+        a.name,
+        a.role,
+        a.status,
+        COUNT(t.id) as total,
+        SUM(CASE WHEN t.status IN ('awaiting_owner', 'assigned', 'in_progress') THEN 1 ELSE 0 END) as active,
+        SUM(CASE WHEN t.status IN ('review', 'quality_review') THEN 1 ELSE 0 END) as review,
+        SUM(CASE WHEN t.status = 'done' THEN 1 ELSE 0 END) as done,
+        SUM(CASE WHEN t.status = 'failed' THEN 1 ELSE 0 END) as failed
+      FROM agents a
+      LEFT JOIN tasks t ON t.assigned_to = a.name AND t.workspace_id = a.workspace_id
+      WHERE a.workspace_id = ? AND a.name IN (${CANONICAL_CITARA_AGENTS.map(() => '?').join(',')})
+      GROUP BY a.id
+      ORDER BY a.name
+    `).all(workspaceId, ...CANONICAL_CITARA_AGENTS) as AgentRow[]
+
+    const recentTasks = db.prepare(`
+      SELECT id, title, status, priority, assigned_to, updated_at, resolution, error_message
+      FROM tasks
+      WHERE workspace_id = ?
+      ORDER BY updated_at DESC
+      LIMIT ?
+    `).all(workspaceId, limit) as TaskRow[]
+
+    const byTopic = agents.map(agent => ({
+      topic: TOPIC_BY_AGENT[agent.name] || agent.name.replace(/^Cítara\s+/, ''),
+      agent: agent.name,
+      role: agent.role,
+      status: 'Hermes Adapter queue-ready',
+      tasks: {
+        total: Number(agent.total || 0),
+        active: Number(agent.active || 0),
+        review: Number(agent.review || 0),
+        done: Number(agent.done || 0),
+        failed: Number(agent.failed || 0),
+      },
+      signal: Number(agent.failed || 0) > 0 ? 'attention' : Number(agent.active || 0) > 0 ? 'working' : 'clear',
+    }))
+
+    const report = {
+      ok: true,
+      generated_at: new Date().toISOString(),
+      workspace_id: workspaceId,
+      title: 'Resumo do General — Cítara Mission Control',
+      summary: buildExecutiveSummary(counts, agents),
+      counts,
+      topics: byTopic,
+      recent_tasks: recentTasks.map(task => ({
+        ...task,
+        updated_at_iso: new Date(Number(task.updated_at || 0) * 1000).toISOString(),
+      })),
+      next_actions: [
+        counts.awaiting_owner ? 'Rodar Fleet Runner para processar fila awaiting_owner.' : null,
+        counts.quality_review ? 'Revisar tasks em quality_review e aprovar/concluir.' : null,
+        counts.failed ? 'Abrir tasks failed e corrigir causa antes de reenfileirar.' : null,
+        !counts.awaiting_owner && !counts.quality_review && !counts.failed ? 'Criar próxima task real por agente/cliente ou importar de ClickUp/WhatsApp.' : null,
+      ].filter(Boolean),
+    }
+
+    return NextResponse.json(report)
+  } catch (error) {
+    logger.error({ err: error }, 'GET /api/citara/general-report error')
+    return NextResponse.json({ error: 'Failed to build Cítara General report' }, { status: 500 })
+  }
+}

--- a/src/app/api/citara/general-summary/route.ts
+++ b/src/app/api/citara/general-summary/route.ts
@@ -1,0 +1,191 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireRole } from '@/lib/auth'
+import { getDatabase } from '@/lib/db'
+import { logger } from '@/lib/logger'
+
+type TaskRow = {
+  id: number
+  title: string
+  description?: string | null
+  status: string
+  priority: string
+  assigned_to?: string | null
+  created_at: number
+  updated_at: number
+  completed_at?: number | null
+  tags?: string | null
+  metadata?: string | null
+  outcome?: string | null
+  error_message?: string | null
+  resolution?: string | null
+  project_name?: string | null
+  project_slug?: string | null
+}
+
+const SPECIALIST_TOPICS = [
+  'Comando Nexus',
+  'Inteligência',
+  'Laboratório',
+  'Crescimento',
+  'Orgânico',
+  'Web',
+  'Busca',
+  'Comercial',
+  'Operações',
+]
+
+function safeJson(value: string | null | undefined): any {
+  if (!value) return null
+  try { return JSON.parse(value) } catch { return null }
+}
+
+function parseTags(value: string | null | undefined): string[] {
+  const parsed = safeJson(value)
+  if (Array.isArray(parsed)) return parsed.filter((x) => typeof x === 'string')
+  if (typeof value === 'string' && value.trim()) return value.split(',').map((x) => x.trim()).filter(Boolean)
+  return []
+}
+
+function inferClient(task: TaskRow): string {
+  const metadata = safeJson(task.metadata) || {}
+  if (typeof metadata.client === 'string' && metadata.client.trim()) return metadata.client.trim()
+  if (typeof metadata.cliente === 'string' && metadata.cliente.trim()) return metadata.cliente.trim()
+  if (task.project_name) return task.project_name
+
+  const tags = parseTags(task.tags)
+  const clientTag = tags.find((tag) => tag.startsWith('cliente:') || tag.startsWith('client:'))
+  if (clientTag) return clientTag.split(':').slice(1).join(':').trim() || 'Sem cliente'
+
+  return 'Cítara / Interno'
+}
+
+function inferTopic(task: TaskRow): string {
+  const metadata = safeJson(task.metadata) || {}
+  if (typeof metadata.topic === 'string' && metadata.topic.trim()) return metadata.topic.trim()
+  const assigned = task.assigned_to || ''
+  const match = SPECIALIST_TOPICS.find((topic) => assigned.toLowerCase().includes(topic.toLowerCase()))
+  return match || 'Geral'
+}
+
+function taskRisk(task: TaskRow): 'blocked' | 'review' | 'running' | 'queued' | 'ok' {
+  if (task.status === 'failed') return 'blocked'
+  if (task.status === 'quality_review' || task.status === 'review') return 'review'
+  if (task.status === 'in_progress') return 'running'
+  if (task.status === 'awaiting_owner' || task.status === 'assigned' || task.status === 'inbox') return 'queued'
+  return 'ok'
+}
+
+export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  try {
+    const workspaceId = auth.user.workspace_id ?? 1
+    const db = getDatabase()
+    const rows = db.prepare(`
+      SELECT
+        t.*,
+        p.name AS project_name,
+        p.slug AS project_slug
+      FROM tasks t
+      LEFT JOIN projects p ON p.id = t.project_id AND p.workspace_id = t.workspace_id
+      WHERE t.workspace_id = ?
+      ORDER BY t.updated_at DESC
+      LIMIT 500
+    `).all(workspaceId) as TaskRow[]
+
+    const statusCounts: Record<string, number> = {}
+    const topicCounts: Record<string, number> = {}
+    const clients = new Map<string, any>()
+    const needsApproval: any[] = []
+    const blocked: any[] = []
+    const recentDone: any[] = []
+
+    for (const task of rows) {
+      statusCounts[task.status] = (statusCounts[task.status] || 0) + 1
+      const topic = inferTopic(task)
+      const client = inferClient(task)
+      const risk = taskRisk(task)
+      topicCounts[topic] = (topicCounts[topic] || 0) + 1
+
+      if (!clients.has(client)) {
+        clients.set(client, {
+          name: client,
+          total: 0,
+          by_status: {},
+          by_topic: {},
+          open: 0,
+          review: 0,
+          failed: 0,
+          done: 0,
+          last_activity_at: 0,
+          top_tasks: [],
+        })
+      }
+      const c = clients.get(client)
+      c.total += 1
+      c.by_status[task.status] = (c.by_status[task.status] || 0) + 1
+      c.by_topic[topic] = (c.by_topic[topic] || 0) + 1
+      c.last_activity_at = Math.max(c.last_activity_at, task.updated_at || task.created_at || 0)
+      if (task.status === 'done') c.done += 1
+      else c.open += 1
+      if (task.status === 'quality_review' || task.status === 'review') c.review += 1
+      if (task.status === 'failed') c.failed += 1
+      if (c.top_tasks.length < 5 && task.status !== 'done') {
+        c.top_tasks.push({ id: task.id, title: task.title, status: task.status, priority: task.priority, assigned_to: task.assigned_to, risk })
+      }
+
+      const compact = {
+        id: task.id,
+        title: task.title,
+        client,
+        topic,
+        status: task.status,
+        priority: task.priority,
+        assigned_to: task.assigned_to,
+        updated_at: task.updated_at,
+        resolution: task.resolution,
+        error_message: task.error_message,
+      }
+      if (risk === 'review') needsApproval.push(compact)
+      if (risk === 'blocked') blocked.push(compact)
+      if (task.status === 'done' && recentDone.length < 12) recentDone.push(compact)
+    }
+
+    const openTotal = rows.filter((t) => !['done'].includes(t.status)).length
+    const summary = {
+      generated_at: new Date().toISOString(),
+      workspace_id: workspaceId,
+      health: blocked.length > 0 ? 'attention' : needsApproval.length > 0 ? 'review' : openTotal > 0 ? 'active' : 'clear',
+      headline: `${openTotal} abertas · ${needsApproval.length} em aprovação · ${blocked.length} bloqueadas · ${statusCounts.done || 0} concluídas`,
+      status_counts: statusCounts,
+      topic_counts: topicCounts,
+      clients: Array.from(clients.values()).sort((a, b) => b.last_activity_at - a.last_activity_at),
+      general_report: {
+        nexus_command: {
+          focus: needsApproval.length ? 'Aprovar entregas em revisão e destravar fila.' : 'Fila limpa; criar próximas tasks por cliente.',
+          needs_approval: needsApproval.slice(0, 20),
+          blocked: blocked.slice(0, 20),
+        },
+        specialists: SPECIALIST_TOPICS.map((topic) => ({
+          topic,
+          total: topicCounts[topic] || 0,
+          open: rows.filter((t) => inferTopic(t) === topic && t.status !== 'done').length,
+          review: rows.filter((t) => inferTopic(t) === topic && (t.status === 'quality_review' || t.status === 'review')).length,
+          failed: rows.filter((t) => inferTopic(t) === topic && t.status === 'failed').length,
+        })),
+        recent_done: recentDone,
+      },
+      next_actions: [
+        'Aprovar/reprovar tasks em quality_review usando botões claros no painel.',
+        'Enviar tasks reais por cliente com metadata.client/cliente para alimentar dashboard por cliente.',
+        'Configurar CLICKUP_API_TOKEN e CLICKUP_LIST_ID para ativar sync direto com ClickUp.',
+      ],
+    }
+
+    return NextResponse.json(summary)
+  } catch (error) {
+    logger.error({ err: error }, 'GET /api/citara/general-summary error')
+    return NextResponse.json({ error: 'Failed to build Cítara general summary' }, { status: 500 })
+  }
+}

--- a/src/app/api/hermes/direct-worker/route.ts
+++ b/src/app/api/hermes/direct-worker/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { existsSync } from 'node:fs'
+import { requireRole } from '@/lib/auth'
+import { runCommand } from '@/lib/command'
+import { logger } from '@/lib/logger'
+
+const DEFAULT_ADAPTER_DIR = '/Users/phfer/hermes-workspaces/citara-tech-brain/mission-control-adapter'
+const DEFAULT_DIRECT_CLIENT = `${DEFAULT_ADAPTER_DIR}/hermes_direct_worker_client.py`
+const DEFAULT_MINIONS_WORKER = '/Users/phfer/hermes-workspaces/research/minions/server/workers/hermes_worker.py'
+
+function adapterDir(): string {
+  return process.env.CITARA_MC_ADAPTER_DIR || DEFAULT_ADAPTER_DIR
+}
+
+function directClientPath(): string {
+  return process.env.CITARA_HERMES_DIRECT_CLIENT || DEFAULT_DIRECT_CLIENT
+}
+
+function directWorkerScript(): string {
+  return process.env.CITARA_HERMES_DIRECT_WORKER_SCRIPT || DEFAULT_MINIONS_WORKER
+}
+
+/**
+ * GET /api/hermes/direct-worker
+ * Health/status endpoint for the Minions-inspired Hermes Direct Worker.
+ *
+ * This does not process Mission Control tasks. It verifies that the JSONL worker
+ * can boot and import Hermes AIAgent directly, keeping the feature safe and
+ * reversible behind CITARA_HERMES_EXECUTOR=direct / --executor direct.
+ */
+export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  const client = directClientPath()
+  const worker = directWorkerScript()
+  const cwd = adapterDir()
+
+  if (!existsSync(client)) {
+    return NextResponse.json({ ok: false, error: `Direct client not found: ${client}`, client, worker, cwd }, { status: 500 })
+  }
+  if (!existsSync(worker)) {
+    return NextResponse.json({ ok: false, error: `Minions worker not found: ${worker}`, client, worker, cwd }, { status: 500 })
+  }
+
+  try {
+    const startedAt = Date.now()
+    const result = await runCommand('python3', [client], {
+      cwd,
+      timeoutMs: 30_000,
+      env: {
+        ...process.env,
+        CITARA_HERMES_DIRECT_WORKER_SCRIPT: worker,
+      },
+    })
+    const elapsedMs = Date.now() - startedAt
+    let health: any = null
+    try { health = JSON.parse(result.stdout || '{}') } catch { health = null }
+
+    return NextResponse.json({
+      ok: result.code === 0,
+      code: result.code,
+      elapsed_ms: elapsedMs,
+      client,
+      worker,
+      cwd,
+      health,
+      stdout: (result.stdout || '').slice(0, 4000),
+      stderr: (result.stderr || '').slice(0, 4000),
+      usage: {
+        dry_run: 'python3 controlled_fleet_runner.py --dry-run --json --executor direct',
+        real_queue: 'python3 controlled_fleet_runner.py --executor direct --notify-empty',
+        env_flag: 'CITARA_HERMES_EXECUTOR=direct',
+      },
+    }, { status: result.code === 0 ? 200 : 503 })
+  } catch (err: any) {
+    logger.error({ err }, 'Hermes direct worker health failed')
+    return NextResponse.json({
+      ok: false,
+      error: err?.message || 'Hermes direct worker health failed',
+      timed_out: Boolean(err?.timedOut),
+      stdout: (err?.stdout || '').slice(0, 4000),
+      stderr: (err?.stderr || '').slice(0, 4000),
+      client,
+      worker,
+      cwd,
+    }, { status: 500 })
+  }
+}

--- a/src/app/api/hermes/fleet-runner/route.ts
+++ b/src/app/api/hermes/fleet-runner/route.ts
@@ -1,0 +1,167 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { existsSync, readFileSync } from 'node:fs'
+import { requireRole } from '@/lib/auth'
+import { runCommand } from '@/lib/command'
+import { getDatabase } from '@/lib/db'
+import { logger } from '@/lib/logger'
+
+const DEFAULT_SCRIPT = '/Users/phfer/.hermes/scripts/citara_mission_control_fleet_runner.sh'
+const DEFAULT_CWD = '/Users/phfer/hermes-workspaces/citara-tech-brain/mission-control-adapter'
+const DEFAULT_LOG_PATH = '/Users/phfer/hermes-workspaces/citara-tech-brain/mission-control-adapter/logs/citara-fleet-runner.jsonl'
+
+function fleetRunnerScriptPath(): string {
+  return process.env.CITARA_MC_FLEET_RUNNER_SCRIPT || DEFAULT_SCRIPT
+}
+
+function fleetRunnerCwd(): string {
+  return process.env.CITARA_MC_FLEET_RUNNER_CWD || DEFAULT_CWD
+}
+
+function fleetRunnerLogPath(): string {
+  return process.env.CITARA_MC_FLEET_RUNNER_LOG || DEFAULT_LOG_PATH
+}
+
+function clip(value: string, limit = 8000): string {
+  if (!value || value.length <= limit) return value
+  return `${value.slice(0, limit - 80).trimEnd()}\n\n[... clipped ${value.length - limit} chars ...]`
+}
+
+function readLastRunnerEvent(): Record<string, any> | null {
+  try {
+    const logPath = fleetRunnerLogPath()
+    if (!existsSync(logPath)) return null
+    const raw = readFileSync(logPath, 'utf8').trim()
+    if (!raw) return null
+    const last = raw.split('\n').filter(Boolean).at(-1)
+    return last ? JSON.parse(last) : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * GET /api/hermes/fleet-runner
+ * Operational status for the Cítara Hermes Adapter fleet runner.
+ */
+export async function GET(request: NextRequest) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  try {
+    const db = getDatabase()
+    const workspaceId = auth.user.workspace_id ?? 1
+    const agentRows = db.prepare(`
+      SELECT name, status, last_activity, config
+      FROM agents
+      WHERE workspace_id = ? AND hidden = 0
+    `).all(workspaceId) as Array<{ name: string; status: string; last_activity?: string | null; config?: string | null }>
+
+    const hermesAgents = agentRows.filter((agent) => {
+      try {
+        const cfg = agent.config ? JSON.parse(agent.config) : {}
+        return cfg?.runtime === 'hermes' && cfg?.adapter === 'citara-hermes-adapter'
+      } catch {
+        return false
+      }
+    })
+
+    const countsRows = db.prepare(`
+      SELECT status, COUNT(*) as count
+      FROM tasks
+      WHERE workspace_id = ?
+      GROUP BY status
+    `).all(workspaceId) as Array<{ status: string; count: number }>
+
+    const taskCounts = Object.fromEntries(countsRows.map((row) => [row.status, row.count || 0]))
+    const pendingHermesRows = db.prepare(`
+      SELECT assigned_to, COUNT(*) as count
+      FROM tasks
+      WHERE workspace_id = ? AND status = 'awaiting_owner'
+      GROUP BY assigned_to
+    `).all(workspaceId) as Array<{ assigned_to: string; count: number }>
+
+    return NextResponse.json({
+      ok: true,
+      script: fleetRunnerScriptPath(),
+      cwd: fleetRunnerCwd(),
+      log_path: fleetRunnerLogPath(),
+      agents: {
+        total: agentRows.length,
+        hermes_adapter: hermesAgents.length,
+        idle_or_ready: hermesAgents.filter((a) => a.status === 'idle' || a.status === 'offline').length,
+      },
+      tasks: {
+        counts: taskCounts,
+        awaiting_owner: taskCounts.awaiting_owner || 0,
+        quality_review: taskCounts.quality_review || 0,
+        failed: taskCounts.failed || 0,
+        pending_by_agent: pendingHermesRows,
+      },
+      last_runner_event: readLastRunnerEvent(),
+    })
+  } catch (err: any) {
+    logger.error({ err }, 'Cítara Hermes fleet runner status failed')
+    return NextResponse.json({ ok: false, error: err?.message || 'Fleet runner status failed' }, { status: 500 })
+  }
+}
+
+/**
+ * POST /api/hermes/fleet-runner
+ * Manual trigger for the Cítara Hermes Adapter fleet runner.
+ *
+ * This does not use Mission Control's native OpenClaw/Claude scheduler. It runs
+ * the same controlled script used by Hermes Cron, which consumes only
+ * `awaiting_owner` tasks and returns them to `quality_review`/`failed`.
+ */
+export async function POST(request: NextRequest) {
+  const auth = requireRole(request, 'operator')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+
+  const script = fleetRunnerScriptPath()
+  const cwd = fleetRunnerCwd()
+
+  if (!existsSync(script)) {
+    return NextResponse.json({ success: false, error: `Fleet runner script not found: ${script}` }, { status: 500 })
+  }
+
+  try {
+    let body: any = {}
+    try { body = await request.json() } catch { body = {} }
+
+    const notifyEmpty = body?.notify_empty !== false
+    const args = notifyEmpty ? ['--notify-empty'] : []
+    const startedAt = Date.now()
+    const result = await runCommand(script, args, {
+      cwd,
+      timeoutMs: 240_000,
+      env: {
+        ...process.env,
+        CITARA_MC_MANUAL_TRIGGER: '1',
+      },
+    })
+    const elapsedMs = Date.now() - startedAt
+
+    logger.info({ actor: auth.user.username, elapsedMs }, 'Cítara Hermes fleet runner manual trigger completed')
+    return NextResponse.json({
+      success: true,
+      code: result.code,
+      elapsed_ms: elapsedMs,
+      stdout: clip(result.stdout),
+      stderr: clip(result.stderr),
+      script,
+      cwd,
+    })
+  } catch (err: any) {
+    logger.error({ err, actor: auth.user.username }, 'Cítara Hermes fleet runner manual trigger failed')
+    return NextResponse.json({
+      success: false,
+      error: err?.message || 'Fleet runner failed',
+      code: err?.code ?? null,
+      timed_out: Boolean(err?.timedOut),
+      stdout: clip(err?.stdout || ''),
+      stderr: clip(err?.stderr || ''),
+      script,
+      cwd,
+    }, { status: 500 })
+  }
+}

--- a/src/app/api/memory/graph/route.ts
+++ b/src/app/api/memory/graph/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { existsSync, readdirSync, statSync } from 'fs'
+import { existsSync, readdirSync, statSync, readFileSync } from 'fs'
+import os from 'os'
 import path from 'path'
-import Database from 'better-sqlite3'
-import { config } from '@/lib/config'
 import { requireRole } from '@/lib/auth'
 import { readLimiter } from '@/lib/rate-limit'
 import { logger } from '@/lib/logger'
@@ -21,57 +20,115 @@ interface AgentGraphData {
   files: AgentFileInfo[]
 }
 
-const memoryDbDir = config.openclawStateDir
-  ? path.join(config.openclawStateDir, 'memory')
-  : ''
+const HERMES_HOME = process.env.HERMES_HOME || path.join(os.homedir(), '.hermes')
+const MAX_SESSION_FILES_PER_PROFILE = 80
 
-function getAgentData(dbPath: string, agentName: string): AgentGraphData | null {
+function countApproxChunks(filePath: string): { chunks: number; textSize: number } {
   try {
-    const dbStat = statSync(dbPath)
-    const db = new Database(dbPath, { readonly: true, fileMustExist: true })
+    const stat = statSync(filePath)
+    if (!stat.isFile()) return { chunks: 0, textSize: 0 }
 
-    let files: AgentFileInfo[] = []
-    let totalChunks = 0
-    let totalFiles = 0
-
-    try {
-      // Check if chunks table exists
-      const tableCheck = db
-        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='chunks'")
-        .get() as { name: string } | undefined
-
-      if (tableCheck) {
-        // Use COUNT only — skip SUM(LENGTH(text)) which forces a full data scan
-        const rows = db
-          .prepare(
-            'SELECT path, COUNT(*) as chunks FROM chunks GROUP BY path ORDER BY chunks DESC'
-          )
-          .all() as Array<{ path: string; chunks: number }>
-
-        files = rows.map((r) => ({
-          path: r.path || '(unknown)',
-          chunks: r.chunks,
-          textSize: 0,
-        }))
-
-        totalChunks = files.reduce((sum, f) => sum + f.chunks, 0)
-        totalFiles = files.length
-      }
-    } finally {
-      db.close()
+    // Keep large files cheap: estimate chunks by bytes instead of reading huge JSONL files.
+    if (stat.size > 512 * 1024) {
+      return { chunks: Math.max(1, Math.ceil(stat.size / 4096)), textSize: stat.size }
     }
 
-    return {
-      name: agentName,
-      dbSize: dbStat.size,
-      totalChunks,
-      totalFiles,
-      files,
+    const text = readFileSync(filePath, 'utf8')
+    const trimmed = text.trim()
+    if (!trimmed) return { chunks: 0, textSize: stat.size }
+
+    // JSONL session files: each message-ish row is a useful node chunk.
+    if (filePath.endsWith('.jsonl')) {
+      const lines = trimmed.split(/\r?\n/).filter(Boolean).length
+      return { chunks: Math.max(1, lines), textSize: text.length }
     }
-  } catch (err) {
-    logger.warn(`Failed to read memory DB for agent "${agentName}": ${err}`)
-    return null
+
+    // Markdown profile memory: split by memory separators / paragraphs.
+    const sections = trimmed
+      .split(/\n(?:§|---|#{1,6}\s+|\n)\n/g)
+      .map(s => s.trim())
+      .filter(Boolean)
+    return { chunks: Math.max(1, sections.length), textSize: text.length }
+  } catch {
+    return { chunks: 0, textSize: 0 }
   }
+}
+
+function addFile(files: AgentFileInfo[], root: string, absolutePath: string) {
+  if (!existsSync(absolutePath)) return
+  const stat = statSync(absolutePath)
+  if (!stat.isFile()) return
+  const rel = path.relative(root, absolutePath) || path.basename(absolutePath)
+  const { chunks, textSize } = countApproxChunks(absolutePath)
+  files.push({ path: rel, chunks, textSize })
+}
+
+function collectSessionFiles(files: AgentFileInfo[], root: string, sessionsDir: string) {
+  if (!existsSync(sessionsDir)) return
+  const entries = readdirSync(sessionsDir)
+    .filter(f => f.endsWith('.jsonl'))
+    .map(f => path.join(sessionsDir, f))
+    .filter(f => {
+      try { return statSync(f).isFile() } catch { return false }
+    })
+    .sort((a, b) => statSync(b).mtimeMs - statSync(a).mtimeMs)
+    .slice(0, MAX_SESSION_FILES_PER_PROFILE)
+
+  for (const filePath of entries) addFile(files, root, filePath)
+}
+
+function getHermesProfileData(name: string, root: string): AgentGraphData | null {
+  if (!existsSync(root)) return null
+
+  const files: AgentFileInfo[] = []
+  addFile(files, root, path.join(root, 'memories', 'MEMORY.md'))
+  addFile(files, root, path.join(root, 'memories', 'USER.md'))
+  collectSessionFiles(files, root, path.join(root, 'sessions'))
+
+  // state.db is the Hermes session/search database. We show it as an index node,
+  // but do not parse internals here; user-facing graph should not be OpenClaw-specific.
+  addFile(files, root, path.join(root, 'state.db'))
+
+  if (files.length === 0) return null
+
+  const dbSize = files.reduce((sum, file) => sum + file.textSize, 0)
+  const totalChunks = files.reduce((sum, file) => sum + file.chunks, 0)
+
+  return {
+    name,
+    dbSize,
+    totalChunks,
+    totalFiles: files.length,
+    files: files.sort((a, b) => b.chunks - a.chunks),
+  }
+}
+
+function collectHermesMemoryGraph(agentFilter: string): AgentGraphData[] {
+  const agents: AgentGraphData[] = []
+
+  const defaultProfile = getHermesProfileData('Hermes default', HERMES_HOME)
+  if (defaultProfile && (agentFilter === 'all' || agentFilter === defaultProfile.name)) {
+    agents.push(defaultProfile)
+  }
+
+  const profilesRoot = path.join(HERMES_HOME, 'profiles')
+  if (existsSync(profilesRoot)) {
+    const profileDirs = readdirSync(profilesRoot)
+      .map(name => ({ name, root: path.join(profilesRoot, name) }))
+      .filter(item => {
+        try { return statSync(item.root).isDirectory() } catch { return false }
+      })
+
+    for (const profile of profileDirs) {
+      const displayName = `Hermes ${profile.name}`
+      if (agentFilter !== 'all' && agentFilter !== displayName && agentFilter !== profile.name) continue
+      const data = getHermesProfileData(displayName, profile.root)
+      if (data) agents.push(data)
+    }
+  }
+
+  agents.sort((a, b) => b.totalChunks - a.totalChunks)
+  return agents
 }
 
 export async function GET(request: NextRequest) {
@@ -81,35 +138,20 @@ export async function GET(request: NextRequest) {
   const limited = readLimiter(request)
   if (limited) return limited
 
-  if (!memoryDbDir || !existsSync(memoryDbDir)) {
-    return NextResponse.json(
-      { error: 'Memory directory not available', agents: [] },
-      { status: 404 }
-    )
-  }
-
   const agentFilter = request.nextUrl.searchParams.get('agent') || 'all'
 
   try {
-    const entries = readdirSync(memoryDbDir).filter((f) => f.endsWith('.sqlite'))
-    const agents: AgentGraphData[] = []
-
-    for (const entry of entries) {
-      const agentName = entry.replace('.sqlite', '')
-
-      if (agentFilter !== 'all' && agentName !== agentFilter) continue
-
-      const dbPath = path.join(memoryDbDir, entry)
-      const data = getAgentData(dbPath, agentName)
-      if (data) agents.push(data)
+    if (!existsSync(HERMES_HOME)) {
+      return NextResponse.json(
+        { error: 'Hermes home not available', agents: [], hermesHome: HERMES_HOME },
+        { status: 404 }
+      )
     }
 
-    // Sort by total chunks descending
-    agents.sort((a, b) => b.totalChunks - a.totalChunks)
-
-    return NextResponse.json({ agents })
+    const agents = collectHermesMemoryGraph(agentFilter)
+    return NextResponse.json({ agents, hermesHome: HERMES_HOME })
   } catch (err) {
-    logger.error(`Failed to build memory graph data: ${err}`)
+    logger.error(`Failed to build Hermes memory graph data: ${err}`)
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
 }

--- a/src/components/layout/nav-rail.tsx
+++ b/src/components/layout/nav-rail.tsx
@@ -30,6 +30,7 @@ const navGroups: NavGroup[] = [
     id: 'core',
     items: [
       { id: 'overview', label: 'Overview', icon: <OverviewIcon />, priority: true, essential: true },
+      { id: 'citara-command', label: 'Cítara', icon: <span className="text-sm font-bold">C</span>, priority: true, essential: true },
       { id: 'agents', label: 'Agents', icon: <AgentsIcon />, priority: true, essential: true },
       { id: 'tasks', label: 'Tasks', icon: <TasksIcon />, priority: true, essential: true },
       { id: 'chat', label: 'Chat', icon: <ChatIcon />, priority: false, essential: true },
@@ -85,6 +86,7 @@ const navGroups: NavGroup[] = [
 // Map nav item IDs to translation keys in the 'nav' namespace
 const navItemTranslationKeys: Record<string, string> = {
   overview: 'overview',
+  'citara-command': 'citaraCommand',
   agents: 'agents',
   tasks: 'tasks',
   chat: 'chat',

--- a/src/components/layout/nav-rail.tsx
+++ b/src/components/layout/nav-rail.tsx
@@ -31,6 +31,7 @@ const navGroups: NavGroup[] = [
     items: [
       { id: 'overview', label: 'Overview', icon: <OverviewIcon />, priority: true, essential: true },
       { id: 'citara-command', label: 'Cítara', icon: <span className="text-sm font-bold">C</span>, priority: true, essential: true },
+      { id: 'project-os', label: 'Project OS', icon: <span className="text-sm font-bold">P</span>, priority: true, essential: true },
       { id: 'agents', label: 'Agents', icon: <AgentsIcon />, priority: true, essential: true },
       { id: 'tasks', label: 'Tasks', icon: <TasksIcon />, priority: true, essential: true },
       { id: 'chat', label: 'Chat', icon: <ChatIcon />, priority: false, essential: true },

--- a/src/components/panels/citara-command-center-panel.tsx
+++ b/src/components/panels/citara-command-center-panel.tsx
@@ -4,10 +4,12 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import {
   approvalActionLabel,
+  buildBenchmarkOptimizationCards,
   commandCenterHealthLabel,
   formatLastRunnerEvent,
   summarizeCommandCenter,
   type ApprovalAction,
+  type BenchmarkStatus,
   type FleetRunnerEvent,
 } from '@/lib/citara-command-center'
 
@@ -104,6 +106,12 @@ const actionToneClass: Record<string, string> = {
   success: 'border-emerald-500/40 text-emerald-200 hover:bg-emerald-500/10',
   warning: 'border-amber-500/40 text-amber-200 hover:bg-amber-500/10',
   danger: 'border-red-500/40 text-red-200 hover:bg-red-500/10',
+}
+
+const benchmarkStatusClass: Record<BenchmarkStatus, string> = {
+  ok: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-200',
+  watch: 'border-cyan-500/30 bg-cyan-500/10 text-cyan-200',
+  action: 'border-amber-500/30 bg-amber-500/10 text-amber-200',
 }
 
 function MetricCard({ label, value, hint }: { label: string; value: string | number; hint?: string }) {
@@ -215,12 +223,12 @@ export function CitaraCommandCenterPanel() {
   useEffect(() => { fetchData() }, [fetchData])
 
   const counts = report?.counts || fleet?.tasks?.counts || {}
-  const awaitingOwner = Number(counts.awaiting_owner || fleet?.tasks?.awaiting_owner || 0)
-  const inProgress = Number(counts.in_progress || 0)
-  const qualityReview = Number(counts.quality_review || fleet?.tasks?.quality_review || 0)
-  const failed = Number(counts.failed || fleet?.tasks?.failed || 0)
-  const done = Number(counts.done || 0)
-  const agentsReady = Number(fleet?.agents?.hermes_adapter || report?.topics?.length || 0)
+  const awaitingOwner = Number(counts.awaiting_owner ?? fleet?.tasks?.awaiting_owner ?? 0)
+  const inProgress = Number(counts.in_progress ?? 0)
+  const qualityReview = Number(counts.quality_review ?? fleet?.tasks?.quality_review ?? 0)
+  const failed = Number(counts.failed ?? fleet?.tasks?.failed ?? 0)
+  const done = Number(counts.done ?? 0)
+  const agentsReady = Number(fleet?.agents?.hermes_adapter ?? report?.topics?.length ?? 0)
   const health = commandCenterHealthLabel({ awaiting_owner: awaitingOwner, in_progress: inProgress, quality_review: qualityReview, failed, done })
   const summaryLines = summarizeCommandCenter({ agentsReady, awaitingOwner, inProgress, qualityReview, failed, done })
   const approvalTasks = summary?.general_report?.nexus_command?.needs_approval || []
@@ -280,6 +288,17 @@ export function CitaraCommandCenterPanel() {
 
   const focus = summary?.general_report?.nexus_command?.focus || report?.next_actions?.[0] || 'Sem bloqueios críticos; definir próxima task real por cliente/agente.'
   const lastRunner = useMemo(() => formatLastRunnerEvent(fleet?.last_runner_event), [fleet?.last_runner_event])
+  const benchmarkCards = useMemo(() => buildBenchmarkOptimizationCards({
+    awaitingOwner,
+    inProgress,
+    qualityReview,
+    failed,
+    done,
+    agentsReady,
+    topics: report?.topics || [],
+    clients: summary?.clients || [],
+    lastRunnerEvent: fleet?.last_runner_event || null,
+  }), [agentsReady, awaitingOwner, done, failed, fleet?.last_runner_event, inProgress, qualityReview, report?.topics, summary?.clients])
 
   return (
     <div className="space-y-6 p-4 md:p-6">
@@ -314,6 +333,33 @@ export function CitaraCommandCenterPanel() {
         <MetricCard label="Falhas" value={failed} hint="failed" />
         <MetricCard label="Concluídas" value={done} hint="done" />
       </div>
+
+      <section className="rounded-xl border border-border bg-card/80 p-4">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <div>
+            <h2 className="text-sm font-semibold text-foreground">Benchmark cirúrgico aplicado</h2>
+            <p className="mt-1 text-xs text-muted-foreground">1 otimização operacional extraída de Langfuse, LangSmith, CrewAI, AutoGPT, Dify e Flowise.</p>
+          </div>
+          <span className="text-xs text-muted-foreground">read-only · sem mudar execução</span>
+        </div>
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          {benchmarkCards.map(card => (
+            <div key={card.source} className="rounded-lg border border-border/70 bg-background/50 p-3">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <div className="text-sm font-medium text-foreground">{card.source}</div>
+                  <div className="mt-1 text-xs text-muted-foreground">{card.optimization}</div>
+                </div>
+                <span className={`rounded-full border px-2 py-0.5 text-[11px] uppercase ${benchmarkStatusClass[card.status]}`}>
+                  {card.status}
+                </span>
+              </div>
+              <p className="mt-3 text-xs text-muted-foreground">Sinal: {card.signal}</p>
+              <p className="mt-2 text-xs text-foreground/90">Ação: {card.action}</p>
+            </div>
+          ))}
+        </div>
+      </section>
 
       <div className="grid gap-4 xl:grid-cols-[1.2fr_0.8fr]">
         <section className="rounded-xl border border-border bg-card/80 p-4">

--- a/src/components/panels/citara-command-center-panel.tsx
+++ b/src/components/panels/citara-command-center-panel.tsx
@@ -3,9 +3,11 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import {
+  approvalActionLabel,
   commandCenterHealthLabel,
   formatLastRunnerEvent,
   summarizeCommandCenter,
+  type ApprovalAction,
   type FleetRunnerEvent,
 } from '@/lib/citara-command-center'
 
@@ -98,6 +100,12 @@ const toneClass: Record<string, string> = {
   critical: 'border-red-500/30 bg-red-500/10 text-red-200',
 }
 
+const actionToneClass: Record<string, string> = {
+  success: 'border-emerald-500/40 text-emerald-200 hover:bg-emerald-500/10',
+  warning: 'border-amber-500/40 text-amber-200 hover:bg-amber-500/10',
+  danger: 'border-red-500/40 text-red-200 hover:bg-red-500/10',
+}
+
 function MetricCard({ label, value, hint }: { label: string; value: string | number; hint?: string }) {
   return (
     <div className="rounded-xl border border-border bg-card/80 p-4 shadow-sm">
@@ -108,7 +116,21 @@ function MetricCard({ label, value, hint }: { label: string; value: string | num
   )
 }
 
-function TaskList({ title, tasks, empty }: { title: string; tasks?: CompactTask[]; empty: string }) {
+function TaskList({
+  title,
+  tasks,
+  empty,
+  reviewActions = false,
+  actingTaskId,
+  onApprovalAction,
+}: {
+  title: string
+  tasks?: CompactTask[]
+  empty: string
+  reviewActions?: boolean
+  actingTaskId?: number | null
+  onApprovalAction?: (task: CompactTask, action: ApprovalAction) => void
+}) {
   const visible = (tasks || []).slice(0, 6)
   return (
     <section className="rounded-xl border border-border bg-card/80 p-4">
@@ -138,6 +160,25 @@ function TaskList({ title, tasks, empty }: { title: string; tasks?: CompactTask[
                   {task.error_message || task.resolution}
                 </p>
               )}
+              {reviewActions && onApprovalAction && (
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {(['approve', 'request_changes', 'reject'] as ApprovalAction[]).map(action => {
+                    const meta = approvalActionLabel(action)
+                    return (
+                      <Button
+                        key={`${task.id}-${action}`}
+                        variant="outline"
+                        size="sm"
+                        className={actionToneClass[meta.tone]}
+                        disabled={actingTaskId === task.id}
+                        onClick={() => onApprovalAction(task, action)}
+                      >
+                        {actingTaskId === task.id ? 'Aplicando...' : meta.label}
+                      </Button>
+                    )
+                  })}
+                </div>
+              )}
             </div>
           ))}
         </div>
@@ -152,6 +193,7 @@ export function CitaraCommandCenterPanel() {
   const [fleet, setFleet] = useState<FleetStatus | null>(null)
   const [loading, setLoading] = useState(true)
   const [running, setRunning] = useState(false)
+  const [actingTaskId, setActingTaskId] = useState<number | null>(null)
   const [message, setMessage] = useState<{ ok: boolean; text: string } | null>(null)
 
   const fetchData = useCallback(async () => {
@@ -205,6 +247,34 @@ export function CitaraCommandCenterPanel() {
       setMessage({ ok: false, text: 'Erro de rede ao executar Fleet Runner.' })
     } finally {
       setRunning(false)
+    }
+  }
+
+  const applyApprovalAction = async (task: CompactTask, action: ApprovalAction) => {
+    const meta = approvalActionLabel(action)
+    setActingTaskId(task.id)
+    setMessage(null)
+    try {
+      const res = await fetch('/api/citara/approval', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          task_id: task.id,
+          action,
+          note: `${meta.label} via Cítara Command Center`,
+        }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (res.ok && data.ok) {
+        setMessage({ ok: true, text: `Task #${task.id}: ${meta.label} aplicado com sucesso.` })
+        await fetchData()
+      } else {
+        setMessage({ ok: false, text: data.error || `Falha ao aplicar ${meta.label.toLowerCase()} na task #${task.id}.` })
+      }
+    } catch {
+      setMessage({ ok: false, text: `Erro de rede ao aplicar ação na task #${task.id}.` })
+    } finally {
+      setActingTaskId(null)
     }
   }
 
@@ -283,7 +353,14 @@ export function CitaraCommandCenterPanel() {
       </div>
 
       <div className="grid gap-4 xl:grid-cols-2">
-        <TaskList title="Aguardando aprovação humana" tasks={approvalTasks} empty="Nenhuma entrega em quality_review agora." />
+        <TaskList
+          title="Aguardando aprovação humana"
+          tasks={approvalTasks}
+          empty="Nenhuma entrega em quality_review agora."
+          reviewActions
+          actingTaskId={actingTaskId}
+          onApprovalAction={applyApprovalAction}
+        />
         <TaskList title="Bloqueios / falhas" tasks={blockedTasks} empty="Nenhuma task failed aberta." />
       </div>
 

--- a/src/components/panels/citara-command-center-panel.tsx
+++ b/src/components/panels/citara-command-center-panel.tsx
@@ -1,0 +1,342 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  commandCenterHealthLabel,
+  formatLastRunnerEvent,
+  summarizeCommandCenter,
+  type FleetRunnerEvent,
+} from '@/lib/citara-command-center'
+
+type TopicStatus = {
+  topic: string
+  agent: string
+  role?: string
+  status?: string
+  signal?: 'attention' | 'working' | 'clear' | string
+  tasks?: {
+    total?: number
+    active?: number
+    review?: number
+    done?: number
+    failed?: number
+  }
+}
+
+type CompactTask = {
+  id: number
+  title: string
+  status: string
+  priority?: string
+  assigned_to?: string | null
+  topic?: string
+  client?: string
+  updated_at?: number
+  error_message?: string | null
+  resolution?: string | null
+}
+
+type GeneralReport = {
+  ok?: boolean
+  title?: string
+  generated_at?: string
+  summary?: string[]
+  counts?: Record<string, number>
+  topics?: TopicStatus[]
+  recent_tasks?: CompactTask[]
+  next_actions?: string[]
+}
+
+type GeneralSummary = {
+  health?: string
+  headline?: string
+  clients?: Array<{
+    name: string
+    open: number
+    review: number
+    failed: number
+    done: number
+    total: number
+    top_tasks?: CompactTask[]
+  }>
+  general_report?: {
+    nexus_command?: {
+      focus?: string
+      needs_approval?: CompactTask[]
+      blocked?: CompactTask[]
+    }
+  }
+  next_actions?: string[]
+}
+
+type FleetStatus = {
+  ok?: boolean
+  script?: string
+  cwd?: string
+  log_path?: string
+  agents?: {
+    total?: number
+    hermes_adapter?: number
+    idle_or_ready?: number
+  }
+  tasks?: {
+    awaiting_owner?: number
+    quality_review?: number
+    failed?: number
+    counts?: Record<string, number>
+  }
+  last_runner_event?: FleetRunnerEvent | null
+  error?: string
+}
+
+const toneClass: Record<string, string> = {
+  clear: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-200',
+  active: 'border-cyan-500/30 bg-cyan-500/10 text-cyan-200',
+  running: 'border-blue-500/30 bg-blue-500/10 text-blue-200',
+  review: 'border-amber-500/30 bg-amber-500/10 text-amber-200',
+  critical: 'border-red-500/30 bg-red-500/10 text-red-200',
+}
+
+function MetricCard({ label, value, hint }: { label: string; value: string | number; hint?: string }) {
+  return (
+    <div className="rounded-xl border border-border bg-card/80 p-4 shadow-sm">
+      <div className="text-xs uppercase tracking-wide text-muted-foreground">{label}</div>
+      <div className="mt-2 text-2xl font-semibold text-foreground">{value}</div>
+      {hint && <div className="mt-1 text-xs text-muted-foreground">{hint}</div>}
+    </div>
+  )
+}
+
+function TaskList({ title, tasks, empty }: { title: string; tasks?: CompactTask[]; empty: string }) {
+  const visible = (tasks || []).slice(0, 6)
+  return (
+    <section className="rounded-xl border border-border bg-card/80 p-4">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <h3 className="text-sm font-semibold text-foreground">{title}</h3>
+        <span className="text-xs text-muted-foreground">{visible.length}</span>
+      </div>
+      {visible.length === 0 ? (
+        <p className="text-sm text-muted-foreground">{empty}</p>
+      ) : (
+        <div className="space-y-2">
+          {visible.map(task => (
+            <div key={`${title}-${task.id}`} className="rounded-lg border border-border/70 bg-background/60 p-3">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="truncate text-sm font-medium text-foreground">#{task.id} · {task.title}</div>
+                  <div className="mt-1 text-xs text-muted-foreground">
+                    {task.client || task.topic || task.assigned_to || 'Cítara'} · {task.status}
+                  </div>
+                </div>
+                <span className="rounded-full border border-border px-2 py-0.5 text-[11px] uppercase text-muted-foreground">
+                  {task.priority || 'normal'}
+                </span>
+              </div>
+              {(task.error_message || task.resolution) && (
+                <p className="mt-2 line-clamp-2 text-xs text-muted-foreground">
+                  {task.error_message || task.resolution}
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}
+
+export function CitaraCommandCenterPanel() {
+  const [report, setReport] = useState<GeneralReport | null>(null)
+  const [summary, setSummary] = useState<GeneralSummary | null>(null)
+  const [fleet, setFleet] = useState<FleetStatus | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [running, setRunning] = useState(false)
+  const [message, setMessage] = useState<{ ok: boolean; text: string } | null>(null)
+
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    try {
+      const [reportRes, summaryRes, fleetRes] = await Promise.all([
+        fetch('/api/citara/general-report?limit=8').then(r => r.json()).catch(() => null),
+        fetch('/api/citara/general-summary').then(r => r.json()).catch(() => null),
+        fetch('/api/hermes/fleet-runner').then(r => r.json()).catch(() => null),
+      ])
+      setReport(reportRes)
+      setSummary(summaryRes)
+      setFleet(fleetRes)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { fetchData() }, [fetchData])
+
+  const counts = report?.counts || fleet?.tasks?.counts || {}
+  const awaitingOwner = Number(counts.awaiting_owner || fleet?.tasks?.awaiting_owner || 0)
+  const inProgress = Number(counts.in_progress || 0)
+  const qualityReview = Number(counts.quality_review || fleet?.tasks?.quality_review || 0)
+  const failed = Number(counts.failed || fleet?.tasks?.failed || 0)
+  const done = Number(counts.done || 0)
+  const agentsReady = Number(fleet?.agents?.hermes_adapter || report?.topics?.length || 0)
+  const health = commandCenterHealthLabel({ awaiting_owner: awaitingOwner, in_progress: inProgress, quality_review: qualityReview, failed, done })
+  const summaryLines = summarizeCommandCenter({ agentsReady, awaitingOwner, inProgress, qualityReview, failed, done })
+  const approvalTasks = summary?.general_report?.nexus_command?.needs_approval || []
+  const blockedTasks = summary?.general_report?.nexus_command?.blocked || []
+  const topClients = (summary?.clients || []).slice(0, 5)
+
+  const runFleetRunner = async () => {
+    setRunning(true)
+    setMessage(null)
+    try {
+      const res = await fetch('/api/hermes/fleet-runner', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ notify_empty: true }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (res.ok && data.success) {
+        setMessage({ ok: true, text: String(data.stdout || 'Fleet Runner executado com sucesso.').trim() })
+        await fetchData()
+      } else {
+        setMessage({ ok: false, text: data.error || 'Falha ao executar Fleet Runner.' })
+      }
+    } catch {
+      setMessage({ ok: false, text: 'Erro de rede ao executar Fleet Runner.' })
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  const focus = summary?.general_report?.nexus_command?.focus || report?.next_actions?.[0] || 'Sem bloqueios críticos; definir próxima task real por cliente/agente.'
+  const lastRunner = useMemo(() => formatLastRunnerEvent(fleet?.last_runner_event), [fleet?.last_runner_event])
+
+  return (
+    <div className="space-y-6 p-4 md:p-6">
+      <div className="flex flex-col gap-4 rounded-2xl border border-border bg-gradient-to-br from-card via-card to-background p-5 shadow-sm lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <div className="text-xs uppercase tracking-[0.25em] text-muted-foreground">Cítara Nexus</div>
+          <h1 className="mt-2 text-2xl font-semibold text-foreground">Command Center</h1>
+          <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+            Cockpit dos 9 tópicos Cítara: fila Hermes Adapter, aprovações, falhas, clientes e Resumo do General.
+          </p>
+        </div>
+        <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center">
+          <span className={`rounded-full border px-3 py-1 text-sm font-medium ${toneClass[health.tone] || toneClass.active}`}>
+            {health.label}
+          </span>
+          <Button onClick={fetchData} variant="outline" disabled={loading || running}>Atualizar</Button>
+          <Button onClick={runFleetRunner} disabled={running}>{running ? 'Rodando...' : 'Rodar Fleet Runner'}</Button>
+        </div>
+      </div>
+
+      {message && (
+        <div className={`rounded-xl border p-3 text-sm ${message.ok ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-200' : 'border-red-500/30 bg-red-500/10 text-red-200'}`}>
+          <pre className="whitespace-pre-wrap font-sans">{message.text}</pre>
+        </div>
+      )}
+
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-6">
+        <MetricCard label="Agentes" value={`${agentsReady}/9`} hint="Hermes Adapter ready" />
+        <MetricCard label="Fila" value={awaitingOwner} hint="awaiting_owner" />
+        <MetricCard label="Executando" value={inProgress} hint="in_progress" />
+        <MetricCard label="Revisão" value={qualityReview} hint="quality_review" />
+        <MetricCard label="Falhas" value={failed} hint="failed" />
+        <MetricCard label="Concluídas" value={done} hint="done" />
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-[1.2fr_0.8fr]">
+        <section className="rounded-xl border border-border bg-card/80 p-4">
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <h2 className="text-sm font-semibold text-foreground">Resumo do General</h2>
+            <span className="text-xs text-muted-foreground">{report?.generated_at ? new Date(report.generated_at).toLocaleString() : loading ? 'carregando' : 'sem timestamp'}</span>
+          </div>
+          <div className="rounded-lg border border-border/70 bg-background/60 p-4">
+            <div className="text-sm font-medium text-foreground">Foco atual</div>
+            <p className="mt-1 text-sm text-muted-foreground">{focus}</p>
+          </div>
+          <div className="mt-4 grid gap-2 md:grid-cols-2">
+            {summaryLines.map(line => (
+              <div key={line} className="rounded-lg border border-border/70 bg-background/40 px-3 py-2 text-sm text-muted-foreground">
+                {line}
+              </div>
+            ))}
+          </div>
+          <div className="mt-4 text-xs text-muted-foreground">
+            Último Fleet Runner: {lastRunner}
+          </div>
+        </section>
+
+        <section className="rounded-xl border border-border bg-card/80 p-4">
+          <h2 className="text-sm font-semibold text-foreground">Próximas ações</h2>
+          <div className="mt-3 space-y-2">
+            {(report?.next_actions || summary?.next_actions || []).slice(0, 5).map((action, idx) => (
+              <div key={`${idx}-${action}`} className="rounded-lg border border-border/70 bg-background/50 px-3 py-2 text-sm text-muted-foreground">
+                {action}
+              </div>
+            ))}
+          </div>
+          <p className="mt-4 text-xs text-muted-foreground">
+            {health.description}
+          </p>
+        </section>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <TaskList title="Aguardando aprovação humana" tasks={approvalTasks} empty="Nenhuma entrega em quality_review agora." />
+        <TaskList title="Bloqueios / falhas" tasks={blockedTasks} empty="Nenhuma task failed aberta." />
+      </div>
+
+      <section className="rounded-xl border border-border bg-card/80 p-4">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <h2 className="text-sm font-semibold text-foreground">9 tópicos especialistas</h2>
+          <span className="text-xs text-muted-foreground">Nexus Command + 8 lanes</span>
+        </div>
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          {(report?.topics || []).map(topic => (
+            <div key={topic.agent} className="rounded-lg border border-border/70 bg-background/50 p-3">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <div className="text-sm font-medium text-foreground">{topic.topic}</div>
+                  <div className="mt-1 text-xs text-muted-foreground">{topic.agent}</div>
+                </div>
+                <span className="rounded-full border border-border px-2 py-0.5 text-[11px] text-muted-foreground">
+                  {topic.signal || 'clear'}
+                </span>
+              </div>
+              <div className="mt-3 grid grid-cols-5 gap-1 text-center text-[11px] text-muted-foreground">
+                <span>total<br /><b className="text-foreground">{topic.tasks?.total || 0}</b></span>
+                <span>ativas<br /><b className="text-foreground">{topic.tasks?.active || 0}</b></span>
+                <span>rev<br /><b className="text-foreground">{topic.tasks?.review || 0}</b></span>
+                <span>done<br /><b className="text-foreground">{topic.tasks?.done || 0}</b></span>
+                <span>fail<br /><b className="text-foreground">{topic.tasks?.failed || 0}</b></span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-xl border border-border bg-card/80 p-4">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <h2 className="text-sm font-semibold text-foreground">Clientes / frentes</h2>
+          <span className="text-xs text-muted-foreground">top 5 por atividade recente</span>
+        </div>
+        <div className="grid gap-3 lg:grid-cols-5">
+          {topClients.length === 0 ? (
+            <p className="text-sm text-muted-foreground">Sem clientes/frentes com task registrada.</p>
+          ) : topClients.map(client => (
+            <div key={client.name} className="rounded-lg border border-border/70 bg-background/50 p-3">
+              <div className="truncate text-sm font-medium text-foreground">{client.name}</div>
+              <div className="mt-2 grid grid-cols-2 gap-1 text-xs text-muted-foreground">
+                <span>abertas: <b className="text-foreground">{client.open}</b></span>
+                <span>rev: <b className="text-foreground">{client.review}</b></span>
+                <span>falhas: <b className="text-foreground">{client.failed}</b></span>
+                <span>done: <b className="text-foreground">{client.done}</b></span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/components/panels/orchestration-bar.tsx
+++ b/src/components/panels/orchestration-bar.tsx
@@ -11,6 +11,41 @@ interface Agent {
   role: string
   status: string
   session_key?: string
+  taskStats?: {
+    total: number
+    assigned: number
+    in_progress: number
+    quality_review: number
+    done: number
+    completed?: number
+  }
+}
+
+interface FleetRunnerStatus {
+  ok: boolean
+  agents?: {
+    total: number
+    hermes_adapter: number
+    idle_or_ready: number
+  }
+  tasks?: {
+    awaiting_owner: number
+    quality_review: number
+    failed: number
+    counts?: Record<string, number>
+  }
+  last_runner_event?: {
+    ts?: string
+    exit_code?: number
+    elapsed_seconds?: number
+    summary?: {
+      agents_checked?: number
+      tasks_found?: number
+      tasks_processed?: number
+      errors?: unknown[]
+    }
+  } | null
+  error?: string
 }
 
 interface WorkflowTemplate {
@@ -61,14 +96,18 @@ export function OrchestrationBar() {
   const [filterTag, setFilterTag] = useState<string | null>(null)
   const [expandedId, setExpandedId] = useState<number | null>(null)
   const [spawning, setSpawning] = useState<number | null>(null)
+  const [fleetRunnerRunning, setFleetRunnerRunning] = useState(false)
+  const [fleetStatus, setFleetStatus] = useState<FleetRunnerStatus | null>(null)
 
   const fetchData = useCallback(async () => {
-    const [agentRes, templateRes] = await Promise.all([
+    const [agentRes, templateRes, fleetRes] = await Promise.all([
       fetch('/api/agents').then(r => r.json()).catch(() => ({ agents: [] })),
       fetch('/api/workflows').then(r => r.json()).catch(() => ({ templates: [] })),
+      fetch('/api/hermes/fleet-runner').then(r => r.json()).catch(() => null),
     ])
     setAgents(agentRes.agents || [])
     setTemplates(templateRes.templates || [])
+    setFleetStatus(fleetRes)
   }, [])
 
   useEffect(() => { fetchData() }, [fetchData])
@@ -104,6 +143,34 @@ export function OrchestrationBar() {
       setCommandResult({ ok: false, text: 'Network error' })
     } finally {
       setSending(false)
+    }
+  }
+
+  const runFleetRunner = async () => {
+    setFleetRunnerRunning(true)
+    setCommandResult(null)
+    try {
+      const res = await fetch('/api/hermes/fleet-runner', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ notify_empty: true }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (res.ok && data.success) {
+        const output = String(data.stdout || '').trim()
+        const matchProcessed = output.match(/Tasks processadas: (\d+)/)
+        const matchFound = output.match(/Tasks encontradas: (\d+)/)
+        const processed = matchProcessed?.[1] ?? '0'
+        const found = matchFound?.[1] ?? '0'
+        setCommandResult({ ok: true, text: `Hermes fleet runner OK — ${processed}/${found} tasks processadas` })
+        await fetchData()
+      } else {
+        setCommandResult({ ok: false, text: data.error || 'Fleet runner failed' })
+      }
+    } catch {
+      setCommandResult({ ok: false, text: 'Fleet runner network error' })
+    } finally {
+      setFleetRunnerRunning(false)
     }
   }
 
@@ -221,9 +288,16 @@ export function OrchestrationBar() {
   }
 
   // Fleet metrics
+  const adapterAgentCount = fleetStatus?.agents?.hermes_adapter ?? agents.filter(a => a.status === 'idle' || a.status === 'busy').length
   const onlineCount = agents.filter(a => a.status === 'idle' || a.status === 'busy').length
   const busyCount = agents.filter(a => a.status === 'busy').length
   const errorCount = agents.filter(a => a.status === 'error').length
+  const awaitingOwnerCount = fleetStatus?.tasks?.awaiting_owner ?? 0
+  const qualityReviewCount = fleetStatus?.tasks?.quality_review ?? 0
+  const failedTaskCount = fleetStatus?.tasks?.failed ?? 0
+  const lastRunnerSummary = fleetStatus?.last_runner_event?.summary
+  const lastRunnerTs = fleetStatus?.last_runner_event?.ts
+  const lastRunnerExit = fleetStatus?.last_runner_event?.exit_code
 
   return (
     <div className="border-b border-border bg-card/50">
@@ -536,11 +610,38 @@ export function OrchestrationBar() {
       {/* Fleet Tab */}
       {activeTab === 'fleet' && (
         <div className="p-4 pt-3">
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-            <FleetCard label={t('totalAgents')} value={agents.length} />
-            <FleetCard label={t('online')} value={onlineCount} color="green" />
-            <FleetCard label={t('busy')} value={busyCount} color="amber" />
-            <FleetCard label={t('errors')} value={errorCount} color={errorCount > 0 ? 'red' : undefined} />
+          <div className="flex items-center justify-between gap-3 mb-3">
+            <div>
+              <div className="text-sm font-medium text-foreground">Hermes Adapter Fleet</div>
+              <div className="text-xs text-muted-foreground">
+                Processa tasks Cítara em awaiting_owner agora, sem esperar o cron de 5 minutos.
+              </div>
+            </div>
+            <Button
+              onClick={runFleetRunner}
+              disabled={fleetRunnerRunning}
+              size="sm"
+              title="Processar fila Hermes Adapter agora"
+            >
+              {fleetRunnerRunning ? 'Processando...' : 'Processar fila Hermes agora'}
+            </Button>
+          </div>
+          <div className="grid grid-cols-2 md:grid-cols-6 gap-3">
+            <FleetCard label="Hermes agents" value={adapterAgentCount} color="green" />
+            <FleetCard label="Online" value={onlineCount} color="green" />
+            <FleetCard label="Fila" value={awaitingOwnerCount} color={awaitingOwnerCount > 0 ? 'amber' : undefined} />
+            <FleetCard label="Revisão" value={qualityReviewCount} color={qualityReviewCount > 0 ? 'amber' : undefined} />
+            <FleetCard label="Falhas" value={failedTaskCount || errorCount} color={(failedTaskCount || errorCount) > 0 ? 'red' : undefined} />
+            <FleetCard label="Busy" value={busyCount} color="amber" />
+          </div>
+          <div className="mt-3 rounded-lg border border-border bg-secondary/30 px-3 py-2 text-xs text-muted-foreground">
+            <div className="flex flex-wrap gap-x-4 gap-y-1">
+              <span><span className="text-foreground">Último runner:</span> {lastRunnerTs || 'sem log'}</span>
+              <span><span className="text-foreground">Exit:</span> {lastRunnerExit ?? '—'}</span>
+              <span><span className="text-foreground">Checados:</span> {lastRunnerSummary?.agents_checked ?? '—'}</span>
+              <span><span className="text-foreground">Encontradas:</span> {lastRunnerSummary?.tasks_found ?? '—'}</span>
+              <span><span className="text-foreground">Processadas:</span> {lastRunnerSummary?.tasks_processed ?? '—'}</span>
+            </div>
           </div>
           {agents.length > 0 && (
             <div className="mt-3 flex flex-wrap gap-1.5">

--- a/src/components/panels/project-os-panel.tsx
+++ b/src/components/panels/project-os-panel.tsx
@@ -1,0 +1,589 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Button } from '@/components/ui/button'
+
+interface Project {
+  id: number
+  name: string
+  slug: string
+  description?: string | null
+  ticket_prefix: string
+  status: string
+  github_repo?: string | null
+  deadline?: number | null
+  color?: string | null
+  task_count?: number
+  assigned_agents?: string[]
+}
+
+interface Task {
+  id: number
+  title: string
+  description?: string | null
+  status: 'backlog' | 'inbox' | 'assigned' | 'awaiting_owner' | 'in_progress' | 'review' | 'quality_review' | 'done' | 'failed'
+  priority: 'low' | 'medium' | 'high' | 'critical' | 'urgent'
+  project_id?: number | null
+  project_name?: string | null
+  ticket_ref?: string
+  assigned_to?: string | null
+  due_date?: number | null
+  tags?: string[]
+  metadata?: Record<string, unknown>
+  updated_at?: number
+  created_at?: number
+}
+
+type Section = 'projects' | 'ideas' | 'snapshots' | 'archive' | 'settings'
+
+type CreateMode = 'task' | 'idea'
+
+const COLUMNS: Array<{ key: Task['status']; label: string; hint: string }> = [
+  { key: 'backlog', label: 'Planejado', hint: 'ideia já validada / backlog' },
+  { key: 'in_progress', label: 'Fazendo', hint: 'execução ativa' },
+  { key: 'review', label: 'Finalizando', hint: 'revisão, aprovação ou ajustes' },
+  { key: 'quality_review', label: 'Pronto', hint: 'qualidade / pronto para entregar' },
+  { key: 'done', label: 'Concluído', hint: 'fechado' },
+]
+
+const statusLabel: Record<string, string> = {
+  backlog: 'Planejado',
+  inbox: 'Inbox',
+  assigned: 'Atribuído',
+  awaiting_owner: 'Aguardando Paulo',
+  in_progress: 'Fazendo',
+  review: 'Finalizando',
+  quality_review: 'Pronto',
+  done: 'Concluído',
+  failed: 'Falhou',
+}
+
+const priorityTone: Record<string, string> = {
+  low: 'border-emerald-500/30 text-emerald-300 bg-emerald-500/10',
+  medium: 'border-blue-500/30 text-blue-300 bg-blue-500/10',
+  high: 'border-amber-500/30 text-amber-300 bg-amber-500/10',
+  critical: 'border-red-500/30 text-red-300 bg-red-500/10',
+  urgent: 'border-fuchsia-500/30 text-fuchsia-300 bg-fuchsia-500/10',
+}
+
+function fmtDate(ts?: number | null) {
+  if (!ts) return 'sem prazo'
+  return new Date(ts * 1000).toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit' })
+}
+
+function normalizeTasks(tasks: Task[]) {
+  return tasks.map(task => ({
+    ...task,
+    tags: Array.isArray(task.tags) ? task.tags : [],
+    metadata: task.metadata && typeof task.metadata === 'object' ? task.metadata : {},
+  }))
+}
+
+function taskIsIdea(task: Task) {
+  return task.tags?.includes('ideia') || task.tags?.includes('idea') || task.metadata?.kind === 'idea'
+}
+
+function taskMatchesColumn(task: Task, column: Task['status']) {
+  if (column === 'backlog') return task.status === 'backlog' || task.status === 'inbox' || task.status === 'assigned' || task.status === 'awaiting_owner'
+  if (column === 'review') return task.status === 'review'
+  return task.status === column
+}
+
+export function ProjectOSPanel() {
+  const [section, setSection] = useState<Section>('projects')
+  const [projects, setProjects] = useState<Project[]>([])
+  const [tasks, setTasks] = useState<Task[]>([])
+  const [selectedProjectId, setSelectedProjectId] = useState<number | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [createMode, setCreateMode] = useState<CreateMode>('task')
+  const [quickForm, setQuickForm] = useState({ title: '', description: '', priority: 'medium' as Task['priority'] })
+  const [projectForm, setProjectForm] = useState({ name: '', ticket_prefix: '', description: '' })
+
+  const activeProjects = useMemo(() => projects.filter(p => p.status !== 'archived'), [projects])
+  const archivedProjects = useMemo(() => projects.filter(p => p.status === 'archived'), [projects])
+  const selectedProject = useMemo(
+    () => activeProjects.find(p => p.id === selectedProjectId) || activeProjects[0] || projects[0] || null,
+    [activeProjects, projects, selectedProjectId]
+  )
+
+  const projectTasks = useMemo(() => {
+    if (!selectedProject) return []
+    return tasks.filter(task => task.project_id === selectedProject.id)
+  }, [tasks, selectedProject])
+
+  const ideas = useMemo(() => tasks.filter(taskIsIdea), [tasks])
+  const openTasks = useMemo(() => projectTasks.filter(t => t.status !== 'done' && t.status !== 'failed'), [projectTasks])
+  const blockedTasks = useMemo(() => projectTasks.filter(t => t.status === 'awaiting_owner' || t.status === 'failed'), [projectTasks])
+  const completedTasks = useMemo(() => projectTasks.filter(t => t.status === 'done'), [projectTasks])
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true)
+      const [projectsRes, tasksRes] = await Promise.all([
+        fetch('/api/projects?includeArchived=1', { cache: 'no-store' }),
+        fetch('/api/tasks?limit=200', { cache: 'no-store' }),
+      ])
+      const projectsData = await projectsRes.json().catch(() => ({}))
+      const tasksData = await tasksRes.json().catch(() => ({}))
+      if (!projectsRes.ok) throw new Error(projectsData.error || 'Falha ao carregar projetos')
+      if (!tasksRes.ok) throw new Error(tasksData.error || 'Falha ao carregar tarefas')
+      const nextProjects = Array.isArray(projectsData.projects) ? projectsData.projects : []
+      setProjects(nextProjects)
+      setTasks(normalizeTasks(Array.isArray(tasksData.tasks) ? tasksData.tasks : []))
+      setSelectedProjectId(prev => prev || nextProjects.find((p: Project) => p.status !== 'archived')?.id || nextProjects[0]?.id || null)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Falha ao carregar Project OS')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { load() }, [load])
+
+  const createProject = async (event: React.FormEvent) => {
+    event.preventDefault()
+    if (!projectForm.name.trim()) return
+    try {
+      setSaving(true)
+      const response = await fetch('/api/projects', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(projectForm),
+      })
+      const data = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(data.error || 'Falha ao criar projeto')
+      setProjectForm({ name: '', ticket_prefix: '', description: '' })
+      await load()
+      if (data.project?.id) setSelectedProjectId(data.project.id)
+      setSection('projects')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Falha ao criar projeto')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const createItem = async (event: React.FormEvent) => {
+    event.preventDefault()
+    if (!quickForm.title.trim() || !selectedProject) return
+    const isIdea = createMode === 'idea'
+    try {
+      setSaving(true)
+      const response = await fetch('/api/tasks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: quickForm.title.trim(),
+          description: quickForm.description.trim() || null,
+          priority: quickForm.priority,
+          status: isIdea ? 'inbox' : 'backlog',
+          project_id: selectedProject.id,
+          tags: isIdea ? ['ideia'] : ['project-os'],
+          metadata: { source: 'project-os', kind: isIdea ? 'idea' : 'task' },
+        }),
+      })
+      const data = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(data.error || 'Falha ao criar item')
+      setQuickForm({ title: '', description: '', priority: 'medium' })
+      await load()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Falha ao criar item')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const moveTask = async (task: Task, status: Task['status']) => {
+    try {
+      setSaving(true)
+      const response = await fetch('/api/tasks', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tasks: [{ id: task.id, status }] }),
+      })
+      const data = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(data.error || 'Falha ao mover card')
+      setTasks(prev => prev.map(t => t.id === task.id ? { ...t, status } : t))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Falha ao mover card')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const sidebarItems: Array<{ key: Section; label: string; count?: number }> = [
+    { key: 'projects', label: 'Projetos', count: activeProjects.length },
+    { key: 'ideas', label: 'Ideias', count: ideas.length },
+    { key: 'snapshots', label: 'Snapshots' },
+    { key: 'archive', label: 'Arquivo', count: archivedProjects.length },
+    { key: 'settings', label: 'Ajustes' },
+  ]
+
+  if (loading) {
+    return <div className="p-6 text-sm text-muted-foreground">Carregando Project OS...</div>
+  }
+
+  return (
+    <div className="min-h-full bg-[#05070a] text-foreground">
+      <div className="border-b border-cyan-500/20 bg-gradient-to-r from-cyan-950/30 via-background to-fuchsia-950/20 px-5 py-4">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <p className="text-[11px] uppercase tracking-[0.35em] text-cyan-300/70">Cítara Mission Control</p>
+            <h1 className="mt-1 text-2xl font-black tracking-tight text-white">Project OS</h1>
+            <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+              Projetos, clientes, ideias, snapshots e execução em um lugar só — sem virar outro app solto.
+            </p>
+          </div>
+          <div className="grid grid-cols-3 gap-2 text-center sm:flex">
+            <Stat label="Projetos" value={activeProjects.length} />
+            <Stat label="Abertos" value={tasks.filter(t => t.status !== 'done' && t.status !== 'failed').length} />
+            <Stat label="Ideias" value={ideas.length} />
+          </div>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mx-5 mt-4 rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-200">
+          {error}
+        </div>
+      )}
+
+      <div className="grid min-h-[calc(100vh-150px)] grid-cols-1 lg:grid-cols-[250px_minmax(0,1fr)]">
+        <aside className="border-b border-border/70 bg-black/25 p-4 lg:border-b-0 lg:border-r">
+          <div className="space-y-1">
+            {sidebarItems.map(item => (
+              <button
+                key={item.key}
+                onClick={() => setSection(item.key)}
+                className={`flex w-full items-center justify-between rounded-lg px-3 py-2 text-left text-sm transition ${
+                  section === item.key ? 'bg-cyan-500/15 text-cyan-100 ring-1 ring-cyan-400/30' : 'text-muted-foreground hover:bg-white/5 hover:text-foreground'
+                }`}
+              >
+                <span>{item.label}</span>
+                {typeof item.count === 'number' && <span className="rounded-full bg-white/10 px-2 py-0.5 text-[11px]">{item.count}</span>}
+              </button>
+            ))}
+          </div>
+
+          <div className="mt-5 rounded-xl border border-border/70 bg-card/50 p-3">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Projeto ativo</p>
+            <div className="mt-3 space-y-2">
+              {activeProjects.slice(0, 12).map(project => (
+                <button
+                  key={project.id}
+                  onClick={() => { setSelectedProjectId(project.id); setSection('projects') }}
+                  className={`w-full rounded-lg border px-3 py-2 text-left transition ${
+                    selectedProject?.id === project.id ? 'border-fuchsia-400/40 bg-fuchsia-500/10' : 'border-border bg-background/60 hover:border-cyan-400/30'
+                  }`}
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: project.color || '#22d3ee' }} />
+                    <span className="truncate text-sm font-medium">{project.name}</span>
+                  </div>
+                  <div className="mt-1 text-[11px] text-muted-foreground">{project.ticket_prefix} · {project.task_count || 0} cards</div>
+                </button>
+              ))}
+            </div>
+          </div>
+        </aside>
+
+        <section className="min-w-0 p-4 lg:p-5">
+          {section === 'projects' && selectedProject && (
+            <ProjectsSection
+              project={selectedProject}
+              tasks={projectTasks}
+              openTasks={openTasks}
+              blockedTasks={blockedTasks}
+              completedTasks={completedTasks}
+              createMode={createMode}
+              setCreateMode={setCreateMode}
+              quickForm={quickForm}
+              setQuickForm={setQuickForm}
+              createItem={createItem}
+              moveTask={moveTask}
+              saving={saving}
+            />
+          )}
+
+          {section === 'ideas' && (
+            <IdeasSection ideas={ideas} projects={projects} moveTask={moveTask} saving={saving} />
+          )}
+
+          {section === 'snapshots' && (
+            <SnapshotsSection projects={activeProjects} tasks={tasks} />
+          )}
+
+          {section === 'archive' && (
+            <ArchiveSection projects={archivedProjects} />
+          )}
+
+          {section === 'settings' && (
+            <SettingsSection projectForm={projectForm} setProjectForm={setProjectForm} createProject={createProject} saving={saving} />
+          )}
+
+          {section === 'projects' && !selectedProject && (
+            <EmptyState title="Nenhum projeto ainda" description="Crie o primeiro projeto em Ajustes para começar o Project OS." />
+          )}
+        </section>
+      </div>
+    </div>
+  )
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2 min-w-[88px]">
+      <div className="text-lg font-black text-white">{value}</div>
+      <div className="text-[10px] uppercase tracking-wide text-muted-foreground">{label}</div>
+    </div>
+  )
+}
+
+function ProjectsSection(props: {
+  project: Project
+  tasks: Task[]
+  openTasks: Task[]
+  blockedTasks: Task[]
+  completedTasks: Task[]
+  createMode: CreateMode
+  setCreateMode: (mode: CreateMode) => void
+  quickForm: { title: string; description: string; priority: Task['priority'] }
+  setQuickForm: (value: { title: string; description: string; priority: Task['priority'] }) => void
+  createItem: (event: React.FormEvent) => void
+  moveTask: (task: Task, status: Task['status']) => Promise<void>
+  saving: boolean
+}) {
+  const { project, tasks, openTasks, blockedTasks, completedTasks } = props
+  return (
+    <div className="space-y-4">
+      <div className="rounded-2xl border border-border bg-card/70 p-4 shadow-2xl shadow-cyan-950/10">
+        <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+          <div>
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="rounded bg-cyan-500/10 px-2 py-1 text-xs font-bold text-cyan-200 ring-1 ring-cyan-400/20">{project.ticket_prefix}</span>
+              <h2 className="text-2xl font-black text-white">{project.name}</h2>
+            </div>
+            <p className="mt-2 max-w-3xl text-sm text-muted-foreground">{project.description || 'Sem descrição — use como hub visual deste cliente/projeto.'}</p>
+            <div className="mt-3 flex flex-wrap gap-2 text-xs text-muted-foreground">
+              {project.github_repo && <span className="rounded border border-border px-2 py-1">GitHub: {project.github_repo}</span>}
+              <span className="rounded border border-border px-2 py-1">Prazo: {fmtDate(project.deadline)}</span>
+              <span className="rounded border border-border px-2 py-1">Agentes: {project.assigned_agents?.length || 0}</span>
+            </div>
+          </div>
+          <div className="grid grid-cols-3 gap-2 text-center">
+            <Stat label="Abertos" value={openTasks.length} />
+            <Stat label="Bloqueios" value={blockedTasks.length} />
+            <Stat label="Done" value={completedTasks.length} />
+          </div>
+        </div>
+      </div>
+
+      <form onSubmit={props.createItem} className="rounded-2xl border border-dashed border-fuchsia-400/30 bg-fuchsia-950/10 p-4">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-end">
+          <div className="flex gap-2 lg:self-center">
+            <ModeButton active={props.createMode === 'task'} onClick={() => props.setCreateMode('task')}>Tarefa</ModeButton>
+            <ModeButton active={props.createMode === 'idea'} onClick={() => props.setCreateMode('idea')}>Ideia</ModeButton>
+          </div>
+          <input
+            value={props.quickForm.title}
+            onChange={e => props.setQuickForm({ ...props.quickForm, title: e.target.value })}
+            placeholder={props.createMode === 'idea' ? 'Capturar ideia rápida...' : 'Nova tarefa do projeto...'}
+            className="min-w-0 flex-1 rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground outline-none focus:border-cyan-400/50"
+          />
+          <select
+            value={props.quickForm.priority}
+            onChange={e => props.setQuickForm({ ...props.quickForm, priority: e.target.value as Task['priority'] })}
+            className="rounded-lg border border-border bg-background px-3 py-2 text-sm"
+          >
+            <option value="low">baixa</option>
+            <option value="medium">média</option>
+            <option value="high">alta</option>
+            <option value="critical">crítica</option>
+            <option value="urgent">urgente</option>
+          </select>
+          <Button type="submit" disabled={props.saving || !props.quickForm.title.trim()}>Criar</Button>
+        </div>
+        <textarea
+          value={props.quickForm.description}
+          onChange={e => props.setQuickForm({ ...props.quickForm, description: e.target.value })}
+          placeholder="Contexto curto, link, próximo passo, critério de pronto..."
+          rows={2}
+          className="mt-3 w-full resize-none rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground outline-none focus:border-cyan-400/50"
+        />
+      </form>
+
+      <div className="grid gap-3 xl:grid-cols-5">
+        {COLUMNS.map(column => {
+          const columnTasks = tasks.filter(task => taskMatchesColumn(task, column.key) && !taskIsIdea(task))
+          return (
+            <div key={column.key} className="rounded-2xl border border-border bg-black/20 p-3">
+              <div className="mb-3 flex items-start justify-between gap-2">
+                <div>
+                  <h3 className="text-sm font-black text-white">{column.label}</h3>
+                  <p className="text-[11px] text-muted-foreground">{column.hint}</p>
+                </div>
+                <span className="rounded-full bg-white/10 px-2 py-0.5 text-xs">{columnTasks.length}</span>
+              </div>
+              <div className="space-y-2">
+                {columnTasks.map(task => <TaskCard key={task.id} task={task} moveTask={props.moveTask} saving={props.saving} />)}
+                {columnTasks.length === 0 && <div className="rounded-lg border border-dashed border-border px-3 py-8 text-center text-xs text-muted-foreground">vazio</div>}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function TaskCard({ task, moveTask, saving }: { task: Task; moveTask: (task: Task, status: Task['status']) => Promise<void>; saving: boolean }) {
+  return (
+    <article className="rounded-xl border border-white/10 bg-card p-3 shadow-sm transition hover:border-cyan-400/30">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="text-sm font-semibold leading-snug text-white">{task.title}</p>
+          <p className="mt-1 text-[11px] text-muted-foreground">{task.ticket_ref || `#${task.id}`} · {statusLabel[task.status] || task.status}</p>
+        </div>
+        <span className={`shrink-0 rounded border px-1.5 py-0.5 text-[10px] ${priorityTone[task.priority] || priorityTone.medium}`}>{task.priority}</span>
+      </div>
+      {task.description && <p className="mt-2 line-clamp-3 text-xs text-muted-foreground">{task.description}</p>}
+      {task.assigned_to && <p className="mt-2 text-[11px] text-cyan-200">@{task.assigned_to}</p>}
+      <div className="mt-3 flex flex-wrap gap-1.5">
+        {COLUMNS.map(col => (
+          <button
+            key={col.key}
+            disabled={saving || task.status === col.key}
+            onClick={() => moveTask(task, col.key)}
+            className="rounded border border-border px-2 py-1 text-[10px] text-muted-foreground hover:border-cyan-400/40 hover:text-cyan-100 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            {col.label}
+          </button>
+        ))}
+      </div>
+    </article>
+  )
+}
+
+function IdeasSection({ ideas, projects, moveTask, saving }: { ideas: Task[]; projects: Project[]; moveTask: (task: Task, status: Task['status']) => Promise<void>; saving: boolean }) {
+  return (
+    <div className="space-y-4">
+      <SectionTitle title="Ideias soltas" subtitle="Tudo que entrou como pensamento bruto antes de virar projeto/tarefa." />
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {ideas.map(idea => (
+          <div key={idea.id} className="rounded-2xl border border-border bg-card/70 p-4">
+            <div className="text-xs text-muted-foreground">{projects.find(p => p.id === idea.project_id)?.name || 'Projeto geral'} · {idea.ticket_ref || `#${idea.id}`}</div>
+            <h3 className="mt-2 text-base font-bold text-white">{idea.title}</h3>
+            {idea.description && <p className="mt-2 text-sm text-muted-foreground">{idea.description}</p>}
+            <div className="mt-4 flex gap-2">
+              <Button size="sm" variant="outline" disabled={saving} onClick={() => moveTask(idea, 'backlog')}>Virar backlog</Button>
+              <Button size="sm" variant="ghost" disabled={saving} onClick={() => moveTask(idea, 'in_progress')}>Começar</Button>
+            </div>
+          </div>
+        ))}
+        {ideas.length === 0 && <EmptyState title="Sem ideias capturadas" description="Use o formulário do projeto ativo e selecione Ideia." />}
+      </div>
+    </div>
+  )
+}
+
+function SnapshotsSection({ projects, tasks }: { projects: Project[]; tasks: Task[] }) {
+  const snapshots = projects.map(project => {
+    const scoped = tasks.filter(task => task.project_id === project.id)
+    const open = scoped.filter(task => task.status !== 'done' && task.status !== 'failed')
+    const stale = open.filter(task => task.updated_at && Date.now() / 1000 - task.updated_at > 7 * 86400)
+    return { project, scoped, open, stale, done: scoped.filter(task => task.status === 'done') }
+  })
+  return (
+    <div className="space-y-4">
+      <SectionTitle title="Snapshots" subtitle="Foto executiva de cada projeto: aberto, parado e concluído." />
+      <div className="grid gap-3 lg:grid-cols-2">
+        {snapshots.map(({ project, scoped, open, stale, done }) => (
+          <div key={project.id} className="rounded-2xl border border-border bg-card/70 p-4">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <h3 className="font-black text-white">{project.name}</h3>
+                <p className="text-xs text-muted-foreground">Snapshot gerado agora pelo Mission Control</p>
+              </div>
+              <span className="rounded bg-white/10 px-2 py-1 text-xs">{project.ticket_prefix}</span>
+            </div>
+            <div className="mt-4 grid grid-cols-4 gap-2 text-center">
+              <Stat label="Total" value={scoped.length} />
+              <Stat label="Aberto" value={open.length} />
+              <Stat label="Parado" value={stale.length} />
+              <Stat label="Done" value={done.length} />
+            </div>
+            <p className="mt-3 text-sm text-muted-foreground">
+              Próxima ação sugerida: {stale.length ? 'destravar cards parados há mais de 7 dias.' : open.length ? 'priorizar o próximo card aberto.' : 'manter arquivado ou criar próxima frente.'}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function ArchiveSection({ projects }: { projects: Project[] }) {
+  return (
+    <div className="space-y-4">
+      <SectionTitle title="Arquivo" subtitle="Projetos arquivados para referência e recuperação futura." />
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {projects.map(project => (
+          <div key={project.id} className="rounded-2xl border border-border bg-card/60 p-4 opacity-75">
+            <h3 className="font-bold text-white">{project.name}</h3>
+            <p className="mt-1 text-sm text-muted-foreground">{project.description || 'Sem descrição'}</p>
+          </div>
+        ))}
+        {projects.length === 0 && <EmptyState title="Arquivo vazio" description="Nenhum projeto arquivado por enquanto." />}
+      </div>
+    </div>
+  )
+}
+
+function SettingsSection({ projectForm, setProjectForm, createProject, saving }: {
+  projectForm: { name: string; ticket_prefix: string; description: string }
+  setProjectForm: (value: { name: string; ticket_prefix: string; description: string }) => void
+  createProject: (event: React.FormEvent) => void
+  saving: boolean
+}) {
+  return (
+    <div className="max-w-3xl space-y-4">
+      <SectionTitle title="Ajustes do Project OS" subtitle="Crie hubs para clientes, produtos internos e frentes estratégicas." />
+      <form onSubmit={createProject} className="rounded-2xl border border-border bg-card/70 p-4 space-y-3">
+        <div className="grid gap-3 md:grid-cols-[1fr_160px]">
+          <input value={projectForm.name} onChange={e => setProjectForm({ ...projectForm, name: e.target.value })} placeholder="Nome do projeto/cliente" className="rounded-lg border border-border bg-background px-3 py-2 text-sm" />
+          <input value={projectForm.ticket_prefix} onChange={e => setProjectForm({ ...projectForm, ticket_prefix: e.target.value })} placeholder="Prefixo: EMASFI" className="rounded-lg border border-border bg-background px-3 py-2 text-sm" />
+        </div>
+        <textarea value={projectForm.description} onChange={e => setProjectForm({ ...projectForm, description: e.target.value })} rows={4} placeholder="Descrição, objetivo, links e regra de uso..." className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm" />
+        <Button type="submit" disabled={saving || !projectForm.name.trim()}>Criar projeto</Button>
+      </form>
+      <div className="rounded-2xl border border-cyan-400/20 bg-cyan-950/10 p-4 text-sm text-cyan-100/80">
+        <strong>Regra Cítara:</strong> use projetos para clientes e produtos internos; use ideias para ruído bruto; use snapshots para decidir o próximo movimento.
+      </div>
+    </div>
+  )
+}
+
+function ModeButton({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
+  return <button type="button" onClick={onClick} className={`rounded-lg border px-3 py-2 text-sm ${active ? 'border-cyan-400/40 bg-cyan-500/15 text-cyan-100' : 'border-border text-muted-foreground hover:text-foreground'}`}>{children}</button>
+}
+
+function SectionTitle({ title, subtitle }: { title: string; subtitle: string }) {
+  return (
+    <div>
+      <h2 className="text-xl font-black text-white">{title}</h2>
+      <p className="mt-1 text-sm text-muted-foreground">{subtitle}</p>
+    </div>
+  )
+}
+
+function EmptyState({ title, description }: { title: string; description: string }) {
+  return (
+    <div className="rounded-2xl border border-dashed border-border bg-card/50 p-8 text-center">
+      <h3 className="font-bold text-white">{title}</h3>
+      <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+    </div>
+  )
+}

--- a/src/components/panels/task-board-panel.tsx
+++ b/src/components/panels/task-board-panel.tsx
@@ -7,6 +7,7 @@ import { useMissionControl } from '@/store'
 import { useSmartPoll } from '@/lib/use-smart-poll'
 
 import { createClientLogger } from '@/lib/client-logger'
+import { getTaskDocumentInfo } from '@/lib/task-documents'
 
 import { useFocusTrap } from '@/lib/use-focus-trap'
 
@@ -1231,7 +1232,14 @@ function TaskDetailModal({
   const [reviewNotes, setReviewNotes] = useState('')
   const [reviewError, setReviewError] = useState<string | null>(null)
   const mentionTargets = useMentionTargets()
-  const [activeTab, setActiveTab] = useState<'details' | 'comments' | 'quality' | 'session'>('details')
+  const [activeTab, setActiveTab] = useState<'details' | 'document' | 'comments' | 'quality' | 'session'>('details')
+  const documentInfo = getTaskDocumentInfo(task)
+  const documentContent = typeof task.metadata?.document_content === 'string'
+    ? task.metadata.document_content
+    : (task.description || '')
+  const descriptionPreview = task.description && documentInfo.hasFullDocument && task.description.length > 420
+    ? `${task.description.slice(0, 420).trim()}...`
+    : task.description
   const [reviewer, setReviewer] = useState('aegis')
 
   const fetchReviews = useCallback(async () => {
@@ -1432,7 +1440,7 @@ function TaskDetailModal({
 
   return (
     <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4" onClick={(e) => { if (e.target === e.currentTarget) onClose() }}>
-      <div ref={dialogRef} role="dialog" aria-modal="true" aria-labelledby="task-detail-title" className="bg-card border border-border rounded-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto shadow-2xl shadow-black/30">
+      <div ref={dialogRef} role="dialog" aria-modal="true" aria-labelledby="task-detail-title" className="bg-card border border-border rounded-xl max-w-5xl w-full max-h-[90vh] overflow-y-auto shadow-2xl shadow-black/30">
         {/* Header */}
         <div className="px-6 pt-5 pb-4 border-b border-border/50">
           <div className="flex justify-between items-start gap-4">
@@ -1481,9 +1489,20 @@ function TaskDetailModal({
               </Button>
             </div>
           </div>
-          {task.description ? (
+          {descriptionPreview ? (
             <div className="mt-3 text-sm text-foreground/80">
-              <MarkdownRenderer content={task.description} />
+              {documentInfo.hasFullDocument && (
+                <div className="mb-3 rounded-lg border border-primary/20 bg-primary/5 p-3 text-xs text-muted-foreground">
+                  <div className="font-medium text-primary">Documento completo disponível</div>
+                  <div>
+                    Este card tem {documentInfo.wordCount.toLocaleString()} palavras. Use a aba <button type="button" onClick={() => setActiveTab('document')} className="text-primary underline underline-offset-2">Documento completo</button> para ler sem truncamento.
+                  </div>
+                  {documentInfo.sourceFile && (
+                    <div className="mt-1 font-mono text-[11px] break-all">Fonte: {documentInfo.sourceFile}</div>
+                  )}
+                </div>
+              )}
+              <MarkdownRenderer content={descriptionPreview} />
             </div>
           ) : (
             <p className="mt-2 text-xs text-muted-foreground/50 italic">{t('noDescription')}</p>
@@ -1520,7 +1539,7 @@ function TaskDetailModal({
         {/* Content */}
         <div className="px-6 py-4">
           <div className="flex gap-1.5 mb-4" role="tablist" aria-label={t('taskDetailTabs')}>
-            {(['details', 'comments', 'quality'] as const).map(tab => (
+            {(['details', ...(documentInfo.hasFullDocument ? ['document'] as const : []), 'comments', 'quality'] as const).map(tab => (
               <button
                 key={tab}
                 type="button"
@@ -1534,7 +1553,7 @@ function TaskDetailModal({
                     : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50'
                 }`}
               >
-                {tab === 'details' ? t('tabDetails') : tab === 'comments' ? t('tabComments') : t('tabQualityReview')}
+                {tab === 'details' ? t('tabDetails') : tab === 'document' ? 'Documento completo' : tab === 'comments' ? t('tabComments') : t('tabQualityReview')}
                 {tab === 'comments' && comments.length > 0 && (
                   <span className="ml-1.5 text-[10px] text-muted-foreground/60">{comments.length}</span>
                 )}
@@ -1680,6 +1699,26 @@ function TaskDetailModal({
                   </Button>
                 </div>
               )}
+            </div>
+          )}
+
+          {activeTab === 'document' && documentInfo.hasFullDocument && (
+            <div id="tabpanel-document" role="tabpanel" aria-label="Documento completo" className="mt-4 space-y-4">
+              <div className="rounded-lg border border-border/40 bg-secondary/20 p-3 text-xs text-muted-foreground">
+                <div className="flex flex-wrap gap-3">
+                  {documentInfo.client && <span><strong className="text-foreground">Cliente:</strong> {documentInfo.client}</span>}
+                  {documentInfo.artifactType && <span><strong className="text-foreground">Tipo:</strong> {documentInfo.artifactType}</span>}
+                  <span><strong className="text-foreground">Tamanho:</strong> {documentInfo.wordCount.toLocaleString()} palavras / {documentInfo.charCount.toLocaleString()} caracteres</span>
+                </div>
+                {documentInfo.sourceFile && (
+                  <div className="mt-2 font-mono text-[11px] break-all">
+                    <strong className="text-foreground font-sans">Arquivo fonte:</strong> {documentInfo.sourceFile}
+                  </div>
+                )}
+              </div>
+              <article className="rounded-lg border border-border/40 bg-card/60 p-5 prose prose-invert prose-sm max-w-none text-foreground/90">
+                <MarkdownRenderer content={documentContent} />
+              </article>
             </div>
           )}
 

--- a/src/lib/__tests__/citara-command-center.test.ts
+++ b/src/lib/__tests__/citara-command-center.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import {
+  commandCenterHealthLabel,
+  formatLastRunnerEvent,
+  summarizeCommandCenter,
+} from '../citara-command-center'
+
+describe('citara command center helpers', () => {
+  it('prioritizes failed tasks over review, running and queue states', () => {
+    expect(commandCenterHealthLabel({ failed: 1, quality_review: 3, in_progress: 2, awaiting_owner: 4 })).toEqual({
+      tone: 'critical',
+      label: 'Atenção',
+      description: 'Existem falhas abertas que precisam de correção.',
+    })
+  })
+
+  it('summarizes the operational state for the Cítara Command Center', () => {
+    expect(summarizeCommandCenter({
+      agentsReady: 9,
+      awaitingOwner: 2,
+      inProgress: 1,
+      qualityReview: 3,
+      failed: 0,
+      done: 7,
+    })).toEqual([
+      '9/9 agentes Cítara prontos',
+      '2 tasks aguardando Hermes Adapter',
+      '1 task em execução',
+      '3 entregas aguardando revisão humana',
+      '7 concluídas',
+    ])
+  })
+
+  it('formats the latest fleet runner event with processed/found counters', () => {
+    expect(formatLastRunnerEvent({
+      ts: '2026-05-26T22:28:16-0300',
+      exit_code: 0,
+      elapsed_seconds: 8.4,
+      summary: { agents_checked: 9, tasks_found: 4, tasks_processed: 3, errors: [] },
+    })).toEqual('2026-05-26T22:28:16-0300 · exit 0 · 3/4 tasks processadas · 9 agentes · 8.4s')
+  })
+})

--- a/src/lib/__tests__/citara-command-center.test.ts
+++ b/src/lib/__tests__/citara-command-center.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  approvalActionLabel,
   commandCenterHealthLabel,
   formatLastRunnerEvent,
   summarizeCommandCenter,
@@ -38,5 +39,11 @@ describe('citara command center helpers', () => {
       elapsed_seconds: 8.4,
       summary: { agents_checked: 9, tasks_found: 4, tasks_processed: 3, errors: [] },
     })).toEqual('2026-05-26T22:28:16-0300 · exit 0 · 3/4 tasks processadas · 9 agentes · 8.4s')
+  })
+
+  it('labels approval actions consistently for the review buttons', () => {
+    expect(approvalActionLabel('approve')).toEqual({ label: 'Aprovar', tone: 'success' })
+    expect(approvalActionLabel('request_changes')).toEqual({ label: 'Pedir ajustes', tone: 'warning' })
+    expect(approvalActionLabel('reject')).toEqual({ label: 'Reprovar', tone: 'danger' })
   })
 })

--- a/src/lib/__tests__/citara-command-center.test.ts
+++ b/src/lib/__tests__/citara-command-center.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   approvalActionLabel,
+  buildBenchmarkOptimizationCards,
   commandCenterHealthLabel,
   formatLastRunnerEvent,
   summarizeCommandCenter,
@@ -45,5 +46,35 @@ describe('citara command center helpers', () => {
     expect(approvalActionLabel('approve')).toEqual({ label: 'Aprovar', tone: 'success' })
     expect(approvalActionLabel('request_changes')).toEqual({ label: 'Pedir ajustes', tone: 'warning' })
     expect(approvalActionLabel('reject')).toEqual({ label: 'Reprovar', tone: 'danger' })
+  })
+
+  it('builds one surgical benchmark optimization per external mission control reference', () => {
+    const cards = buildBenchmarkOptimizationCards({
+      agentsReady: 9,
+      awaitingOwner: 2,
+      inProgress: 1,
+      qualityReview: 1,
+      failed: 0,
+      done: 6,
+      topics: [
+        { topic: 'Growth', tasks: { active: 2, review: 1, failed: 0 } },
+        { topic: 'Ops', tasks: { active: 0, review: 0, failed: 0 } },
+      ],
+      clients: [
+        { name: 'EMASFI', open: 3, review: 1, failed: 0 },
+      ],
+      lastRunnerEvent: {
+        ts: '2026-05-26T22:28:16-0300',
+        exit_code: 0,
+        elapsed_seconds: 8.4,
+        summary: { agents_checked: 9, tasks_found: 4, tasks_processed: 3, errors: [] },
+      },
+    })
+
+    expect(cards.map(card => card.source)).toEqual(['Langfuse', 'LangSmith', 'CrewAI', 'AutoGPT', 'Dify', 'Flowise'])
+    expect(cards).toHaveLength(6)
+    expect(cards.find(card => card.source === 'CrewAI')?.signal).toContain('Growth')
+    expect(cards.find(card => card.source === 'Flowise')?.signal).toContain('EMASFI')
+    expect(cards.find(card => card.source === 'LangSmith')?.status).toBe('action')
   })
 })

--- a/src/lib/__tests__/onboarding-session.test.ts
+++ b/src/lib/__tests__/onboarding-session.test.ts
@@ -14,7 +14,7 @@ describe('onboarding-session', () => {
     ).toEqual({ shouldOpen: true, replayFromStart: false })
   })
 
-  it('replays onboarding from the start on a fresh session after completion', () => {
+  it('does not replay onboarding automatically on a fresh session after completion', () => {
     expect(
       getOnboardingSessionDecision({
         isAdmin: true,
@@ -23,7 +23,7 @@ describe('onboarding-session', () => {
         skipped: false,
         dismissedThisSession: false,
       })
-    ).toEqual({ shouldOpen: true, replayFromStart: true })
+    ).toEqual({ shouldOpen: false, replayFromStart: false })
   })
 
   it('does not reopen onboarding once dismissed in the current session', () => {

--- a/src/lib/__tests__/task-documents.test.ts
+++ b/src/lib/__tests__/task-documents.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { getTaskDocumentInfo } from '../task-documents'
+
+describe('getTaskDocumentInfo', () => {
+  it('detects long markdown descriptions as full documents and exposes source file metadata', () => {
+    const markdown = `# Campaign\n\n${'Long body\n'.repeat(80)}`
+
+    const info = getTaskDocumentInfo({
+      description: markdown,
+      metadata: {
+        source_file: '/Users/phfer/hermes-workspaces/cerberus/clients/alfaiataria-guerreiro/campanhas/2026-05-26-dia-dos-namorados.md',
+        client: 'Alfaiataria Guerreiro',
+        artifact_type: 'campaign_plan',
+      },
+    })
+
+    expect(info.hasFullDocument).toBe(true)
+    expect(info.sourceFile).toBe('/Users/phfer/hermes-workspaces/cerberus/clients/alfaiataria-guerreiro/campanhas/2026-05-26-dia-dos-namorados.md')
+    expect(info.client).toBe('Alfaiataria Guerreiro')
+    expect(info.artifactType).toBe('campaign_plan')
+    expect(info.wordCount).toBeGreaterThan(100)
+  })
+
+  it('does not mark short operational descriptions as full documents', () => {
+    const info = getTaskDocumentInfo({
+      description: 'Small task description.',
+      metadata: {},
+    })
+
+    expect(info.hasFullDocument).toBe(false)
+    expect(info.wordCount).toBe(3)
+  })
+})

--- a/src/lib/citara-command-center.ts
+++ b/src/lib/citara-command-center.ts
@@ -1,4 +1,6 @@
 export type CommandCenterTone = 'clear' | 'active' | 'review' | 'running' | 'critical'
+export type ApprovalAction = 'approve' | 'request_changes' | 'reject'
+export type ApprovalActionTone = 'success' | 'warning' | 'danger'
 
 export interface CommandCenterCounts {
   awaiting_owner?: number
@@ -87,6 +89,12 @@ export function summarizeCommandCenter(input: CommandCenterSummaryInput): string
     plural(input.qualityReview, 'entrega aguardando revisão humana', 'entregas aguardando revisão humana'),
     `${input.done} concluídas`,
   ]
+}
+
+export function approvalActionLabel(action: ApprovalAction): { label: string; tone: ApprovalActionTone } {
+  if (action === 'approve') return { label: 'Aprovar', tone: 'success' }
+  if (action === 'request_changes') return { label: 'Pedir ajustes', tone: 'warning' }
+  return { label: 'Reprovar', tone: 'danger' }
 }
 
 export function formatLastRunnerEvent(event: FleetRunnerEvent | null | undefined): string {

--- a/src/lib/citara-command-center.ts
+++ b/src/lib/citara-command-center.ts
@@ -1,0 +1,103 @@
+export type CommandCenterTone = 'clear' | 'active' | 'review' | 'running' | 'critical'
+
+export interface CommandCenterCounts {
+  awaiting_owner?: number
+  in_progress?: number
+  quality_review?: number
+  review?: number
+  failed?: number
+  done?: number
+}
+
+export interface CommandCenterSummaryInput {
+  agentsReady: number
+  awaitingOwner: number
+  inProgress: number
+  qualityReview: number
+  failed: number
+  done: number
+}
+
+export interface FleetRunnerEvent {
+  ts?: string
+  exit_code?: number
+  elapsed_seconds?: number
+  summary?: {
+    agents_checked?: number
+    tasks_found?: number
+    tasks_processed?: number
+    errors?: unknown[]
+  }
+}
+
+export function commandCenterHealthLabel(counts: CommandCenterCounts): {
+  tone: CommandCenterTone
+  label: string
+  description: string
+} {
+  const failed = Number(counts.failed || 0)
+  const review = Number(counts.quality_review || counts.review || 0)
+  const running = Number(counts.in_progress || 0)
+  const queue = Number(counts.awaiting_owner || 0)
+
+  if (failed > 0) {
+    return {
+      tone: 'critical',
+      label: 'Atenção',
+      description: 'Existem falhas abertas que precisam de correção.',
+    }
+  }
+  if (review > 0) {
+    return {
+      tone: 'review',
+      label: 'Revisão',
+      description: 'Há entregas aguardando aprovação humana.',
+    }
+  }
+  if (running > 0) {
+    return {
+      tone: 'running',
+      label: 'Executando',
+      description: 'Hermes está processando tasks agora.',
+    }
+  }
+  if (queue > 0) {
+    return {
+      tone: 'active',
+      label: 'Fila ativa',
+      description: 'Há tasks prontas para o Hermes Adapter.',
+    }
+  }
+  return {
+    tone: 'clear',
+    label: 'Limpo',
+    description: 'Sem falhas, sem fila e sem revisão pendente.',
+  }
+}
+
+function plural(value: number, singular: string, pluralLabel: string): string {
+  return `${value} ${value === 1 ? singular : pluralLabel}`
+}
+
+export function summarizeCommandCenter(input: CommandCenterSummaryInput): string[] {
+  return [
+    `${input.agentsReady}/9 agentes Cítara prontos`,
+    plural(input.awaitingOwner, 'task aguardando Hermes Adapter', 'tasks aguardando Hermes Adapter'),
+    plural(input.inProgress, 'task em execução', 'tasks em execução'),
+    plural(input.qualityReview, 'entrega aguardando revisão humana', 'entregas aguardando revisão humana'),
+    `${input.done} concluídas`,
+  ]
+}
+
+export function formatLastRunnerEvent(event: FleetRunnerEvent | null | undefined): string {
+  if (!event) return 'Sem execução registrada ainda'
+
+  const ts = event.ts || 'sem timestamp'
+  const exitCode = typeof event.exit_code === 'number' ? event.exit_code : 'n/a'
+  const processed = Number(event.summary?.tasks_processed || 0)
+  const found = Number(event.summary?.tasks_found || 0)
+  const agents = Number(event.summary?.agents_checked || 0)
+  const elapsed = typeof event.elapsed_seconds === 'number' ? `${event.elapsed_seconds.toFixed(1)}s` : 'tempo n/a'
+
+  return `${ts} · exit ${exitCode} · ${processed}/${found} tasks processadas · ${agents} agentes · ${elapsed}`
+}

--- a/src/lib/citara-command-center.ts
+++ b/src/lib/citara-command-center.ts
@@ -32,6 +32,47 @@ export interface FleetRunnerEvent {
   }
 }
 
+export type BenchmarkSource = 'Langfuse' | 'LangSmith' | 'CrewAI' | 'AutoGPT' | 'Dify' | 'Flowise'
+export type BenchmarkStatus = 'ok' | 'watch' | 'action'
+
+export interface CommandCenterBenchmarkInput {
+  awaitingOwner: number
+  inProgress: number
+  qualityReview: number
+  failed: number
+  done: number
+  agentsReady: number
+  topics?: Array<{
+    topic: string
+    agent?: string
+    signal?: string
+    tasks?: {
+      total?: number
+      active?: number
+      review?: number
+      done?: number
+      failed?: number
+    }
+  }>
+  clients?: Array<{
+    name: string
+    open?: number
+    review?: number
+    failed?: number
+    done?: number
+    total?: number
+  }>
+  lastRunnerEvent?: FleetRunnerEvent | null
+}
+
+export interface CommandCenterBenchmarkCard {
+  source: BenchmarkSource
+  optimization: string
+  signal: string
+  action: string
+  status: BenchmarkStatus
+}
+
 export function commandCenterHealthLabel(counts: CommandCenterCounts): {
   tone: CommandCenterTone
   label: string
@@ -108,4 +149,85 @@ export function formatLastRunnerEvent(event: FleetRunnerEvent | null | undefined
   const elapsed = typeof event.elapsed_seconds === 'number' ? `${event.elapsed_seconds.toFixed(1)}s` : 'tempo n/a'
 
   return `${ts} · exit ${exitCode} · ${processed}/${found} tasks processadas · ${agents} agentes · ${elapsed}`
+}
+
+function statusFor(count: number, warnAt = 1): BenchmarkStatus {
+  return count >= warnAt ? 'action' : 'ok'
+}
+
+function busiestTopic(input: CommandCenterBenchmarkInput): string {
+  const topic = (input.topics || [])
+    .slice()
+    .sort((a, b) => Number(b.tasks?.active || 0) + Number(b.tasks?.review || 0) + Number(b.tasks?.failed || 0)
+      - (Number(a.tasks?.active || 0) + Number(a.tasks?.review || 0) + Number(a.tasks?.failed || 0)))[0]
+
+  if (!topic) return 'Sem tópico dominante nesta leitura.'
+  const load = Number(topic.tasks?.active || 0) + Number(topic.tasks?.review || 0) + Number(topic.tasks?.failed || 0)
+  return `${topic.topic}: ${load} pendências visíveis.`
+}
+
+function topClient(input: CommandCenterBenchmarkInput): string {
+  const client = (input.clients || [])
+    .slice()
+    .sort((a, b) => Number(b.open || 0) + Number(b.review || 0) + Number(b.failed || 0)
+      - (Number(a.open || 0) + Number(a.review || 0) + Number(a.failed || 0)))[0]
+
+  if (!client) return 'Sem cliente dominante nesta leitura.'
+  const load = Number(client.open || 0) + Number(client.review || 0) + Number(client.failed || 0)
+  return `${client.name}: ${load} itens abertos/revisão/falha.`
+}
+
+export function buildBenchmarkOptimizationCards(input: CommandCenterBenchmarkInput): CommandCenterBenchmarkCard[] {
+  const runnerErrors = Array.isArray(input.lastRunnerEvent?.summary?.errors)
+    ? input.lastRunnerEvent?.summary?.errors?.length || 0
+    : 0
+  const processed = Number(input.lastRunnerEvent?.summary?.tasks_processed || 0)
+  const found = Number(input.lastRunnerEvent?.summary?.tasks_found || 0)
+  const totalVisible = input.awaitingOwner + input.inProgress + input.qualityReview + input.failed + input.done
+  const doneRate = totalVisible > 0 ? Math.round((input.done / totalVisible) * 100) : 100
+
+  return [
+    {
+      source: 'Langfuse',
+      optimization: 'Trace-first: evidência de custo/erro junto da execução',
+      signal: runnerErrors > 0 ? `${runnerErrors} erro(s) no último runner.` : `Último runner processou ${processed}/${found} tasks.`,
+      action: runnerErrors > 0 ? 'Abrir log da execução antes de rodar nova leva.' : 'Manter o último runner como trilha auditável do Resumo do General.',
+      status: statusFor(runnerErrors),
+    },
+    {
+      source: 'LangSmith',
+      optimization: 'Checkpoint humano: revisar antes de seguir',
+      signal: `${input.qualityReview} entrega(s) em quality_review.`,
+      action: input.qualityReview > 0 ? 'Aprovar, pedir ajustes ou reprovar direto pelo card.' : 'Sem checkpoint humano pendente agora.',
+      status: statusFor(input.qualityReview),
+    },
+    {
+      source: 'CrewAI',
+      optimization: 'Visão por missão/equipe, não só task solta',
+      signal: busiestTopic(input),
+      action: 'Usar o tópico mais carregado como próxima missão da frota.',
+      status: input.inProgress > 0 || input.awaitingOwner > 0 ? 'watch' : 'ok',
+    },
+    {
+      source: 'AutoGPT',
+      optimization: 'Action block reutilizável para fila pronta',
+      signal: `${input.awaitingOwner} task(s) aguardando Hermes Adapter.`,
+      action: input.awaitingOwner > 0 ? 'Rodar Fleet Runner como bloco operacional seguro.' : 'Criar próxima task awaiting_owner antes de rodar automação.',
+      status: input.awaitingOwner > 0 ? 'watch' : 'ok',
+    },
+    {
+      source: 'Dify',
+      optimization: 'Ops Health simples: sucesso, falha e gargalo visível',
+      signal: `${doneRate}% concluídas na amostra visível; ${input.failed} falha(s).`,
+      action: input.failed > 0 ? 'Resolver falhas antes de aumentar volume.' : 'Acompanhar taxa de conclusão no Command Center.',
+      status: statusFor(input.failed),
+    },
+    {
+      source: 'Flowise',
+      optimization: 'Debug overlay: status por nó/cliente em vez de log cru',
+      signal: topClient(input),
+      action: 'Priorizar o cliente/frente com maior carga operacional.',
+      status: input.failed > 0 || input.qualityReview > 0 ? 'watch' : 'ok',
+    },
+  ]
 }

--- a/src/lib/onboarding-session.ts
+++ b/src/lib/onboarding-session.ts
@@ -26,7 +26,7 @@ export function getOnboardingSessionDecision(
   }
 
   if (params.completed || params.skipped) {
-    return { shouldOpen: true, replayFromStart: true }
+    return { shouldOpen: false, replayFromStart: false }
   }
 
   return { shouldOpen: false, replayFromStart: false }

--- a/src/lib/task-documents.ts
+++ b/src/lib/task-documents.ts
@@ -1,0 +1,43 @@
+export interface TaskDocumentInput {
+  description?: string | null
+  metadata?: Record<string, any> | null
+}
+
+export interface TaskDocumentInfo {
+  hasFullDocument: boolean
+  sourceFile?: string
+  client?: string
+  artifactType?: string
+  wordCount: number
+  charCount: number
+}
+
+const MARKDOWN_DOCUMENT_PATTERN = /(^|\n)#{1,3}\s+\S|(^|\n)\*\*[^*]+:\*\*/
+const FULL_DOCUMENT_WORD_THRESHOLD = 100
+const FULL_DOCUMENT_CHAR_THRESHOLD = 1200
+
+export function getTaskDocumentInfo(task: TaskDocumentInput): TaskDocumentInfo {
+  const description = task.description || ''
+  const metadata = task.metadata || {}
+  const sourceFile = typeof metadata.source_file === 'string' ? metadata.source_file : undefined
+  const client = typeof metadata.client === 'string' ? metadata.client : undefined
+  const artifactType = typeof metadata.artifact_type === 'string' ? metadata.artifact_type : undefined
+  const words = description.trim().match(/\S+/g) || []
+  const wordCount = words.length
+  const charCount = description.length
+  const looksLikeMarkdownDocument = MARKDOWN_DOCUMENT_PATTERN.test(description)
+  const hasFullDocument = Boolean(
+    sourceFile ||
+    metadata.document_content ||
+    (looksLikeMarkdownDocument && (wordCount >= FULL_DOCUMENT_WORD_THRESHOLD || charCount >= FULL_DOCUMENT_CHAR_THRESHOLD))
+  )
+
+  return {
+    hasFullDocument,
+    sourceFile,
+    client,
+    artifactType,
+    wordCount,
+    charCount,
+  }
+}

--- a/src/lib/websocket.ts
+++ b/src/lib/websocket.ts
@@ -72,6 +72,7 @@ const lastSeqRef: { current: number | null } = { current: null }
 const tokenOnlyFallbackRef: { current: boolean } = { current: false }
 const tokenOnlyFallbackTriedRef: { current: boolean } = { current: false }
 const wsPathFallbackTriedRef: { current: Set<string> } = { current: new Set() }
+const connectHandshakeSentRef: { current: boolean } = { current: false }
 
 export function useWebSocket() {
   const maxReconnectAttempts = 10
@@ -214,6 +215,9 @@ export function useWebSocket() {
 
   // Send the connect handshake (async for Ed25519 device identity signing)
   const sendConnectHandshake = useCallback(async (ws: WebSocket, nonce?: string) => {
+    if (connectHandshakeSentRef.current) return
+    connectHandshakeSentRef.current = true
+
     let device: {
       id: string
       publicKey: string
@@ -694,6 +698,7 @@ export function useWebSocket() {
     }
     reconnectUrl.current = normalizedUrl
     handshakeCompleteRef.current = false
+    connectHandshakeSentRef.current = false
     manualDisconnectRef.current = false
     nonRetryableErrorRef.current = null
     lastSeqRef.current = null
@@ -701,6 +706,7 @@ export function useWebSocket() {
     try {
       const ws = new WebSocket(normalizedUrl)
       wsRef.current = ws
+      let challengeFallbackTimeout: ReturnType<typeof setTimeout> | undefined
 
       ws.onopen = () => {
         log.info(`Connected to ${normalizedUrl}`)
@@ -709,11 +715,24 @@ export function useWebSocket() {
           url: normalizedUrl,
           reconnectAttempts: 0
         })
-        // Wait for connect.challenge from server
+        // Newer gateways send connect.challenge first so we can sign its nonce.
+        // Older/local gateways wait for the client to initiate connect. If no
+        // challenge arrives quickly, send the same connect request without a
+        // nonce to avoid an idle socket that eventually reconnect-spams logs.
         log.debug('Waiting for connect challenge')
+        challengeFallbackTimeout = setTimeout(() => {
+          if (ws.readyState === WebSocket.OPEN && !handshakeCompleteRef.current && !connectHandshakeSentRef.current) {
+            log.info('No connect challenge received; sending client-initiated handshake')
+            sendConnectHandshake(ws)
+          }
+        }, 750)
       }
 
       ws.onmessage = (event) => {
+        if (challengeFallbackTimeout) {
+          clearTimeout(challengeFallbackTimeout)
+          challengeFallbackTimeout = undefined
+        }
         try {
           const frame = JSON.parse(event.data) as GatewayFrame
           handleGatewayFrame(frame, ws)
@@ -730,6 +749,10 @@ export function useWebSocket() {
       }
 
       ws.onclose = (event) => {
+        if (challengeFallbackTimeout) {
+          clearTimeout(challengeFallbackTimeout)
+          challengeFallbackTimeout = undefined
+        }
         log.info(`Disconnected from Gateway: ${event.code} ${event.reason}`)
         setConnection({ isConnected: false })
         handshakeCompleteRef.current = false
@@ -827,7 +850,7 @@ export function useWebSocket() {
       }
       setConnection({ isConnected: false })
     }
-  }, [setConnection, handleGatewayFrame, addLog, stopHeartbeat, normalizeWebSocketUrl, shouldSuppressWebSocketError])
+  }, [setConnection, handleGatewayFrame, addLog, stopHeartbeat, normalizeWebSocketUrl, shouldSuppressWebSocketError, sendConnectHandshake])
 
   // Keep ref in sync so onclose always calls the latest version of connect
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Replaces OpenClaw-specific memory graph lookup with Hermes memory/session/profile discovery under ~/.hermes
- Adds Project OS panel route/navigation and task document metadata helpers
- Adds direct Hermes worker health endpoint for the Mission Control adapter

## Validation
- pnpm typecheck
- pnpm exec vitest run src/lib/__tests__/task-documents.test.ts
- pnpm build

Note: a full `pnpm test -- --run src/lib/__tests__/task-documents.test.ts` invocation accidentally ran the broader suite and exposed an existing unrelated failure in `src/lib/__tests__/task-dispatch-reconciliation.test.ts` (expected gateway call count).