### PR TITLE
feat(workspaces): native brand + isolation fields (issue #677 slice 1)

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1161,7 +1161,15 @@
     "decommissionQueuedDryRun": "تمت إضافة إيقاف التشغيل التجريبي لـ {slug} لقائمة الانتظار",
     "decommissionQueued": "تمت إضافة إيقاف تشغيل {slug} لقائمة الانتظار",
     "optionalReason": "سبب اختياري لـ {action}:",
-    "jobActioned": "تم {action} الوظيفة #{jobId}"
+    "jobActioned": "تم {action} الوظيفة #{jobId}",
+    "workspaceFieldsTitle": "مساحات العمل",
+    "workspaceFieldsDesc": "وسم العلامة التجارية وعزل ذاكرة الوكلاء لكل مساحة عمل.",
+    "workspaceBrandPlaceholder": "العلامة التجارية (اختياري)",
+    "isolationShared": "مشترك",
+    "isolationStrict": "صارم",
+    "save": "حفظ",
+    "saving": "جارٍ الحفظ...",
+    "workspaceFieldsSaved": "تم تحديث مساحة العمل {name}"
   },
   "auditTrail": {
     "title": "مسار التدقيق",

--- a/messages/de.json
+++ b/messages/de.json
@@ -1161,7 +1161,15 @@
     "decommissionQueuedDryRun": "Probelauf-Stilllegung für {slug} eingereiht",
     "decommissionQueued": "Stilllegung für {slug} eingereiht",
     "optionalReason": "Optionale Begründung für {action}:",
-    "jobActioned": "Job #{jobId} wurde {action}"
+    "jobActioned": "Job #{jobId} wurde {action}",
+    "workspaceFieldsTitle": "Workspaces",
+    "workspaceFieldsDesc": "Brand-Tag und Agenten-Speicher-Isolation pro Workspace.",
+    "workspaceBrandPlaceholder": "Brand (optional)",
+    "isolationShared": "Geteilt",
+    "isolationStrict": "Strikt",
+    "save": "Speichern",
+    "saving": "Speichert...",
+    "workspaceFieldsSaved": "Workspace {name} aktualisiert"
   },
   "auditTrail": {
     "title": "Prüfprotokoll",

--- a/messages/en.json
+++ b/messages/en.json
@@ -771,7 +771,6 @@
     "colFailed": "Failed",
     "retryTask": "Retry Task",
     "colDone": "Done",
-    "colFailed": "Failed",
     "recurring": "RECURRING",
     "spawned": "SPAWNED",
     "spawnedFromTask": "Spawned from task #{id}",
@@ -1166,7 +1165,15 @@
     "decommissionQueuedDryRun": "Decommission job queued for {slug} (dry-run)",
     "decommissionQueued": "Decommission job queued for {slug}",
     "optionalReason": "Optional reason for {action}:",
-    "jobActioned": "Job #{jobId} {action}d"
+    "jobActioned": "Job #{jobId} {action}d",
+    "workspaceFieldsTitle": "Workspaces",
+    "workspaceFieldsDesc": "Brand tag and agent memory isolation per workspace.",
+    "workspaceBrandPlaceholder": "Brand (optional)",
+    "isolationShared": "Shared",
+    "isolationStrict": "Strict",
+    "save": "Save",
+    "saving": "Saving...",
+    "workspaceFieldsSaved": "Workspace {name} updated"
   },
   "auditTrail": {
     "title": "Audit Trail",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1161,7 +1161,15 @@
     "decommissionQueuedDryRun": "Retiro simulacro encolado para {slug}",
     "decommissionQueued": "Retiro encolado para {slug}",
     "optionalReason": "Motivo opcional para {action}:",
-    "jobActioned": "Trabajo #{jobId} {action}"
+    "jobActioned": "Trabajo #{jobId} {action}",
+    "workspaceFieldsTitle": "Espacios de trabajo",
+    "workspaceFieldsDesc": "Etiqueta de marca y aislamiento de memoria de agentes por espacio de trabajo.",
+    "workspaceBrandPlaceholder": "Marca (opcional)",
+    "isolationShared": "Compartido",
+    "isolationStrict": "Estricto",
+    "save": "Guardar",
+    "saving": "Guardando...",
+    "workspaceFieldsSaved": "Espacio de trabajo {name} actualizado"
   },
   "auditTrail": {
     "title": "Registro de auditoría",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1161,7 +1161,15 @@
     "decommissionQueuedDryRun": "Simulation de désaffectation mise en file pour {slug}",
     "decommissionQueued": "Désaffectation mise en file pour {slug}",
     "optionalReason": "Raison optionnelle pour {action} :",
-    "jobActioned": "Travail #{jobId} {action}"
+    "jobActioned": "Travail #{jobId} {action}",
+    "workspaceFieldsTitle": "Espaces de travail",
+    "workspaceFieldsDesc": "Tag de marque et isolation mémoire des agents par espace de travail.",
+    "workspaceBrandPlaceholder": "Marque (optionnel)",
+    "isolationShared": "Partagé",
+    "isolationStrict": "Strict",
+    "save": "Enregistrer",
+    "saving": "Enregistrement...",
+    "workspaceFieldsSaved": "Espace de travail {name} mis à jour"
   },
   "auditTrail": {
     "title": "Journal d'audit",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1161,7 +1161,15 @@
     "decommissionQueuedDryRun": "{slug} のドライラン廃止がキューされました",
     "decommissionQueued": "{slug} の廃止がキューされました",
     "optionalReason": "{action} の任意の理由：",
-    "jobActioned": "ジョブ #{jobId} が{action}されました"
+    "jobActioned": "ジョブ #{jobId} が{action}されました",
+    "workspaceFieldsTitle": "ワークスペース",
+    "workspaceFieldsDesc": "ワークスペースごとのブランドタグとエージェントメモリの分離設定。",
+    "workspaceBrandPlaceholder": "ブランド（任意）",
+    "isolationShared": "共有",
+    "isolationStrict": "厳格",
+    "save": "保存",
+    "saving": "保存中...",
+    "workspaceFieldsSaved": "ワークスペース {name} を更新しました"
   },
   "auditTrail": {
     "title": "監査ログ",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1161,7 +1161,15 @@
     "decommissionQueuedDryRun": "{slug}에 대한 드라이런 해제가 큐에 추가되었습니다",
     "decommissionQueued": "{slug}에 대한 해제가 큐에 추가되었습니다",
     "optionalReason": "{action}에 대한 선택적 이유:",
-    "jobActioned": "작업 #{jobId}가 {action}되었습니다"
+    "jobActioned": "작업 #{jobId}가 {action}되었습니다",
+    "workspaceFieldsTitle": "워크스페이스",
+    "workspaceFieldsDesc": "워크스페이스별 브랜드 태그 및 에이전트 메모리 격리 설정.",
+    "workspaceBrandPlaceholder": "브랜드 (선택)",
+    "isolationShared": "공유",
+    "isolationStrict": "엄격",
+    "save": "저장",
+    "saving": "저장 중...",
+    "workspaceFieldsSaved": "워크스페이스 {name} 업데이트됨"
   },
   "auditTrail": {
     "title": "감사 로그",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1161,7 +1161,15 @@
     "decommissionQueuedDryRun": "Simulação de desativação enfileirada para {slug}",
     "decommissionQueued": "Desativação enfileirada para {slug}",
     "optionalReason": "Motivo opcional para {action}:",
-    "jobActioned": "Trabalho #{jobId} foi {action}"
+    "jobActioned": "Trabalho #{jobId} foi {action}",
+    "workspaceFieldsTitle": "Espaços de trabalho",
+    "workspaceFieldsDesc": "Etiqueta de marca e isolamento de memória dos agentes por espaço de trabalho.",
+    "workspaceBrandPlaceholder": "Marca (opcional)",
+    "isolationShared": "Compartilhado",
+    "isolationStrict": "Estrito",
+    "save": "Salvar",
+    "saving": "Salvando...",
+    "workspaceFieldsSaved": "Espaço de trabalho {name} atualizado"
   },
   "auditTrail": {
     "title": "Trilha de auditoria",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -1161,7 +1161,15 @@
     "decommissionQueuedDryRun": "Пробный вывод для {slug} поставлен в очередь",
     "decommissionQueued": "Вывод для {slug} поставлен в очередь",
     "optionalReason": "Необязательная причина для {action}:",
-    "jobActioned": "Задача #{jobId} была {action}"
+    "jobActioned": "Задача #{jobId} была {action}",
+    "workspaceFieldsTitle": "Рабочие пространства",
+    "workspaceFieldsDesc": "Тег бренда и изоляция памяти агентов для каждого рабочего пространства.",
+    "workspaceBrandPlaceholder": "Бренд (необязательно)",
+    "isolationShared": "Общий",
+    "isolationStrict": "Строгий",
+    "save": "Сохранить",
+    "saving": "Сохранение...",
+    "workspaceFieldsSaved": "Рабочее пространство {name} обновлено"
   },
   "auditTrail": {
     "title": "Журнал аудита",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1401,7 +1401,15 @@
     "decommissionQueuedDryRun": "已为 {slug} 排队预演停用",
     "decommissionQueued": "已为 {slug} 排队停用",
     "optionalReason": "{action} 的可选原因：",
-    "jobActioned": "任务 #{jobId} 已{action}"
+    "jobActioned": "任务 #{jobId} 已{action}",
+    "workspaceFieldsTitle": "工作区",
+    "workspaceFieldsDesc": "每个工作区的品牌标签和代理记忆隔离策略。",
+    "workspaceBrandPlaceholder": "品牌（可选）",
+    "isolationShared": "共享",
+    "isolationStrict": "严格",
+    "save": "保存",
+    "saving": "保存中...",
+    "workspaceFieldsSaved": "工作区 {name} 已更新"
   },
   "auditTrail": {
     "title": "审计日志",

--- a/src/app/api/workspaces/[id]/route.ts
+++ b/src/app/api/workspaces/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireRole } from '@/lib/auth'
 import { getDatabase, logAuditEvent } from '@/lib/db'
