### PR TITLE
fix(security): harden CI publishing and webhook delivery

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -31,7 +31,10 @@ jobs:
       github.event_name == 'push' ||
       (
         github.event_name == 'workflow_run' &&
-        github.event.workflow_run.conclusion == 'success'
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_branch == 'main' &&
+        github.event.workflow_run.head_repository.full_name == github.repository
       )
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/screenshot-drift.yml
+++ b/.github/workflows/screenshot-drift.yml
@@ -67,9 +67,13 @@ jobs:
         # Fork PRs get a read-only token — label/comment calls would 403.
         if: steps.ui_changed.outputs.count > 0 && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v9
+        env:
+          CHANGED_UI_PATHS: ${{ steps.ui_changed.outputs.paths }}
         with:
           script: |
-            const paths = `${{ steps.ui_changed.outputs.paths }}`;
+            // Treat filenames as data. Direct expression interpolation here would
+            // allow a crafted filename to break out of this JavaScript program.
+            const paths = process.env.CHANGED_UI_PATHS || '';
             const body = [
               '## 📸 Screenshot Drift Check',
               '',

--- a/.github/workflows/star-chart.yml
+++ b/.github/workflows/star-chart.yml
@@ -24,12 +24,12 @@ jobs:
 
       - name: Commit if changed
         run: |
-          if git diff --quiet -- assets; then
+          if git diff --quiet -- docs/star-history-light.svg docs/star-history-dark.svg; then
             echo "No chart changes."
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add docs/star-history-light.svg assets/star-history-dark.svg
+          git add docs/star-history-light.svg docs/star-history-dark.svg
           git commit -m "chore: refresh star-history charts"
           git push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Open-source dashboard for AI agent orchestration. Manage agent fleets, track tasks, monitor costs, and orchestrate workflows.
 
-**Stack**: Next.js 16, React 19, TypeScript 5, SQLite (better-sqlite3), Tailwind CSS 3, Zustand, pnpm
+**Stack**: Next.js 16, React 19, TypeScript 5, SQLite (better-sqlite3), Tailwind CSS 4, Zustand, pnpm
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ mission-control/
 | Layer | Technology |
 |-------|------------|
 | Framework | Next.js 16 (App Router) |
-| UI | React 19, Tailwind CSS 3.4 |
+| UI | React 19, Tailwind CSS 4 |
 | Language | TypeScript 5.7 |
 | Database | SQLite via better-sqlite3 (WAL mode) |
 | State | Zustand 5 |

--- a/package.json
+++ b/package.json
@@ -91,23 +91,5 @@
     "type": "git",
     "url": "https://github.com/builderz-labs/mission-control.git"
   },
-  "packageManager": "pnpm@10.29.3",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@parcel/watcher",
-      "@swc/core",
-      "better-sqlite3",
-      "esbuild",
-      "node-pty",
-      "sharp",
-      "unrs-resolver"
-    ],
-    "minimumReleaseAge": 10080,
-    "minimumReleaseAgeExclude": [],
-    "overrides": {
-      "postcss@8": ">=8.5.10",
-      "ts-deepmerge": ">=8.0.0",
-      "eslint-plugin-react-hooks": "~7.0.1"
-    }
-  }
+  "packageManager": "pnpm@10.29.3"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,16 @@
+onlyBuiltDependencies:
+  - '@parcel/watcher'
+  - '@swc/core'
+  - better-sqlite3
+  - esbuild
+  - node-pty
+  - sharp
+  - unrs-resolver
+
+minimumReleaseAge: 10080
+minimumReleaseAgeExclude: []
+
+overrides:
+  postcss@8: '>=8.5.10'
+  ts-deepmerge: '>=8.0.0'
+  eslint-plugin-react-hooks: ~7.0.1

--- a/src/app/api/webhooks/route.ts
+++ b/src/app/api/webhooks/route.ts
@@ -6,32 +6,7 @@ import { mutationLimiter } from '@/lib/rate-limit'
 import { logger } from '@/lib/logger'
 import { validateBody, createWebhookSchema } from '@/lib/validation'
 import { requireWorkspaceId } from '@/lib/enforcement/workspace-scope'
