### PR TITLE
fix(security): hash global API key at rest (sha256), one-time plaintext reveal

### DIFF
--- a/src/app/api/tokens/rotate/route.ts
+++ b/src/app/api/tokens/rotate/route.ts
@@ -1,11 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { randomBytes } from 'crypto'
-import { requireRole } from '@/lib/auth'
+import { requireRole, hashApiKey } from '@/lib/auth'
 import { getDatabase, logAuditEvent } from '@/lib/db'
 import { mutationLimiter } from '@/lib/rate-limit'
 
-interface ApiKeyRow {
-  value: string
+interface ApiKeyHashRow {
   updated_by: string | null
   updated_at: number
 }
@@ -13,6 +12,8 @@ interface ApiKeyRow {
 /**
  * Mask an API key for display: show first 4 and last 5 chars.
  * e.g. "mc_a1b2c3d4e5f6g7h8i9j0" -> "mc_a****j0"
+ * Only possible for env keys — DB keys are stored as sha256 hashes and
+ * cannot be displayed after creation.
  */
 function maskApiKey(key: string): string {
   if (key.length <= 9) return '****'
@@ -28,14 +29,16 @@ export async function GET(request: NextRequest) {
 
   const db = getDatabase()
 
-  // Check for DB-stored override first
+  // Check for DB-stored override first. Only the sha256 hash is stored,
+  // so the key itself cannot be shown (not even masked) after creation.
   const row = db.prepare(
-    "SELECT value, updated_by, updated_at FROM settings WHERE key = 'security.api_key'"
-  ).get() as ApiKeyRow | undefined
+    "SELECT updated_by, updated_at FROM settings WHERE key = 'security.api_key_hash'"
+  ).get() as ApiKeyHashRow | undefined
 
   if (row) {
     return NextResponse.json({
-      masked_key: maskApiKey(row.value),
+      masked_key: null,
+      configured: true,
       source: 'database',
       last_rotated_at: row.updated_at,
       last_rotated_by: row.updated_by,
@@ -47,6 +50,7 @@ export async function GET(request: NextRequest) {
   if (envKey) {
     return NextResponse.json({
       masked_key: maskApiKey(envKey),
+      configured: true,
       source: 'environment',
       last_rotated_at: null,
       last_rotated_by: null,
@@ -55,6 +59,7 @@ export async function GET(request: NextRequest) {
 
   return NextResponse.json({
     masked_key: null,
+    configured: false,
     source: 'none',
     last_rotated_at: null,
     last_rotated_by: null,
@@ -63,6 +68,9 @@ export async function GET(request: NextRequest) {
 
 /**
  * POST /api/tokens/rotate - Generate and store a new API key
+ *
+ * Only sha256(key) is persisted (settings 'security.api_key_hash');
+ * the plaintext key is returned exactly once in this response.
  */
 export async function POST(request: NextRequest) {
   const auth = requireRole(request, 'admin')
@@ -71,32 +79,43 @@ export async function POST(request: NextRequest) {
   const rateCheck = mutationLimiter(request)
   if (rateCheck) return rateCheck
 
-  // Generate a new key: mc_ prefix + 32 random hex chars
+  // Generate a new key: mc_ prefix + 48 random hex chars
   const newKey = 'mc_' + randomBytes(24).toString('hex')
 
   const db = getDatabase()
 
   // Get old key info for audit trail
-  const existing = db.prepare(
+  const existingHash = db.prepare(
+    "SELECT key FROM settings WHERE key = 'security.api_key_hash'"
+  ).get() as { key: string } | undefined
+  const existingLegacy = db.prepare(
     "SELECT value FROM settings WHERE key = 'security.api_key'"
   ).get() as { value: string } | undefined
 
-  const oldSource = existing ? 'database' : (process.env.API_KEY || '').trim() ? 'environment' : 'none'
-  const oldMasked = existing
-    ? maskApiKey(existing.value)
-    : (process.env.API_KEY || '').trim()
+  const oldSource = existingHash || existingLegacy
+    ? 'database'
+    : (process.env.API_KEY || '').trim() ? 'environment' : 'none'
+  // Hashed keys cannot be masked — only legacy plaintext or env keys can.
+  const oldMasked = existingLegacy
+    ? maskApiKey(existingLegacy.value)
+    : !existingHash && (process.env.API_KEY || '').trim()
       ? maskApiKey((process.env.API_KEY || '').trim())
       : null
 
-  // Store new key in settings table (overrides env var)
-  db.prepare(`
-    INSERT INTO settings (key, value, description, category, updated_by, updated_at)
-    VALUES ('security.api_key', ?, 'Active API key (overrides API_KEY env var)', 'security', ?, unixepoch())
-    ON CONFLICT(key) DO UPDATE SET
-      value = excluded.value,
-      updated_by = excluded.updated_by,
-      updated_at = unixepoch()
-  `).run(newKey, auth.user.username)
+  // Store only the hash in settings (overrides env var); remove any legacy
+  // plaintext row so the raw key never remains at rest.
+  const writeTxn = db.transaction(() => {
+    db.prepare(`
+      INSERT INTO settings (key, value, description, category, updated_by, updated_at)
+      VALUES ('security.api_key_hash', ?, 'SHA-256 hash of the active API key (overrides API_KEY env var)', 'security', ?, unixepoch())
+      ON CONFLICT(key) DO UPDATE SET
+        value = excluded.value,
+        updated_by = excluded.updated_by,
+        updated_at = unixepoch()
+    `).run(hashApiKey(newKey), auth.user.username)
+    db.prepare("DELETE FROM settings WHERE key = 'security.api_key'").run()
+  })
+  writeTxn()
 
   // Audit log
   const ipAddress = request.headers.get('x-forwarded-for') || request.headers.get('x-real-ip') || 'unknown'

--- a/src/components/panels/settings-panel.tsx
+++ b/src/components/panels/settings-panel.tsx
@@ -26,6 +26,7 @@ interface Setting {
 
 interface ApiKeyInfo {
   masked_key: string | null
+  configured: boolean
   source: string
   last_rotated_at: number | null
   last_rotated_by: string | null
@@ -702,7 +703,10 @@ export function SettingsPanel() {
             {/* Current key display */}
             <div className="mt-3 flex items-center gap-2">
               <code className="text-xs font-mono bg-background border border-border rounded px-2 py-1 text-muted-foreground">
-                {apiKeyLoading ? 'Loading...' : apiKeyInfo?.masked_key || 'No API key configured'}
+                {apiKeyLoading
+                  ? 'Loading...'
+                  : apiKeyInfo?.masked_key
+                    || (apiKeyInfo?.configured ? 'Configured (stored as hash — not displayable)' : 'No API key configured')}
               </code>
             </div>
 

--- a/src/lib/__tests__/global-api-key-hash.test.ts
+++ b/src/lib/__tests__/global-api-key-hash.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import Database from 'better-sqlite3'
+import { createHash } from 'crypto'
+import { runMigrations } from '@/lib/migrations'
+import { requireRole } from '@/lib/auth'
+import { GET, POST } from '@/app/api/tokens/rotate/route'
+
+/**
+ * Security fix S1: the dashboard-rotated global API key must be stored as a
+ * SHA-256 hash (settings 'security.api_key_hash'), never in plaintext.
+ * The plaintext key is returned exactly once, in the rotation response.
+ *
+ * Uses a real in-memory SQLite database with the production migrations.
+ */
+
+let db: InstanceType<typeof Database>
+
+vi.mock('@/lib/db', () => ({
+  getDatabase: () => db,
+  logAuditEvent: vi.fn(),
+}))
+
+vi.mock('@/lib/password', () => ({
+  hashPassword: vi.fn((p: string) => `hashed:${p}`),
+  verifyPassword: vi.fn(() => false),
+  verifyPasswordWithRehashCheck: vi.fn(() => ({ valid: false, needsRehash: false })),
+}))
+
+// Prevent event-bus singleton side-effects
+vi.mock('@/lib/event-bus', () => ({
+  eventBus: { broadcast: vi.fn(), on: vi.fn(), emit: vi.fn() },
+}))
+
+vi.mock('@/lib/security-events', () => ({
+  logSecurityEvent: vi.fn(),
+}))
+
+vi.mock('@/lib/rate-limit', () => ({
+  mutationLimiter: vi.fn(() => null),
+}))
+
+function sha256Hex(value: string): string {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+function makeRequest(headers: Record<string, string> = {}, method = 'GET'): Request {
+  return new Request('http://localhost/api/tokens/rotate', {
+    method,
+    headers: new Headers(headers),
+  })
+}
+
+function getSetting(key: string): string | undefined {
+  const row = db.prepare('SELECT value FROM settings WHERE key = ?').get(key) as { value: string } | undefined
+  return row?.value
+}
+
+const originalEnv = process.env
+
+beforeEach(() => {
+  process.env = { ...originalEnv, API_KEY: 'bootstrap-env-key' }
+  db = new Database(':memory:')
+  runMigrations(db)
+})
+
+afterEach(() => {
+  process.env = originalEnv
+  db?.close()
+})
+
+describe('POST /api/tokens/rotate (hash at rest)', () => {
+  it('stores only the sha256 hash of the new key, never the plaintext', async () => {
+    const res = await POST(makeRequest({ 'x-api-key': 'bootstrap-env-key' }, 'POST') as any)
+    expect(res.status).toBe(200)
+    const data = await res.json()
+
+    // Response returns the plaintext key exactly once, same shape as before
+    expect(data.key).toMatch(/^mc_[0-9a-f]{48}$/)
+    expect(data.masked_key).toContain('****')
+    expect(data.rotated_by).toBe('api')
+
+    // Only the hash is at rest; no plaintext row remains
+    expect(getSetting('security.api_key_hash')).toBe(sha256Hex(data.key))
+    expect(getSetting('security.api_key')).toBeUndefined()
+
+    // The plaintext key does not appear anywhere in the settings table
+    const allValues = (db.prepare('SELECT value FROM settings').all() as Array<{ value: string }>)
+      .map((r) => r.value)
+    expect(allValues).not.toContain(data.key)
+  })
+
+  it('deletes a legacy plaintext security.api_key row on rotation', async () => {
+    db.prepare(`
+      INSERT INTO settings (key, value, category) VALUES ('security.api_key', 'mc_legacyplaintextkey123', 'security')
+      ON CONFLICT(key) DO UPDATE SET value = excluded.value
+    `).run()
+
+    const res = await POST(makeRequest({ 'x-api-key': 'mc_legacyplaintextkey123' }, 'POST') as any)
+    expect(res.status).toBe(200)
+    const data = await res.json()
+
+    expect(getSetting('security.api_key')).toBeUndefined()
+    expect(getSetting('security.api_key_hash')).toBe(sha256Hex(data.key))
+  })
+
+  it('the returned plaintext key authenticates as admin via the hash path', async () => {
+    const res = await POST(makeRequest({ 'x-api-key': 'bootstrap-env-key' }, 'POST') as any)
+    const data = await res.json()
+
+    const auth = requireRole(makeRequest({ 'x-api-key': data.key }), 'admin')
+    expect(auth.error).toBeUndefined()
+    expect(auth.user).toBeDefined()
+    expect(auth.user!.username).toBe('api')
+    expect(auth.user!.role).toBe('admin')
+  })
+
+  it('rejects wrong keys and the old env key once a DB hash is set', async () => {
+    const res = await POST(makeRequest({ 'x-api-key': 'bootstrap-env-key' }, 'POST') as any)
+    const data = await res.json()
+    expect(data.key).toBeDefined()
+
+    // Wrong key
+    const wrong = requireRole(makeRequest({ 'x-api-key': 'mc_' + '0'.repeat(48) }), 'viewer')
+    expect(wrong.status).toBe(401)
+    expect(wrong.user).toBeUndefined()
+
+    // Presenting the raw hash itself must not work either
+    const hash = getSetting('security.api_key_hash')!
+    const viaHash = requireRole(makeRequest({ 'x-api-key': hash }), 'viewer')
+    expect(viaHash.status).toBe(401)
+
+    // DB key overrides env: old env key no longer authenticates
+    const env = requireRole(makeRequest({ 'x-api-key': 'bootstrap-env-key' }), 'viewer')
+    expect(env.status).toBe(401)
+  })
+})
+
+describe('GET /api/tokens/rotate (metadata only)', () => {
+  it('reports configured without exposing key material for DB-stored keys', async () => {
+    const rotateRes = await POST(makeRequest({ 'x-api-key': 'bootstrap-env-key' }, 'POST') as any)
+    const { key } = await rotateRes.json()
+
+    const res = await GET(makeRequest({ 'x-api-key': key }) as any)
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.source).toBe('database')
+    expect(data.configured).toBe(true)
+    expect(data.masked_key).toBeNull()
+    expect(data.last_rotated_by).toBe('api')
+  })
+
+  it('still masks the env key when no DB key is stored', async () => {
+    const res = await GET(makeRequest({ 'x-api-key': 'bootstrap-env-key' }) as any)
+    const data = await res.json()
+    expect(data.source).toBe('environment')
+    expect(data.configured).toBe(true)
+    expect(data.masked_key).toContain('****')
+  })
+})
+
+describe('legacy plaintext fallback in auth', () => {
+  it('accepts a plaintext security.api_key row only while no hash row exists', () => {
+    db.prepare(`
+      INSERT INTO settings (key, value, category) VALUES ('security.api_key', 'mc_legacyplaintextkey123', 'security')
+    `).run()
+
+    const ok = requireRole(makeRequest({ 'x-api-key': 'mc_legacyplaintextkey123' }), 'admin')
+    expect(ok.user).toBeDefined()
+    expect(ok.user!.role).toBe('admin')
+
+    // Once a hash row exists, the hash row wins and the stale plaintext value is ignored
+    db.prepare(`
+      INSERT INTO settings (key, value, category) VALUES ('security.api_key_hash', ?, 'security')
+    `).run(sha256Hex('mc_currentkey456'))
+
+    const stale = requireRole(makeRequest({ 'x-api-key': 'mc_legacyplaintextkey123' }), 'viewer')
+    expect(stale.status).toBe(401)
+
+    const current = requireRole(makeRequest({ 'x-api-key': 'mc_currentkey456' }), 'viewer')
+    expect(current.user).toBeDefined()
+  })
+})
+
+describe('migration 051_hash_global_api_key', () => {
+  it('converts an existing plaintext key to a sha256 hash and removes the plaintext row', () => {
+    // Simulate a pre-migration database: re-insert the plaintext row and
+    // un-apply 051 so the real migration runner re-runs it.
+    db.prepare(`
+      INSERT INTO settings (key, value, category, updated_by, updated_at)
+      VALUES ('security.api_key', 'mc_oldplaintextsecret', 'security', 'alice', 1234567890)
+    `).run()
+    db.prepare("DELETE FROM schema_migrations WHERE id = '051_hash_global_api_key'").run()
+
+    runMigrations(db)
+
+    expect(getSetting('security.api_key')).toBeUndefined()
+    expect(getSetting('security.api_key_hash')).toBe(sha256Hex('mc_oldplaintextsecret'))
+
+    // Rotation metadata is preserved
+    const row = db.prepare(
+      "SELECT updated_by, updated_at FROM settings WHERE key = 'security.api_key_hash'"
+    ).get() as { updated_by: string | null; updated_at: number }
+    expect(row.updated_by).toBe('alice')
+    expect(row.updated_at).toBe(1234567890)
+
+    // The converted key still authenticates
+    const auth = requireRole(makeRequest({ 'x-api-key': 'mc_oldplaintextsecret' }), 'admin')
+    expect(auth.user).toBeDefined()
+  })
+
+  it('is a no-op when no plaintext key exists', () => {
+    db.prepare("DELETE FROM schema_migrations WHERE id = '051_hash_global_api_key'").run()
+    runMigrations(db)
+    expect(getSetting('security.api_key')).toBeUndefined()
+    expect(getSetting('security.api_key_hash')).toBeUndefined()
+  })
+})

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -468,9 +468,8 @@ export function getUserFromRequest(request: Request): User | null {
 
   // Check API key - DB override first, then env var
   const apiKey = extractApiKeyFromHeaders(request.headers)
-  const configuredApiKey = resolveActiveApiKey()
 
-  if (configuredApiKey && apiKey && safeCompare(apiKey, configuredApiKey)) {
+  if (apiKey && matchesGlobalApiKey(apiKey)) {
     // FR-D2: Log warning when global admin API key is used.
     // Prefer agent-scoped keys (POST /api/agents/{id}/keys) for least-privilege access.
     try {
@@ -562,19 +561,36 @@ export function getUserFromRequest(request: Request): User | null {
 }
 
 /**
- * Resolve the active API key: check DB settings override first, then env var.
+ * Check a presented key against the active global API key.
+ *
+ * DB settings override the env var (same precedence as before):
+ * - 'security.api_key_hash' stores sha256(key) — compare hash-to-hash so the
+ *   plaintext key is never at rest in SQLite (S1).
+ * - Legacy 'security.api_key' (plaintext) is only honored when no hash row
+ *   exists; migration 051 converts and deletes it, so this is dead post-migration.
+ * - API_KEY env var is operator-controlled plaintext and compared directly.
  */
-function resolveActiveApiKey(): string {
+function matchesGlobalApiKey(presentedKey: string): boolean {
   try {
     const db = getDatabase()
-    const row = db.prepare(
+    const hashRow = db.prepare(
+      "SELECT value FROM settings WHERE key = 'security.api_key_hash'"
+    ).get() as { value: string } | undefined
+    if (hashRow?.value) {
+      return safeCompare(hashApiKey(presentedKey), hashRow.value)
+    }
+    // Legacy plaintext row (pre-migration databases only)
+    const legacyRow = db.prepare(
       "SELECT value FROM settings WHERE key = 'security.api_key'"
     ).get() as { value: string } | undefined
-    if (row?.value) return row.value
+    if (legacyRow?.value) {
+      return safeCompare(presentedKey, legacyRow.value)
+    }
   } catch {
     // DB not ready yet — fall back to env
   }
-  return (process.env.API_KEY || '').trim()
+  const envKey = (process.env.API_KEY || '').trim()
+  return envKey ? safeCompare(presentedKey, envKey) : false
 }
 
 function extractApiKeyFromHeaders(headers: Headers): string | null {
@@ -595,7 +611,7 @@ function extractApiKeyFromHeaders(headers: Headers): string | null {
   return null
 }
 
-function hashApiKey(rawKey: string): string {
+export function hashApiKey(rawKey: string): string {
   return createHash('sha256').update(rawKey).digest('hex')
 }
 

--- a/src/lib/migrations.ts
+++ b/src/lib/migrations.ts
@@ -1428,6 +1428,30 @@ const migrations: Migration[] = [
       db.exec(`ALTER TABLE mcp_call_log ADD COLUMN signature TEXT DEFAULT NULL`)
       db.exec(`ALTER TABLE mcp_call_log ADD COLUMN public_key TEXT DEFAULT NULL`)
     }
+  },
+  {
+    id: '051_hash_global_api_key',
+    up(db: Database.Database) {
+      // Migrate the plaintext global API key (settings 'security.api_key') to a
+      // SHA-256 hash stored under 'security.api_key_hash'. After this migration
+      // the plaintext key is never at rest — it is only returned once at rotation,
+      // so a DB read (file copy, backup dump) no longer yields a live credential.
+      const row = db.prepare(
+        "SELECT value, updated_by, updated_at FROM settings WHERE key = 'security.api_key'"
+      ).get() as { value: string; updated_by: string | null; updated_at: number } | undefined
+      if (row?.value) {
+        const hashed = createHash('sha256').update(row.value).digest('hex')
+        db.prepare(`
+          INSERT INTO settings (key, value, description, category, updated_by, updated_at)
+          VALUES ('security.api_key_hash', ?, 'SHA-256 hash of the active API key (overrides API_KEY env var)', 'security', ?, ?)
+          ON CONFLICT(key) DO UPDATE SET
+            value = excluded.value,
+            updated_by = excluded.updated_by,
+            updated_at = excluded.updated_at
+        `).run(hashed, row.updated_by, row.updated_at)
+      }
+      db.prepare("DELETE FROM settings WHERE key = 'security.api_key'").run()
+    }
   }
 ]
 


### PR DESCRIPTION
Top finding (S1) from the security audit: the dashboard-rotated global API key was stored **plaintext** in the `settings` table and granted unconditional admin on match — so any DB read (file copy, `/api/backup` dump, exfiltrated volume) yielded a permanent admin credential. Session tokens and agent keys were already hashed; this was the lone plaintext credential.

- Rotation now stores only `sha256(key)` in `security.api_key_hash` (same helper as the agent-key path); plaintext is returned exactly once in the rotate response
- Auth prefers the hash row; legacy plaintext row accepted only until migration `051_hash_global_api_key` converts it (preserving rotation metadata); `API_KEY` env behavior unchanged (operator-controlled, still shadowed by DB keys exactly as before)
- Side effect fixed: `GET /api/settings` previously returned the plaintext key verbatim to any admin API caller — post-migration only the hash exists
- Settings UI now shows "Configured (stored as hash — not displayable)"; the only way to see a key is rotating
- 9 new tests through the real migration runner (hash stored, plaintext gone, returned key authenticates, wrong/stale/hash-as-key rejected, migration converts + preserves metadata, no-op on clean DBs)

Full suite: **1087/1087 green**, typecheck clean, no new lint warnings.