### PR TITLE
fix: harden privileged install boundaries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -136,6 +136,18 @@ NEXT_PUBLIC_COORDINATOR_AGENT=coordinator
 # OPENCLAW_SOUL_TEMPLATES_DIR=/path/to/.openclaw/templates/souls
 # OPENCLAW_BIN=openclaw
 
+# Remote runtime installer integrity (required for dashboard-triggered installs)
+# Fetch each installer through a trusted channel, review it, then record the
+# lowercase SHA-256 digest here. Mission Control fails closed if the digest is
+# absent or if the downloaded bytes change.
+# MC_ENABLE_RUNTIME_INSTALLS=1
+# MC_OPENCLAW_INSTALLER_SHA256=
+# MC_HERMES_INSTALLER_SHA256=
+# Per-user installs from the super-admin organization flow are separately pinned:
+# MC_OPENCLAW_GIT_COMMIT=<reviewed 40-character commit SHA>
+# MC_CLAUDE_CODE_VERSION=<exact semver>
+# MC_CODEX_VERSION=<exact semver>
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # 1Password Integration (optional)
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/docs/SECURITY-HARDENING.md
+++ b/docs/SECURITY-HARDENING.md
@@ -175,6 +175,31 @@ MC_RETAIN_TOKEN_USAGE_DAYS=90      # Token/cost records
 MC_RETAIN_GATEWAY_SESSIONS_DAYS=90 # Gateway session history
 ```
 
+### 11. Runtime Installer Integrity
+
+Dashboard-triggered OpenClaw and Hermes installations execute third-party
+shell installers. Local runtime installation is disabled by default. Enable it
+only after reviewing the source and rollback path. Mission Control also
+requires an operator-approved SHA-256 digest before either remote script can
+run:
+
+```env
+MC_ENABLE_RUNTIME_INSTALLS=1
+MC_OPENCLAW_INSTALLER_SHA256=<64 lowercase hex characters>
+MC_HERMES_INSTALLER_SHA256=<64 lowercase hex characters>
+# Required only for per-user installs from the super-admin organization flow:
+MC_OPENCLAW_GIT_COMMIT=<reviewed 40-character commit SHA>
+MC_CLAUDE_CODE_VERSION=<exact semver>
+MC_CODEX_VERSION=<exact semver>
+```
+
+Download the installer separately through a trusted channel, inspect it, and
+calculate its digest with `sha256sum install.sh` (Linux) or
+`shasum -a 256 install.sh` (macOS). If the publisher changes the installer,
+the dashboard install fails closed until you review the new bytes and update
+the configured digest. Regex and optional AI review remain defense-in-depth;
+they do not replace provenance verification.
+
 ---
 
 ## OpenClaw Gateway Hardening

--- a/ops/mc-provisioner-daemon.js
+++ b/ops/mc-provisioner-daemon.js
@@ -2,7 +2,7 @@
 
 const fs = require('fs')
 const net = require('net')
-const { spawn } = require('child_process')
+const { execFileSync, spawn } = require('child_process')
 const path = require('path')
 
 const SOCKET_PATH = process.env.MC_PROVISIONER_SOCKET || '/run/mc-provisioner.sock'
@@ -281,8 +281,12 @@ const server = net.createServer((socket) => {
 server.listen(SOCKET_PATH, () => {
   fs.chmodSync(SOCKET_PATH, 0o660)
   try {
-    const group = require('child_process').execSync(`getent group ${SOCKET_GROUP} | cut -d: -f3`).toString('utf8').trim()
-    const gid = Number(group)
+    const group = execFileSync('/usr/bin/getent', ['group', SOCKET_GROUP], {
+      encoding: 'utf8',
+      timeout: 5000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim()
+    const gid = Number(group.split(':')[2])
     if (Number.isInteger(gid)) {
       fs.chownSync(SOCKET_PATH, 0, gid)
     }

--- a/src/app/api/agent-runtimes/route.ts
+++ b/src/app/api/agent-runtimes/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { requireRole } from '@/lib/auth'
 import { detectAllRuntimes, detectRuntime, startInstall, getInstallJob, getActiveJobs, generateDockerSidecar } from '@/lib/agent-runtimes'
 import type { RuntimeId, DeploymentMode } from '@/lib/agent-runtimes'
+import { runtimeInstallsEnabled } from '@/lib/runtime-install-security'
 import { clearHermesDetectionCache } from '@/lib/hermes-sessions'
 import { logAuditEvent } from '@/lib/db'
 import { logger } from '@/lib/logger'
@@ -20,7 +21,7 @@ export async function GET(request: NextRequest) {
   const activeJobs = getActiveJobs()
   const isDocker = existsSync('/.dockerenv')
 
-  return NextResponse.json({ runtimes, activeJobs, isDocker })
+  return NextResponse.json({ runtimes, activeJobs, isDocker, runtimeInstallsEnabled: runtimeInstallsEnabled() })
 }
 
 export async function POST(request: NextRequest) {
@@ -44,6 +45,11 @@ export async function POST(request: NextRequest) {
     }
     if (!VALID_MODES.has(mode)) {
       return NextResponse.json({ error: 'Invalid mode. Use: local, docker' }, { status: 400 })
+    }
+    if (mode === 'local' && !runtimeInstallsEnabled()) {
+      return NextResponse.json({
+        error: 'Local runtime installs are disabled. Set MC_ENABLE_RUNTIME_INSTALLS=1 after reviewing the supply-chain requirements.',
+      }, { status: 403 })
     }
 
     logger.info({ runtime, mode, actor: auth.user.username }, 'Starting agent runtime install')

--- a/src/app/api/releases/update/route.ts
+++ b/src/app/api/releases/update/route.ts
@@ -5,6 +5,7 @@ import { join } from 'path'
 import { requireRole } from '@/lib/auth'
 import { getDatabase } from '@/lib/db'
 import { APP_VERSION } from '@/lib/version'
+import { normalizeReleaseTag } from '@/lib/release-update-security'
 
 const UPDATE_TIMEOUT = 5 * 60 * 1000 // 5 minutes
 const MAX_BUFFER = 10 * 1024 * 1024 // 10 MB
@@ -32,20 +33,19 @@ export async function POST(request: Request) {
   const user = auth.user!
   const cwd = process.cwd()
   const steps: { step: string; output: string }[] = []
+  let originalRef: string | null = null
+  let checkoutPerformed = false
 
   try {
     // Parse target version from request body
     const body = await request.json().catch(() => ({}))
-    const targetVersion: string | undefined = body.targetVersion
-    if (!targetVersion) {
+    const tag = normalizeReleaseTag(body.targetVersion)
+    if (!tag) {
       return NextResponse.json(
-        { error: 'Missing targetVersion in request body' },
+        { error: 'targetVersion must be an exact semantic version such as 2.1.0 or v2.1.0' },
         { status: 400 }
       )
     }
-
-    // Normalize to tag format (e.g. "1.2.0" -> "v1.2.0")
-    const tag = targetVersion.startsWith('v') ? targetVersion : `v${targetVersion}`
 
     // 1. Check for uncommitted changes
     const status = git(['status', '--porcelain'], cwd)
@@ -59,14 +59,22 @@ export async function POST(request: Request) {
         { status: 409 }
       )
     }
+    try {
+      originalRef = git(['symbolic-ref', '--quiet', '--short', 'HEAD'], cwd)
+    } catch {
+      originalRef = git(['rev-parse', '--verify', 'HEAD'], cwd)
+    }
 
-    // 2. Fetch tags and release code from origin
-    const fetchOut = git(['fetch', 'origin', '--tags', '--force'], cwd)
-    steps.push({ step: 'git fetch', output: fetchOut || 'OK' })
+    // 2. Fetch the trusted main history and the exact release tag. Fetching an
+    // exact ref prevents a stale or unrelated local tag from being accepted.
+    const fetchMainOut = git(['fetch', 'origin', 'refs/heads/main:refs/remotes/origin/main'], cwd)
+    steps.push({ step: 'git fetch origin main', output: fetchMainOut || 'OK' })
 
     // 3. Verify the tag exists
     try {
-      git(['rev-parse', '--verify', `refs/tags/${tag}`], cwd)
+      git(['ls-remote', '--exit-code', '--tags', 'origin', `refs/tags/${tag}`], cwd)
+      git(['fetch', 'origin', `refs/tags/${tag}:refs/tags/${tag}`, '--force'], cwd)
+      git(['rev-parse', '--verify', `refs/tags/${tag}^{commit}`], cwd)
     } catch {
       return NextResponse.json(
         { error: `Release tag ${tag} not found in remote` },
@@ -74,8 +82,21 @@ export async function POST(request: Request) {
       )
     }
 
+    // A tag fetched from origin is still not a trusted release if it points to
+    // unrelated history. Only release commits reachable from origin/main may
+    // execute dependency lifecycle scripts or the build.
+    try {
+      git(['merge-base', '--is-ancestor', `refs/tags/${tag}^{commit}`, 'origin/main'], cwd)
+    } catch {
+      return NextResponse.json(
+        { error: `Release tag ${tag} is not part of the trusted origin/main history` },
+        { status: 409 }
+      )
+    }
+
     // 4. Checkout the release tag
     const checkoutOut = git(['checkout', tag], cwd)
+    checkoutPerformed = true
     steps.push({ step: `git checkout ${tag}`, output: checkoutOut })
 
     // 5. Install dependencies
@@ -88,7 +109,7 @@ export async function POST(request: Request) {
 
     // 7. Read new version from package.json
     const newPkg = JSON.parse(readFileSync(join(cwd, 'package.json'), 'utf-8'))
-    const newVersion: string = newPkg.version ?? targetVersion
+    const newVersion: string = newPkg.version ?? tag.slice(1)
 
     // 8. Log to audit_log
     try {
@@ -123,11 +144,26 @@ export async function POST(request: Request) {
       err?.message ||
       'Unknown error during update'
 
+    let rollback: { attempted: boolean; restored: boolean; detail?: string } = {
+      attempted: false,
+      restored: false,
+    }
+    if (checkoutPerformed && originalRef) {
+      rollback = { attempted: true, restored: false }
+      try {
+        git(['checkout', originalRef], cwd)
+        rollback.restored = true
+      } catch (rollbackErr: any) {
+        rollback.detail = rollbackErr?.stderr?.toString?.()?.trim() || rollbackErr?.message || 'Rollback failed'
+      }
+    }
+
     return NextResponse.json(
       {
         error: 'Update failed',
         detail: message,
         steps,
+        rollback,
       },
       { status: 500 }
     )

--- a/src/app/api/super/os-users/route.ts
+++ b/src/app/api/super/os-users/route.ts
@@ -6,6 +6,8 @@ import path from 'path'
 import { requireRole, getUserFromRequest } from '@/lib/auth'
 import { getDatabase, logAuditEvent } from '@/lib/db'
 import { logger } from '@/lib/logger'
+import { resolvePinnedUserToolSpec, runtimeInstallsEnabled } from '@/lib/runtime-install-security'
+import type { UserRuntimeTool } from '@/lib/runtime-install-security'
 
 export interface OsUser {
   username: string
@@ -63,11 +65,13 @@ function checkToolExists(homeDir: string, tool: string): boolean {
 function installToolForUser(
   homeDir: string,
   username: string,
-  tool: 'openclaw' | 'claude' | 'codex'
+  tool: UserRuntimeTool,
+  packageSpec: string,
 ): { success: boolean; error?: string } {
   try {
     if (tool === 'openclaw') {
-      // openclaw is managed by MC — create dir structure + install latest from npm
+      // OpenClaw is managed by MC — create its directory structure and install
+      // the operator-reviewed immutable Git commit.
       const openclawDir = path.join(/*turbopackIgnore: true*/ homeDir, '.openclaw')
       const workspaceDir = path.join(/*turbopackIgnore: true*/ homeDir, 'workspace')
       for (const dir of [openclawDir, workspaceDir]) {
@@ -78,9 +82,8 @@ function installToolForUser(
           fs.mkdirSync(/*turbopackIgnore: true*/ dir, { recursive: true })
         }
       }
-      // Install latest openclaw from GitHub (always latest) with npm fallback
       try {
-        execFileSync('/usr/bin/sudo', ['-n', '-u', username, 'npm', 'install', '-g', 'openclaw/openclaw'], {
+        execFileSync('/usr/bin/sudo', ['-n', '-u', username, 'npm', 'install', '-g', packageSpec], {
           timeout: 120000,
           stdio: 'pipe',
           env: { ...process.env, HOME: homeDir },
@@ -97,7 +100,7 @@ function installToolForUser(
     if (tool === 'claude') {
       // Install claude code CLI globally for the user
       try {
-        execFileSync('/usr/bin/sudo', ['-n', '-u', username, 'npm', 'install', '-g', '@anthropic-ai/claude-code@latest'], {
+        execFileSync('/usr/bin/sudo', ['-n', '-u', username, 'npm', 'install', '-g', packageSpec], {
           timeout: 120000,
           stdio: 'pipe',
           env: { ...process.env, HOME: homeDir },
@@ -119,7 +122,7 @@ function installToolForUser(
     if (tool === 'codex') {
       // Install codex CLI globally for the user
       try {
-        execFileSync('/usr/bin/sudo', ['-n', '-u', username, 'npm', 'install', '-g', '@openai/codex@latest'], {
+        execFileSync('/usr/bin/sudo', ['-n', '-u', username, 'npm', 'install', '-g', packageSpec], {
           timeout: 120000,
           stdio: 'pipe',
           env: { ...process.env, HOME: homeDir },
@@ -270,6 +273,27 @@ export async function POST(request: NextRequest) {
   const installOpenclaw = !!body.install_openclaw
   const installClaude = !!body.install_claude
   const installCodex = !!body.install_codex
+  const toolsToInstall: UserRuntimeTool[] = []
+  if (installOpenclaw) toolsToInstall.push('openclaw')
+  // When OpenClaw is selected, Claude and Codex are bundled.
+  if (installClaude && !installOpenclaw) toolsToInstall.push('claude')
+  if (installCodex && !installOpenclaw) toolsToInstall.push('codex')
+
+  const pinnedToolSpecs = new Map<UserRuntimeTool, string>()
+  if (toolsToInstall.length > 0) {
+    if (!runtimeInstallsEnabled()) {
+      return NextResponse.json({
+        error: 'Runtime installs are disabled. Set MC_ENABLE_RUNTIME_INSTALLS=1 after reviewing the supply-chain requirements.',
+      }, { status: 403 })
+    }
+    for (const tool of toolsToInstall) {
+      const resolved = resolvePinnedUserToolSpec(tool)
+      if ('error' in resolved) {
+        return NextResponse.json({ error: resolved.error, tool }, { status: 400 })
+      }
+      pinnedToolSpecs.set(tool, resolved.spec)
+    }
+  }
 
   // Validate username (safe for OS user creation — alphanumeric + dash/underscore)
   if (!/^[a-z][a-z0-9_-]{1,30}[a-z0-9]$/.test(username)) {
@@ -396,14 +420,8 @@ export async function POST(request: NextRequest) {
 
     // Install requested tools (non-fatal)
     const installResults: Record<string, { success: boolean; error?: string }> = {}
-    const toolsToInstall: Array<'openclaw' | 'claude' | 'codex'> = []
-    if (installOpenclaw) toolsToInstall.push('openclaw')
-    // When openclaw is selected, claude+codex are bundled — skip separate installs
-    if (installClaude && !installOpenclaw) toolsToInstall.push('claude')
-    if (installCodex && !installOpenclaw) toolsToInstall.push('codex')
-
     for (const tool of toolsToInstall) {
-      installResults[tool] = installToolForUser(homeDir, username, tool)
+      installResults[tool] = installToolForUser(homeDir, username, tool, pinnedToolSpecs.get(tool)!)
     }
 
     const installSummary = Object.entries(installResults)

--- a/src/components/settings/agent-runtimes-section.tsx
+++ b/src/components/settings/agent-runtimes-section.tsx
@@ -32,6 +32,7 @@ interface Props {
 export function AgentRuntimesSection({ showFeedback }: Props) {
   const [runtimes, setRuntimes] = useState<RuntimeStatus[]>([])
   const [isDocker, setIsDocker] = useState(false)
+  const [runtimeInstallsEnabled, setRuntimeInstallsEnabled] = useState(false)
   const [loading, setLoading] = useState(true)
   const [activeJobs, setActiveJobs] = useState<Record<string, InstallJob>>({})
   const [expandedOutput, setExpandedOutput] = useState<string | null>(null)
@@ -44,6 +45,7 @@ export function AgentRuntimesSection({ showFeedback }: Props) {
       const data = await res.json()
       setRuntimes(data.runtimes || [])
       setIsDocker(data.isDocker || false)
+      setRuntimeInstallsEnabled(data.runtimeInstallsEnabled === true)
     } catch {
       // ignore
     } finally {
@@ -154,6 +156,12 @@ export function AgentRuntimesSection({ showFeedback }: Props) {
         Install and manage agent runtimes for running AI agents.
       </p>
 
+      {!runtimeInstallsEnabled && (
+        <div className="mb-3 p-2 rounded border border-amber-500/20 bg-amber-500/5 text-xs text-muted-foreground">
+          Local installs are disabled by default. Review the runtime supply-chain settings before enabling them.
+        </div>
+      )}
+
       {isDocker && (
         <div className="mb-3 p-2 rounded border border-void-cyan/20 bg-void-cyan/5 text-xs text-muted-foreground">
           Running in Docker — install directly or use sidecar services for production.
@@ -241,7 +249,16 @@ export function AgentRuntimesSection({ showFeedback }: Props) {
                         <Button variant="ghost" size="sm" onClick={() => handleDetect(rt.id)} className="text-2xs h-6 px-2">Refresh</Button>
                         {!rt.installed && !justInstalled && (
                           <>
-                            <Button variant="ghost" size="sm" onClick={() => handleInstall(rt.id)} className="text-2xs h-6 px-2">Install</Button>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              disabled={!runtimeInstallsEnabled}
+                              title={runtimeInstallsEnabled ? undefined : 'Enable reviewed runtime installs in the server environment first'}
+                              onClick={() => handleInstall(rt.id)}
+                              className="text-2xs h-6 px-2"
+                            >
+                              Install
+                            </Button>
                             {isDocker && (
                               <Button variant="ghost" size="sm" onClick={() => handleCopyCompose(rt.id)} className="text-2xs h-6 px-2">Sidecar YAML</Button>
                             )}
@@ -270,7 +287,7 @@ export function AgentRuntimesSection({ showFeedback }: Props) {
                     {installFailed && (
                       <div className="mt-2 space-y-1">
                         <p className="text-2xs text-red-400">Install failed: {job?.error || 'Unknown error'}</p>
-                        <Button variant="ghost" size="sm" onClick={() => handleInstall(rt.id)} className="text-2xs h-6 px-2">Retry</Button>
+                        <Button variant="ghost" size="sm" disabled={!runtimeInstallsEnabled} onClick={() => handleInstall(rt.id)} className="text-2xs h-6 px-2">Retry</Button>
                       </div>
                     )}
 

--- a/src/lib/__tests__/agent-runtime-install-security.test.ts
+++ b/src/lib/__tests__/agent-runtime-install-security.test.ts
@@ -1,0 +1,59 @@
+import { createHash } from 'node:crypto'
+import { describe, expect, it } from 'vitest'
+import { parseScriptReviewVerdict } from '@/lib/agent-runtimes'
+import { isValidInstallerSha256, resolvePinnedUserToolSpec, runtimeInstallsEnabled, verifyInstallerSha256 } from '@/lib/runtime-install-security'
+
+describe('runtime installer digest verification', () => {
+  const installer = '#!/bin/sh\necho verified\n'
+  const digest = createHash('sha256').update(installer, 'utf8').digest('hex')
+
+  it('accepts only exact SHA-256 values', () => {
+    expect(isValidInstallerSha256(digest)).toBe(true)
+    expect(isValidInstallerSha256(digest.toUpperCase())).toBe(true)
+    expect(isValidInstallerSha256('')).toBe(false)
+    expect(isValidInstallerSha256('sha256:' + digest)).toBe(false)
+    expect(isValidInstallerSha256('g'.repeat(64))).toBe(false)
+  })
+
+  it('accepts matching content and rejects changed content', () => {
+    expect(verifyInstallerSha256(installer, digest)).toEqual({
+      valid: true,
+      actualSha256: digest,
+    })
+    expect(verifyInstallerSha256(`${installer}echo changed\n`, digest).valid).toBe(false)
+  })
+
+  it('fails closed for missing or malformed expected digests', () => {
+    expect(verifyInstallerSha256(installer, '').valid).toBe(false)
+    expect(verifyInstallerSha256(installer, 'not-a-digest').valid).toBe(false)
+  })
+
+  it('requires an explicit runtime install opt-in', () => {
+    expect(runtimeInstallsEnabled({})).toBe(false)
+    expect(runtimeInstallsEnabled({ MC_ENABLE_RUNTIME_INSTALLS: 'true' })).toBe(false)
+    expect(runtimeInstallsEnabled({ MC_ENABLE_RUNTIME_INSTALLS: '1' })).toBe(true)
+  })
+
+  it('does not treat malformed AI output as a safe verdict', () => {
+    expect(parseScriptReviewVerdict('SAFE: reviewed')).toEqual({ safe: true, detail: 'SAFE: reviewed' })
+    expect(parseScriptReviewVerdict('UNSAFE: exfiltration')).toEqual({ safe: false, detail: 'UNSAFE: exfiltration' })
+    expect(parseScriptReviewVerdict('probably safe')).toBeNull()
+    expect(parseScriptReviewVerdict('')).toBeNull()
+  })
+
+  it('requires immutable per-user tool package specs', () => {
+    const commit = 'a'.repeat(40)
+    expect(resolvePinnedUserToolSpec('openclaw', { MC_OPENCLAW_GIT_COMMIT: commit })).toEqual({
+      spec: `github:openclaw/openclaw#${commit}`,
+    })
+    expect(resolvePinnedUserToolSpec('claude', { MC_CLAUDE_CODE_VERSION: '1.2.3' })).toEqual({
+      spec: '@anthropic-ai/claude-code@1.2.3',
+    })
+    expect(resolvePinnedUserToolSpec('codex', { MC_CODEX_VERSION: '0.9.0-beta.1' })).toEqual({
+      spec: '@openai/codex@0.9.0-beta.1',
+    })
+    expect(resolvePinnedUserToolSpec('openclaw', {})).toHaveProperty('error')
+    expect(resolvePinnedUserToolSpec('claude', { MC_CLAUDE_CODE_VERSION: 'latest' })).toHaveProperty('error')
+    expect(resolvePinnedUserToolSpec('codex', { MC_CODEX_VERSION: '^1.2.3' })).toHaveProperty('error')
+  })
+})

