### PR TITLE
Fix legacy agent fallback writeback + OpenClaw config-compatibility note

### DIFF
--- a/docs/openclaw-config-compatibility.md
+++ b/docs/openclaw-config-compatibility.md
@@ -1,0 +1,55 @@
+# OpenClaw Config Compatibility Note
+
+Date: 2026-04-01
+
+## Incident
+
+An OpenClaw install failed to start the gateway because `~/.openclaw/openclaw.json`
+contained a legacy top-level `fallbacks` key inside `agents.list[*]`.
+
+The runtime schema rejected entries like:
+
+```json
+{
+  "id": "coder",
+  "model": "anthropic/claude-sonnet-4-6",
+  "fallbacks": []
+}
+```
+
+Doctor output showed:
+
+```text
+Invalid config:
+- agents.list.0: Unrecognized key: "fallbacks"
+```
+
+## Root Cause
+
+Mission Control still normalized `model.fallbacks`, but it also preserved any old
+top-level `agent.fallbacks` already present in `openclaw.json` during write-back.
+
+That meant any agent edited from the dashboard could keep re-saving an invalid
+gateway config even if the current UI no longer depended on that field.
+
+## Fix
+
+The write-back normalizer in `src/lib/agent-sync.ts` now removes legacy
+top-level `agent.fallbacks` before writing back to `openclaw.json`.
+
+Regression coverage lives in:
+
+- `src/lib/__tests__/agent-sync.test.ts`
+
+## Recovery
+
+If this happens again on a live install:
+
+1. Remove `fallbacks` from each entry in `agents.list` inside `~/.openclaw/openclaw.json`.
+2. Run `openclaw doctor`.
+3. Verify with `openclaw gateway status`.
+
+Expected result:
+
+- `openclaw doctor` no longer reports `Unrecognized key: "fallbacks"`.
+- `openclaw gateway status` shows `Runtime: running` and `RPC probe: ok`.

--- a/src/lib/__tests__/agent-sync.test.ts
+++ b/src/lib/__tests__/agent-sync.test.ts
@@ -72,7 +72,7 @@ describe('removeAgentFromConfig', () => {
     expect(parsed.agents.list).toEqual([{ id: 'keep-me', name: 'keep-me' }])
   })
 
-  it('normalizes nested model.primary payloads when writing config', async () => {
+  it('normalizes nested model.primary payloads and drops legacy agent fallbacks when writing config', async () => {
     tempDir = mkdtempSync(path.join(os.tmpdir(), 'mc-agent-sync-'))
     const configPath = path.join(tempDir, 'openclaw.json')
     writeFileSync(
@@ -82,6 +82,7 @@ describe('removeAgentFromConfig', () => {
           list: [
             {
               id: 'neo',
+              fallbacks: ['openai/codex-mini-latest'],
               model: {
                 primary: {
                   primary: 'anthropic/claude-sonnet-4-20250514',
@@ -114,5 +115,6 @@ describe('removeAgentFromConfig', () => {
       primary: 'anthropic/claude-sonnet-4-20250514',
       fallbacks: ['openrouter/anthropic/claude-sonnet-4'],
     })
+    expect(parsed.agents.list[0].fallbacks).toBeUndefined()
   })
 })

--- a/src/lib/agent-sync.ts
+++ b/src/lib/agent-sync.ts
@@ -457,9 +457,12 @@ function normalizeModelConfig(model: unknown): unknown {
 
 function normalizeAgentConfigForOpenClaw(agentConfig: any): any {
   if (!agentConfig || typeof agentConfig !== 'object') return agentConfig
-  if (!('model' in agentConfig)) return agentConfig
+  const normalized = { ...agentConfig }
+  delete normalized.fallbacks
+
+  if (!('model' in normalized)) return normalized
   return {
-    ...agentConfig,
-    model: normalizeModelConfig(agentConfig.model),
+    ...normalized,
+    model: normalizeModelConfig(normalized.model),
   }
 }


### PR DESCRIPTION
## Summary
Two small, self-contained legacy-config fixes, rebased cleanly onto current `main` (no conflicts).

- **Fix legacy agent fallback writeback** — corrects the writeback path for the legacy agent fallback config.
- **Add note for legacy OpenClaw fallback config** — adds `docs/openclaw-config-compatibility.md` documenting the legacy fallback behaviour.

## Notes
- Branch is `ahead 2 / behind 0` of `main` — a clean fast-forward.
- No dependency, schema, or model-catalog changes; docs + a small fallback fix only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)