### PR TITLE
fix(docker): expand onlyBuiltDependencies for pnpm 11+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:22.22.0-slim AS base
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@11 --activate
 WORKDIR /app
 
 FROM base AS deps

--- a/package.json
+++ b/package.json
@@ -95,8 +95,13 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "node-pty"
+    "@parcel/watcher",
+    "@swc/core",
+    "better-sqlite3",
+    "esbuild",
+    "node-pty",
+    "sharp",
+    "unrs-resolver"
     ]
   }
 }


### PR DESCRIPTION
Fixes #702

### Changes
- Expanded `pnpm.onlyBuiltDependencies` in `package.json` to include all native modules required by pnpm 11+.
- Pinned `Dockerfile` to `pnpm@11` (optional hardening).

This resolves `ERR_PNPM_IGNORED_BUILDS` during fresh Docker installs.