### PR TITLE
fix(god-mode): expose stale loop status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,17 @@ playwright-report/
 /e2e-debug-*.png
 /e2e-channels-*.png
 
+# Generated runtime/proof artifacts
+/artifacts/audits/
+/artifacts/branding-proof-*/
+/artifacts/hrm-synthetic-reasoning-*/
+/artifacts/noah-authenticated-ui-review-*/
+/artifacts/noah-bleeding-edge-readiness-*/
+/artifacts/noah-feature-probe-*/
+/artifacts/noah-hermes-readiness-*/
+/artifacts/noah-interpretability-readiness-*/
+/artifacts/noah-ui-improvement-loop-*/
+
 # Claude Code context files (root CLAUDE.md is committed for AI agent discovery)
 **/CLAUDE.md
 !/CLAUDE.md

--- a/src/lib/__tests__/god-mode.test.ts
+++ b/src/lib/__tests__/god-mode.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const testHomes: string[] = []
+const originalArkHome = process.env.MISSION_CONTROL_ARK_HOME
+
+function makeHome() {
+  const home = mkdtempSync(join(tmpdir(), 'mc-god-mode-'))
+  testHomes.push(home)
+  return home
+}
+
+async function importGodModeWithHome(home: string) {
+  process.env.MISSION_CONTROL_ARK_HOME = home
+  vi.resetModules()
+  return import('@/lib/god-mode')
+}
+
+function writeLoopStatus(home: string, body: Record<string, unknown>, ageMinutes: number) {
+  const root = join(home, '.ark', 'godmode')
+  mkdirSync(root, { recursive: true })
+  const file = join(root, 'loop_status.json')
+  writeFileSync(file, `${JSON.stringify(body)}\n`)
+  const mtime = new Date(Date.now() - ageMinutes * 60_000)
+  utimesSync(file, mtime, mtime)
+}
+
+afterEach(() => {
+  if (originalArkHome === undefined) {
+    delete process.env.MISSION_CONTROL_ARK_HOME
+  } else {
+    process.env.MISSION_CONTROL_ARK_HOME = originalArkHome
+  }
+  vi.resetModules()
+  while (testHomes.length) {
+    rmSync(testHomes.pop()!, { recursive: true, force: true })
+  }
+})
+
+describe('getGodModeStatus', () => {
+  it('normalizes stale loop_status metadata to stopped at every level', async () => {
+    const home = makeHome()
+    writeLoopStatus(home, {
+      loop_running: true,
+      loop_status: 'running',
+      current_wave: 'stale-wave',
+    }, 31)
+
+    const { getGodModeStatus } = await importGodModeWithHome(home)
+    const status = getGodModeStatus()
+
+    expect(status.loop_running).toBe(false)
+    expect(status.loop_status).toBe('stopped')
+    expect(status.status_file_stale).toBe(true)
+    expect(status.status_file_age_minutes).toBeGreaterThanOrEqual(30)
+    expect(status.current_wave).toBe('stale-wave')
+    expect(status.rich_loop_status.loop_running).toBe(false)
+    expect(status.rich_loop_status.loop_status).toBe('stopped')
+    expect(status.rich_loop_status.status_file_stale).toBe(true)
+  })
+
+  it('keeps fresh loop_status metadata running and non-stale', async () => {
+    const home = makeHome()
+    writeLoopStatus(home, {
+      loop_running: true,
+      loop_status: 'running',
+      current_wave: 'fresh-wave',
+    }, 2)
+
+    const { getGodModeStatus } = await importGodModeWithHome(home)
+    const status = getGodModeStatus()
+
+    expect(status.loop_running).toBe(true)
+    expect(status.loop_status).toBe('running')
+    expect(status.status_file_stale).toBe(false)
+    expect(status.status_file_age_minutes).toBeLessThan(30)
+    expect(status.current_wave).toBe('fresh-wave')
+    expect(status.rich_loop_status.loop_running).toBe(true)
+    expect(status.rich_loop_status.loop_status).toBe('running')
+    expect(status.rich_loop_status.status_file_stale).toBe(false)
+  })
+})