-
-const WEBHOOK_BLOCKED_HOSTNAMES = new Set([
-  'localhost', '127.0.0.1', '::1', '0.0.0.0',
-  'metadata.google.internal', 'metadata.internal', 'instance-data',
-])
-
-function isBlockedWebhookUrl(urlStr: string): boolean {
-  try {
-    const url = new URL(urlStr)
-    const hostname = url.hostname
-    if (WEBHOOK_BLOCKED_HOSTNAMES.has(hostname)) return true
-    if (hostname.endsWith('.local')) return true
-    // Block private IPv4 ranges
-    if (/^\d{1,3}(\.\d{1,3}){3}$/.test(hostname)) {
-      const parts = hostname.split('.').map(Number)
-      if (parts[0] === 10) return true
-      if (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) return true
-      if (parts[0] === 192 && parts[1] === 168) return true
-      if (parts[0] === 169 && parts[1] === 254) return true
-      if (parts[0] === 127) return true
-    }
-    return false
-  } catch {
-    return true
-  }
-}
+import { isBlockedWebhookUrl } from '@/lib/webhooks'
 
 /**
  * GET /api/webhooks - List all webhooks with delivery stats

--- a/src/lib/__tests__/task-dispatch.test.ts
+++ b/src/lib/__tests__/task-dispatch.test.ts
@@ -1,5 +1,42 @@
 import { describe, expect, it } from 'vitest'
-import { resolveTaskDispatchModelOverride } from '@/lib/task-dispatch'
+import Database from 'better-sqlite3'
+import { insertDispatchTokenUsage, resolveTaskDispatchModelOverride } from '@/lib/task-dispatch'
+
+describe('insertDispatchTokenUsage', () => {
+  it('persists dispatch usage using the current token_usage schema', () => {
+    const db = new Database(':memory:')
+    db.exec(`
+      CREATE TABLE token_usage (
+        model TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        input_tokens INTEGER NOT NULL,
+        output_tokens INTEGER NOT NULL,
+        created_at INTEGER NOT NULL,
+        workspace_id INTEGER NOT NULL,
+        cost_usd REAL
+      )
+    `)
+
+    insertDispatchTokenUsage(db, {
+      model: 'test-model',
+      sessionId: 'task-42',
+      inputTokens: 120,
+      outputTokens: 30,
+      workspaceId: 7,
+    }, 1_700_000_000)
+
+    expect(db.prepare('SELECT * FROM token_usage').get()).toEqual({
+      model: 'test-model',
+      session_id: 'task-42',
+      input_tokens: 120,
+      output_tokens: 30,
+      created_at: 1_700_000_000,
+      workspace_id: 7,
+      cost_usd: 0,
+    })
+    db.close()
+  })
+})
 
 describe('resolveTaskDispatchModelOverride', () => {
   it('returns null when the agent has no explicit dispatch model override', () => {

--- a/src/lib/__tests__/webhooks.test.ts
+++ b/src/lib/__tests__/webhooks.test.ts
@@ -1,6 +1,27 @@
 import { describe, expect, it } from 'vitest'
 import { createHmac } from 'crypto'
-import { verifyWebhookSignature, nextRetryDelay } from '../webhooks'
+import { isBlockedWebhookUrl, verifyWebhookSignature, nextRetryDelay } from '../webhooks'
+
+describe('isBlockedWebhookUrl', () => {
+  it.each([
+    'http://127.0.0.1/hook',
+    'http://10.0.0.1/hook',
+    'http://100.64.0.1/hook',
+    'http://169.254.169.254/latest/meta-data',
+    'http://192.168.1.2/hook',
+    'http://[::1]/hook',
+    'http://[fd00::1]/hook',
+    'http://service.local/hook',
+    'file:///etc/passwd',
+  ])('blocks internal destination %s', (url) => {
+    expect(isBlockedWebhookUrl(url)).toBe(true)
+  })
+
+  it('allows public HTTP and HTTPS destinations', () => {
+    expect(isBlockedWebhookUrl('https://hooks.example.com/events')).toBe(false)
+    expect(isBlockedWebhookUrl('http://203.0.113.10/events')).toBe(false)
+  })
+})
 
 describe('verifyWebhookSignature', () => {
   const secret = 'test-secret-key-1234'

--- a/src/lib/task-dispatch.ts
+++ b/src/lib/task-dispatch.ts
@@ -10,6 +10,7 @@ import { getAllGatewaySessions } from './sessions'
 import { parseJsonlTranscript, readSessionJsonl, type TranscriptMessage } from './transcript-parser'
 import { syncTaskOutbound } from './github-sync-engine'
 import { classifyModelProvider, getDispatchModelId, getModelByAlias } from './models'
+import type Database from 'better-sqlite3'
 
 const AGENT_DISPATCH_ACCEPT_TIMEOUT_MS = 60_000
 
@@ -45,6 +46,42 @@ interface DispatchableTask {
   tags?: string[]
   /** Raw tasks.metadata JSON — carries optional per-task sandbox overrides. */
   metadata?: string | null
