### PR TITLE
security: harden execution approvals

### DIFF
--- a/src/app/api/exec-approvals/route.ts
+++ b/src/app/api/exec-approvals/route.ts
@@ -16,7 +16,7 @@ const allowlistUpdateSchema = z.object({
     z.string().min(1).max(256),
     z.array(allowlistPatternSchema).max(500),
   ).refine((agents) => Object.keys(agents).length <= 500),
-  hash: z.union([z.literal(''), z.string().regex(/^[a-f0-9]{64}$/i)]).optional(),
+  hash: z.string().max(256).optional(),
 }).strict()
 
 const approvalResponseSchema = z.object({
@@ -119,7 +119,11 @@ export async function PUT(request: NextRequest) {
 
   const parsed = allowlistUpdateSchema.safeParse(await request.json().catch(() => null))
   if (!parsed.success) {
-    return NextResponse.json({ error: 'Invalid execution allowlist request' }, { status: 400 })
+    const agentsInvalid = parsed.error.issues.some((issue) => issue.path[0] === 'agents')
+    const error = agentsInvalid
+      ? 'Invalid execution allowlist request: agents is required or malformed'
+      : 'Invalid execution allowlist request'
+    return NextResponse.json({ error }, { status: 400 })
   }
   const body = parsed.data
 

--- a/src/app/api/exec-approvals/route.ts
+++ b/src/app/api/exec-approvals/route.ts
@@ -3,7 +3,27 @@ import { createHash } from 'node:crypto'
 import { requireRole } from '@/lib/auth'
 import { config } from '@/lib/config'
 import { logger } from '@/lib/logger'
+import { execApprovalLimiter } from '@/lib/rate-limit'
 import path from 'node:path'
+import { z } from 'zod'
+
+const allowlistPatternSchema = z.object({
+  pattern: z.string().max(4096),
+}).strict()
+
+const allowlistUpdateSchema = z.object({
+  agents: z.record(
+    z.string().min(1).max(256),
+    z.array(allowlistPatternSchema).max(500),
+  ).refine((agents) => Object.keys(agents).length <= 500),
+  hash: z.union([z.literal(''), z.string().regex(/^[a-f0-9]{64}$/i)]).optional(),
+}).strict()
+
+const approvalResponseSchema = z.object({
+  id: z.string().trim().min(1).max(512),
+  action: z.enum(['approve', 'deny', 'always_allow']),
+  reason: z.string().trim().max(2000).optional(),
+}).strict()
 
 function gatewayUrl(p: string): string {
   return `http://${config.gatewayHost}:${config.gatewayPort}${p}`
@@ -94,16 +114,14 @@ export async function PUT(request: NextRequest) {
   const auth = requireRole(request, 'operator')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
 
-  let body: { agents: Record<string, { pattern: string }[]>; hash?: string }
-  try {
-    body = await request.json()
-  } catch {
-    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
-  }
+  const rateCheck = execApprovalLimiter(`${auth.user.workspace_id}:${auth.user.id}`)
+  if (rateCheck) return rateCheck
 
-  if (!body.agents || typeof body.agents !== 'object') {
-    return NextResponse.json({ error: 'Missing required field: agents' }, { status: 400 })
+  const parsed = allowlistUpdateSchema.safeParse(await request.json().catch(() => null))
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid execution allowlist request' }, { status: 400 })
   }
+  const body = parsed.data
 
   const filePath = execApprovalsPath()
   try {
@@ -164,21 +182,14 @@ export async function POST(request: NextRequest) {
   const auth = requireRole(request, 'operator')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
 
-  let body: { id: string; action: string; reason?: string }
-  try {
-    body = await request.json()
-  } catch {
-    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
-  }
+  const rateCheck = execApprovalLimiter(`${auth.user.workspace_id}:${auth.user.id}`)
+  if (rateCheck) return rateCheck
 
-  if (!body.id || typeof body.id !== 'string') {
-    return NextResponse.json({ error: 'Missing required field: id' }, { status: 400 })
+  const parsed = approvalResponseSchema.safeParse(await request.json().catch(() => null))
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid execution approval response' }, { status: 400 })
   }
-
-  const validActions = ['approve', 'deny', 'always_allow']
-  if (!validActions.includes(body.action)) {
-    return NextResponse.json({ error: `Invalid action. Must be one of: ${validActions.join(', ')}` }, { status: 400 })
-  }
+  const body = parsed.data
 
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), 5000)

--- a/src/components/modals/exec-approval-overlay.tsx
+++ b/src/components/modals/exec-approval-overlay.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useCallback } from 'react'
 import { Button } from '@/components/ui/button'
 import { useMissionControl, type ExecApprovalRequest } from '@/store'
 import { useWebSocket } from '@/lib/websocket'
+import { apiFetch, ApiError } from '@/lib/api-client'
 
 const RISK_BORDER: Record<ExecApprovalRequest['risk'], string> = {
   low: 'border-l-green-500',
@@ -48,13 +49,14 @@ export function ExecApprovalOverlay() {
 
   const pending = execApprovals.filter(a => a.status === 'pending')
   const active = pending[0]
+  const activeId = active?.id
 
   // Tick every second to update expiry countdown
   useEffect(() => {
-    if (!active) return
+    if (!activeId) return
     const interval = setInterval(() => setTick(t => t + 1), 1000)
     return () => clearInterval(interval)
-  }, [active?.id])
+  }, [activeId])
 
   // Auto-expire client-side
   useEffect(() => {
@@ -81,10 +83,10 @@ export function ExecApprovalOverlay() {
       // Fallback to HTTP
       try {
         const action = decision === 'deny' ? 'deny' : decision === 'allow-always' ? 'always_allow' : 'approve'
-        const res = await fetch('/api/exec-approvals', {
+        const res = await apiFetch<Response>('/api/exec-approvals', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ id: active.id, action }),
+          raw: true,
         })
         if (!res.ok) {
           const data = await res.json().catch(() => ({}))
@@ -92,8 +94,15 @@ export function ExecApprovalOverlay() {
           setBusy(false)
           return
         }
-      } catch {
-        setError('Failed to reach gateway')
+      } catch (requestError) {
+        if (requestError instanceof ApiError && requestError.code !== 'NETWORK_ERROR') {
+          const payload = requestError.payload
+          const detail = payload && typeof payload === 'object' && 'error' in payload
+            && typeof payload.error === 'string' ? payload.error : null
+          setError(detail || requestError.message || 'Failed to send decision')
+        } else {
+          setError('Failed to reach gateway')
+        }
         setBusy(false)
         return
       }

--- a/src/components/panels/exec-approval-panel.tsx
+++ b/src/components/panels/exec-approval-panel.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import { useMissionControl, type ExecApprovalRequest } from '@/store'
 import { useWebSocket } from '@/lib/websocket'
 import { matchesGlobPattern } from '@/lib/exec-approval-utils'
+import { apiFetch, ApiError } from '@/lib/api-client'
 
 type FilterTab = 'all' | 'pending' | 'resolved'
 type PanelView = 'approvals' | 'allowlist'
@@ -42,6 +43,8 @@ export function ExecApprovalPanel() {
   const { sendMessage } = useWebSocket()
   const [filter, setFilter] = useState<FilterTab>('pending')
   const [view, setView] = useState<PanelView>('approvals')
+  const [resolvingId, setResolvingId] = useState<string | null>(null)
+  const [actionError, setActionError] = useState<string | null>(null)
 
   const pendingCount = execApprovals.filter(a => a.status === 'pending').length
 
@@ -62,7 +65,11 @@ export function ExecApprovalPanel() {
     })
   }, [execApprovals, filter, now])
 
-  const handleAction = (id: string, decision: 'allow-once' | 'allow-always' | 'deny') => {
+  const handleAction = async (id: string, decision: 'allow-once' | 'allow-always' | 'deny') => {
+    if (resolvingId) return
+    setResolvingId(id)
+    setActionError(null)
+
     const sent = sendMessage({
       type: 'req',
       method: 'exec.approval.resolve',
@@ -72,15 +79,29 @@ export function ExecApprovalPanel() {
 
     if (!sent) {
       const action = decision === 'deny' ? 'deny' : decision === 'allow-always' ? 'always_allow' : 'approve'
-      fetch('/api/exec-approvals', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id, action }),
-      }).catch(() => {})
+      try {
+        const res = await apiFetch<Response>('/api/exec-approvals', {
+          method: 'POST',
+          body: JSON.stringify({ id, action }),
+          raw: true,
+        })
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}))
+          throw new Error(data.error || 'Failed to send decision')
+        }
+      } catch (error) {
+        const payload = error instanceof ApiError ? error.payload : null
+        const detail = payload && typeof payload === 'object' && 'error' in payload
+          && typeof payload.error === 'string' ? payload.error : null
+        setActionError(detail || (error instanceof Error ? error.message : 'Failed to send decision'))
+        setResolvingId(null)
+        return
+      }
     }
 
     const newStatus = decision === 'deny' ? 'denied' : 'approved'
     updateExecApproval(id, { status: newStatus as ExecApprovalRequest['status'] })
+    setResolvingId(null)
   }
 
   return (
@@ -124,6 +145,12 @@ export function ExecApprovalPanel() {
         </button>
       </div>
 
+      {actionError && (
+        <div role="alert" className="mb-4 rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-400">
+          {actionError}
+        </div>
+      )}
+
       {view === 'approvals' ? (
         <>
           {/* Filter tabs */}
@@ -157,6 +184,7 @@ export function ExecApprovalPanel() {
                   key={approval.id}
                   approval={approval}
                   onAction={handleAction}
+                  busy={resolvingId === approval.id}
                 />
               ))}
             </div>
@@ -185,7 +213,7 @@ function AllowlistEditor({ execApprovals }: { execApprovals: ExecApprovalRequest
     setLoading(true)
     setError(null)
     try {
-      const res = await fetch('/api/exec-approvals?action=allowlist')
+      const res = await apiFetch<Response>('/api/exec-approvals?action=allowlist', { raw: true })
       if (!res.ok) {
         const data = await res.json().catch(() => ({}))
         throw new Error(data.error || `HTTP ${res.status}`)
@@ -207,10 +235,10 @@ function AllowlistEditor({ execApprovals }: { execApprovals: ExecApprovalRequest
     setSaving(true)
     setError(null)
     try {
-      const res = await fetch('/api/exec-approvals', {
+      const res = await apiFetch<Response>('/api/exec-approvals', {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ agents, hash }),
+        raw: true,
       })
       const data = await res.json()
       if (!res.ok) {
@@ -438,9 +466,11 @@ function AgentAllowlistCard({
 function ApprovalCard({
   approval,
   onAction,
+  busy,
 }: {
   approval: ExecApprovalRequest
-  onAction: (id: string, decision: 'allow-once' | 'allow-always' | 'deny') => void
+  onAction: (id: string, decision: 'allow-once' | 'allow-always' | 'deny') => Promise<void>
+  busy: boolean
 }) {
   const t = useTranslations('execApproval')
   const riskBorder = RISK_BORDER[approval.risk]
@@ -500,6 +530,7 @@ function ApprovalCard({
             <Button
               size="sm"
               className="bg-green-600 hover:bg-green-700 text-white"
+              disabled={busy}
               onClick={() => onAction(approval.id, 'allow-once')}
             >
               {t('allowOnce')}
@@ -507,6 +538,7 @@ function ApprovalCard({
             <Button
               variant="outline"
               size="sm"
+              disabled={busy}
               onClick={() => onAction(approval.id, 'allow-always')}
             >
               {t('alwaysAllow')}
@@ -514,6 +546,7 @@ function ApprovalCard({
             <Button
               size="sm"
               className="bg-red-600 hover:bg-red-700 text-white"
+              disabled={busy}
               onClick={() => onAction(approval.id, 'deny')}
             >
               {t('deny')}

--- a/src/lib/__tests__/exec-approvals-route-security.test.ts
+++ b/src/lib/__tests__/exec-approvals-route-security.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest, NextResponse } from 'next/server'
+
+const requireRoleMock = vi.fn()
+const execApprovalLimiterMock = vi.fn<(key: string) => NextResponse | null>(() => null)
+const realFetch = global.fetch
+
+vi.mock('@/lib/auth', () => ({ requireRole: requireRoleMock }))
+vi.mock('@/lib/rate-limit', () => ({ execApprovalLimiter: execApprovalLimiterMock }))
+vi.mock('@/lib/config', () => ({
+  config: {
+    gatewayHost: '127.0.0.1',
+    gatewayPort: 18789,
+    openclawHome: '/tmp/openclaw-test',
+  },
+}))
+vi.mock('@/lib/logger', () => ({ logger: { error: vi.fn(), warn: vi.fn() } }))
+
+const operator = {
+  user: { id: 7, username: 'operator', role: 'operator', workspace_id: 3 },
+}
+
+function request(method: 'POST' | 'PUT', body: unknown) {
+  return new NextRequest('http://localhost/api/exec-approvals', {
+    method,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('exec approvals route security', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    requireRoleMock.mockReturnValue(operator)
+    execApprovalLimiterMock.mockReturnValue(null)
+    global.fetch = vi.fn()
+  })
+
+  afterEach(() => {
+    global.fetch = realFetch
+  })
+
+  it('fails authentication before rate limiting or contacting the gateway', async () => {
+    requireRoleMock.mockReturnValue({ error: 'Authentication required', status: 401 })
+    const { POST } = await import('@/app/api/exec-approvals/route')
+
+    const response = await POST(request('POST', { id: 'approval-1', action: 'approve' }))
+
+    expect(response.status).toBe(401)
+    expect(execApprovalLimiterMock).not.toHaveBeenCalled()
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it.each(['POST', 'PUT'] as const)('rate limits authenticated %s mutations before parsing side effects', async (method) => {
+    execApprovalLimiterMock.mockReturnValue(
+      NextResponse.json({ error: 'Too many execution approval changes' }, { status: 429 }),
+    )
+    const route = await import('@/app/api/exec-approvals/route')
+
+    const response = await route[method](request(method, {}))
+
+    expect(response.status).toBe(429)
+    expect(execApprovalLimiterMock).toHaveBeenCalledWith('3:7')
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('rejects malformed approval responses without contacting the gateway', async () => {
+    const { POST } = await import('@/app/api/exec-approvals/route')
+
+    const response = await POST(request('POST', {
+      id: 'approval-1',
+      action: 'approve',
+      unexpected: true,
+    }))
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({ error: 'Invalid execution approval response' })
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('rejects malformed allowlist records instead of throwing', async () => {
+    const { PUT } = await import('@/app/api/exec-approvals/route')
+
+    const response = await PUT(request('PUT', {
+      agents: { assistant: { pattern: 'git *' } },
+    }))
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({ error: 'Invalid execution allowlist request' })
+  })
+
+  it('forwards a bounded normalized approval response to the configured gateway', async () => {
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+    const { POST } = await import('@/app/api/exec-approvals/route')
+
+    const response = await POST(request('POST', {
+      id: '  approval-1  ',
+      action: 'deny',
+      reason: '  not expected  ',
+    }))
+
+    expect(response.status).toBe(200)
+    expect(execApprovalLimiterMock).toHaveBeenCalledWith('3:7')
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://127.0.0.1:18789/api/exec-approvals/respond',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ id: 'approval-1', action: 'deny', reason: 'not expected' }),
+      }),
+    )
+  })
+})

--- a/src/lib/__tests__/exec-approvals-route-security.test.ts
+++ b/src/lib/__tests__/exec-approvals-route-security.test.ts
@@ -87,7 +87,9 @@ describe('exec approvals route security', () => {
     }))
 
     expect(response.status).toBe(400)
-    await expect(response.json()).resolves.toEqual({ error: 'Invalid execution allowlist request' })
+    await expect(response.json()).resolves.toEqual({
+      error: 'Invalid execution allowlist request: agents is required or malformed',
+    })
   })
 
   it('forwards a bounded normalized approval response to the configured gateway', async () => {

--- a/src/lib/__tests__/rate-limit.test.ts
+++ b/src/lib/__tests__/rate-limit.test.ts
@@ -1,13 +1,41 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { createRateLimiter } from '@/lib/rate-limit'
+import { createKeyedRateLimiter, createRateLimiter } from '@/lib/rate-limit'
 
 describe('createRateLimiter', () => {
+  const originalDisableRateLimit = process.env.MC_DISABLE_RATE_LIMIT
+  const originalTestMode = process.env.MISSION_CONTROL_TEST_MODE
+
   beforeEach(() => {
     vi.useFakeTimers()
   })
 
   afterEach(() => {
     vi.useRealTimers()
+    if (originalDisableRateLimit === undefined) delete process.env.MC_DISABLE_RATE_LIMIT
+    else process.env.MC_DISABLE_RATE_LIMIT = originalDisableRateLimit
+    if (originalTestMode === undefined) delete process.env.MISSION_CONTROL_TEST_MODE
+    else process.env.MISSION_CONTROL_TEST_MODE = originalTestMode
+  })
+
+  it('tracks authenticated identities independently with a keyed limiter', () => {
+    const limiter = createKeyedRateLimiter({ windowMs: 60_000, maxRequests: 1 })
+
+    expect(limiter('workspace-1:user-1')).toBeNull()
+    expect(limiter('workspace-1:user-2')).toBeNull()
+    expect(limiter('workspace-1:user-1')?.status).toBe(429)
+  })
+
+  it('does not bypass a critical keyed limiter in test mode', () => {
+    process.env.MC_DISABLE_RATE_LIMIT = '1'
+    process.env.MISSION_CONTROL_TEST_MODE = '1'
+    const limiter = createKeyedRateLimiter({
+      windowMs: 60_000,
+      maxRequests: 1,
+      critical: true,
+    })
+
+    expect(limiter('workspace-1:user-1')).toBeNull()
+    expect(limiter('workspace-1:user-1')?.status).toBe(429)
   })
 
   function makeRequest(ip: string = '127.0.0.1'): Request {

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -233,6 +233,14 @@ export const passwordChangeLimiter = createKeyedRateLimiter({
   critical: true,
 })
 
+/** Execution approvals and persistent allowlist edits: 30/min per operator. */
+export const execApprovalLimiter = createKeyedRateLimiter({
+  windowMs: 60_000,
+  maxRequests: 30,
+  message: 'Too many execution approval changes. Try again in a minute.',
+  critical: true,
+})
+
 /** Self-registration: 5/min per IP (prevent spam registrations) */
 export const selfRegisterLimiter = createRateLimiter({
   windowMs: 60_000,


### PR DESCRIPTION
## Summary
- enforce a critical, per-workspace/operator rate limit on approval and allowlist mutations
- strictly validate and bound gateway payloads before forwarding them
- use authenticated API handling in both approval clients and preserve server errors
- prevent failed HTTP fallbacks or duplicate clicks from falsely resolving approvals locally
- add route and limiter security regressions

## Verification
- focused ESLint: passed
- focused Vitest: 15 tests passed
- TypeScript: passed
- full lint, test, production build, and standalone artifact check: passed locally
- diff hygiene: passed

## Audit note
The strict devgod repository scan is not baseline-green: it currently flags deliberate credential-scanner fixtures/regex definitions and an existing device-identity token stored in localStorage. Neither category is introduced or modified by this PR; both remain explicit follow-up audit items rather than being suppressed here.