### PR TITLE
security: harden security auto-fix

### DIFF
--- a/src/app/api/security-scan/fix/route.ts
+++ b/src/app/api/security-scan/fix/route.ts
@@ -8,6 +8,8 @@ import { config } from '@/lib/config'
 import { getDatabase } from '@/lib/db'
 import { logger } from '@/lib/logger'
 import { FIX_SAFETY, runSecurityScan, type FixSafety } from '@/lib/security-scan'
+import { securityFixLimiter } from '@/lib/rate-limit'
+import { z } from 'zod'
 
 export interface FixResult {
   id: string
@@ -16,6 +18,12 @@ export interface FixResult {
   detail: string
   fixSafety?: FixSafety
 }
+
+const fixRequestSchema = z.object({
+  ids: z.array(
+    z.string().min(1).max(128).refine((id) => id in FIX_SAFETY, 'Unknown security check id'),
+  ).min(1).max(50).optional(),
+}).strict()
 
 function shouldMutateRuntimeEnv() {
   return process.env.MISSION_CONTROL_TEST_MODE !== '1'
@@ -59,14 +67,15 @@ export async function POST(request: NextRequest) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
 
-  // Optional: pass { ids: ["check_id"] } to fix only specific issues
-  let targetIds: Set<string> | null = null
-  try {
-    const body = await request.json()
-    if (Array.isArray(body?.ids) && body.ids.length > 0) {
-      targetIds = new Set(body.ids as string[])
-    }
-  } catch { /* no body = fix all */ }
+  const rateCheck = securityFixLimiter(`${auth.user.workspace_id}:${auth.user.id}`)
+  if (rateCheck) return rateCheck
+
+  // Omit ids to intentionally fix all currently supported checks.
+  const parsed = fixRequestSchema.safeParse(await request.json().catch(() => null))
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid security fix request' }, { status: 400 })
+  }
+  const targetIds = parsed.data.ids ? new Set(parsed.data.ids) : null
 
   const shouldFix = (id: string) => !targetIds || targetIds.has(id)
 
@@ -338,7 +347,14 @@ export async function POST(request: NextRequest) {
       const files = wwOutput.split('\n').filter(Boolean).slice(0, 20)
       let fixedCount = 0
       for (const f of files) {
-        try { chmodSync(f, 0o755); fixedCount++ } catch { /* skip */ }
+        try {
+          const currentMode = statSync(f).mode & 0o777
+          const hardenedMode = currentMode & ~0o002
+          if (hardenedMode !== currentMode) {
+            chmodSync(f, hardenedMode)
+            fixedCount++
+          }
+        } catch { /* skip */ }
       }
       if (fixedCount > 0) {
         results.push({ id: 'world_writable', name: 'World-writable files', fixed: true, detail: `Fixed permissions on ${fixedCount} file(s)`, fixSafety: FIX_SAFETY['world_writable'] })

--- a/src/components/onboarding/security-scan-card.tsx
+++ b/src/components/onboarding/security-scan-card.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback, useEffect } from 'react'
 import { Button } from '@/components/ui/button'
 import { Loader } from '@/components/ui/loader'
+import { apiFetch, ApiError } from '@/lib/api-client'
 
 type CheckSeverity = 'critical' | 'high' | 'medium' | 'low'
 type FixSafety = 'safe' | 'requires-restart' | 'requires-review' | 'manual-only'
@@ -33,6 +34,25 @@ interface ScanResult {
     runtime: Category
     os: Category
   }
+}
+
+interface FixResponse {
+  attempted?: number
+  fixed?: number
+  failed?: number
+  remaining?: number
+  remainingAutoFixable?: number
+  remainingManual?: number
+  note?: string
+  error?: string
+}
+
+function requestErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof ApiError) {
+    if (error.code === 'UNAUTHENTICATED' || error.code === 'FORBIDDEN') return 'Admin access required'
+    return error.message || fallback
+  }
+  return error instanceof Error ? error.message : fallback
 }
 
 // Check IDs that the /api/security-scan/fix endpoint can auto-fix, with safety levels
