### PR TITLE
chore(process): dependabot policy, fork-safe drift check, gateway token write-guard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,12 @@ updates:
     cooldown:
       default-days: 7
     groups:
+      # Minor + patch only. Majors (Tailwind 4, TS 6, vitest 4, ...) each
+      # need a deliberate migration and must arrive as individual PRs, not
+      # buried in a 27-package group (see #743, which failed CI this way).
       js-deps:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
     open-pull-requests-limit: 5
 
   - package-ecosystem: "github-actions"
@@ -24,6 +28,9 @@ updates:
       day: "monday"
     cooldown:
       default-days: 7
+    groups:
+      gh-actions:
+        patterns: ["*"]
 
   - package-ecosystem: "docker"
     directory: "/"
@@ -32,3 +39,8 @@ updates:
       day: "monday"
     cooldown:
       default-days: 7
+    ignore:
+      # Track the active LTS line; the newest majors skip LTS and carry
+      # native-module ABI risk for better-sqlite3/node-pty (see #749).
+      - dependency-name: "node"
+        versions: [">=25"]

--- a/.github/workflows/screenshot-drift.yml
+++ b/.github/workflows/screenshot-drift.yml
@@ -40,7 +40,8 @@ jobs:
             core.setOutput('paths', uiPaths.slice(0, 10).join('\n'));
 
       - name: Add label if UI changed
-        if: steps.ui_changed.outputs.count > 0
+        # Fork PRs get a read-only token — label/comment calls would 403.
+        if: steps.ui_changed.outputs.count > 0 && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           script: |
@@ -63,7 +64,8 @@ jobs:
             });
 
       - name: Post checklist comment
-        if: steps.ui_changed.outputs.count > 0
+        # Fork PRs get a read-only token — label/comment calls would 403.
+        if: steps.ui_changed.outputs.count > 0 && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           script: |

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ docs/_*.png
 # Claude Code context files (root CLAUDE.md is committed for AI agent discovery)
 **/CLAUDE.md
 !/CLAUDE.md
+
+# IDE state
+.vs/

--- a/src/app/api/gateway-config/route.ts
+++ b/src/app/api/gateway-config/route.ts
@@ -129,7 +129,7 @@ export async function PUT(request: NextRequest) {
   const body = result.data
 
   // Block writes to sensitive paths
-  const blockedPaths = ['gateway.auth.password', 'gateway.auth.secret']
+  const blockedPaths = ['gateway.auth.password', 'gateway.auth.secret', 'gateway.auth.token']
   for (const key of Object.keys(body.updates)) {
     if (blockedPaths.some(bp => key.startsWith(bp))) {
       return NextResponse.json({ error: `Cannot modify protected field: ${key}` }, { status: 403 })


### PR DESCRIPTION
Process fixes surfaced by the repo audit:

- **dependabot**: `js-deps` group now minor+patch only — majors (Tailwind 4 / TS 6 / vitest 4) arrive as individual PRs instead of a 27-package group that fails CI as one unit (#743); group GitHub Actions bumps to cut PR noise; docker ignores node >=25 so the base image tracks the LTS line (#749 context — 22→26 skips 24 LTS and risks better-sqlite3/node-pty ABI breaks)
- **screenshot-drift workflow**: label/comment steps now skip fork PRs, where the `pull_request` token is read-only and the API calls 403 — it was failing on exactly the external contributions it targets
- **gateway-config**: add `gateway.auth.token` to the blocked write paths — `password`/`secret` were protected but the bearer token could be overwritten via a config update (complements #747)
- **.gitignore**: ignore `.vs/` IDE state (#741 accidentally committed Copilot index artifacts)