--- a/src/lib/__tests__/provisioner-command-security.test.ts
+++ b/src/lib/__tests__/provisioner-command-security.test.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('privileged provisioner command boundary', () => {
+  it('does not interpolate the configured group into a shell command', () => {
+    const source = readFileSync(resolve(process.cwd(), 'ops/mc-provisioner-daemon.js'), 'utf8')
+    expect(source).not.toContain('execSync(`getent group')
+    expect(source).toContain("execFileSync('/usr/bin/getent', ['group', SOCKET_GROUP]")
+  })
+})

--- a/src/lib/__tests__/release-update-security.test.ts
+++ b/src/lib/__tests__/release-update-security.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeReleaseTag } from '@/lib/release-update-security'
+
+describe('release update target validation', () => {
+  it.each([
+    ['2.1.0', 'v2.1.0'],
+    ['v2.1.0', 'v2.1.0'],
+    ['2.1.0-rc.1', 'v2.1.0-rc.1'],
+    ['2.1.0+build.7', 'v2.1.0+build.7'],
+  ])('normalizes %s', (input, expected) => {
+    expect(normalizeReleaseTag(input)).toBe(expected)
+  })
+
+  it.each([
+    undefined,
+    null,
+    '',
+    'latest',
+    'v1',
+    '01.2.3',
+    '1.2.3/../../main',
+    '--help',
+    '1.2.3\nmain',
+  ])('rejects unsafe or non-semver target %j', (input) => {
+    expect(normalizeReleaseTag(input)).toBeNull()
+  })
+})