@@ -118,19 +138,14 @@ export function SecurityScanCard({ compact = false, autoScan = false }: { compac
     }
   }, [])
 
-  const runScan = useCallback(async () => {
+  const runScan = useCallback(async (preserveFixResult = false) => {
     setLoading(true)
     setError(null)
-    setFixResult(null)
+    if (!preserveFixResult) setFixResult(null)
     try {
-      const res = await fetch('/api/security-scan')
-      if (!res.ok) {
-        setError(res.status === 401 ? 'Admin access required' : 'Scan failed')
-        return
-      }
-      setResult(await res.json())
-    } catch {
-      setError('Failed to connect')
+      setResult(await apiFetch<ScanResult>('/api/security-scan'))
+    } catch (err) {
+      setError(requestErrorMessage(err, 'Scan failed'))
     } finally {
       setLoading(false)
     }
@@ -141,18 +156,18 @@ export function SecurityScanCard({ compact = false, autoScan = false }: { compac
     setFixing(fixKey)
     setFixResult(null)
     try {
-      const res = await fetch('/api/security-scan/fix', {
+      const res = await apiFetch<Response>('/api/security-scan/fix', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
         body: ids ? JSON.stringify({ ids }) : '{}',
+        raw: true,
       })
+      const data = await res.json().catch(() => ({})) as FixResponse
       if (!res.ok) {
-        setFixResult({ attempted: 0, fixed: 0, failed: 1, remaining: 0, remainingAutoFixable: 0, remainingManual: 0, note: res.status === 401 ? 'Admin access required' : 'Fix failed' })
+        setFixResult({ attempted: 0, fixed: 0, failed: 1, remaining: 0, remainingAutoFixable: 0, remainingManual: 0, note: data.error || 'Fix failed' })
         return
       }
-      const data = await res.json()
       setFixResult({
-        attempted: data.attempted ?? data.fixed + data.failed,
+        attempted: data.attempted ?? (data.fixed ?? 0) + (data.failed ?? 0),
         fixed: data.fixed ?? 0,
         failed: data.failed ?? 0,
         remaining: data.remaining ?? 0,
@@ -160,12 +175,11 @@ export function SecurityScanCard({ compact = false, autoScan = false }: { compac
         remainingManual: data.remainingManual ?? 0,
         note: data.note,
       })
-      // Re-scan after fixes
-      setTimeout(() => runScan(), 1500)
-    } catch {
-      setFixResult({ attempted: 0, fixed: 0, failed: 1, remaining: 0, remainingAutoFixable: 0, remainingManual: 0, note: 'Network error' })
+      await runScan(true)
+    } catch (err) {
+      setFixResult({ attempted: 0, fixed: 0, failed: 1, remaining: 0, remainingAutoFixable: 0, remainingManual: 0, note: requestErrorMessage(err, 'Fix failed') })
     } finally {
-      setTimeout(() => setFixing(null), 1500)
+      setFixing(null)
     }
   }, [runScan])
 
@@ -182,7 +196,7 @@ export function SecurityScanCard({ compact = false, autoScan = false }: { compac
           <p className="text-sm text-muted-foreground mb-1">Run a comprehensive security scan of your installation</p>
           <p className="text-xs text-muted-foreground/60">Checks credentials, network config, OpenClaw hardening, and runtime security</p>
         </div>
-        <Button onClick={runScan} variant="outline" size="sm" className="border-void-cyan/30 text-void-cyan hover:bg-void-cyan/10">
+        <Button onClick={() => runScan()} variant="outline" size="sm" className="border-void-cyan/30 text-void-cyan hover:bg-void-cyan/10">
           Run Security Scan
         </Button>
       </div>
@@ -234,8 +248,8 @@ export function SecurityScanCard({ compact = false, autoScan = false }: { compac
   if (error) {
     return (
       <div className="flex flex-col items-center gap-3 py-6">
-        <p className="text-sm text-red-400">{error}</p>
-        <Button onClick={runScan} variant="outline" size="sm">Retry</Button>
+        <p role="alert" className="text-sm text-red-400">{error}</p>
+        <Button onClick={() => runScan()} variant="outline" size="sm">Retry</Button>
       </div>
     )
   }
@@ -261,7 +275,7 @@ export function SecurityScanCard({ compact = false, autoScan = false }: { compac
             <div className="text-xs text-muted-foreground">Security score</div>
           </div>
         </div>
-        <Button onClick={runScan} variant="ghost" size="sm" className="text-xs text-muted-foreground hover:text-foreground">
+        <Button onClick={() => runScan()} variant="ghost" size="sm" className="text-xs text-muted-foreground hover:text-foreground">
           Re-scan
         </Button>
       </div>
@@ -302,7 +316,7 @@ export function SecurityScanCard({ compact = false, autoScan = false }: { compac
 
       {/* Fix result feedback */}
       {fixResult && (
-        <div className={`text-xs px-3 py-2 rounded-lg border ${fixResult.failed > 0 ? 'bg-amber-500/10 border-amber-500/20 text-amber-300' : 'bg-green-500/10 border-green-500/20 text-green-300'}`}>
+        <div role="status" className={`text-xs px-3 py-2 rounded-lg border ${fixResult.failed > 0 ? 'bg-amber-500/10 border-amber-500/20 text-amber-300' : 'bg-green-500/10 border-green-500/20 text-green-300'}`}>
           {fixResult.attempted > 0 && <span>{fixResult.attempted} auto-fix attempt{fixResult.attempted > 1 ? 's' : ''}. </span>}
           {fixResult.fixed > 0 && <span>{fixResult.fixed} issue{fixResult.fixed > 1 ? 's' : ''} fixed. </span>}
           {fixResult.failed > 0 && <span>{fixResult.failed} failed. </span>}

--- a/src/lib/__tests__/security-scan-fix-route.test.ts
+++ b/src/lib/__tests__/security-scan-fix-route.test.ts
@@ -1,11 +1,20 @@
-import { mkdtempSync, readFileSync, writeFileSync, rmSync } from 'node:fs'
+import { chmodSync, mkdtempSync, readFileSync, statSync, writeFileSync, rmSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { NextRequest } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
+
+const { requireRoleMock, securityFixLimiterMock } = vi.hoisted(() => ({
+  requireRoleMock: vi.fn(),
+  securityFixLimiterMock: vi.fn(),
+}))
 
 vi.mock('@/lib/auth', () => ({
-  requireRole: vi.fn(() => ({ user: { role: 'admin', workspace_id: 1 } })),
+  requireRole: requireRoleMock,
+}))
+
+vi.mock('@/lib/rate-limit', () => ({
+  securityFixLimiter: securityFixLimiterMock,
 }))
 
 vi.mock('@/lib/config', () => ({
@@ -23,6 +32,7 @@ vi.mock('@/lib/logger', () => ({
 vi.mock('@/lib/security-scan', () => ({
   FIX_SAFETY: {
     rate_limiting: 'safe',
+    world_writable: 'safe',
   },
   runSecurityScan: vi.fn(() => ({
     categories: {
@@ -44,11 +54,62 @@ describe('security-scan fix route env mutation', () => {
   let tempDir = ''
 
   beforeEach(() => {
+    vi.clearAllMocks()
+    requireRoleMock.mockReturnValue({ user: { id: 7, username: 'admin', role: 'admin', workspace_id: 3 } })
+    securityFixLimiterMock.mockReturnValue(null)
     tempDir = mkdtempSync(path.join(os.tmpdir(), 'mc-security-fix-'))
     process.chdir(tempDir)
     writeFileSync(path.join(tempDir, '.env'), 'MC_DISABLE_RATE_LIMIT=1\n', 'utf-8')
     writeFileSync(path.join(tempDir, '.env.local'), '', 'utf-8')
     process.env = { ...originalEnv }
+  })
+
+  function request(body: string) {
+    return new NextRequest('http://localhost/api/security-scan/fix', {
+      method: 'POST',
+      body,
+      headers: { 'content-type': 'application/json' },
+    })
+  }
+
+  it('authenticates before rate limiting or parsing mutation input', async () => {
+    requireRoleMock.mockReturnValue({ error: 'Authentication required', status: 401 })
+    const { POST } = await import('@/app/api/security-scan/fix/route')
+
+    const response = await POST(request('{not-json'))
+
+    expect(response.status).toBe(401)
+    expect(securityFixLimiterMock).not.toHaveBeenCalled()
+    expect(readFileSync(path.join(tempDir, '.env'), 'utf-8')).toContain('MC_DISABLE_RATE_LIMIT=1')
+  })
+
+  it('rate limits by workspace and admin before parsing or mutation', async () => {
+    securityFixLimiterMock.mockReturnValue(
+      NextResponse.json({ error: 'Too many security fix attempts' }, { status: 429 }),
+    )
+    const { POST } = await import('@/app/api/security-scan/fix/route')
+
+    const response = await POST(request('{not-json'))
+
+    expect(response.status).toBe(429)
+    expect(securityFixLimiterMock).toHaveBeenCalledWith('3:7')
+    expect(readFileSync(path.join(tempDir, '.env'), 'utf-8')).toContain('MC_DISABLE_RATE_LIMIT=1')
+  })
+
+  it.each([
+    ['malformed JSON', '{not-json'],
+    ['empty ids', JSON.stringify({ ids: [] })],
+    ['unknown ids', JSON.stringify({ ids: ['not-a-fix'] })],
+    ['extra fields', JSON.stringify({ unexpected: true })],
+    ['oversized ids', JSON.stringify({ ids: Array.from({ length: 51 }, () => 'rate_limiting') })],
+  ])('rejects %s without applying broad fixes', async (_label, body) => {
+    const { POST } = await import('@/app/api/security-scan/fix/route')
+
+    const response = await POST(request(body))
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({ error: 'Invalid security fix request' })
+    expect(readFileSync(path.join(tempDir, '.env'), 'utf-8')).toContain('MC_DISABLE_RATE_LIMIT=1')
   })
 
   afterEach(() => {
@@ -88,5 +149,17 @@ describe('security-scan fix route env mutation', () => {
     const response = await POST(request)
     expect(response.status).toBe(200)
     expect(process.env.MC_DISABLE_RATE_LIMIT).toBeUndefined()
+  })
+
+  it('removes only the world-write bit without granting execute permissions', async () => {
+    const filePath = path.join(tempDir, 'world-writable.txt')
+    writeFileSync(filePath, 'data', 'utf-8')
+    chmodSync(filePath, 0o666)
+
+    const { POST } = await import('@/app/api/security-scan/fix/route')
+    const response = await POST(request(JSON.stringify({ ids: ['world_writable'] })))
+
+    expect(response.status).toBe(200)
+    expect(statSync(filePath).mode & 0o777).toBe(0o664)
   })
 })

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -241,6 +241,14 @@ export const execApprovalLimiter = createKeyedRateLimiter({
   critical: true,
 })
 
+/** Privileged security configuration and filesystem repairs: 5/min per admin. */
+export const securityFixLimiter = createKeyedRateLimiter({
+  windowMs: 60_000,
+  maxRequests: 5,
+  message: 'Too many security fix attempts. Try again in a minute.',
+  critical: true,
+})
+
 /** Self-registration: 5/min per IP (prevent spam registrations) */
 export const selfRegisterLimiter = createRateLimiter({
   windowMs: 60_000,


### PR DESCRIPTION
## Summary

- fail closed on malformed, empty, oversized, unknown, or extra security-fix input while preserving the intentional empty-object fix-all contract
- apply a critical per-admin/workspace limiter before privileged filesystem or configuration mutation
- remove only the world-writable permission bit instead of forcing executable permissions onto regular files
- use the authenticated API client in the security scan card and make fix/rescan state deterministic
- add regression coverage for authorization order, limiting order, strict validation, and safe file modes

## Verification

- pnpm lint
- pnpm test: 107 files, 1,189 tests
- pnpm build
- pnpm artifact:check
- pnpm exec playwright test tests/security-scan-api.spec.ts: 15 tests
- strict security scan
- git diff --check