### PR TITLE
feat(dispatch): opt-in sandbox flags for host CLI dispatch

### DIFF
--- a/src/lib/__tests__/task-dispatch-sandbox.test.ts
+++ b/src/lib/__tests__/task-dispatch-sandbox.test.ts
@@ -1,0 +1,183 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterAll, describe, expect, it } from 'vitest'
+import {
+  CLAUDE_CLI_ALLOWED_TOOL_NAMES,
+  CLI_MAX_BUDGET_USD_CEILING,
+  clampCliMaxBudgetUsd,
+  filterCliAllowedTools,
+  resolveCliDispatchCwd,
+  resolveCliSandboxOptions,
+} from '@/lib/task-dispatch'
+
+// Real directory layout for cwd-scoping tests:
+//   root/            (workspace root)
+//   root/project/    (valid cwd)
+//   root/escape-link -> outside/   (symlink escape)
+//   outside/         (sibling of root, must never be reachable)
+const base = fs.mkdtempSync(path.join(os.tmpdir(), 'mc-sandbox-test-'))
+const root = path.join(base, 'root')
+const project = path.join(root, 'project')
+const outside = path.join(base, 'outside')
+fs.mkdirSync(project, { recursive: true })
+fs.mkdirSync(outside, { recursive: true })
+const escapeLink = path.join(root, 'escape-link')
+fs.symlinkSync(outside, escapeLink, 'dir')
+// realpath the expectations: on macOS os.tmpdir() itself sits behind a symlink
+const realRoot = fs.realpathSync(root)
+const realProject = fs.realpathSync(project)
+
+afterAll(() => {
+  fs.rmSync(base, { recursive: true, force: true })
+})
+
+describe('filterCliAllowedTools', () => {
+  it('passes through tools on the conservative allowlist, deduplicated', () => {
+    expect(filterCliAllowedTools(['Read', 'Grep', 'Read'])).toEqual(['Read', 'Grep'])
+  })
+
+  it('drops unknown tools while keeping valid ones', () => {
+    expect(filterCliAllowedTools(['Read', 'DangerousTool', 'Bash(rm:*)', 'Bash']))
+      .toEqual(['Read', 'Bash'])
+  })
+
+  it('never admits --dangerously-skip-permissions or non-string entries', () => {
+    expect(filterCliAllowedTools(['--dangerously-skip-permissions', 42, null])).toBeNull()
+  })
+
+  it('returns null (flag omitted, fail closed) for non-arrays and all-invalid lists', () => {
+    expect(filterCliAllowedTools(undefined)).toBeNull()
+    expect(filterCliAllowedTools('Read,Grep')).toBeNull()
+    expect(filterCliAllowedTools([])).toBeNull()
+    expect(filterCliAllowedTools(['NotATool'])).toBeNull()
+  })
+
+  it('accepts every name in the exported allowlist constant', () => {
+    expect(filterCliAllowedTools([...CLAUDE_CLI_ALLOWED_TOOL_NAMES]))
+      .toEqual([...CLAUDE_CLI_ALLOWED_TOOL_NAMES])
+  })
+})
+
+describe('clampCliMaxBudgetUsd', () => {
+  it('passes through a sane finite positive budget', () => {
+    expect(clampCliMaxBudgetUsd(5)).toBe(5)
+    expect(clampCliMaxBudgetUsd(0.5)).toBe(0.5)
+  })
+
+  it('caps at the ceiling', () => {
+    expect(clampCliMaxBudgetUsd(10_000)).toBe(CLI_MAX_BUDGET_USD_CEILING)
+    expect(clampCliMaxBudgetUsd(CLI_MAX_BUDGET_USD_CEILING)).toBe(CLI_MAX_BUDGET_USD_CEILING)
+  })
+
+  it('rejects zero, negatives, non-finite values, and non-numbers', () => {
+    expect(clampCliMaxBudgetUsd(0)).toBeNull()
+    expect(clampCliMaxBudgetUsd(-3)).toBeNull()
+    expect(clampCliMaxBudgetUsd(Number.POSITIVE_INFINITY)).toBeNull()
+    expect(clampCliMaxBudgetUsd(Number.NaN)).toBeNull()
+    expect(clampCliMaxBudgetUsd('5')).toBeNull()
+    expect(clampCliMaxBudgetUsd(undefined)).toBeNull()
+  })
+})
+
+describe('resolveCliDispatchCwd', () => {
+  it('is disabled when no workspace root is configured', () => {
+    expect(resolveCliDispatchCwd('project', '')).toBeNull()
+    expect(resolveCliDispatchCwd(realProject, '')).toBeNull()
+  })
+
+  it('resolves a relative path inside the root', () => {
+    expect(resolveCliDispatchCwd('project', root)).toBe(realProject)
+  })
+
+  it('resolves an absolute path inside the root', () => {
+    expect(resolveCliDispatchCwd(project, root)).toBe(realProject)
+  })
+
+  it('accepts the root itself', () => {
+    expect(resolveCliDispatchCwd('.', root)).toBe(realRoot)
+  })
+
+  it('rejects ../ traversal out of the root', () => {
+    expect(resolveCliDispatchCwd('../outside', root)).toBeNull()
+    expect(resolveCliDispatchCwd('project/../../outside', root)).toBeNull()
+  })
+
+  it('rejects absolute paths outside the root', () => {
+    expect(resolveCliDispatchCwd(outside, root)).toBeNull()
+    expect(resolveCliDispatchCwd(os.tmpdir(), root)).toBeNull()
+  })
+
+  it('rejects symlinks inside the root that point outside it', () => {
+    expect(resolveCliDispatchCwd('escape-link', root)).toBeNull()
+  })
+
+  it('rejects a sibling directory that shares the root as a path prefix', () => {
+    // root2 startsWith(root) as a string but is not inside root/
+    const sibling = `${root}2`
+    fs.mkdirSync(sibling, { recursive: true })
+    expect(resolveCliDispatchCwd(sibling, root)).toBeNull()
+  })
+
+  it('rejects missing paths and non-directories', () => {
+    expect(resolveCliDispatchCwd('does-not-exist', root)).toBeNull()
+    const file = path.join(root, 'file.txt')
+    fs.writeFileSync(file, 'x')
+    expect(resolveCliDispatchCwd('file.txt', root)).toBeNull()
+  })
+
+  it('ignores non-string and empty input', () => {
+    expect(resolveCliDispatchCwd(undefined, root)).toBeNull()
+    expect(resolveCliDispatchCwd('   ', root)).toBeNull()
+    expect(resolveCliDispatchCwd(42, root)).toBeNull()
+  })
+})
+
+describe('resolveCliSandboxOptions', () => {
+  it('returns all-null (today\'s behavior) when nothing is configured', () => {
+    expect(resolveCliSandboxOptions({ id: 1, agent_config: null, metadata: null }, ''))
+      .toEqual({ allowedTools: null, maxBudgetUsd: null, cwd: null })
+    expect(resolveCliSandboxOptions({ id: 1, agent_config: '{"openclawId":"main"}', metadata: '{}' }, root))
+      .toEqual({ allowedTools: null, maxBudgetUsd: null, cwd: null })
+  })
+
+  it('sources options from the agent config', () => {
+    const agent_config = JSON.stringify({
+      dispatchAllowedTools: ['Read', 'Grep', 'BogusTool'],
+      dispatchMaxBudgetUsd: 250,
+      dispatchCwd: 'project',
+    })
+    expect(resolveCliSandboxOptions({ id: 1, agent_config, metadata: null }, root)).toEqual({
+      allowedTools: ['Read', 'Grep'],
+      maxBudgetUsd: CLI_MAX_BUDGET_USD_CEILING,
+      cwd: realProject,
+    })
+  })
+
+  it('lets tasks.metadata override individual fields (camelCase and snake_case)', () => {
+    const agent_config = JSON.stringify({
+      dispatchAllowedTools: ['Read'],
+      dispatchMaxBudgetUsd: 10,
+      dispatchCwd: 'project',
+    })
+    const metadata = JSON.stringify({
+      dispatch_max_budget_usd: 2,
+      dispatchAllowedTools: ['Bash', 'Edit'],
+    })
+    expect(resolveCliSandboxOptions({ id: 1, agent_config, metadata }, root)).toEqual({
+      allowedTools: ['Bash', 'Edit'],
+      maxBudgetUsd: 2,
+      cwd: realProject, // untouched by metadata → agent config wins
+    })
+  })
+
+  it('disables cwd when no workspace root is configured even if requested', () => {
+    const agent_config = JSON.stringify({ dispatchCwd: 'project' })
+    expect(resolveCliSandboxOptions({ id: 1, agent_config, metadata: null }, '').cwd).toBeNull()
+  })
+
+  it('ignores malformed agent config and metadata payloads', () => {
+    expect(resolveCliSandboxOptions({ id: 1, agent_config: '{not json', metadata: '[1,2]' }, root))
+      .toEqual({ allowedTools: null, maxBudgetUsd: null, cwd: null })
+  })
+})

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -113,6 +113,12 @@ export const config = {
   // assignee stay unassigned). When set, new tasks with no assigned_to are
   // routed to this agent name.
   coordinatorAgent: (process.env.MC_COORDINATOR_AGENT || '').trim(),
+  // Workspace root for host-CLI dispatch cwd scoping (issue #720). Opt-in:
+  // empty string means the per-agent/per-task `dispatchCwd` feature is OFF
+  // and CLI dispatch always inherits the server's own cwd. When set, a
+  // requested cwd must resolve (symlinks included) to a directory inside
+  // this root or it is rejected.
+  workspaceRoot: (process.env.MC_WORKSPACE_ROOT || '').trim(),
   gnap: {
     enabled: process.env.GNAP_ENABLED === 'true',
     repoPath: resolvedGnapRepoPath,

--- a/src/lib/task-dispatch.ts
+++ b/src/lib/task-dispatch.ts
@@ -1,4 +1,5 @@
-import { existsSync } from 'node:fs'
+import { existsSync, realpathSync, statSync } from 'node:fs'
+import path from 'node:path'
 import { spawn } from 'node:child_process'
 import { getDatabase, db_helpers } from './db'
 import { callOpenClawGateway } from './openclaw-gateway'
@@ -41,6 +42,8 @@ interface DispatchableTask {
   project_ticket_no: number | null
   project_id: number | null
   tags?: string[]
+  /** Raw tasks.metadata JSON — carries optional per-task sandbox overrides. */
+  metadata?: string | null
 }
 
 // ---------------------------------------------------------------------------
@@ -76,6 +79,144 @@ function resolveGatewayAgentId(task: DispatchableTask): string {
     } catch { /* ignore */ }
   }
   return task.agent_name
+}
+
+// ---------------------------------------------------------------------------
+// Host-CLI sandbox flags (issue #720)
+// ---------------------------------------------------------------------------
+//
+// Opt-in safety flags for the host CLI dispatch paths (`claude` / `codex`).
+// Source of truth is the agent's config JSON (agents.config), using the same
+// flat naming style as `dispatchModel`:
+//
+//   { "dispatchAllowedTools": ["Read", "Grep"], "dispatchMaxBudgetUsd": 5,
+//     "dispatchCwd": "repos/my-project" }
+//
+// Each field can be overridden per task via tasks.metadata (camelCase or
+// snake_case, mirroring existing metadata keys like dispatch_session_id):
+//
+//   { "dispatch_allowed_tools": [...], "dispatch_max_budget_usd": 2,
+//     "dispatch_cwd": "..." }
+//
+// Absent config means today's behavior, byte-for-byte: no extra CLI flags,
+// no spawn cwd.
+
+/**
+ * Tool names the Claude Code CLI accepts for `--allowedTools`. Conservative
+ * exact-match allowlist — entries not listed here (including `Bash(...)`
+ * specifier syntax) are dropped with a warning. `--dangerously-skip-permissions`
+ * is never passed by task dispatch.
+ */
+export const CLAUDE_CLI_ALLOWED_TOOL_NAMES = [
+  'Task', 'Bash', 'Glob', 'Grep', 'Read', 'Edit', 'MultiEdit', 'Write',
+  'NotebookEdit', 'WebFetch', 'WebSearch', 'TodoWrite',
+] as const
+
+/** Ceiling for `--max-budget-usd` regardless of what the config asks for. */
+export const CLI_MAX_BUDGET_USD_CEILING = 100
+
+export interface CliDispatchSandboxOptions {
+  allowedTools: string[] | null
+  maxBudgetUsd: number | null
+  cwd: string | null
+}
+
+/**
+ * Validate a configured allowed-tools list against CLAUDE_CLI_ALLOWED_TOOL_NAMES.
+ * Unknown entries are dropped with a warning. Returns null when the input is
+ * not a list or nothing survives filtering — in `--print` mode, omitting
+ * `--allowedTools` is the more restrictive default (tools stay gated), so an
+ * all-invalid list fails closed, not open.
+ */
+export function filterCliAllowedTools(input: unknown, taskId?: number): string[] | null {
+  if (!Array.isArray(input)) return null
+  const valid: string[] = []
+  const rejected: string[] = []
+  for (const entry of input) {
+    if (typeof entry === 'string' && (CLAUDE_CLI_ALLOWED_TOOL_NAMES as readonly string[]).includes(entry)) {
+      if (!valid.includes(entry)) valid.push(entry)
+    } else {
+      rejected.push(typeof entry === 'string' ? entry : typeof entry)
+    }
+  }
+  if (rejected.length > 0) {
+    logger.warn({ taskId, rejected: rejected.slice(0, 20) },
+      'Ignoring allowed-tools entries not in the Claude CLI tool allowlist')
+  }
+  return valid.length > 0 ? valid : null
+}
+
+/** Clamp a configured max budget to a finite positive number ≤ the ceiling. */
+export function clampCliMaxBudgetUsd(input: unknown, taskId?: number): number | null {
+  if (typeof input !== 'number' || !Number.isFinite(input) || input <= 0) {
+    if (input !== undefined && input !== null) {
+      logger.warn({ taskId }, 'Ignoring invalid dispatch max budget (must be a finite positive number)')
+    }
+    return null
+  }
+  return Math.min(input, CLI_MAX_BUDGET_USD_CEILING)
+}
+
+/**
+ * Resolve a configured dispatch cwd to a real directory inside the operator's
+ * workspace root (config.workspaceRoot / MC_WORKSPACE_ROOT). Relative paths
+ * resolve against the root. Both sides go through fs.realpathSync before the
+ * prefix check, so `../` traversal and symlink escapes are rejected. Returns
+ * null (feature off) when no workspace root is configured.
+ */
+export function resolveCliDispatchCwd(input: unknown, workspaceRoot: string, taskId?: number): string | null {
+  if (typeof input !== 'string' || !input.trim()) return null
+  if (!workspaceRoot) {
+    logger.warn({ taskId }, 'Ignoring dispatch cwd: MC_WORKSPACE_ROOT is not configured')
+    return null
+  }
+  try {
+    const realRoot = realpathSync(path.resolve(workspaceRoot))
+    const realCwd = realpathSync(path.resolve(realRoot, input.trim()))
+    if (realCwd !== realRoot && !realCwd.startsWith(realRoot + path.sep)) {
+      logger.warn({ taskId }, 'Ignoring dispatch cwd: resolves outside the configured workspace root')
+      return null
+    }
+    if (!statSync(realCwd).isDirectory()) {
+      logger.warn({ taskId }, 'Ignoring dispatch cwd: not a directory')
+      return null
+    }
+    return realCwd
+  } catch {
+    logger.warn({ taskId }, 'Ignoring dispatch cwd: path does not exist or is not accessible')
+    return null
+  }
+}
+
+/**
+ * Resolve the opt-in CLI sandbox options for a task: agent config first,
+ * per-field override from tasks.metadata. All fields validated; anything
+ * invalid degrades to "flag not passed" (today's behavior).
+ */
+export function resolveCliSandboxOptions(
+  task: Pick<DispatchableTask, 'id' | 'agent_config' | 'metadata'>,
+  workspaceRoot: string = config.workspaceRoot,
+): CliDispatchSandboxOptions {
+  let agentCfg: Record<string, any> = {}
+  if (task.agent_config) {
+    try {
+      const parsed = JSON.parse(task.agent_config)
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) agentCfg = parsed
+    } catch { /* ignore */ }
+  }
+  const meta = safeParseMetadata(task.metadata)
+
+  const pick = (camel: string, snake: string): unknown => {
+    if (meta[camel] !== undefined) return meta[camel]
+    if (meta[snake] !== undefined) return meta[snake]
+    return agentCfg[camel]
+  }
+
+  return {
+    allowedTools: filterCliAllowedTools(pick('dispatchAllowedTools', 'dispatch_allowed_tools'), task.id),
+    maxBudgetUsd: clampCliMaxBudgetUsd(pick('dispatchMaxBudgetUsd', 'dispatch_max_budget_usd'), task.id),
+    cwd: resolveCliDispatchCwd(pick('dispatchCwd', 'dispatch_cwd'), workspaceRoot, task.id),
+  }
 }
 
 function buildTaskPrompt(task: DispatchableTask, rejectionFeedback?: string | null): string {
@@ -725,15 +866,26 @@ async function callClaudeViaCli(
   model: string,
 ): Promise<AgentResponseParsed> {
   const soul = getAgentSoulContent(task)
+  const sandbox = resolveCliSandboxOptions(task)
   const args = ['--print', '--output-format', 'json', '--model', model]
+  if (sandbox.allowedTools) args.push('--allowedTools', sandbox.allowedTools.join(','))
+  if (sandbox.maxBudgetUsd !== null) args.push('--max-budget-usd', String(sandbox.maxBudgetUsd))
   if (soul) args.push('--append-system-prompt', soul)
 
-  logger.info({ taskId: task.id, model, agent: task.agent_name }, 'Dispatching task via Claude CLI')
+  const sandboxApplied = sandbox.allowedTools !== null || sandbox.maxBudgetUsd !== null || sandbox.cwd !== null
+  logger.info(
+    {
+      taskId: task.id, model, agent: task.agent_name,
+      ...(sandboxApplied ? { sandbox: { allowedTools: sandbox.allowedTools, maxBudgetUsd: sandbox.maxBudgetUsd, cwd: sandbox.cwd } } : {}),
+    },
+    'Dispatching task via Claude CLI',
+  )
 
   return await new Promise<AgentResponseParsed>((resolve, reject) => {
     const proc = spawn('claude', args, {
       stdio: ['pipe', 'pipe', 'pipe'],
       env: { ...process.env, CI: '1' },
+      ...(sandbox.cwd ? { cwd: sandbox.cwd } : {}),
     })
     let stdout = ''
     let stderr = ''
@@ -892,12 +1044,19 @@ async function callCodexViaCli(
   if (model && /^gpt-/i.test(model)) args.push('--model', model)
   args.push('-')
 
-  logger.info({ taskId: task.id, model, agent: task.agent_name }, 'Dispatching task via Codex CLI')
+  // Workspace-scoped cwd only (issue #720) — codex's own --sandbox flag
+  // handling above stays untouched.
+  const dispatchCwd = resolveCliSandboxOptions(task).cwd
+  logger.info(
+    { taskId: task.id, model, agent: task.agent_name, ...(dispatchCwd ? { sandbox: { cwd: dispatchCwd } } : {}) },
+    'Dispatching task via Codex CLI',
+  )
 
   return await new Promise<AgentResponseParsed>((resolve, reject) => {
     const proc = spawn('codex', args, {
       stdio: ['pipe', 'pipe', 'pipe'],
       env: { ...process.env },
+      ...(dispatchCwd ? { cwd: dispatchCwd } : {}),
     })
     let stdout = ''
     let stderr = ''


### PR DESCRIPTION
Closes #720.

Implements the issue's four asks with the guardrails from the maintainer triage comment:

- **`allowedTools`** → `--allowedTools` — every entry validated against an exported `CLAUDE_CLI_ALLOWED_TOOL_NAMES` allowlist (exact match; `Bash(...)` specifiers rejected); unknown entries warn-and-drop; an all-invalid list omits the flag entirely, which in `--print` mode is the *more restrictive* default — fails closed. `--dangerously-skip-permissions` is never passed.
- **`maxBudgetUsd`** → `--max-budget-usd` — finite positive, ceiling-capped at 100.
- **`cwd`** → spawn option for both `claude` and `codex` dispatch — must resolve (`realpathSync`) inside the new `MC_WORKSPACE_ROOT`; rejects `../` traversal, symlink escapes, and sibling-prefix dirs; feature disabled entirely when the root is unset.
- Config source of truth: `agents.config` flat `dispatch*` keys with per-task `tasks.metadata` override (camelCase or snake_case), mirroring the existing `dispatchModel`/`dispatch_run_id` precedent — the `sandbox` namespace is already occupied by synced OpenClaw settings.
- Absent config → dispatch args byte-identical to today. Applied flags are logged (no secrets).

Validation: typecheck clean, 0 new lint findings, **1114/1114 tests green (30 new)** covering allowlist filtering, budget clamping, and cwd escape rejection.