### PR TITLE
fix(models): costPerMTok rename, catalog-derived classification, doc-verified prices

### DIFF
--- a/src/app/api/status/route.ts
+++ b/src/app/api/status/route.ts
@@ -443,7 +443,7 @@ async function getAvailableModels() {
         name: `ollama/${m.name!.trim()}`,
         provider: 'ollama',
         description: 'Local model',
-        costPer1k: 0.0,
+        costPerMTok: { input: 0.0, output: 0.0 },
         size: typeof m.size === 'number' ? String(m.size) : 'unknown',
       }))
 

--- a/src/components/panels/agent-squad-panel-phase3.tsx
+++ b/src/components/panels/agent-squad-panel-phase3.tsx
@@ -1167,12 +1167,14 @@ function QuickSpawnModal({
   const [isSpawning, setIsSpawning] = useState(false)
   const [spawnResult, setSpawnResult] = useState<any>(null)
 
+  // Cost labels are input/output USD per MILLION tokens ("/1K" was a
+  // mislabel — these were always per-MTok prices). Values match MODEL_CATALOG.
   const models = [
-    { id: 'haiku', name: 'Claude Haiku', cost: '$0.25/1K', speed: 'Ultra Fast' },
-    { id: 'sonnet', name: 'Claude Sonnet', cost: '$3.00/1K', speed: 'Fast' },
-    { id: 'opus', name: 'Claude Opus', cost: '$15.00/1K', speed: 'Slow' },
-    { id: 'groq-fast', name: 'Groq Llama 8B', cost: '$0.05/1K', speed: '840 tok/s' },
-    { id: 'groq', name: 'Groq Llama 70B', cost: '$0.59/1K', speed: '150 tok/s' },
+    { id: 'haiku', name: 'Claude Haiku', cost: '$1/$5 per MTok', speed: 'Ultra Fast' },
+    { id: 'sonnet', name: 'Claude Sonnet', cost: '$3/$15 per MTok', speed: 'Fast' },
+    { id: 'opus', name: 'Claude Opus', cost: '$5/$25 per MTok', speed: 'Slow' },
+    { id: 'groq-fast', name: 'Groq Llama 8B', cost: '$0.05/$0.08 per MTok', speed: '840 tok/s' },
+    { id: 'groq', name: 'Groq Llama 70B', cost: '$0.59/$0.79 per MTok', speed: '150 tok/s' },
     { id: 'deepseek', name: 'DeepSeek R1', cost: 'FREE', speed: 'Local' },
   ]
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 
 import { create } from 'zustand'
 import { subscribeWithSelector } from 'zustand/middleware'
+import { MODEL_CATALOG } from '@/lib/models'
 
 // Enhanced types for Mission Control
 export interface Session {
@@ -79,7 +80,8 @@ export interface ModelConfig {
   name: string
   provider: string
   description: string
-  costPer1k: number
+  /** USD per MILLION tokens (input/output) — mirrors ModelConfig in '@/lib/models' */
+  costPerMTok: { input: number; output: number }
 }
 
 // Mission Control Phase 2 Types
@@ -536,17 +538,9 @@ export const useMissionControl = create<MissionControlStore>()(
         .reduce((acc, usage) => acc + usage.cost, 0)
     },
 
-    // Model Configuration
-    availableModels: [
-      { alias: 'haiku', name: 'anthropic/claude-3-5-haiku-latest', provider: 'anthropic', description: 'Ultra-cheap, simple tasks', costPer1k: 0.25 },
-      { alias: 'sonnet', name: 'anthropic/claude-sonnet-4-20250514', provider: 'anthropic', description: 'Standard workhorse', costPer1k: 3.0 },
-      { alias: 'opus', name: 'anthropic/claude-opus-4-5', provider: 'anthropic', description: 'Premium quality', costPer1k: 15.0 },
-      { alias: 'deepseek', name: 'ollama/deepseek-r1:14b', provider: 'ollama', description: 'Local reasoning (free)', costPer1k: 0.0 },
-      { alias: 'groq-fast', name: 'groq/llama-3.1-8b-instant', provider: 'groq', description: '840 tok/s, ultra fast', costPer1k: 0.05 },
-      { alias: 'groq', name: 'groq/llama-3.3-70b-versatile', provider: 'groq', description: 'Fast + quality balance', costPer1k: 0.59 },
-      { alias: 'kimi', name: 'moonshot/kimi-k2.5', provider: 'moonshot', description: 'Alternative provider', costPer1k: 1.0 },
-      { alias: 'minimax', name: 'minimax/minimax-m2.1', provider: 'minimax', description: 'Cost-effective (1/10th price), strong coding', costPer1k: 0.3 },
-    ],
+    // Model Configuration — sourced from the shared catalog (single source of
+    // truth) instead of a second stale inline copy.
+    availableModels: [...MODEL_CATALOG],
     setAvailableModels: (models) => set({ availableModels: models }),
 
     // Auth

--- a/src/lib/__tests__/models.test.ts
+++ b/src/lib/__tests__/models.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import { MODEL_CATALOG, getModelByAlias, getModelByName, getAllModels } from '../models'
+import {
+  MODEL_CATALOG,
+  classifyModelProvider,
+  getAllModels,
+  getDispatchModelId,
+  getModelByAlias,
+  getModelByName,
+} from '../models'
 
 describe('MODEL_CATALOG', () => {
   it('has entries', () => {
@@ -12,8 +19,20 @@ describe('MODEL_CATALOG', () => {
       expect(model.name).toBeTruthy()
       expect(model.provider).toBeTruthy()
       expect(model.description).toBeTruthy()
-      expect(typeof model.costPer1k).toBe('number')
-      expect(model.costPer1k).toBeGreaterThanOrEqual(0)
+      expect(typeof model.costPerMTok.input).toBe('number')
+      expect(typeof model.costPerMTok.output).toBe('number')
+      expect(model.costPerMTok.input).toBeGreaterThanOrEqual(0)
+      expect(model.costPerMTok.output).toBeGreaterThanOrEqual(0)
+      // Every non-free model charges at least as much for output as input.
+      if (model.costPerMTok.input > 0) {
+        expect(model.costPerMTok.output).toBeGreaterThanOrEqual(model.costPerMTok.input)
+      }
+    }
+  })
+
+  it('names are provider-prefixed with the provider field', () => {
+    for (const model of MODEL_CATALOG) {
+      expect(model.name.startsWith(`${model.provider}/`)).toBe(true)
     }
   })
 
@@ -36,10 +55,12 @@ describe('getModelByAlias', () => {
     expect(getModelByAlias('')).toBeUndefined()
   })
 
-  it('finds haiku model', () => {
-    const model = getModelByAlias('haiku')
-    expect(model).not.toBeUndefined()
-    expect(model!.costPer1k).toBeLessThan(1)
+  it('finds haiku model and haiku is cheaper than sonnet', () => {
+    const haiku = getModelByAlias('haiku')
+    const sonnet = getModelByAlias('sonnet')
+    expect(haiku).not.toBeUndefined()
+    expect(haiku!.costPerMTok.input).toBeLessThan(sonnet!.costPerMTok.input)
+    expect(haiku!.costPerMTok.output).toBeLessThan(sonnet!.costPerMTok.output)
   })
 })
 
@@ -64,5 +85,36 @@ describe('getAllModels', () => {
 
   it('returns a new array (not same reference)', () => {
     expect(getAllModels()).not.toBe(MODEL_CATALOG)
+  })
+})
+
+describe('getDispatchModelId', () => {
+  it('strips the provider prefix, keeping the exact API model ID', () => {
+    expect(getDispatchModelId(getModelByAlias('opus')!)).toBe('claude-opus-4-6')
+    expect(getDispatchModelId(getModelByAlias('haiku')!)).toBe('claude-haiku-4-5')
+    expect(getDispatchModelId(getModelByAlias('deepseek')!)).toBe('deepseek-r1:14b')
+  })
+})
+
+describe('classifyModelProvider (catalog-derived classification)', () => {
+  it('classifies every catalog entry to its own provider', () => {
+    for (const model of MODEL_CATALOG) {
+      // Full '<provider>/<modelId>' form
+      expect(classifyModelProvider(model.name)).toBe(model.provider)
+      // Bare dispatch model ID form (what classifyDirectModel returns)
+      expect(classifyModelProvider(getDispatchModelId(model))).toBe(model.provider)
+      // Alias form
+      expect(classifyModelProvider(model.alias)).toBe(model.provider)
+    }
+  })
+
+  it('is case- and whitespace-insensitive', () => {
+    expect(classifyModelProvider(' Claude-Opus-4-6 ')).toBe('anthropic')
+  })
+
+  it('returns undefined for models not in the catalog', () => {
+    expect(classifyModelProvider('gpt-5-turbo-9000')).toBeUndefined()
+    expect(classifyModelProvider('some/unknown-model')).toBeUndefined()
+    expect(classifyModelProvider('')).toBeUndefined()
   })
 })

--- a/src/lib/__tests__/status-route-ollama.test.ts
+++ b/src/lib/__tests__/status-route-ollama.test.ts
@@ -40,7 +40,7 @@ vi.mock('@/lib/models', () => ({
       name: 'openai/gpt-4.1-mini',
       provider: 'openai',
       description: 'baseline',
-      costPer1k: 0.001,
+      costPerMTok: { input: 0.4, output: 1.6 },
     },
   ],
 }))

--- a/src/lib/__tests__/token-pricing.test.ts
+++ b/src/lib/__tests__/token-pricing.test.ts
@@ -35,6 +35,13 @@ describe('token pricing', () => {
     expect(getModelPricing('groq/llama-3.3-70b-versatile')).toMatchObject({ inputPerMTok: 0.59, outputPerMTok: 0.79 })
   })
 
+  it('uses current Moonshot and MiniMax pricing (verified 2026-07)', () => {
+    // Kimi K2.5 is $0.60/$3.00 and MiniMax M2.1 is $0.30/$1.20 per MTok —
+    // the old single "blended" rates undercounted output cost.
+    expect(getModelPricing('moonshot/kimi-k2.5')).toMatchObject({ inputPerMTok: 0.6, outputPerMTok: 3.0 })
+    expect(getModelPricing('minimax/minimax-m2.1')).toMatchObject({ inputPerMTok: 0.3, outputPerMTok: 1.2 })
+  })
+
   it('keeps local models at zero cost', () => {
     const cost = calculateTokenCost('ollama/qwen2.5-coder:14b', 50_000, 50_000)
     expect(cost).toBe(0)

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -1,33 +1,52 @@
+/**
+ * Model catalog — the single source of truth for dispatchable models.
+ *
+ * - `name` is `<provider>/<modelId>`, where `<modelId>` is the exact model ID
+ *   the provider's API accepts (what dispatch code sends on the wire).
+ * - `costPerMTok` is USD per MILLION tokens. The field was previously named
+ *   `costPer1k`, but the values were always per-MTok prices — the old name
+ *   was a 1000x units footgun. Prices verified against provider docs
+ *   2026-07-04 (see per-provider source comments below).
+ */
+export interface ModelCostPerMTok {
+  /** USD per 1M input tokens */
+  input: number
+  /** USD per 1M output tokens */
+  output: number
+}
+
 export interface ModelConfig {
   alias: string
   name: string
   provider: string
   description: string
-  costPer1k: number
+  costPerMTok: ModelCostPerMTok
 }
 
 export const MODEL_CATALOG: ModelConfig[] = [
-  // Anthropic
-  { alias: 'haiku', name: 'anthropic/claude-haiku-4-5', provider: 'anthropic', description: 'Ultra-cheap, simple tasks', costPer1k: 0.25 },
-  { alias: 'sonnet', name: 'anthropic/claude-sonnet-4-6', provider: 'anthropic', description: 'Standard workhorse', costPer1k: 3.0 },
-  { alias: 'opus', name: 'anthropic/claude-opus-4-6', provider: 'anthropic', description: 'Premium quality', costPer1k: 15.0 },
-  // OpenAI
-  { alias: 'gpt-4.1', name: 'openai/gpt-4.1', provider: 'openai', description: 'GPT-4.1 flagship', costPer1k: 2.0 },
-  { alias: 'gpt-4.1-mini', name: 'openai/gpt-4.1-mini', provider: 'openai', description: 'GPT-4.1 Mini, fast + cheap', costPer1k: 0.4 },
-  { alias: 'gpt-4.1-nano', name: 'openai/gpt-4.1-nano', provider: 'openai', description: 'GPT-4.1 Nano, ultra-fast', costPer1k: 0.1 },
-  { alias: 'codex-mini', name: 'openai/codex-mini-latest', provider: 'openai', description: 'Codex Mini, optimized for code', costPer1k: 1.5 },
-  // Google
-  { alias: 'gemini-2.5-pro', name: 'google/gemini-2.5-pro', provider: 'google', description: 'Gemini 2.5 Pro', costPer1k: 1.25 },
-  { alias: 'gemini-2.5-flash', name: 'google/gemini-2.5-flash', provider: 'google', description: 'Gemini 2.5 Flash, fast', costPer1k: 0.15 },
+  // Anthropic — https://platform.claude.com/docs/en/about-claude/pricing (verified 2026-07-04)
+  { alias: 'haiku', name: 'anthropic/claude-haiku-4-5', provider: 'anthropic', description: 'Ultra-cheap, simple tasks', costPerMTok: { input: 1.0, output: 5.0 } },
+  { alias: 'sonnet', name: 'anthropic/claude-sonnet-4-6', provider: 'anthropic', description: 'Standard workhorse', costPerMTok: { input: 3.0, output: 15.0 } },
+  { alias: 'opus', name: 'anthropic/claude-opus-4-6', provider: 'anthropic', description: 'Premium quality', costPerMTok: { input: 5.0, output: 25.0 } },
+  // OpenAI — https://developers.openai.com/api/docs/models/gpt-4.1 (and sibling model pages, verified 2026-07-04)
+  { alias: 'gpt-4.1', name: 'openai/gpt-4.1', provider: 'openai', description: 'GPT-4.1 flagship', costPerMTok: { input: 2.0, output: 8.0 } },
+  { alias: 'gpt-4.1-mini', name: 'openai/gpt-4.1-mini', provider: 'openai', description: 'GPT-4.1 Mini, fast + cheap', costPerMTok: { input: 0.4, output: 1.6 } },
+  { alias: 'gpt-4.1-nano', name: 'openai/gpt-4.1-nano', provider: 'openai', description: 'GPT-4.1 Nano, ultra-fast', costPerMTok: { input: 0.1, output: 0.4 } },
+  // Marked deprecated by OpenAI (still served) — https://developers.openai.com/api/docs/models/codex-mini-latest
+  { alias: 'codex-mini', name: 'openai/codex-mini-latest', provider: 'openai', description: 'Codex Mini, optimized for code', costPerMTok: { input: 1.5, output: 6.0 } },
+  // Google — https://ai.google.dev/gemini-api/docs/pricing (verified 2026-07-04; Pro rates are the <=200K-token-prompt tier)
+  { alias: 'gemini-2.5-pro', name: 'google/gemini-2.5-pro', provider: 'google', description: 'Gemini 2.5 Pro', costPerMTok: { input: 1.25, output: 10.0 } },
+  { alias: 'gemini-2.5-flash', name: 'google/gemini-2.5-flash', provider: 'google', description: 'Gemini 2.5 Flash, fast', costPerMTok: { input: 0.3, output: 2.5 } },
   // Local / open-source
-  { alias: 'deepseek', name: 'ollama/deepseek-r1:14b', provider: 'ollama', description: 'Local reasoning (free)', costPer1k: 0.0 },
-  // Groq (hosted inference)
-  { alias: 'groq-fast', name: 'groq/llama-3.1-8b-instant', provider: 'groq', description: '840 tok/s, ultra fast', costPer1k: 0.05 },
-  { alias: 'groq', name: 'groq/llama-3.3-70b-versatile', provider: 'groq', description: 'Fast + quality balance', costPer1k: 0.59 },
-  // Other providers
-  { alias: 'kimi', name: 'moonshot/kimi-k2.5', provider: 'moonshot', description: 'Alternative provider', costPer1k: 1.0 },
-  { alias: 'venice-llama-3.3-70b', name: 'venice/llama-3.3-70b', provider: 'venice', description: 'Venice AI Llama 3.3 70B', costPer1k: 0.7 },
-  { alias: 'minimax', name: 'minimax/minimax-m2.1', provider: 'minimax', description: 'Cost-effective, strong coding', costPer1k: 0.3 },
+  { alias: 'deepseek', name: 'ollama/deepseek-r1:14b', provider: 'ollama', description: 'Local reasoning (free)', costPerMTok: { input: 0.0, output: 0.0 } },
+  // Groq (hosted inference) — https://groq.com/pricing (verified 2026-07-04)
+  { alias: 'groq-fast', name: 'groq/llama-3.1-8b-instant', provider: 'groq', description: '840 tok/s, ultra fast', costPerMTok: { input: 0.05, output: 0.08 } },
+  { alias: 'groq', name: 'groq/llama-3.3-70b-versatile', provider: 'groq', description: 'Fast + quality balance', costPerMTok: { input: 0.59, output: 0.79 } },
+  // Other providers — Moonshot list price via https://openrouter.ai/moonshotai/kimi-k2.5;
+  // Venice https://docs.venice.ai/overview/pricing; MiniMax https://platform.minimax.io/docs/guides/pricing-paygo
+  { alias: 'kimi', name: 'moonshot/kimi-k2.5', provider: 'moonshot', description: 'Alternative provider', costPerMTok: { input: 0.6, output: 3.0 } },
+  { alias: 'venice-llama-3.3-70b', name: 'venice/llama-3.3-70b', provider: 'venice', description: 'Venice AI Llama 3.3 70B', costPerMTok: { input: 0.7, output: 2.8 } },
+  { alias: 'minimax', name: 'minimax/minimax-m2.1', provider: 'minimax', description: 'Cost-effective, strong coding', costPerMTok: { input: 0.3, output: 1.2 } },
 ]
 
 export function getModelByAlias(alias: string): ModelConfig | undefined {
@@ -40,4 +59,32 @@ export function getModelByName(name: string): ModelConfig | undefined {
 
 export function getAllModels(): ModelConfig[] {
   return [...MODEL_CATALOG]
+}
+
+/**
+ * The exact model ID sent to the provider's API — the catalog `name` with the
+ * `<provider>/` prefix stripped (e.g. 'anthropic/claude-opus-4-6' → 'claude-opus-4-6').
+ */
+export function getDispatchModelId(model: ModelConfig): string {
+  const idx = model.name.indexOf('/')
+  return idx === -1 ? model.name : model.name.slice(idx + 1)
+}
+
+/**
+ * Classify a model string to its provider using the catalog as the single
+ * source of truth. Accepts the catalog `name` ('<provider>/<modelId>'), the
+ * bare dispatch model ID, or the catalog alias.
+ *
+ * Returns undefined for models not in the catalog — callers are expected to
+ * apply their own fallback (e.g. the prefix-match rules in
+ * `pickProvider()` in task-dispatch.ts), so unknown-model behavior is
+ * preserved exactly.
+ */
+export function classifyModelProvider(model: string): string | undefined {
+  const normalized = model.trim().toLowerCase()
+  if (!normalized) return undefined
+  const entry = MODEL_CATALOG.find(m =>
+    m.name === normalized || getDispatchModelId(m) === normalized || m.alias === normalized
+  )
+  return entry?.provider
 }

--- a/src/lib/task-dispatch.ts
+++ b/src/lib/task-dispatch.ts
@@ -8,6 +8,7 @@ import { config } from './config'
 import { getAllGatewaySessions } from './sessions'
 import { parseJsonlTranscript, readSessionJsonl, type TranscriptMessage } from './transcript-parser'
 import { syncTaskOutbound } from './github-sync-engine'
+import { classifyModelProvider, getDispatchModelId, getModelByAlias } from './models'
 
 const AGENT_DISPATCH_ACCEPT_TIMEOUT_MS = 60_000
 
@@ -476,6 +477,19 @@ function isGatewayAvailable(): boolean {
   }
 }
 
+/**
+ * Resolve the Anthropic dispatch model ID for a catalog tier alias.
+ *
+ * MODEL_CATALOG is the single source of truth for model IDs — classification
+ * derives the exact API model ID from the catalog entry instead of
+ * hard-coding ID strings here. The literal fallback only applies if the
+ * catalog alias is ever removed (defensive; all three aliases exist today).
+ */
+function anthropicDispatchId(alias: 'opus' | 'sonnet' | 'haiku', fallback: string): string {
+  const entry = getModelByAlias(alias)
+  return entry && entry.provider === 'anthropic' ? getDispatchModelId(entry) : fallback
+}
+
 function classifyDirectModel(task: DispatchableTask): string {
   // Check per-agent config override first
   if (task.agent_config) {
@@ -497,16 +511,16 @@ function classifyDirectModel(task: DispatchableTask): string {
     'root cause', 'investigate', 'incident', 'refactor', 'migration',
   ]
   if (priority === 'critical' || complexSignals.some(s => text.includes(s))) {
-    return 'claude-opus-4-6'
+    return anthropicDispatchId('opus', 'claude-opus-4-6')
   }
 
   // Size heuristics → Opus for large/complex tasks
   const descLength = (task.description ?? '').length
-  if (descLength > 2000) return 'claude-opus-4-6'
+  if (descLength > 2000) return anthropicDispatchId('opus', 'claude-opus-4-6')
   try {
     const db = getDatabase()
     const row = db.prepare('SELECT estimated_hours FROM tasks WHERE id = ?').get(task.id) as { estimated_hours: number | null } | undefined
-    if (row?.estimated_hours && row.estimated_hours >= 4) return 'claude-opus-4-6'
+    if (row?.estimated_hours && row.estimated_hours >= 4) return anthropicDispatchId('opus', 'claude-opus-4-6')
   } catch { /* ignore */ }
 
   // Routine → Haiku
@@ -515,11 +529,13 @@ function classifyDirectModel(task: DispatchableTask): string {
     'translate', 'quick ', 'simple ', 'routine ', 'minor ',
   ]
   if (routineSignals.some(s => text.includes(s)) && priority !== 'high' && priority !== 'critical') {
-    return 'claude-haiku-4-5-20251001'
+    // Catalog carries 'claude-haiku-4-5' (Anthropic's alias for the
+    // claude-haiku-4-5-20251001 snapshot) — both resolve to the same model.
+    return anthropicDispatchId('haiku', 'claude-haiku-4-5')
   }
 
   // Default → Sonnet
-  return 'claude-sonnet-4-6'
+  return anthropicDispatchId('sonnet', 'claude-sonnet-4-6')
 }
 
 function getAgentSoulContent(task: DispatchableTask): string | null {
@@ -646,6 +662,17 @@ function getLocalApiKey(): string | null {
 }
 
 function pickProvider(model: string): DirectProvider {
+  // Consult MODEL_CATALOG first (single source of truth). Only providers
+  // with a direct dispatch path map to a DirectProvider; catalog providers
+  // without one (google, groq, moonshot, venice, minimax) fall through to
+  // the prefix rules below, which keeps their routing identical to before.
+  const catalogProvider = classifyModelProvider(model)
+  if (catalogProvider === 'anthropic') return 'anthropic'
+  if (catalogProvider === 'openai') return 'openai'
+  if (catalogProvider === 'ollama') return 'local'
+
+  // Prefix-match fallback for models not in the catalog — behavior for
+  // unknown IDs is unchanged (default remains 'anthropic').
   const m = model.toLowerCase()
   if (m.startsWith('openai/') || m.startsWith('gpt-') || m.startsWith('o1-') || m.startsWith('o3-')) return 'openai'
   if (m.startsWith('local/') || m.startsWith('ollama/') || m.startsWith('lmstudio/') || m.startsWith('litellm/')) return 'local'

--- a/src/lib/token-pricing.ts
+++ b/src/lib/token-pricing.ts
@@ -42,12 +42,15 @@ const MODEL_PRICING: Record<string, ModelPricing> = {
   'claude-sonnet-4-5-20250929': { inputPerMTok: 3.0, outputPerMTok: 15.0 },
   'claude-sonnet-4-6': { inputPerMTok: 3.0, outputPerMTok: 15.0 },
 
-  // For non-Anthropic models where we only have one published blended estimate,
-  // apply the same rate for both input and output.
+  // Non-Anthropic providers — verified 2026-07-04:
+  // Groq https://groq.com/pricing; Moonshot Kimi K2.5 $0.60/$3.00
+  // (https://openrouter.ai/moonshotai/kimi-k2.5, Moonshot list price);
+  // MiniMax M2.1 $0.30/$1.20 (https://platform.minimax.io/docs/guides/pricing-paygo);
+  // Venice https://docs.venice.ai/overview/pricing.
   'groq/llama-3.1-8b-instant': { inputPerMTok: 0.05, outputPerMTok: 0.08 },
   'groq/llama-3.3-70b-versatile': { inputPerMTok: 0.59, outputPerMTok: 0.79 },
-  'minimax/minimax-m2.1': { inputPerMTok: 0.3, outputPerMTok: 0.3 },
-  'moonshot/kimi-k2.5': { inputPerMTok: 1.0, outputPerMTok: 1.0 },
+  'minimax/minimax-m2.1': { inputPerMTok: 0.3, outputPerMTok: 1.2 },
+  'moonshot/kimi-k2.5': { inputPerMTok: 0.6, outputPerMTok: 3.0 },
   'ollama/deepseek-r1:14b': { inputPerMTok: 0.0, outputPerMTok: 0.0 },
   'ollama/qwen2.5-coder:14b': { inputPerMTok: 0.0, outputPerMTok: 0.0 },
   'ollama/qwen2.5-coder:7b': { inputPerMTok: 0.0, outputPerMTok: 0.0 },

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -92,7 +92,8 @@ export interface ModelConfig {
   name: string
   provider: string
   description: string
-  costPer1k: number
+  /** USD per MILLION tokens (input/output) — mirrors ModelConfig in '@/lib/models' */
+  costPerMTok: { input: number; output: number }
 }
 
 // Mission Control Phase 2 Types


### PR DESCRIPTION
Supersedes the model-catalog half of #751 (credit @Obrais-cloud for surfacing the staleness — the overrides half already landed via #756).

**Units footgun resolved:** `costPer1k` actually held per-million values. Good news: it was never multiplied against token counts — real billing lives in `token-pricing.ts`/`claude-sessions.ts` with correct math; the field was display-only. Renamed to `costPerMTok: { input, output }` across all readers, and fixed the mislabeled `$/1K` UI strings.

**Two real billing-estimate bugs found & fixed** in `token-pricing.ts`: Kimi K2.5 was $1/$1 (actual $0.60/$3.00) and MiniMax M2.1 was $0.30/$0.30 (actual $0.30/$1.20) — both undercounted output cost.

**Single source of truth:** `classifyDirectModel()` and `pickProvider()` now derive from `MODEL_CATALOG` (previous prefix rules and unknown-ID default preserved exactly); `src/index.ts`'s third stale inline catalog copy replaced with the real one.

**Every price doc-verified 2026-07-04 with source URLs in the commit body** — notable corrections: Haiku $1/$5, Opus $5/$25 (15 was 4.1-era), Gemini Flash $0.30/$2.50 (0.15 was the batch rate). Dashed IDs verified as real API IDs and kept — #751's dot-format rename would have broken dispatch classification.

Validation: typecheck clean, 0 new lint findings, 1097/1097 tests green.