### PR TITLE
ci: pin workflow actions by commit

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,7 +17,6 @@ concurrency:
 permissions:
   contents: read
   packages: write
-  id-token: write
 
 env:
   GHCR_IMAGE: ghcr.io/${{ github.repository }}
@@ -39,18 +38,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4.1.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.1.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4.2.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -58,14 +57,14 @@ jobs:
 
       - name: Log in to Docker Hub
         if: env.DOCKERHUB_ENABLED == 'true'
-        uses: docker/login-action@v4.2.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v6.1.0
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             ${{ env.GHCR_IMAGE }}
@@ -79,7 +78,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push image
-        uses: docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -14,16 +14,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup pnpm
         # Version comes from package.json#packageManager (pnpm@10.29.3) — the
         # single source of truth. action-setup@v4 errors if a `version:` is also
         # set here (ERR_PNPM_BAD_PM_VERSION), so do not re-specify it.
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
@@ -32,6 +32,9 @@ jobs:
         run: |
           git config --global user.email "ci@mission-control.dev"
           git config --global user.name "CI"
+
+      - name: Verify immutable workflow action pins
+        run: python3 scripts/check-workflow-action-pins.py
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/screenshot-drift.yml
+++ b/.github/workflows/screenshot-drift.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Check for UI changes
         id: ui_changed
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const { data: files } = await github.rest.pulls.listFiles({
@@ -42,7 +42,7 @@ jobs:
       - name: Add label if UI changed
         # Fork PRs get a read-only token — label/comment calls would 403.
         if: steps.ui_changed.outputs.count > 0 && github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             // Ensure the label exists
@@ -66,7 +66,7 @@ jobs:
       - name: Post checklist comment
         # Fork PRs get a read-only token — label/comment calls would 403.
         if: steps.ui_changed.outputs.count > 0 && github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           CHANGED_UI_PATHS: ${{ steps.ui_changed.outputs.paths }}
         with:

--- a/.github/workflows/star-chart.yml
+++ b/.github/workflows/star-chart.yml
@@ -15,7 +15,7 @@ jobs:
   refresh:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Generate charts
         env:

--- a/scripts/check-workflow-action-pins.py
+++ b/scripts/check-workflow-action-pins.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Fail when a workflow executes a remote action through a mutable ref."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+WORKFLOW_DIR = Path(".github/workflows")
+USES_PATTERN = re.compile(r"^\s*(?:-\s*)?uses:\s*([^\s#]+)", re.MULTILINE)
+PIN_PATTERN = re.compile(r"^[^@\s]+@[0-9a-f]{40}$")
+
+
+def main() -> int:
+    failures: list[str] = []
+    checked = 0
+
+    for workflow in sorted((*WORKFLOW_DIR.glob("*.yml"), *WORKFLOW_DIR.glob("*.yaml"))):
+        content = workflow.read_text(encoding="utf-8")
+        for match in USES_PATTERN.finditer(content):
+            reference = match.group(1)
+            if reference.startswith("./"):
+                continue
+            checked += 1
+            if not PIN_PATTERN.fullmatch(reference):
+                line = content.count("\n", 0, match.start()) + 1
+                failures.append(f"{workflow}:{line}: mutable action reference: {reference}")
+
+    if failures:
+        print("Workflow action pin check failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+
+    print(f"Workflow action pin check passed ({checked} remote references)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- pin all 14 remote GitHub Actions references to immutable official release commits
- update Docker publishing actions to the official v4.2/v4.4/v6.2/v7.3 release commits
- remove the unused OIDC write permission from the Docker workflow
- add a CI verifier that rejects mutable remote action references

## Security rationale

Mutable action tags can be retargeted upstream. Full commit pins make the workflow dependency graph reproducible and reviewable, while the verifier prevents regressions. Removing the unused id-token permission also reduces workflow privilege.

## Verification

- resolved release tags through the GitHub API and verified official repositories
- workflow action pin checker passes for all 14 remote references
- all workflow YAML parses successfully
- lint: 0 errors (115 pre-existing warnings)
- typecheck passed
- unit tests passed
- production webpack build passed
- artifact prepare/check passed
- Playwright: 513 passed