--- a/src/lib/agent-runtimes.ts
+++ b/src/lib/agent-runtimes.ts
@@ -8,6 +8,14 @@ import { scanForInjection } from './injection-guard'
 import { isHermesInstalled, isHermesGatewayRunning, clearHermesDetectionCache } from './hermes-sessions'
 import { isOpenCodeInstalled, getOpenCodeVersion, scanOpenCodeSessions } from './opencode-sessions'
 import { logger } from './logger'
+import {
+  isValidInstallerSha256,
+  resolvePinnedUserToolSpec,
+  runtimeInstallsEnabled,
+  verifyInstallerSha256,
+} from './runtime-install-security'
+
+export { runtimeInstallsEnabled } from './runtime-install-security'
 
 // ---------------------------------------------------------------------------
 // Security review for downloaded installer scripts
@@ -27,9 +35,15 @@ interface ScriptReviewResult {
  */
 async function downloadAndReviewScript(
   url: string,
+  expectedSha256: string,
   job: InstallJob,
   env: NodeJS.ProcessEnv,
 ): Promise<{ scriptPath: string; tempDir: string } | null> {
+  if (!isValidInstallerSha256(expectedSha256)) {
+    job.output += '> SECURITY: Installer blocked because no valid SHA-256 digest is configured.\n'
+    return null
+  }
+
   // 1. Download to unpredictable temp dir (prevents symlink race)
   const tempDir = mkdtempSync(join(tmpdir(), 'mc-install-'))
   const scriptPath = join(tempDir, 'install.sh')
@@ -55,9 +69,11 @@ async function downloadAndReviewScript(
   }
 
   // 2. Read and scan with injection guard (regex baseline)
+  let installerBytes: Buffer
   let content: string
   try {
-    content = readFileSync(scriptPath, 'utf-8')
+    installerBytes = readFileSync(scriptPath)
+    content = installerBytes.toString('utf8')
   } catch {
     job.output += '> Failed to read downloaded script\n'
     rmSync(tempDir, { recursive: true, force: true })
@@ -69,6 +85,14 @@ async function downloadAndReviewScript(
     rmSync(tempDir, { recursive: true, force: true })
     return null
   }
+
+  const digest = verifyInstallerSha256(installerBytes, expectedSha256)
+  if (!digest.valid) {
+    job.output += `> SECURITY: Installer SHA-256 mismatch (received ${digest.actualSha256}).\n`
+    rmSync(tempDir, { recursive: true, force: true })
+    return null
+  }
+  job.output += `> Verified installer SHA-256: ${digest.actualSha256}\n`
 
   const regexReport = scanForInjection(content, { context: 'shell' })
   if (!regexReport.safe) {
@@ -149,14 +173,20 @@ ${truncated}
     const data = await res.json() as { content: Array<{ type: string; text?: string }> }
     const text = data.content?.find(b => b.type === 'text')?.text?.trim() || ''
 
-    if (text.startsWith('UNSAFE:')) {
-      return { safe: false, detail: text }
-    }
-    return { safe: true, detail: text }
+    const verdict = parseScriptReviewVerdict(text)
+    if (!verdict) logger.warn('AI script review returned an inconclusive verdict — skipping')
+    return verdict
   } catch (err: any) {
     logger.warn({ err: err.message }, 'AI script review error — skipping')
     return null
   }
+}
+
+export function parseScriptReviewVerdict(text: string): ScriptReviewResult | null {
+  const verdict = text.trim()
+  if (verdict.startsWith('UNSAFE:')) return { safe: false, detail: verdict }
+  if (verdict.startsWith('SAFE:')) return { safe: true, detail: verdict }
+  return null
 }
 
 export type RuntimeId = 'openclaw' | 'hermes' | 'claude' | 'codex' | 'opencode'
@@ -597,7 +627,12 @@ async function installOpenClawLocal(job: InstallJob): Promise<void> {
   }
   try {
     // Download, review, then execute from secure temp dir
-    const reviewed = await downloadAndReviewScript('https://get.openclaw.dev', job, env)
+    const reviewed = await downloadAndReviewScript(
+      'https://get.openclaw.dev',
+      process.env.MC_OPENCLAW_INSTALLER_SHA256 || '',
+      job,
+      env,
+    )
     if (!reviewed) {
       job.status = 'failed'
       job.error = 'Installer download or security review failed'
@@ -605,12 +640,15 @@ async function installOpenClawLocal(job: InstallJob): Promise<void> {
       return
     }
 
-    const result = await runCommand('bash', [reviewed.scriptPath, '--non-interactive'], {
-      timeoutMs: 300_000, env,
-      onData: (chunk) => { job.output += chunk },
-    })
-
-    rmSync(reviewed.tempDir, { recursive: true, force: true })
+    let result
+    try {
+      result = await runCommand('bash', [reviewed.scriptPath, '--non-interactive'], {
+        timeoutMs: 300_000, env,
+        onData: (chunk) => { job.output += chunk },
+      })
+    } finally {
+      rmSync(reviewed.tempDir, { recursive: true, force: true })
+    }
 
     // Verify the binary actually exists after install
     const { installed: verified } = detectBinary([config.openclawBin || 'openclaw'])
@@ -657,7 +695,12 @@ async function installHermesLocal(job: InstallJob): Promise<void> {
     const hermesUrl = 'https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh'
 
     // Download, review, then execute from secure temp dir
-    const reviewed = await downloadAndReviewScript(hermesUrl, job, env)
+    const reviewed = await downloadAndReviewScript(
+      hermesUrl,
+      process.env.MC_HERMES_INSTALLER_SHA256 || '',
+      job,
+      env,
+    )
     if (!reviewed) {
       job.status = 'failed'
       job.error = 'Installer download or security review failed'
@@ -668,12 +711,15 @@ async function installHermesLocal(job: InstallJob): Promise<void> {
     // Patch /dev/tty check for non-TTY environments before running
     await runCommand('sed', ['-i.bak', 's/\\[ -e \\/dev\\/tty \\]/false/g', reviewed.scriptPath], { timeoutMs: 5_000 }).catch(() => {})
 
-    const result = await runCommand('bash', [reviewed.scriptPath, '--skip-setup'], {
-      timeoutMs: 600_000, env,
-      onData: (chunk) => { job.output += chunk },
-    })
-
-    rmSync(reviewed.tempDir, { recursive: true, force: true })
+    let result
+    try {
+      result = await runCommand('bash', [reviewed.scriptPath, '--skip-setup'], {
+        timeoutMs: 600_000, env,
+        onData: (chunk) => { job.output += chunk },
+      })
+    } finally {
+      rmSync(reviewed.tempDir, { recursive: true, force: true })
+    }
 
     // Verify install actually worked — check for the binary
     clearHermesDetectionCache()
@@ -704,7 +750,12 @@ async function installHermesLocal(job: InstallJob): Promise<void> {
 
 async function installClaudeLocal(job: InstallJob): Promise<void> {
   job.output += '> Installing Claude Code...\n'
-  if (await runInstallCmd('npm', ['install', '-g', '@anthropic-ai/claude-code'], job)) {
+  const resolved = resolvePinnedUserToolSpec('claude')
+  if ('error' in resolved) {
+    job.status = 'failed'
+    job.error = resolved.error
+    job.output += `> SECURITY: ${resolved.error}\n`
+  } else if (await runInstallCmd('npm', ['install', '-g', resolved.spec], job)) {
     job.status = 'success'
     job.output += '\n> Claude Code installed successfully.\n'
     job.output += '> Run "claude login" to authenticate.\n'
@@ -717,7 +768,12 @@ async function installClaudeLocal(job: InstallJob): Promise<void> {
 
 async function installCodexLocal(job: InstallJob): Promise<void> {
   job.output += '> Installing Codex CLI...\n'
-  if (await runInstallCmd('npm', ['install', '-g', '@openai/codex'], job)) {
+  const resolved = resolvePinnedUserToolSpec('codex')
+  if ('error' in resolved) {
+    job.status = 'failed'
+    job.error = resolved.error
+    job.output += `> SECURITY: ${resolved.error}\n`
+  } else if (await runInstallCmd('npm', ['install', '-g', resolved.spec], job)) {
     job.status = 'success'
     job.output += '\n> Codex CLI installed successfully.\n'
     job.output += '> Run "codex auth" to authenticate.\n'

--- a/src/lib/release-update-security.ts
+++ b/src/lib/release-update-security.ts
@@ -1,0 +1,9 @@
+const SEMVER_RELEASE = /^(?:v)?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
+
+export function normalizeReleaseTag(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  const match = SEMVER_RELEASE.exec(trimmed)
+  if (!match) return null
+  return trimmed.startsWith('v') ? trimmed : `v${trimmed}`
+}

--- a/src/lib/runtime-install-security.ts
+++ b/src/lib/runtime-install-security.ts
@@ -1,0 +1,48 @@
+import { createHash, timingSafeEqual } from 'node:crypto'
+
+export type UserRuntimeTool = 'openclaw' | 'claude' | 'codex'
+
+export interface InstallerDigestResult {
+  valid: boolean
+  actualSha256: string
+}
+
+const EXACT_NPM_VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/
+
+export function runtimeInstallsEnabled(env: Record<string, string | undefined> = process.env): boolean {
+  return env.MC_ENABLE_RUNTIME_INSTALLS === '1'
+}
+
+export function isValidInstallerSha256(value: string | undefined): boolean {
+  return /^[a-f0-9]{64}$/i.test(String(value || '').trim())
+}
+
+export function verifyInstallerSha256(content: string | Buffer, expectedSha256: string): InstallerDigestResult {
+  const actualSha256 = createHash('sha256').update(content).digest('hex')
+  if (!isValidInstallerSha256(expectedSha256)) return { valid: false, actualSha256 }
+
+  const expected = Buffer.from(expectedSha256.trim().toLowerCase(), 'hex')
+  const actual = Buffer.from(actualSha256, 'hex')
+  return { valid: timingSafeEqual(actual, expected), actualSha256 }
+}
+
+export function resolvePinnedUserToolSpec(
+  tool: UserRuntimeTool,
+  env: Record<string, string | undefined> = process.env,
+): { spec: string } | { error: string } {
+  if (tool === 'openclaw') {
+    const commit = String(env.MC_OPENCLAW_GIT_COMMIT || '').trim().toLowerCase()
+    if (!/^[a-f0-9]{40}$/.test(commit)) {
+      return { error: 'MC_OPENCLAW_GIT_COMMIT must be a reviewed 40-character commit SHA' }
+    }
+    return { spec: `github:openclaw/openclaw#${commit}` }
+  }
+
+  const envName = tool === 'claude' ? 'MC_CLAUDE_CODE_VERSION' : 'MC_CODEX_VERSION'
+  const version = String(env[envName] || '').trim()
+  if (!EXACT_NPM_VERSION.test(version)) {
+    return { error: `${envName} must be an exact semantic version` }
+  }
+  const packageName = tool === 'claude' ? '@anthropic-ai/claude-code' : '@openai/codex'
+  return { spec: `${packageName}@${version}` }
+}


### PR DESCRIPTION
## Summary
- disable remote runtime installers by default behind MC_ENABLE_RUNTIME_INSTALLS=1
- require SHA-256 verification for remote shell installers and exact versions or commits for package and source installs
- harden release self-update tag validation and rollback behavior
- replace shell-interpolated group lookup with argument-safe execution
- document the new operator-controlled trust boundaries and disabled UI state

## Verification
- 20 focused security tests passed
- lint passed with 115 pre-existing warnings and no errors
- typecheck passed
- 1,163 unit tests passed
- production build and standalone artifact check passed
- 513 Playwright tests passed
- v2.1.0 tag verified reachable from origin/main

## Security boundary
Runtime installation remains unavailable unless an operator explicitly opts in and supplies pinned integrity metadata. No private runtime configuration or credentials are included.