### PR TITLE
fix(proxy): let dashboard-rotated mc_ API keys reach route auth

### DIFF
--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -108,4 +108,67 @@ describe('proxy host matching', () => {
     const response = proxy(request)
     expect(response.status).toBe(401)
   })
+
+  it.each([
+    ['dashboard-rotated mc_ key', 'mc_' + 'a1b2c3d4'.repeat(6)],
+    ['agent-scoped mca_ key', 'mca_' + 'a1b2c3d4'.repeat(6)],
+  ])('lets a %s through to route auth (issue #733)', async (_label, key) => {
+    vi.resetModules()
+    vi.doMock('node:os', () => ({
+      default: { hostname: () => 'hetzner-jarv' },
+      hostname: () => 'hetzner-jarv',
+    }))
+
+    const { proxy } = await import('./proxy')
+    const request = {
+      headers: new Headers({ host: 'localhost:3000', 'x-api-key': key }),
+      nextUrl: {
+        host: 'localhost:3000',
+        hostname: 'localhost',
+        pathname: '/api/tasks',
+        searchParams: new URLSearchParams(),
+        clone: () => ({ pathname: '/api/tasks' }),
+      },
+      method: 'GET',
+      cookies: { get: () => undefined },
+    } as any
+
+    setNodeEnv('production')
+    process.env.MC_ALLOWED_HOSTS = 'localhost,127.0.0.1'
+    delete process.env.MC_ALLOW_ANY_HOST
+    delete process.env.API_KEY
+
+    const response = proxy(request)
+    expect(response.status).not.toBe(401)
+  })
+
+  it('still rejects malformed API keys at the proxy gate', async () => {
+    vi.resetModules()
+    vi.doMock('node:os', () => ({
+      default: { hostname: () => 'hetzner-jarv' },
+      hostname: () => 'hetzner-jarv',
+    }))
+
+    const { proxy } = await import('./proxy')
+    const request = {
+      headers: new Headers({ host: 'localhost:3000', 'x-api-key': 'mc_not-hex-and-too-short' }),
+      nextUrl: {
+        host: 'localhost:3000',
+        hostname: 'localhost',
+        pathname: '/api/tasks',
+        searchParams: new URLSearchParams(),
+        clone: () => ({ pathname: '/api/tasks' }),
+      },
+      method: 'GET',
+      cookies: { get: () => undefined },
+    } as any
+
+    setNodeEnv('production')
+    process.env.MC_ALLOWED_HOSTS = 'localhost,127.0.0.1'
+    delete process.env.MC_ALLOW_ANY_HOST
+    delete process.env.API_KEY
+
+    const response = proxy(request)
+    expect(response.status).toBe(401)
+  })
 })

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -211,11 +211,13 @@ export function proxy(request: NextRequest) {
     const apiKey = extractApiKeyFromRequest(request)
     const hasValidApiKey = Boolean(configuredApiKey && apiKey && safeCompare(apiKey, configuredApiKey))
 
-    // Agent-scoped keys are validated in route auth (DB-backed) and should be
-    // allowed to pass through proxy auth gate.
-    const looksLikeAgentApiKey = /^mca_[a-f0-9]{48}$/i.test(apiKey)
+    // DB-backed keys (dashboard-rotated `mc_` global keys and `mca_` agent
+    // keys) are validated in route auth — the edge runtime cannot query
+    // SQLite, so the proxy only shape-checks them and lets route auth decide.
+    // Both formats are exactly 48 hex chars after the prefix.
+    const looksLikeDbBackedApiKey = /^mca?_[a-f0-9]{48}$/i.test(apiKey)
 
-    if (sessionToken || hasValidApiKey || looksLikeAgentApiKey) {
+    if (sessionToken || hasValidApiKey || looksLikeDbBackedApiKey) {
       const { response, nonce } = nextResponseWithNonce(request)
       return addSecurityHeaders(response, request, nonce)
     }


### PR DESCRIPTION
Fixes #733.

The edge middleware can't query SQLite, so DB-backed keys are shape-checked at the proxy and actually validated in route auth. The shape check only accepted `mca_` agent keys — dashboard-rotated `mc_` global keys (same 48-hex format, minted by `/api/tokens/rotate`) were 401'd at the edge before route auth ever saw them, which is why they only worked when `API_KEY` was also set in env.

- `src/proxy.ts`: accept both `mc_`/`mca_` 48-hex shapes (deliberately tighter than the regex suggested in the issue — no unbounded length, no `_`/`-` in the body)
- Route-level DB validation is unchanged and still decides real access; a format-only pass carries the same trust posture as today's `mca_` handling
- Tests: both prefixes pass the gate, malformed keys still 401