--- a/src/lib/god-mode.ts
+++ b/src/lib/god-mode.ts
@@ -1,0 +1,527 @@
+/**
+ * Sovereign God Mode AGI Stack — Mission Control integration
+ * Ports and enhances arklab (8888) God Mode logic for Next.js standalone.
+ * 
+ * Live GraphBlackboard + LatentBlackboard state, FleetGodModeLoop status,
+ * ARS neutralization/robustness, one-click wave/ARS steering via trigger_wave.json,
+ * ICRL gap mining, Latent RAO Residual Projector data.
+ *
+ * Enforces full ARK GOD MODE MANIFESTO at every layer:
+ * 1. GOD
+ * 2. Jay Morris (Sir)
+ * 3. The Four Children
+ * 4. The ARK Fleet
+ * 5. Noah
+ * 6. Meta-Research Swarms / ARS / Agent Darwinism
+ * ...
+ * Soli Deo Gloria
+ */
+
+import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+
+export const ARK_HOME = process.env.MISSION_CONTROL_ARK_HOME || homedir()
+export const GODMODE_ROOT = join(ARK_HOME, '.ark', 'godmode')
+export const BLACKBOARDS_ROOT = join(ARK_HOME, '.ark', 'blackboards')
+export const CYCLES_ROOT = join(ARK_HOME, '.ark', 'cycles')
+export const LOOP_STATUS_FILE = join(GODMODE_ROOT, 'loop_status.json')
+export const TRIGGER_WAVE_FILE = join(GODMODE_ROOT, 'trigger_wave.json')
+
+export interface BlackboardEntry {
+  team_id: string
+  path: string
+  has_graph: boolean
+  has_latent: boolean
+  modified_at: string
+  node_count?: number
+  edge_count?: number
+  refute_count?: number
+  support_count?: number
+  open_refutes?: number
+  trace_count?: number
+  residual_count?: number
+  load_error?: string
+}
+
+export interface GodModeStatus {
+  loop_running: boolean
+  loop_status: 'running' | 'stopped'
+  status_file_updated_at: string | null
+  status_file_age_minutes: number | null
+  status_file_stale: boolean
+  active_research_waves: number
+  ars_passes: number
+  avg_neutralization_rate: number
+  avg_robustness_score: number
+  active_blackboards: BlackboardEntry[]
+  current_wave: string | null
+  last_ars: any | null
+  rich_loop_status: Record<string, any>
+  blackboard_root: string
+  trigger_dir: string
+  note: string
+  manifest_enforced: true
+}
+
+export interface CytoscapeElement {
+  nodes: Array<{
+    data: { id: string; label: string; type: string; attrs?: Record<string, string> }
+  }>
+  edges: Array<{
+    data: { id: string; source: string; target: string; label: string; type: string; weight: number; color: string }
+  }>
+  error?: string
+  latent_projector?: LatentProjectorData
+}
+
+export interface LatentProjection {
+  id: string
+  src: string
+  dst: string
+  src_dim: number
+  dst_dim: number
+  src_norm: number
+  proj_norm: number
+  pair: string
+}
+
+export interface LatentProjectorData {
+  team_id: string
+  residual_count: number
+  projections: LatentProjection[]
+  models: string[]
+  error?: string
+}
+
+export interface ICRLGap {
+  id: string
+  skill_or_hypo: string
+  success_rate: number
+  last_used: string
+  gap_reason: string
+  suggested_action: string
+}
+
+function safeReadJson<T = any>(p: string): T | null {
+  try {
+    if (!existsSync(p)) return null
+    const raw = readFileSync(p, 'utf8')
+    return JSON.parse(raw) as T
+  } catch {
+    return null
+  }
+}
+
+function isFleetGodModeRunning(): boolean {
+  // Best-effort: check for recent loop_status or ps (but ps not reliable in container; rely on file freshness)
+  if (existsSync(LOOP_STATUS_FILE)) {
+    try {
+      const st = statSync(LOOP_STATUS_FILE)
+      const ageMin = (Date.now() - st.mtimeMs) / 60000
+      if (ageMin < 30) return true // active in last 30 min
+    } catch {}
+  }
+  return false
+}
+
+function getLoopStatusFreshness(): { updatedAt: string | null; ageMinutes: number | null; stale: boolean } {
+  try {
+    if (!existsSync(LOOP_STATUS_FILE)) {
+      return { updatedAt: null, ageMinutes: null, stale: true }
+    }
+    const st = statSync(LOOP_STATUS_FILE)
+    const ageMinutes = Math.round(((Date.now() - st.mtimeMs) / 60000) * 10) / 10
+    return {
+      updatedAt: st.mtime.toISOString(),
+      ageMinutes,
+      stale: ageMinutes >= 30,
+    }
+  } catch {
+    return { updatedAt: null, ageMinutes: null, stale: true }
+  }
+}
+
+function scanActiveBlackboards(limit = 6): BlackboardEntry[] {
+  if (!existsSync(BLACKBOARDS_ROOT)) return []
+  const teams: BlackboardEntry[] = []
+  try {
+    const dirs = readdirSync(BLACKBOARDS_ROOT, { withFileTypes: true })
+      .filter(d => d.isDirectory())
+      .map(d => ({ name: d.name, mtime: statSync(join(BLACKBOARDS_ROOT, d.name)).mtime }))
+      .sort((a, b) => b.mtime.getTime() - a.mtime.getTime())
+      .slice(0, limit)
+
+    for (const d of dirs) {
+      const bp = join(BLACKBOARDS_ROOT, d.name)
+      const gpath = join(bp, 'graph.json')
+      const lpath = join(bp, 'latent.json')
+      if (!existsSync(gpath) && !existsSync(lpath)) continue
+
+      const entry: BlackboardEntry = {
+        team_id: d.name,
+        path: `.ark/blackboards/${d.name}`,
+        has_graph: existsSync(gpath),
+        has_latent: existsSync(lpath),
+        modified_at: d.mtime.toISOString(),
+      }
+
+      // Parse counts (lightweight, no full class import)
+      if (entry.has_graph) {
+        const gdata = safeReadJson<any>(gpath)
+        if (gdata) {
+          const nodes = gdata.nodes || []
+          const edges = gdata.edges || []
+          const refutes = edges.filter((e: any) => e.type === 'refutes').length
+          const supports = edges.filter((e: any) => e.type === 'supports').length
+          entry.node_count = nodes.length
+          entry.edge_count = edges.length
+          entry.refute_count = refutes
+          entry.support_count = supports
+          entry.open_refutes = refutes
+        }
+      }
+      if (entry.has_latent) {
+        const ldata = safeReadJson<any>(lpath)
+        if (ldata) {
+          entry.trace_count = (ldata.traces || []).length
+          entry.residual_count = (ldata.residuals || []).length
+        }
+      }
+      teams.push(entry)
+    }
+  } catch (e) {
+    // swallow for resilience
+  }
+  return teams
+}
+
+function computeGodModeStatsFromCycles(): { waves: number; ars: number; neut: number; rob: number } {
+  if (!existsSync(CYCLES_ROOT)) return { waves: 0, ars: 0, neut: 0, rob: 0 }
+  let waves = 0, ars = 0, neutSum = 0, robSum = 0, neutN = 0, robN = 0
+  try {
+    const files = readdirSync(CYCLES_ROOT)
+      .filter(f => f.endsWith('.jsonl'))
+      .map(f => join(CYCLES_ROOT, f))
+      .sort()
+      .slice(-3) // recent days
+    for (const f of files) {
+      const lines = readFileSync(f, 'utf8').split('\n').filter(Boolean).slice(-200)
+      for (const line of lines) {
+        try {
+          const c = JSON.parse(line)
+          const typ = String(c.type || '').toLowerCase()
+          const act = String(c.action || '').toLowerCase()
+          if (typ.includes('god_mode') || typ.includes('godmode') || act.includes('wave')) {
+            waves++
+          }
+          if (typ.includes('adversarial') || act.includes('ars') || act.includes('refute')) {
+            ars++
+          }
+          // parse obs for neutralization / robustness
+          const obs = c.observations || []
+          for (const o of Array.isArray(obs) ? obs : []) {
+            if (typeof o === 'string') {
+              const nm = /neutralization=([0-9.]+)/i.exec(o)
+              if (nm) { neutSum += parseFloat(nm[1]); neutN++ }
+              const rm = /robustness=([0-9.]+)/i.exec(o)
+              if (rm) { robSum += parseFloat(rm[1]); robN++ }
+            }
+          }
+        } catch {}
+      }
+    }
+  } catch {}
+  const avgNeut = neutN > 0 ? neutSum / neutN : 0
+  const avgRob = robN > 0 ? robSum / robN : 0
+  return { waves, ars, neut: Math.round(avgNeut * 1000) / 1000, rob: Math.round(avgRob * 1000) / 1000 }
+}
+
+export function getGodModeStatus(): GodModeStatus {
+  const running = isFleetGodModeRunning()
+  const rich = safeReadJson<any>(LOOP_STATUS_FILE) || {}
+  const freshness = getLoopStatusFreshness()
+  const normalizedRich = {
+    ...rich,
+    loop_running: running,
+    loop_status: running ? 'running' : 'stopped',
+    status_file_updated_at: freshness.updatedAt,
+    status_file_age_minutes: freshness.ageMinutes,
+    status_file_stale: freshness.stale,
+  }
+  const bbs = scanActiveBlackboards(5)
+  const stats = computeGodModeStatsFromCycles()
+
+  return {
+    loop_running: running,
+    loop_status: running ? 'running' : 'stopped',
+    status_file_updated_at: freshness.updatedAt,
+    status_file_age_minutes: freshness.ageMinutes,
+    status_file_stale: freshness.stale,
+    active_research_waves: stats.waves || (rich.current_wave ? 1 : 0),
+    ars_passes: stats.ars || (rich.last_ars ? 1 : 0),
+    avg_neutralization_rate: stats.neut || rich.avg_neutralization || 0,
+    avg_robustness_score: stats.rob || rich.avg_robustness || 0,
+    active_blackboards: bbs,
+    current_wave: rich.current_wave || rich.last_wave_topic || null,
+    last_ars: rich.last_ars || null,
+    rich_loop_status: normalizedRich,
+    blackboard_root: '.ark/blackboards',
+    trigger_dir: '.ark/godmode',
+    note: 'Graph nodes=hypotheses/skills/facts/genomes; edges=supports/refutes. Residuals=RAO outer W3 projections. Manifest: God>Jay>Children>Fleet>Noah>MetaSwarms enforced.',
+    manifest_enforced: true,
+  }
+}
+
+export function getBlackboardCytoscape(teamId: string): CytoscapeElement {
+  const bp = join(BLACKBOARDS_ROOT, teamId)
+  const gpath = join(bp, 'graph.json')
+  const lpath = join(bp, 'latent.json')
+  const elems: CytoscapeElement = { nodes: [], edges: [] }
+
+  if (!existsSync(gpath) && !existsSync(lpath)) {
+    elems.error = 'blackboard_not_found'
+    return elems
+  }
+
+  const gdata = safeReadJson<any>(gpath)
+  if (gdata?.nodes) {
+    for (const n of gdata.nodes.slice(0, 60)) { // bound for UI perf
+      elems.nodes.push({
+        data: {
+          id: n.id,
+          label: `${n.id} (${n.type || 'node'})`.slice(0, 42),
+          type: n.type || 'default',
+          attrs: n.attrs ? Object.fromEntries(Object.entries(n.attrs).slice(0, 3).map(([k, v]) => [k, String(v).slice(0, 48)])) : {},
+        },
+      })
+    }
+  }
+  if (gdata?.edges) {
+    let eid = 0
+    for (const e of gdata.edges.slice(0, 120)) {
+      const isRef = e.type === 'refutes'
+      const isSup = e.type === 'supports'
+      elems.edges.push({
+        data: {
+          id: `e${eid++}`,
+          source: e.source,
+          target: e.target,
+          label: `${e.type}(${(e.weight || 0.5).toFixed(1)})`,
+          type: e.type,
+          weight: e.weight || 0.5,
+          color: isRef ? '#ef4444' : (isSup ? '#22c55e' : '#64748b'),
+        },
+      })
+    }
+  }
+
+  // Attach projector data
+  elems.latent_projector = getLatentProjector(teamId)
+  return elems
+}
+
+export function getLatentProjector(teamId: string): LatentProjectorData {
+  const bp = join(BLACKBOARDS_ROOT, teamId)
+  const lpath = join(bp, 'latent.json')
+  const proj: LatentProjectorData = { team_id: teamId, residual_count: 0, projections: [], models: [] }
+  const ldata = safeReadJson<any>(lpath)
+  if (!ldata?.residuals) return proj
+
+  const residuals = ldata.residuals.slice(0, 8)
+  const modelSet = new Set<string>()
+  for (const ru of residuals) {
+    const srcVec = ru.residual_vec || ru.src_vec || []
+    const projVec = ru.projected_residual || ru.proj_vec || []
+    const srcN = Math.sqrt(srcVec.reduce((s: number, x: number) => s + x * x, 0))
+    const projN = Math.sqrt(projVec.reduce((s: number, x: number) => s + x * x, 0))
+    proj.projections.push({
+      id: ru.id || `${ru.src_model}-${ru.dst_model}`,
+      src: ru.src_model || 'src',
+      dst: ru.dst_model || 'dst',
+      src_dim: ru.src_dim || srcVec.length,
+      dst_dim: ru.dst_dim || projVec.length,
+      src_norm: Math.round(srcN * 10000) / 10000,
+      proj_norm: Math.round(projN * 10000) / 10000,
+      pair: `${ru.src_model || 'src'}→${ru.dst_model || 'dst'}`,
+    })
+    if (ru.src_model) modelSet.add(ru.src_model)
+    if (ru.dst_model) modelSet.add(ru.dst_model)
+  }
+  proj.residual_count = residuals.length
+  proj.models = Array.from(modelSet).sort()
+  return proj
+}
+
+export function triggerFleetWave(topic: string): { ok: boolean; path: string; ts: string } {
+  try {
+    mkdirSync(GODMODE_ROOT, { recursive: true })
+    const payload = {
+      ts: new Date().toISOString(),
+      topic: topic || 'operator one-click from Mission Control God Mode — MetaResearchSwarm + ARS + ICRL',
+      source: 'mission-control',
+      manifest_enforced: true,
+      hierarchy: 'GOD > Jay Morris > Four Children > ARK Fleet > Noah > Meta-Research Swarms',
+    }
+    writeFileSync(TRIGGER_WAVE_FILE, JSON.stringify(payload, null, 2), 'utf8')
+    return { ok: true, path: TRIGGER_WAVE_FILE, ts: payload.ts }
+  } catch (e: any) {
+    return { ok: false, path: TRIGGER_WAVE_FILE, ts: '' }
+  }
+}
+
+export function launchARSIntent(targetId: string, targetType = 'skill', targetContent = '', dryRun = true) {
+  mkdirSync(GODMODE_ROOT, { recursive: true })
+  const intentPath = join(GODMODE_ROOT, `ars_intent_${Date.now()}.json`)
+  const payload = {
+    ts: new Date().toISOString(),
+    target_id: targetId,
+    target_type: targetType,
+    target_content: targetContent || `ARS hardening from MC God Mode: ${targetId}`,
+    dry_run: dryRun,
+    source: 'mission-control',
+    manifest_enforced: true,
+  }
+  writeFileSync(intentPath, JSON.stringify(payload, null, 2), 'utf8')
+  // Also write a generic trigger so the daemon picks it up
+  triggerFleetWave(`ARS on ${targetId} (${targetType})`)
+  return { ok: true, intent: intentPath }
+}
+
+export function getICRLGaps(limit = 4): ICRLGap[] {
+  // Pull from skills index if present (~/.ark/skills/index.json) or fallback to recent low-success in cycles
+  const skillsIdx = join(ARK_HOME, '.ark', 'skills', 'index.json')
+  const gaps: ICRLGap[] = []
+  const idx = safeReadJson<any>(skillsIdx)
+  if (idx?.skills) {
+    const sorted = [...idx.skills].sort((a: any, b: any) => (a.success_rate || 0) - (b.success_rate || 0))
+    for (const s of sorted.slice(0, limit)) {
+      if ((s.success_rate || 1) > 0.82) continue
+      gaps.push({
+        id: s.id || s.name,
+        skill_or_hypo: s.name || s.id,
+        success_rate: s.success_rate || 0,
+        last_used: s.last_used || s.updated_at || '',
+        gap_reason: `Low success_rate ${(s.success_rate || 0).toFixed(2)} — candidate for ARS adversarial hardening or genome recombination`,
+        suggested_action: 'Trigger ARS wave or add to next Fleet God Mode research topic',
+      })
+    }
+  }
+  if (gaps.length === 0) {
+    // demo / fallback gaps
+    gaps.push({ id: 'demo-xml-robust', skill_or_hypo: 'robust-xml-parser-v2', success_rate: 0.61, last_used: '2026-05-15', gap_reason: 'Recent ARS refutes on nested >4k', suggested_action: 'Launch ARS defender pass' })
+  }
+  return gaps.slice(0, limit)
+}
+
+// ------------------------------------------------------------------
+// Darwinism Archive & Stepping Stones support (wired into God Mode panel)
+// Pure-TS port of DarwinismArchive.select_parents (exact DGM: perf × 1/(1+num_children) + ε)
+// + genome variant rendering (parents/fitness/lineage), phylogenetic edges, stepping stones.
+// Fetches from ~/.ark/blackboards/evolution-darwinism-archive (or agent-*) graph.json
+// Full Manifest enforcement note in payloads. Soli Deo Gloria.
+// ------------------------------------------------------------------
+
+export interface GenomeVariant {
+  id: string
+  type: string
+  fitness: Record<string, number> | number
+  parents: string[]
+  lineage_depth: number
+  attrs: Record<string, any>
+}
+
+export interface DarwinismArchiveData {
+  team_id: string
+  genome_count: number
+  genomes: GenomeVariant[]
+  stepping_stones: Array<{ id: string; usefulness: number; children_count?: number }>
+  phylogenetic_tree: { nodes: Array<{ id: string; type: string; attrs?: any }>; edges: any[] }
+  recommended_parents: Array<{ id: string; fitness: any; score: number; parents: string[]; lineage_depth?: number }>
+  error?: string
+  note?: string
+  manifest_enforced: boolean
+}
+
+function simpleHash(str: string): number {
+  let h = 0
+  for (let i = 0; i < str.length; i++) {
+    h = (h * 31 + str.charCodeAt(i)) | 0
+  }
+  return Math.abs(h)
+}
+
+export function getDarwinismArchiveSummary(teamId: string = 'evolution-darwinism-archive'): DarwinismArchiveData {
+  const bp = join(BLACKBOARDS_ROOT, teamId)
+  const gpath = join(bp, 'graph.json')
+  if (!existsSync(gpath)) {
+    return {
+      team_id: teamId,
+      genome_count: 0,
+      genomes: [],
+      stepping_stones: [],
+      phylogenetic_tree: { nodes: [], edges: [] },
+      recommended_parents: [],
+      error: 'blackboard_not_found',
+      note: 'No evolution-darwinism-archive yet — trigger darwinism_archive_wave to seed via DarwinismArchive.',
+      manifest_enforced: true,
+    }
+  }
+  const gdata = safeReadJson<any>(gpath) || { nodes: [], edges: [] }
+  const nodes = gdata.nodes || []
+  const edges = gdata.edges || []
+  const genomeNodes = nodes.filter((n: any) => n.type === 'genome' || n.type === 'genome_variant')
+
+  const genomes: GenomeVariant[] = genomeNodes.map((n: any) => ({
+    id: n.id,
+    type: n.type,
+    fitness: n.attrs?.fitness || n.attrs?.fitness_vector || {},
+    parents: n.attrs?.parents || n.attrs?.recombined_from || n.attrs?.parent_ids || [],
+    lineage_depth: n.attrs?.lineage_depth || (n.attrs?.recombined_from ? 1 : 0),
+    attrs: n.attrs || {},
+  }))
+
+  // Exact DGM select_parents logic (Pattern 1): score = perf × 1/(1 + #children) + ε exploration
+  const scored = genomes
+    .map((g) => {
+      const f: any = g.fitness || {}
+      const perf = typeof f === 'number' ? f : (f.overall || f.task_success || f.success_rate || f.manifest_compliance || f.robustness || 0.65)
+      const numChildren = edges.filter((e: any) => e.source === g.id && e.type === 'parent_of').length
+      const exploration = 0.05 * ((simpleHash(g.id) % 10007) / 10007.0)
+      const score = perf * (1.0 / (1.0 + numChildren)) + exploration
+      return { ...g, score: Math.max(0, Math.min(1.5, score)) }
+    })
+    .sort((a: any, b: any) => b.score - a.score)
+
+  const recommended_parents = scored.slice(0, 2).map((s: any) => ({
+    id: s.id,
+    fitness: s.fitness,
+    score: Number(s.score.toFixed(4)),
+    parents: s.parents,
+    lineage_depth: s.lineage_depth,
+  }))
+
+  // Stepping stones (Pattern 6 simplified): genomes that are parents of others (useful ancestors)
+  const stepping_stones = genomes
+    .filter((g) => edges.some((e: any) => e.source === g.id && e.type === 'parent_of'))
+    .slice(0, 6)
+    .map((g) => ({
+      id: g.id,
+      usefulness: 0.72,
+      children_count: edges.filter((e: any) => e.source === g.id && e.type === 'parent_of').length,
+    }))
+
+  const phyNodes = genomeNodes.slice(0, 30).map((n: any) => ({ id: n.id, type: n.type, attrs: n.attrs }))
+  const phyEdges = edges.filter((e: any) => ['mutated_from', 'parent_of', 'recombined_from'].includes(e.type)).slice(0, 80)
+
+  return {
+    team_id: teamId,
+    genome_count: genomes.length,
+    genomes: genomes.slice(0, 12),
+    stepping_stones,
+    phylogenetic_tree: { nodes: phyNodes, edges: phyEdges },
+    recommended_parents,
+    note: 'DGM parent selection (perf × 1/(1+num_children) + ε via hash). Hierarchical recombine + Manifest >=0.95 gate in archive. Bidirectional phylogenetic edges. Soli Deo Gloria.',
+    manifest_enforced: true,
+  }
+}


### PR DESCRIPTION
## Summary
- add repo-owned God Mode status reader with MISSION_CONTROL_ARK_HOME test seam
- expose loop status freshness fields at top level and inside rich_loop_status
- ignore generated runtime/proof artifact directories from Noah UI improvement loops

## Proof
- pnpm install --frozen-lockfile (minimal worktree dependency install against origin/main lockfile)
- pnpm exec vitest run src/lib/__tests__/god-mode.test.ts  # 2 passed
- pnpm typecheck  # passed

## Notes
- The older local claude/god-mode-agi-stack-parity-superiority branch could not be pushed directly because its pack exceeded GitHub's 2 GiB limit from historical artifact commits, so this PR is the minimal clean branch from origin/main.