### PR TITLE
chore: update groq pricing

### DIFF
--- a/src/lib/__tests__/token-pricing.test.ts
+++ b/src/lib/__tests__/token-pricing.test.ts
@@ -30,6 +30,11 @@ describe('token pricing', () => {
     expect(cost).toBe(18)
   })
 
+  it('uses current Groq pricing for Llama 8B and 70B (verified 2026-06)', () => {
+    expect(getModelPricing('groq/llama-3.1-8b-instant')).toMatchObject({ inputPerMTok: 0.05, outputPerMTok: 0.08 })
+    expect(getModelPricing('groq/llama-3.3-70b-versatile')).toMatchObject({ inputPerMTok: 0.59, outputPerMTok: 0.79 })
+  })
+
   it('keeps local models at zero cost', () => {
     const cost = calculateTokenCost('ollama/qwen2.5-coder:14b', 50_000, 50_000)
     expect(cost).toBe(0)

--- a/src/lib/token-pricing.ts
+++ b/src/lib/token-pricing.ts
@@ -44,8 +44,8 @@ const MODEL_PRICING: Record<string, ModelPricing> = {
 
   // For non-Anthropic models where we only have one published blended estimate,
   // apply the same rate for both input and output.
-  'groq/llama-3.1-8b-instant': { inputPerMTok: 0.05, outputPerMTok: 0.05 },
-  'groq/llama-3.3-70b-versatile': { inputPerMTok: 0.59, outputPerMTok: 0.59 },
+  'groq/llama-3.1-8b-instant': { inputPerMTok: 0.05, outputPerMTok: 0.08 },
+  'groq/llama-3.3-70b-versatile': { inputPerMTok: 0.59, outputPerMTok: 0.79 },
   'minimax/minimax-m2.1': { inputPerMTok: 0.3, outputPerMTok: 0.3 },
   'moonshot/kimi-k2.5': { inputPerMTok: 1.0, outputPerMTok: 1.0 },
   'ollama/deepseek-r1:14b': { inputPerMTok: 0.0, outputPerMTok: 0.0 },


### PR DESCRIPTION
# Summary
- Llama 3.1 8B output: $0.05 -> $0.08/MTok
- Llama 3.3 70B output: $0.59 -> $0.79/MTok

# Risk Level
Low / Medium / High (pick one)

# Tests
List commands run and results.

# Contribution Checklist
- [ ] Tests added/updated for behavior changes
- [ ] Lint/typecheck/build passing
- [ ] Security review done if auth/data/crypto touched
- [ ] DB migration tested if schema changed

# Notes
Anything reviewers should know.