+import { validateBody, updateWorkspaceSchema } from '@/lib/validation'
 import { logger } from '@/lib/logger'
 
 /**
@@ -41,7 +42,7 @@ export async function GET(
 }
 
 /**
- * PUT /api/workspaces/[id] - Update workspace name
+ * PUT /api/workspaces/[id] - Update workspace name, brand, and isolation
  */
 export async function PUT(
   request: NextRequest,
@@ -54,10 +55,11 @@ export async function PUT(
     const db = getDatabase()
     const { id } = await params
     const tenantId = auth.user.tenant_id ?? 1
-    const body = await request.json()
-    const { name } = body
+    const validated = await validateBody(request, updateWorkspaceSchema)
+    if ('error' in validated) return validated.error
+    const { name, brand, isolation } = validated.data
 
-    if (!name || typeof name !== 'string' || name.trim().length === 0) {
+    if (name.trim().length === 0) {
       return NextResponse.json({ error: 'Name is required' }, { status: 400 })
     }
 
@@ -69,11 +71,15 @@ export async function PUT(
       return NextResponse.json({ error: 'Workspace not found' }, { status: 404 })
     }
 
+    // Omitted fields keep their stored values; brand: null explicitly clears it.
+    const nextBrand = brand === undefined ? (existing.brand ?? null) : brand
+    const nextIsolation = isolation === undefined ? (existing.isolation ?? 'shared') : isolation
+
     // Don't allow renaming the default workspace slug
     const now = Math.floor(Date.now() / 1000)
     db.prepare(
-      'UPDATE workspaces SET name = ?, updated_at = ? WHERE id = ? AND tenant_id = ?'
-    ).run(name.trim(), now, Number(id), tenantId)
+      'UPDATE workspaces SET name = ?, brand = ?, isolation = ?, updated_at = ? WHERE id = ? AND tenant_id = ?'
+    ).run(name.trim(), nextBrand, nextIsolation, now, Number(id), tenantId)
 
     logAuditEvent({
       action: 'workspace_updated',
@@ -81,7 +87,14 @@ export async function PUT(
       actor_id: auth.user.id,
       target_type: 'workspace',
       target_id: Number(id),
-      detail: { old_name: existing.name, new_name: name.trim() },
+      detail: {
+        old_name: existing.name,
+        new_name: name.trim(),
+        old_brand: existing.brand ?? null,
+        new_brand: nextBrand,
+        old_isolation: existing.isolation ?? 'shared',
+        new_isolation: nextIsolation,
+      },
     })
 
     const updated = db.prepare('SELECT * FROM workspaces WHERE id = ?').get(Number(id))

--- a/src/app/api/workspaces/route.ts
+++ b/src/app/api/workspaces/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { requireRole } from '@/lib/auth'
 import { getDatabase, logAuditEvent } from '@/lib/db'
 import { listWorkspacesForTenant } from '@/lib/workspaces'
+import { validateBody, createWorkspaceSchema } from '@/lib/validation'
 import { logger } from '@/lib/logger'
 
 export async function GET(request: NextRequest) {
@@ -32,10 +33,11 @@ export async function POST(request: NextRequest) {
   try {
     const db = getDatabase()
     const tenantId = auth.user.tenant_id ?? 1
-    const body = await request.json()
-    const { name, slug } = body
+    const validated = await validateBody(request, createWorkspaceSchema)
+    if ('error' in validated) return validated.error
+    const { name, slug, brand, isolation } = validated.data
 
-    if (!name || typeof name !== 'string' || name.trim().length === 0) {
+    if (name.trim().length === 0) {
       return NextResponse.json({ error: 'Name is required' }, { status: 400 })
     }
 
@@ -56,8 +58,8 @@ export async function POST(request: NextRequest) {
 
     const now = Math.floor(Date.now() / 1000)
     const result = db.prepare(
-      'INSERT INTO workspaces (slug, name, tenant_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?)'
-    ).run(resolvedSlug, name.trim(), tenantId, now, now)
+      'INSERT INTO workspaces (slug, name, tenant_id, brand, isolation, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
+    ).run(resolvedSlug, name.trim(), tenantId, brand ?? null, isolation ?? 'shared', now, now)
 
     const workspace = db.prepare('SELECT * FROM workspaces WHERE id = ?').get(result.lastInsertRowid)
 
@@ -67,7 +69,7 @@ export async function POST(request: NextRequest) {
       actor_id: auth.user.id,
       target_type: 'workspace',
       target_id: Number(result.lastInsertRowid),
-      detail: { name: name.trim(), slug: resolvedSlug },
+      detail: { name: name.trim(), slug: resolvedSlug, brand: brand ?? null, isolation: isolation ?? 'shared' },
     })
 
     return NextResponse.json({ workspace }, { status: 201 })

--- a/src/components/panels/super-admin-panel.tsx
+++ b/src/components/panels/super-admin-panel.tsx
@@ -83,6 +83,21 @@ interface GatewayOption {
   is_primary?: number
 }
 
+// Mission Control workspace row (issue #677 slice 1: native brand + isolation)
+interface WorkspaceRow {
+  id: number
+  slug: string
+  name: string
+  tenant_id: number
+  brand: string | null
+  isolation: 'shared' | 'strict'
+}
+
+interface WorkspaceDraft {
+  brand: string
+  isolation: 'shared' | 'strict'
+}
+
 interface SchedulerTask {
   id: string
   name: string
@@ -131,6 +146,10 @@ export function SuperAdminPanel() {
   const [gatewayOptions, setGatewayOptions] = useState<GatewayOption[]>([])
   const [gatewayLoadError, setGatewayLoadError] = useState<string | null>(null)
 
+  const [workspaces, setWorkspaces] = useState<WorkspaceRow[]>([])
+  const [workspaceDrafts, setWorkspaceDrafts] = useState<Record<number, WorkspaceDraft>>({})
+  const [savingWorkspaceId, setSavingWorkspaceId] = useState<number | null>(null)
+
   const [decommissionDialog, setDecommissionDialog] = useState<DecommissionDialogState>({
     open: false,
     tenant: null,
@@ -164,7 +183,7 @@ export function SuperAdminPanel() {
       // tenants/jobs failure), so swallow their failures here. We keep the
       // HTTP error around for gateways so we can still surface gatewayLoadError.
       let gatewayError: ApiError | null = null
-      const [tenantsJson, jobsJson, gatewaysJson, schedulerJson] = await Promise.all([
+      const [tenantsJson, jobsJson, gatewaysJson, schedulerJson, workspacesJson] = await Promise.all([
         // tenants & jobs: throwing on failure is intentional — caught below and
         // surfaced via setError, matching the original `if (!res.ok) throw` paths.
         apiFetch<any>('/api/super/tenants', { cache: 'no-store' }),
@@ -176,6 +195,8 @@ export function SuperAdminPanel() {
         isLocal
           ? apiFetch<any>('/api/scheduler', { cache: 'no-store' }).catch(() => ({}))
           : Promise.resolve(null),
+        // Workspaces degrade gracefully like gateways/scheduler.
+        apiFetch<any>('/api/workspaces', { cache: 'no-store' }).catch(() => ({})),
       ])
 
       let tenantRows = Array.isArray(tenantsJson?.tenants) ? tenantsJson.tenants : []
@@ -255,6 +276,7 @@ export function SuperAdminPanel() {
       setLocalJobEvents(localEvents)
       setGatewayOptions(gatewayRows.map((g: any) => ({ id: Number(g.id), name: String(g.name), status: g.status, is_primary: g.is_primary })))
       setGatewayLoadError(gatewayError ? apiErrorMessage(gatewayError, 'Failed to load gateways') : null)
+      setWorkspaces(Array.isArray(workspacesJson?.workspaces) ? workspacesJson.workspaces : [])
       setError(null)
     } catch (e) {
       setError(apiErrorMessage(e, 'Failed to load super admin data'))
@@ -262,6 +284,32 @@ export function SuperAdminPanel() {
       setLoading(false)
     }
   }, [currentUser?.username, isLocal])
+
+  const saveWorkspaceFields = async (ws: WorkspaceRow, draft: WorkspaceDraft) => {
+    setSavingWorkspaceId(ws.id)
+    try {
+      await apiFetch(`/api/workspaces/${ws.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: ws.name,
+          brand: draft.brand.trim() === '' ? null : draft.brand.trim(),
+          isolation: draft.isolation,
+        }),
+      })
+      setWorkspaceDrafts((d) => {
+        const next = { ...d }
+        delete next[ws.id]
+        return next
+      })
+      showFeedback(true, t('workspaceFieldsSaved', { name: ws.name }))
+      await load()
+    } catch (e) {
+      showFeedback(false, apiErrorMessage(e, 'Failed to update workspace'))
+    } finally {
+      setSavingWorkspaceId(null)
+    }
+  }
 
   const loadJobDetail = useCallback(async (jobId: number) => {
     if (isLocal && jobId < 0) {
@@ -701,6 +749,63 @@ export function SuperAdminPanel() {
             </div>
           </div>
       </div>
+      )}
+
+      {workspaces.length > 0 && (
+        <div className="rounded-lg border border-border bg-card overflow-hidden">
+          <div className="px-4 py-3 border-b border-border">
+            <h3 className="text-sm font-medium text-foreground">{t('workspaceFieldsTitle')}</h3>
+            <p className="text-xs text-muted-foreground mt-0.5">{t('workspaceFieldsDesc')}</p>
+          </div>
+          <div className="p-3 space-y-2">
+            {workspaces.map((ws) => {
+              const draft = workspaceDrafts[ws.id] ?? {
+                brand: ws.brand ?? '',
+                isolation: ws.isolation ?? 'shared',
+              }
+              const dirty =
+                draft.brand !== (ws.brand ?? '') || draft.isolation !== (ws.isolation ?? 'shared')
+              return (
+                <div key={ws.id} className="flex flex-col md:flex-row md:items-center gap-2">
+                  <div className="md:w-56 min-w-0">
+                    <div className="text-xs font-medium text-foreground truncate">{ws.name}</div>
+                    <div className="text-2xs text-muted-foreground truncate">{ws.slug}</div>
+                  </div>
+                  <input
+                    value={draft.brand}
+                    maxLength={64}
+                    onChange={(e) =>
+                      setWorkspaceDrafts((d) => ({ ...d, [ws.id]: { ...draft, brand: e.target.value } }))
+                    }
+                    placeholder={t('workspaceBrandPlaceholder')}
+                    className="h-8 flex-1 px-3 rounded-md bg-secondary border border-border text-xs text-foreground"
+                  />
+                  <select
+                    value={draft.isolation}
+                    onChange={(e) =>
+                      setWorkspaceDrafts((d) => ({
+                        ...d,
+                        [ws.id]: { ...draft, isolation: e.target.value as 'shared' | 'strict' },
+                      }))
+                    }
+                    className="h-8 px-2 rounded-md bg-secondary border border-border text-xs text-foreground"
+                  >
+                    <option value="shared">{t('isolationShared')}</option>
+                    <option value="strict">{t('isolationStrict')}</option>
+                  </select>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={!dirty || savingWorkspaceId === ws.id}
+                    onClick={() => saveWorkspaceFields(ws, draft)}
+                  >
+                    {savingWorkspaceId === ws.id ? t('saving') : t('save')}
+                  </Button>
+                </div>
+              )
+            })}
+          </div>
+        </div>
       )}
 
       <div className="rounded-lg border border-border bg-card overflow-hidden">

--- a/src/lib/__tests__/workspace-brand-isolation.test.ts
+++ b/src/lib/__tests__/workspace-brand-isolation.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import Database from 'better-sqlite3'
+import { NextRequest } from 'next/server'
+import { runMigrations } from '@/lib/migrations'
+import { createWorkspaceSchema, updateWorkspaceSchema } from '@/lib/validation'
+import { WORKSPACE_ISOLATION_VALUES } from '@/lib/workspaces'
+
+/**
+ * Issue #677 slice 1: native `brand` and `isolation` fields on workspaces.
+ *
+ * SQLite's ALTER TABLE cannot add CHECK constraints, so migration 052 adds the
+ * plain columns and the allowed isolation values ('shared' | 'strict') are
+ * enforced by the zod schemas — these tests cover both layers plus the API
+ * round-trip through the real route handlers on an in-memory database.
+ */
+
+let db: InstanceType<typeof Database>
+
+vi.mock('@/lib/db', () => ({
+  getDatabase: () => db,
+  logAuditEvent: vi.fn(),
+}))
+
+const requireRole = vi.fn()
+vi.mock('@/lib/auth', () => ({
+  requireRole,
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}))
+
+function jsonRequest(url: string, method: string, body: unknown): NextRequest {
+  return new NextRequest(`http://localhost${url}`, {
+    method,
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+beforeEach(() => {
+  db = new Database(':memory:')
+  runMigrations(db)
+  const defaultWs = db.prepare('SELECT tenant_id FROM workspaces WHERE id = 1').get() as { tenant_id: number }
+  requireRole.mockReturnValue({
+    user: { id: 1, username: 'admin', role: 'admin', workspace_id: 1, tenant_id: defaultWs.tenant_id },
+  })
+})
+
+afterEach(() => {
+  db.close()
+  vi.clearAllMocks()
+})
+
+describe('migration 052_workspace_brand_isolation', () => {
+  it('adds brand and isolation columns to workspaces', () => {
+    const cols = db.prepare('PRAGMA table_info(workspaces)').all() as Array<{ name: string }>
+    const names = cols.map((c) => c.name)
+    expect(names).toContain('brand')
+    expect(names).toContain('isolation')
+  })
+
+  it('is recorded in schema_migrations', () => {
+    const row = db.prepare("SELECT id FROM schema_migrations WHERE id = '052_workspace_brand_isolation'").get()
+    expect(row).toBeDefined()
+  })
+
+  it('backfills existing rows with null brand and shared isolation', () => {
+    const ws = db.prepare('SELECT brand, isolation FROM workspaces WHERE id = 1').get() as {
+      brand: string | null
+      isolation: string
+    }
+    expect(ws.brand).toBeNull()
+    expect(ws.isolation).toBe('shared')
+  })
+})
+
+describe('workspace validation schemas', () => {
+  it('accepts every allowed isolation value', () => {
+    for (const isolation of WORKSPACE_ISOLATION_VALUES) {
+      expect(createWorkspaceSchema.safeParse({ name: 'W', isolation }).success).toBe(true)
+      expect(updateWorkspaceSchema.safeParse({ name: 'W', isolation }).success).toBe(true)
+    }
+  })
+
+  it('rejects isolation values outside the enum', () => {
+    for (const isolation of ['isolated', 'open', 'SHARED', '', 42, null]) {
+      expect(createWorkspaceSchema.safeParse({ name: 'W', isolation }).success).toBe(false)
+      expect(updateWorkspaceSchema.safeParse({ name: 'W', isolation }).success).toBe(false)
+    }
+  })
+
+  it('accepts optional brand, nullable to clear, capped at 64 chars', () => {
+    expect(createWorkspaceSchema.safeParse({ name: 'W' }).success).toBe(true)
+    expect(createWorkspaceSchema.safeParse({ name: 'W', brand: 'iaescola' }).success).toBe(true)
+    expect(updateWorkspaceSchema.safeParse({ name: 'W', brand: null }).success).toBe(true)
+    expect(createWorkspaceSchema.safeParse({ name: 'W', brand: 'x'.repeat(64) }).success).toBe(true)
+    expect(createWorkspaceSchema.safeParse({ name: 'W', brand: 'x'.repeat(65) }).success).toBe(false)
+    expect(createWorkspaceSchema.safeParse({ name: 'W', brand: 42 }).success).toBe(false)
+  })
+})
+
+describe('workspaces API round-trip', () => {
+  it('POST /api/workspaces persists brand and isolation', async () => {
+    const { POST } = await import('@/app/api/workspaces/route')
+    const res = await POST(jsonRequest('/api/workspaces', 'POST', {
+      name: 'Petit Roig',
+      brand: 'petit_roig',
+      isolation: 'strict',
+    }))
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body.workspace.brand).toBe('petit_roig')
+    expect(body.workspace.isolation).toBe('strict')
+  })
+
+  it('POST /api/workspaces defaults isolation to shared and brand to null', async () => {
+    const { POST } = await import('@/app/api/workspaces/route')
+    const res = await POST(jsonRequest('/api/workspaces', 'POST', { name: 'Plain' }))
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body.workspace.brand).toBeNull()
+    expect(body.workspace.isolation).toBe('shared')
+  })
+
+  it('POST /api/workspaces rejects invalid isolation values', async () => {
+    const { POST } = await import('@/app/api/workspaces/route')
+    const res = await POST(jsonRequest('/api/workspaces', 'POST', {
+      name: 'Bad',
+      isolation: 'isolated',
+    }))
+    expect(res.status).toBe(400)
+  })
+
+  it('PUT /api/workspaces/[id] updates fields, preserves omitted ones, and clears brand with null', async () => {
+    const { POST } = await import('@/app/api/workspaces/route')
+    const { PUT } = await import('@/app/api/workspaces/[id]/route')
+    const created = await (await POST(jsonRequest('/api/workspaces', 'POST', {
+      name: 'IAEscola',
+      brand: 'iaescola',
+      isolation: 'strict',
+    }))).json()
+    const id = String(created.workspace.id)
+    const params = { params: Promise.resolve({ id }) }
+
+    // Omitting brand/isolation preserves stored values
+    let res = await PUT(jsonRequest(`/api/workspaces/${id}`, 'PUT', { name: 'IAEscola 2' }), params)
+    expect(res.status).toBe(200)
+    let body = await res.json()
+    expect(body.workspace.name).toBe('IAEscola 2')
+    expect(body.workspace.brand).toBe('iaescola')
+    expect(body.workspace.isolation).toBe('strict')
+
+    // Explicit updates apply; brand: null clears
+    res = await PUT(jsonRequest(`/api/workspaces/${id}`, 'PUT', {
+      name: 'IAEscola 2',
+      brand: null,
+      isolation: 'shared',
+    }), params)
+    expect(res.status).toBe(200)
+    body = await res.json()
+    expect(body.workspace.brand).toBeNull()
+    expect(body.workspace.isolation).toBe('shared')
+  })
+
+  it('PUT /api/workspaces/[id] rejects invalid isolation values', async () => {
+    const { PUT } = await import('@/app/api/workspaces/[id]/route')
+    const res = await PUT(
+      jsonRequest('/api/workspaces/1', 'PUT', { name: 'Default Workspace', isolation: 'open' }),
+      { params: Promise.resolve({ id: '1' }) }
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('GET /api/workspaces returns brand and isolation for each workspace', async () => {
+    const { GET, POST } = await import('@/app/api/workspaces/route')
+    await POST(jsonRequest('/api/workspaces', 'POST', { name: 'Branded', brand: 'acme', isolation: 'strict' }))
+    const res = await GET(new NextRequest('http://localhost/api/workspaces'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    const branded = body.workspaces.find((w: { slug: string }) => w.slug === 'branded')
+    expect(branded.brand).toBe('acme')
+    expect(branded.isolation).toBe('strict')
+    for (const ws of body.workspaces) {
+      expect('brand' in ws).toBe(true)
+      expect(WORKSPACE_ISOLATION_VALUES).toContain(ws.isolation)
+    }
+  })
+})

--- a/src/lib/migrations.ts
+++ b/src/lib/migrations.ts
@@ -1452,6 +1452,24 @@ const migrations: Migration[] = [
       }
       db.prepare("DELETE FROM settings WHERE key = 'security.api_key'").run()
     }
+  },
+  {
+    id: '052_workspace_brand_isolation',
+    up(db: Database.Database) {
+      // Issue #677 slice 1: native `brand` and `isolation` fields on workspaces.
+      // - brand: free-text tag for cross-tenant logical grouping (nullable).
+      // - isolation: 'shared' | 'strict' — whether cross-workspace memory access
+      //   from agents is allowed. SQLite's ALTER TABLE cannot add CHECK
+      //   constraints, so the allowed values are enforced in the validation
+      //   layer (see workspace schemas in src/lib/validation.ts).
+      const cols = db.prepare(`PRAGMA table_info(workspaces)`).all() as Array<{ name: string }>
+      if (!cols.some((c) => c.name === 'brand')) {
+        db.exec(`ALTER TABLE workspaces ADD COLUMN brand TEXT DEFAULT NULL`)
+      }
+      if (!cols.some((c) => c.name === 'isolation')) {
+        db.exec(`ALTER TABLE workspaces ADD COLUMN isolation TEXT NOT NULL DEFAULT 'shared'`)
+      }
+    }
   }
 ]
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { ZodSchema, ZodError } from 'zod'
 import { z } from 'zod'
+import { WORKSPACE_ISOLATION_VALUES } from './workspaces'
 
 export async function validateBody<T>(
   request: Request,
@@ -116,6 +117,31 @@ export const createAgentSchema = z.object({
   provision_openclaw_workspace: z.boolean().optional(),
   openclaw_workspace_path: z.string().min(1).max(500).optional(),
   runtime_type: z.enum(['hermes', 'openclaw', 'claude', 'codex', 'custom']).optional(),
+})
+
+// Workspace fields (issue #677 slice 1). The `isolation` CHECK cannot live in
+// SQLite (ALTER TABLE cannot add constraints), so this enum is the enforcement
+// point for allowed values. `brand` is a free-text grouping tag; null clears it.
+const workspaceFields = {
+  name: z.string().min(1, 'Name is required').max(200),
+  slug: z.string().min(1).max(200),
+  brand: z.string().trim().min(1, 'Brand cannot be empty').max(64).nullable(),
+  isolation: z.enum(WORKSPACE_ISOLATION_VALUES),
+}
+
+export const createWorkspaceSchema = z.object({
+  name: workspaceFields.name,
+  slug: workspaceFields.slug.optional(),
+  brand: workspaceFields.brand.optional(),
+  isolation: workspaceFields.isolation.optional(),
+})
+
+// `brand`/`isolation` omitted ⇒ stored values are preserved (no defaults here,
+// same rationale as updateTaskSchema above).
+export const updateWorkspaceSchema = z.object({
+  name: workspaceFields.name,
+  brand: workspaceFields.brand.optional(),
+  isolation: workspaceFields.isolation.optional(),
 })
 
 export const bulkUpdateTaskStatusSchema = z.object({

--- a/src/lib/workspaces.ts
+++ b/src/lib/workspaces.ts
@@ -1,10 +1,20 @@
 import type Database from 'better-sqlite3'
 
+// Allowed workspace isolation policies (issue #677 slice 1):
+// - 'shared': cross-workspace memory access from agents is allowed (default)
+// - 'strict': cross-workspace memory access from agents is not allowed
+// SQLite ALTER TABLE cannot add CHECK constraints, so these values are the
+// single source of truth for the validation layer.
+export const WORKSPACE_ISOLATION_VALUES = ['shared', 'strict'] as const
+export type WorkspaceIsolation = (typeof WORKSPACE_ISOLATION_VALUES)[number]
+
 export interface WorkspaceRecord {
   id: number
   slug: string
   name: string
   tenant_id: number
+  brand: string | null
+  isolation: WorkspaceIsolation
   created_at: number
   updated_at: number
 }
@@ -62,7 +72,7 @@ export function getWorkspaceForTenant(
   tenantId: number
 ): WorkspaceRecord | null {
   const row = db.prepare(`
-    SELECT id, slug, name, tenant_id, created_at, updated_at
+    SELECT id, slug, name, tenant_id, brand, isolation, created_at, updated_at
     FROM workspaces
     WHERE id = ? AND tenant_id = ?
     LIMIT 1
@@ -75,7 +85,7 @@ export function listWorkspacesForTenant(
   tenantId: number
 ): WorkspaceRecord[] {
   return db.prepare(`
-    SELECT id, slug, name, tenant_id, created_at, updated_at
+    SELECT id, slug, name, tenant_id, brand, isolation, created_at, updated_at
     FROM workspaces
     WHERE tenant_id = ?
     ORDER BY CASE WHEN slug = 'default' THEN 0 ELSE 1 END, name COLLATE NOCASE ASC


### PR DESCRIPTION
Refs #677 — implements slice 1 only; the approval-rules engine remains deferred to its own design issue.

- Migration `052_workspace_brand_isolation`: `brand TEXT` (nullable) + `isolation TEXT NOT NULL DEFAULT 'shared'`, idempotent
- **Enum follows the issue author's spec exactly: `shared | strict`** (SQLite can't ALTER-in CHECK constraints, so `WORKSPACE_ISOLATION_VALUES` in `src/lib/workspaces.ts` is the single source of truth, enforced in validation)
- Workspace POST/PUT validated via schema (brand trimmed/64-cap/null-to-clear; omitted fields preserve stored values); audit log records old/new values; role posture unchanged
- Super-admin panel gains a Workspaces card (brand input + isolation select, `apiFetch` throughout); i18n keys added for all 10 locales
- 12 new tests through the real migration runner: migration, schema accept/reject, full API round-trip

Validation: typecheck clean, 0 new lint findings, 1103/1103 tests green.