### PR TITLE
feat: dispatch via host Codex CLI and detect Claude CLI outside Docker

### DIFF
--- a/src/lib/task-dispatch.ts
+++ b/src/lib/task-dispatch.ts
@@ -663,19 +663,50 @@ function stripProviderPrefix(model: string): string {
  * the operator's existing login, plan, and rate limits without requiring
  * an `ANTHROPIC_API_KEY` to be exported into the container.
  */
+let claudeCliAvailableCache: boolean | null = null
 function isClaudeCliAvailable(): boolean {
   try {
-    return existsSync('/home/nextjs/.local/bin/claude')
+    if (existsSync('/home/nextjs/.local/bin/claude')
       || existsSync('/usr/local/bin/claude')
-      || existsSync('/usr/bin/claude')
+      || existsSync('/usr/bin/claude')) return true
+    // Windows native install (~/.local/bin/claude.exe) or any PATH-resolvable
+    // binary: the container paths above never exist outside Docker, so fall
+    // back to actually resolving the CLI. Cached — spawnSync costs ~1s.
+    if (claudeCliAvailableCache !== null) return claudeCliAvailableCache
+    const os = require('node:os')
+    const path = require('node:path')
+    if (existsSync(path.join(os.homedir(), '.local', 'bin', 'claude.exe'))) {
+      claudeCliAvailableCache = true
+      return true
+    }
+    const { spawnSync } = require('node:child_process')
+    const r = spawnSync('claude', ['--version'], { stdio: 'ignore', timeout: 5000 })
+    claudeCliAvailableCache = r.status === 0
+    return claudeCliAvailableCache
+  } catch { return false }
+}
+
+/**
+ * The Codex CLI authenticated via ChatGPT subscription login. When present,
+ * OpenAI-model tasks can dispatch through `codex exec` without an
+ * OPENAI_API_KEY — same idea as the Claude Code CLI path above.
+ */
+let codexCliAvailableCache: boolean | null = null
+function isCodexCliAvailable(): boolean {
+  try {
+    if (codexCliAvailableCache !== null) return codexCliAvailableCache
+    const { spawnSync } = require('node:child_process')
+    const r = spawnSync('codex', ['--version'], { stdio: 'ignore', timeout: 5000 })
+    codexCliAvailableCache = r.status === 0
+    return codexCliAvailableCache
   } catch { return false }
 }
 
 function isDirectDispatchAvailable(provider?: DirectProvider): boolean {
   if (provider === 'anthropic') return !!getAnthropicApiKey() || isClaudeCliAvailable()
-  if (provider === 'openai') return !!getOpenAIApiKey()
+  if (provider === 'openai') return !!getOpenAIApiKey() || isCodexCliAvailable()
   if (provider === 'local') return !!getLocalEndpoint()
-  return !!getAnthropicApiKey() || !!getOpenAIApiKey() || !!getLocalEndpoint() || isClaudeCliAvailable()
+  return !!getAnthropicApiKey() || !!getOpenAIApiKey() || !!getLocalEndpoint() || isClaudeCliAvailable() || isCodexCliAvailable()
 }
 
 /**
@@ -825,8 +856,74 @@ async function callOpenAICompatible(
 
 async function callOpenAIDirectly(task: DispatchableTask, prompt: string, model: string): Promise<AgentResponseParsed> {
   const apiKey = getOpenAIApiKey()
-  if (!apiKey) throw new Error('OPENAI_API_KEY not set — cannot dispatch to OpenAI without gateway')
+  if (!apiKey) {
+    // No API key — fall back to the host Codex CLI (ChatGPT subscription
+    // login), mirroring the Claude CLI path used for Anthropic models.
+    if (isCodexCliAvailable()) return callCodexViaCli(task, prompt, stripProviderPrefix(model))
+    throw new Error('OPENAI_API_KEY not set and Codex CLI not found — cannot dispatch to OpenAI without gateway')
+  }
   return callOpenAICompatible(task, prompt, 'https://api.openai.com/v1', apiKey, stripProviderPrefix(model), 'openai')
+}
+
+/**
+ * Dispatch via the host Codex CLI using the operator's ChatGPT login (no API
+ * key required). One-shot `codex exec` run: prompt over stdin (`-` arg, avoids
+ * Windows argv length limits and quoting), clean result text retrieved via
+ * --output-last-message. The agent soul has no system-prompt flag on codex,
+ * so it is prepended to the prompt body.
+ */
+async function callCodexViaCli(
+  task: DispatchableTask,
+  prompt: string,
+  model: string,
+): Promise<AgentResponseParsed> {
+  const os = require('node:os')
+  const path = require('node:path')
+  const { readFileSync, rmSync } = require('node:fs')
+  const outPath = path.join(os.tmpdir(), `mc-codex-task-${task.id}-${process.pid}-${Date.now()}.txt`)
+
+  const soul = getAgentSoulContent(task)
+  const fullPrompt = soul ? `${soul}\n\n---\n\n${prompt}` : prompt
+
+  const args = ['exec', '--sandbox', 'workspace-write', '--skip-git-repo-check', '--output-last-message', outPath]
+  // ChatGPT-subscription auth only supports the account's model lineup (e.g.
+  // gpt-5.5); claude-* or unsupported gpt ids would 400. Pass --model only for
+  // explicit gpt overrides, otherwise let the CLI use its configured default.
+  if (model && /^gpt-/i.test(model)) args.push('--model', model)
+  args.push('-')
+
+  logger.info({ taskId: task.id, model, agent: task.agent_name }, 'Dispatching task via Codex CLI')
+
+  return await new Promise<AgentResponseParsed>((resolve, reject) => {
+    const proc = spawn('codex', args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env },
+    })
+    let stdout = ''
+    let stderr = ''
+    const timeoutMs = 300_000
+    const timer = setTimeout(() => {
+      proc.kill('SIGTERM')
+      reject(new Error(`Codex CLI timed out after ${timeoutMs / 1000}s`))
+    }, timeoutMs)
+
+    proc.stdout.on('data', (d) => { stdout += d.toString() })
+    proc.stderr.on('data', (d) => { stderr += d.toString() })
+    proc.on('error', (err) => { clearTimeout(timer); reject(err) })
+    proc.on('close', (code) => {
+      clearTimeout(timer)
+      let text: string | null = null
+      try { text = (readFileSync(outPath, 'utf8') as string).trim() || null } catch { /* no output file written */ }
+      try { rmSync(outPath, { force: true }) } catch { /* ignore */ }
+      if (code !== 0 && !text) {
+        return reject(new Error(`codex CLI exited ${code}: ${(stderr || stdout).slice(0, 500)}`))
+      }
+      resolve({ text: text || stdout.trim() || null, sessionId: null })
+    })
+
+    proc.stdin.write(fullPrompt)
+    proc.stdin.end()
+  })
 }
 
 async function callLocalDirectly(task: DispatchableTask, prompt: string, model: string): Promise<AgentResponseParsed> {


### PR DESCRIPTION
## Problem

On a bare-metal host (notably Windows), gateway-free direct dispatch has two gaps:

1. `isClaudeCliAvailable()` only checks Docker-container paths (`/home/nextjs/.local/bin/claude`, `/usr/local/bin/claude`, `/usr/bin/claude`). Outside Docker these never exist, so MC silently falls back to the raw Anthropic API and every task fails with `ANTHROPIC_API_KEY not set — cannot dispatch without gateway`, even when an authenticated Claude Code CLI is on PATH.
2. OpenAI-model tasks hard-require `OPENAI_API_KEY`. Operators who have the Codex CLI authenticated via a ChatGPT subscription have no dispatch path at all — unlike Anthropic models, which already get the `callClaudeViaCli()` subscription path.

## Changes (src/lib/task-dispatch.ts only)

- **`isClaudeCliAvailable()`**: keeps the container-path checks, then also checks the native install location (`~/.local/bin/claude.exe` on Windows) and finally resolves `claude --version` via PATH. Result is cached — `spawnSync` costs ~1s per call and this is hit on every scheduler tick.
- **New `callCodexViaCli()`**: mirrors `callClaudeViaCli()` for OpenAI models, used when no `OPENAI_API_KEY` is configured. One-shot `codex exec --sandbox workspace-write --skip-git-repo-check` run; prompt is fed over stdin (`-` arg — avoids Windows argv length limits and shell quoting), the clean result text is read from `--output-last-message`, and the agent soul is prepended to the prompt body (codex has no `--append-system-prompt` equivalent). `--model` is passed only for explicit `gpt-*` overrides, because ChatGPT-subscription auth rejects models outside the account's lineup with a 400 (e.g. `gpt-5.3-codex` → *"not supported when using Codex with a ChatGPT account"*).
- **`isDirectDispatchAvailable()`**: reports `openai` as available when the Codex CLI is present, so `requeueStaleTasks()` / `dispatchAssignedTasks()` treat CLI-only hosts as dispatch-capable.

## Testing

- `tsc --noEmit` clean; `vitest run src/lib/__tests__/task-dispatch*.test.ts` — 13/13 pass.
- Verified end-to-end on Windows 11 / Node 22, both channels:
  - **Codex**: agent with `dispatchModel: "gpt-5.5"`, task went `assigned → in_progress → codex exec → resolution written → review`, including a Cyrillic prompt through stdin.
  - **Claude**: agent with `dispatchModel: "claude-opus-4-8"`, same full flow through `claude --print` (CLI 2.1.169 resolved from `~/.local/bin/claude.exe` by the new detection).

## Notes

- No behavior change for Docker deployments: container paths are checked first and short-circuit before any spawn.
- When `OPENAI_API_KEY` *is* set, the HTTP path still wins — the CLI is a fallback, same precedence philosophy as the Anthropic path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