+}
+
+interface DispatchTokenUsage {
+  model: string
+  sessionId: string
+  inputTokens: number
+  outputTokens: number
+  workspaceId: number
+}
+
+/** Keep dispatch accounting aligned with the token_usage migration schema. */
+export function insertDispatchTokenUsage(
+  db: Pick<Database.Database, 'prepare'>,
+  usage: DispatchTokenUsage,
+  createdAt = Math.floor(Date.now() / 1000),
+): void {
+  db.prepare(`
+    INSERT INTO token_usage (model, session_id, input_tokens, output_tokens, cost_usd, created_at, workspace_id)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    usage.model,
+    usage.sessionId,
+    usage.inputTokens,
+    usage.outputTokens,
+    0,
+    createdAt,
+    usage.workspaceId,
+  )
+}
+
+function recordDispatchTokenUsage(usage: DispatchTokenUsage): void {
+  try {
+    insertDispatchTokenUsage(getDatabase(), usage)
+  } catch (err) {
+    logger.warn({ err, model: usage.model, workspaceId: usage.workspaceId }, 'Dispatch token usage insert failed')
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -744,23 +781,13 @@ async function callClaudeDirectly(
 
   // Record token usage
   if (data.usage) {
-    try {
-      const db = getDatabase()
-      const now = Math.floor(Date.now() / 1000)
-      db.prepare(`
-        INSERT INTO token_usage (model, session_id, input_tokens, output_tokens, total_tokens, cost, created_at, workspace_id)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-      `).run(
-        model,
-        `task-${task.id}`,
-        data.usage.input_tokens || 0,
-        data.usage.output_tokens || 0,
-        (data.usage.input_tokens || 0) + (data.usage.output_tokens || 0),
-        0, // cost calculated separately
-        now,
-        task.workspace_id,
-      )
-    } catch { /* non-fatal */ }
+    recordDispatchTokenUsage({
+      model,
+      sessionId: `task-${task.id}`,
+      inputTokens: data.usage.input_tokens || 0,
+      outputTokens: data.usage.output_tokens || 0,
+      workspaceId: task.workspace_id,
+    })
   }
 
   return { text, sessionId: null }
@@ -943,23 +970,13 @@ async function callClaudeViaCli(
 
         // Record token usage if reported.
         if (parsed?.usage && (parsed.usage.input_tokens || parsed.usage.output_tokens)) {
-          try {
-            const db = getDatabase()
-            const now = Math.floor(Date.now() / 1000)
-            db.prepare(`
-              INSERT INTO token_usage (model, session_id, input_tokens, output_tokens, total_tokens, cost, created_at, workspace_id)
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-            `).run(
-              model,
-              sessionId || `task-${task.id}`,
-              parsed.usage.input_tokens || 0,
-              parsed.usage.output_tokens || 0,
-              (parsed.usage.input_tokens || 0) + (parsed.usage.output_tokens || 0),
-              0,
-              now,
-              task.workspace_id,
-            )
-          } catch { /* non-fatal */ }
+          recordDispatchTokenUsage({
+            model,
+            sessionId: sessionId || `task-${task.id}`,
+            inputTokens: parsed.usage.input_tokens || 0,
+            outputTokens: parsed.usage.output_tokens || 0,
+            workspaceId: task.workspace_id,
+          })
         }
 
         resolve({ text, sessionId })
@@ -1011,23 +1028,13 @@ async function callOpenAICompatible(
   const text = data.choices?.[0]?.message?.content?.trim() || null
 
   if (data.usage) {
-    try {
-      const db = getDatabase()
-      const now = Math.floor(Date.now() / 1000)
-      db.prepare(`
-        INSERT INTO token_usage (model, session_id, input_tokens, output_tokens, total_tokens, cost, created_at, workspace_id)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-      `).run(
-        model,
-        `task-${task.id}`,
-        data.usage.prompt_tokens || 0,
-        data.usage.completion_tokens || 0,
-        (data.usage.prompt_tokens || 0) + (data.usage.completion_tokens || 0),
-        0,
-        now,
-        task.workspace_id,
-      )
-    } catch { /* non-fatal */ }
+    recordDispatchTokenUsage({
+      model,
+      sessionId: `task-${task.id}`,
+      inputTokens: data.usage.prompt_tokens || 0,
+      outputTokens: data.usage.completion_tokens || 0,
+      workspaceId: task.workspace_id,
+    })
   }
 
   return { text, sessionId: null }

--- a/src/lib/webhooks.ts
+++ b/src/lib/webhooks.ts
@@ -1,4 +1,6 @@
 import { createHmac, timingSafeEqual } from 'crypto'
+import { lookup } from 'node:dns/promises'
+import { isIP } from 'node:net'
 import { eventBus, type ServerEvent } from './event-bus'
 import { logger } from './logger'
 
@@ -32,6 +34,47 @@ interface DeliveryResult {
 const BACKOFF_SECONDS = [30, 300, 1800, 7200, 28800]
 
 const MAX_RETRIES = parseInt(process.env.MC_WEBHOOK_MAX_RETRIES || '5', 10) || 5
+
+const WEBHOOK_BLOCKED_HOSTNAMES = new Set([
+  'localhost', '0.0.0.0', 'metadata.google.internal', 'metadata.internal', 'instance-data',
+])
+
+function isPrivateAddress(address: string): boolean {
+  const normalized = address.toLowerCase().split('%')[0]
+  if (normalized === '::1' || normalized === '::') return true
+  if (normalized.startsWith('fc') || normalized.startsWith('fd') || normalized.startsWith('fe8') || normalized.startsWith('fe9') || normalized.startsWith('fea') || normalized.startsWith('feb')) return true
+  if (normalized.startsWith('::ffff:')) return isPrivateAddress(normalized.slice(7))
+  if (isIP(normalized) !== 4) return false
+
+  const [a, b] = normalized.split('.').map(Number)
+  return a === 0 || a === 10 || a === 127 || a >= 224
+    || (a === 100 && b >= 64 && b <= 127)
+    || (a === 169 && b === 254)
+    || (a === 172 && b >= 16 && b <= 31)
+    || (a === 192 && b === 168)
+    || (a === 198 && (b === 18 || b === 19))
+}
+
+export function isBlockedWebhookUrl(urlStr: string): boolean {
+  try {
+    const url = new URL(urlStr)
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') return true
+    const hostname = url.hostname.toLowerCase().replace(/^\[|\]$/g, '').replace(/\.$/, '')
+    if (!hostname || WEBHOOK_BLOCKED_HOSTNAMES.has(hostname) || hostname.endsWith('.local')) return true
+    return isIP(hostname) !== 0 && isPrivateAddress(hostname)
+  } catch {
+    return true
+  }
+}
+
+async function assertSafeWebhookDestination(urlStr: string): Promise<void> {
+  if (isBlockedWebhookUrl(urlStr)) throw new Error('Webhook URL resolves to a blocked destination')
+  const hostname = new URL(urlStr).hostname.replace(/^\[|\]$/g, '')
+  const addresses = await lookup(hostname, { all: true, verbatim: true })
+  if (addresses.length === 0 || addresses.some(({ address }) => isPrivateAddress(address))) {
+    throw new Error('Webhook URL resolves to a private or internal address')
+  }
+}
 
 // Map event bus events to webhook event types
 const EVENT_MAP: Record<string, string> = {
@@ -203,6 +246,7 @@ async function deliverWebhook(
   let error: string | null = null
 
   try {
+    await assertSafeWebhookDestination(webhook.url)
     const controller = new AbortController()
     const timeout = setTimeout(() => controller.abort(), 10000)
 
@@ -211,6 +255,7 @@ async function deliverWebhook(
       headers,
       body,
       signal: controller.signal,
+      redirect: 'error',
     })
 
     clearTimeout(timeout)


### PR DESCRIPTION
## Summary

- prevent privileged Docker publishing from checking out PR-controlled workflow_run commits
- treat changed filenames as data in github-script to prevent expression-to-script injection
- harden webhook delivery against private IPv4/IPv6, DNS-resolved internal targets, non-HTTP schemes, and redirects
- restore pnpm 10 enforcement of dependency overrides and install-script allowlisting
- fix dispatch token usage inserts and centralize the schema-sensitive write with regression coverage
- repair star-chart workflow paths and update Tailwind 4 documentation

## Security audit context

This is the first focused remediation tranche from a repository-wide review. No open Dependabot alerts were reported. GitHub CodeQL and secret scanning are not currently enabled for this public repository; follow-up hardening should enable them and pin third-party Actions by commit SHA.

## Verification

- pnpm install --frozen-lockfile (no ignored-policy warning)
- pnpm lint (0 errors; pre-existing warnings remain)
- pnpm typecheck
- pnpm api:parity
- pnpm test (101 files, 1,143 tests)
- pnpm build
- git diff --check
- all workflow YAML parsed successfully

## PR queue decision

This supersedes the focused token column fix in #773 with regression coverage. PR #781 is intentionally excluded because its branch contains extensive unrelated fork history. PR #779 is not merged as-is pending supply-chain review of mutable action tags and major action jumps.