### PR TITLE
fix: unify privileged client auth handling

### DIFF
--- a/src/components/layout/openclaw-doctor-banner.tsx
+++ b/src/components/layout/openclaw-doctor-banner.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import { useMissionControl } from '@/store'
+import { apiFetch, ApiError } from '@/lib/api-client'
 
 interface OpenClawDoctorStatus {
   level: 'healthy' | 'warning' | 'error'
@@ -36,7 +37,10 @@ export function OpenClawDoctorBanner() {
 
   async function loadDoctorStatus() {
     try {
-      const res = await fetch('/api/openclaw/doctor', { cache: 'no-store' })
+      const res = await apiFetch<Response>('/api/openclaw/doctor', {
+        cache: 'no-store',
+        raw: true,
+      })
       if (!res.ok) {
         setDoctor(null)
         return
@@ -72,7 +76,10 @@ export function OpenClawDoctorBanner() {
     }, 1400)
 
     try {
-      const res = await fetch('/api/openclaw/doctor', { method: 'POST' })
+      const res = await apiFetch<Response>('/api/openclaw/doctor', {
+        method: 'POST',
+        raw: true,
+      })
       const data = await res.json()
       window.clearInterval(progressTimer)
 
@@ -91,10 +98,20 @@ export function OpenClawDoctorBanner() {
       setFixProgress(progress.map(item => item.detail).filter(Boolean).join(' '))
       setState(data.status?.healthy ? 'success' : 'idle')
       setShowDetails(false)
-    } catch {
+    } catch (error) {
       window.clearInterval(progressTimer)
       setState('error')
-      setErrorMsg(t('networkError'))
+      if (error instanceof ApiError && error.code !== 'NETWORK_ERROR') {
+        const payload = error.payload
+        const detail = payload && typeof payload === 'object' && 'detail' in payload
+          && typeof payload.detail === 'string' ? payload.detail : null
+        const status = payload && typeof payload === 'object' && 'status' in payload
+          ? payload.status as OpenClawDoctorStatus : null
+        setErrorMsg(detail || error.message || t('fixFailed'))
+        if (status) setDoctor(status)
+      } else {
+        setErrorMsg(t('networkError'))
+      }
       setFixProgress('')
     }
   }

--- a/src/components/layout/openclaw-update-banner.tsx
+++ b/src/components/layout/openclaw-update-banner.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { useMissionControl } from '@/store'
 import { Button } from '@/components/ui/button'
+import { apiFetch, ApiError } from '@/lib/api-client'
 
 type UpdateState = 'idle' | 'updating' | 'success' | 'error'
 
@@ -32,7 +33,10 @@ export function OpenClawUpdateBanner() {
     setErrorMsg(null)
 
     try {
-      const res = await fetch('/api/openclaw/update', { method: 'POST' })
+      const res = await apiFetch<Response>('/api/openclaw/update', {
+        method: 'POST',
+        raw: true,
+      })
       const data = await res.json()
 
       if (!res.ok) {
@@ -45,9 +49,16 @@ export function OpenClawUpdateBanner() {
       setNewVersion(data.newVersion)
       // Clear the banner after a few seconds
       setTimeout(() => setOpenclawUpdate(null), 5000)
-    } catch {
+    } catch (error) {
       setState('error')
-      setErrorMsg(t('networkError'))
+      if (error instanceof ApiError && error.code !== 'NETWORK_ERROR') {
+        const payload = error.payload
+        const detail = payload && typeof payload === 'object' && 'detail' in payload
+          && typeof payload.detail === 'string' ? payload.detail : null
+        setErrorMsg(detail || error.message || t('updateFailed'))
+      } else {
+        setErrorMsg(t('networkError'))
+      }
     }
   }
 

--- a/src/components/layout/update-banner.tsx
+++ b/src/components/layout/update-banner.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { useMissionControl } from '@/store'
 import { Button } from '@/components/ui/button'
+import { apiFetch, ApiError } from '@/lib/api-client'
 
 type UpdateState = 'idle' | 'updating' | 'restarting' | 'error'
 
@@ -22,10 +23,10 @@ export function UpdateBanner() {
     setErrorMsg(null)
 
     try {
-      const res = await fetch('/api/releases/update', {
+      const res = await apiFetch<Response>('/api/releases/update', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ targetVersion: updateAvailable!.latestVersion }),
+        raw: true,
       })
       const data = await res.json()
 
@@ -40,7 +41,10 @@ export function UpdateBanner() {
         // Poll until the server comes back up, then reload
         const poll = setInterval(async () => {
           try {
-            const check = await fetch('/api/releases/check', { cache: 'no-store' })
+            const check = await apiFetch<Response>('/api/releases/check', {
+              cache: 'no-store',
+              raw: true,
+            })
             if (check.ok) {
               clearInterval(poll)
               window.location.reload()
@@ -58,9 +62,11 @@ export function UpdateBanner() {
       } else {
         window.location.reload()
       }
-    } catch {
+    } catch (error) {
       setState('error')
-      setErrorMsg(t('networkError'))
+      setErrorMsg(error instanceof ApiError && error.code !== 'NETWORK_ERROR'
+        ? error.message || t('updateFailed')
+        : t('networkError'))
     }
   }
 

--- a/src/lib/__tests__/api-client.test.ts
+++ b/src/lib/__tests__/api-client.test.ts
@@ -79,6 +79,18 @@ describe('apiFetch — global 401 / 403 / 5xx / network handling', () => {
     expect(window.location.href).toBe('http://127.0.0.1:3000/cost-tracker')
   })
 
+  it('preserves the upstream recovery message and payload on 404', async () => {
+    const payload = { error: 'Release tag v9.9.9 not found in remote' }
+    global.fetch = vi.fn().mockResolvedValue(mockResponse(404, payload))
+
+    await expect(apiFetch('/api/releases/update')).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+      status: 404,
+      message: payload.error,
+      payload,
+    })
+  })
+
   it('throws SERVER_ERROR on 500 with upstream message', async () => {
     global.fetch = vi.fn().mockResolvedValue(mockResponse(500, { error: 'database is locked' }))
     await expect(apiFetch('/api/tokens')).rejects.toMatchObject({

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -111,7 +111,13 @@ export async function apiFetch<T = unknown>(
   }
 
   if (response.status === 404) {
-    throw new ApiError('NOT_FOUND', 404, `Not found: ${path}`)
+    const payload = await safeParseJson(response)
+    const msg =
+      (typeof payload === 'object' && payload !== null && 'error' in payload &&
+        typeof (payload as { error: unknown }).error === 'string'
+        ? (payload as { error: string }).error
+        : null) || `Not found: ${path}`
+    throw new ApiError('NOT_FOUND', 404, msg, payload)
   }
 
   if (response.status >= 500) {
@@ -142,4 +148,3 @@ async function safeParseJson(res: Response): Promise<unknown> {
     return null
   }
 }
-


### PR DESCRIPTION
## Summary

- route release updates, OpenClaw updates, and OpenClaw doctor reads/fixes through the shared API client
- restore consistent cookie, session-expiry redirect, 403, 5xx, and network handling on admin-only maintenance controls
- keep restart polling tolerant while the service is temporarily unavailable
- preserve server-provided 404 recovery messages and payloads for missing release tags

## Security rationale

These controls invoke privileged update and repair endpoints. Using the repository-owned API boundary prevents expired sessions from failing silently and avoids misreporting authorization or server failures as generic network errors.

## Verification

- targeted ESLint passed
- API client regression tests passed
- typecheck passed
- full unit suite: 1,170 passed
- full lint: 0 errors; warnings reduced from 115 to 110
- production webpack build passed
- standalone artifact boundary check passed
- git diff check passed