### PR TITLE
fix(mentions): stop arrow-key highlight reset in task board @mention menu

### DIFF
--- a/src/components/panels/task-board-panel.tsx
+++ b/src/components/panels/task-board-panel.tsx
@@ -276,7 +276,13 @@ function MentionTextarea({
           detectMentionQuery(nextValue, e.target.selectionStart || 0)
         }}
         onClick={(e) => detectMentionQuery(value, (e.target as HTMLTextAreaElement).selectionStart || 0)}
-        onKeyUp={(e) => detectMentionQuery(value, (e.target as HTMLTextAreaElement).selectionStart || 0)}
+        onKeyUp={(e) => {
+          // Menu-navigation keys are fully handled in onKeyDown; re-running
+          // detectMentionQuery on their keyup would setActiveIndex(0) and
+          // reset the highlighted option on every arrow press (#661).
+          if (e.key === 'ArrowDown' || e.key === 'ArrowUp' || e.key === 'Enter' || e.key === 'Tab' || e.key === 'Escape') return
+          detectMentionQuery(value, (e.target as HTMLTextAreaElement).selectionStart || 0)
+        }}
         onKeyDown={(e) => {
           if (!open || filtered.length === 0) return
           if (e.key === 'ArrowDown') {


### PR DESCRIPTION
Fixes #661.

The repro is in the task board panel, not chat-input (where the original investigation looked): the textarea's `onKeyUp` re-runs `detectMentionQuery` on every key release, and `detectMentionQuery` unconditionally calls `setActiveIndex(0)` while the `@` query still matches. So every arrow press did `setActiveIndex(prev±1)` (keydown) immediately followed by `setActiveIndex(0)` (keyup) — the reported snap-to-top.

Fix: skip menu-navigation keys (arrows/Enter/Tab/Escape) in `onKeyUp`; they're fully handled in `onKeyDown`. Chat-input already guards this correctly and is unchanged.