### PR TITLE
Fix: restrict gateway bearer token exposure to operator+ roles

### DIFF
--- a/src/app/api/gateways/connect/route.ts
+++ b/src/app/api/gateways/connect/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { requireRole } from '@/lib/auth'
+import { requireRole, ROLE_LEVELS } from '@/lib/auth'
 import { getDatabase } from '@/lib/db'
 import { buildGatewayWebSocketUrl } from '@/lib/gateway-url'
 import { getDetectedGatewayToken } from '@/lib/gateway-runtime'
@@ -177,10 +177,16 @@ export async function POST(request: NextRequest) {
     }
   }
 
+  // Only return the real secret token to operator+ roles. Viewer-role
+  // callers still get connection metadata (ws_url) so existing flows
+  // that merely need to know a gateway exists keep working, but the
+  // actual bearer credential is no longer exposed to the lowest trust tier.
+  const canSeeToken = ROLE_LEVELS[auth.user.role] >= ROLE_LEVELS['operator']
+
   return NextResponse.json({
     id: gateway.id,
     ws_url,
-    token,
-    token_set: token.length > 0,
+    token: canSeeToken ? token : '',
+    token_set: canSeeToken && token.length > 0,
   })
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -623,7 +623,7 @@ function deriveRoleFromScopes(scopes: Set<string>): User['role'] {
  * Role hierarchy levels for access control.
  * viewer < operator < admin
  */
-const ROLE_LEVELS: Record<string, number> = { viewer: 0, operator: 1, admin: 2 }
+export const ROLE_LEVELS: Record<string, number> = { viewer: 0, operator: 1, admin: 2 }
 
 /**
  * Check if a user meets the minimum role requirement.
@@ -642,4 +642,3 @@ export function requireRole(
   }
   return { user }
 }
-


### PR DESCRIPTION
Fixes the issue reported in the security advisory: GET-style POST /api/gateways/connect
returned the real gateway bearer token to any authenticated viewer-role user, not just
operator/admin.

Root cause: the endpoint correctly stays open to `viewer` role (per the existing comment
about not breaking the startup fallback flow), but the response unconditionally included
the secret `token` regardless of the caller's role.

Fix: gate inclusion of the real token value on `auth.user.role >= operator`. Viewer-role
callers still get `ws_url` and connection metadata, just not the raw credential.

Open question for maintainer: please confirm the "startup fallback" flow mentioned in the
original comment authenticates at operator role or above — if it currently relies on a
viewer-level identity to retrieve the actual token, this PR would need an adjustment for
that specific internal path.