### PR TITLE
fix(token-usage): correct INSERT columns so dispatch usage persists

### DIFF
--- a/src/lib/task-dispatch.ts
+++ b/src/lib/task-dispatch.ts
@@ -748,14 +748,13 @@ async function callClaudeDirectly(
       const db = getDatabase()
       const now = Math.floor(Date.now() / 1000)
       db.prepare(`
-        INSERT INTO token_usage (model, session_id, input_tokens, output_tokens, total_tokens, cost, created_at, workspace_id)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO token_usage (model, session_id, input_tokens, output_tokens, cost_usd, created_at, workspace_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
       `).run(
         model,
         `task-${task.id}`,
         data.usage.input_tokens || 0,
         data.usage.output_tokens || 0,
-        (data.usage.input_tokens || 0) + (data.usage.output_tokens || 0),
         0, // cost calculated separately
         now,
         task.workspace_id,
@@ -947,14 +946,13 @@ async function callClaudeViaCli(
             const db = getDatabase()
             const now = Math.floor(Date.now() / 1000)
             db.prepare(`
-              INSERT INTO token_usage (model, session_id, input_tokens, output_tokens, total_tokens, cost, created_at, workspace_id)
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+              INSERT INTO token_usage (model, session_id, input_tokens, output_tokens, cost_usd, created_at, workspace_id)
+              VALUES (?, ?, ?, ?, ?, ?, ?)
             `).run(
               model,
               sessionId || `task-${task.id}`,
               parsed.usage.input_tokens || 0,
               parsed.usage.output_tokens || 0,
-              (parsed.usage.input_tokens || 0) + (parsed.usage.output_tokens || 0),
               0,
               now,
               task.workspace_id,
@@ -1015,14 +1013,13 @@ async function callOpenAICompatible(
       const db = getDatabase()
       const now = Math.floor(Date.now() / 1000)
       db.prepare(`
-        INSERT INTO token_usage (model, session_id, input_tokens, output_tokens, total_tokens, cost, created_at, workspace_id)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO token_usage (model, session_id, input_tokens, output_tokens, cost_usd, created_at, workspace_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
       `).run(
         model,
         `task-${task.id}`,
         data.usage.prompt_tokens || 0,
         data.usage.completion_tokens || 0,
-        (data.usage.prompt_tokens || 0) + (data.usage.completion_tokens || 0),
         0,
         now,
         task.workspace_id,


### PR DESCRIPTION
Problem: the 3 INSERT INTO token_usage in src/lib/task-dispatch.ts write to columns that do not exist (total_tokens, cost). Every insert throws and is swallowed by the non-fatal catch, so token_usage never records dispatch usage and the Cost Tracker reads zero for all providers. Real schema: model, session_id, input_tokens, output_tokens, created_at, workspace_id, task_id, cost_usd, agent_name.

Fix: align the 3 INSERTs with the real columns (drop total_tokens, rename cost -> cost_usd). Minimal, no behavior change beyond the inserts succeeding.

Verified: token_usage had 0 rows before; after the fix a real dispatch run persists a row.
