### PR TITLE
fix: make project updates atomic

### DIFF
--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -3,6 +3,7 @@ import { getDatabase } from '@/lib/db'
 import { requireRole } from '@/lib/auth'
 import { mutationLimiter } from '@/lib/rate-limit'
 import { logger } from '@/lib/logger'
+import { updateProjectSchema, validateBody } from '@/lib/validation'
 import {
   ensureTenantWorkspaceAccess,
   ForbiddenError
@@ -109,30 +110,33 @@ export async function PATCH(
     `).get(projectId, workspaceId, tenantId)
     if (!projectScope) return NextResponse.json({ error: 'Project not found' }, { status: 404 })
 
-    const current = db.prepare(`SELECT * FROM projects WHERE id = ? AND workspace_id = ?`).get(projectId, workspaceId) as any
+    const current = db.prepare(`SELECT id, workspace_id, slug FROM projects WHERE id = ? AND workspace_id = ?`).get(projectId, workspaceId) as {
+      id: number
+      workspace_id: number
+      slug: string
+    } | undefined
     if (!current) return NextResponse.json({ error: 'Project not found' }, { status: 404 })
-    if (current.slug === 'general' && current.workspace_id === workspaceId && current.id === projectId) {
-      const body = await request.json()
-      if (body?.status === 'archived') {
-        return NextResponse.json({ error: 'Default project cannot be archived' }, { status: 400 })
-      }
+
+    const validated = await validateBody(request, updateProjectSchema)
+    if ('error' in validated) return validated.error
+    const body = validated.data
+
+    if (current.slug === 'general' && body.status === 'archived') {
+      return NextResponse.json({ error: 'Default project cannot be archived' }, { status: 400 })
     }
 
-    const body = await request.json()
     const updates: string[] = []
     const paramsList: Array<string | number | null> = []
 
-    if (typeof body?.name === 'string') {
-      const name = body.name.trim()
-      if (!name) return NextResponse.json({ error: 'Project name cannot be empty' }, { status: 400 })
+    if (body.name !== undefined) {
       updates.push('name = ?')
-      paramsList.push(name)
+      paramsList.push(body.name)
     }
-    if (typeof body?.description === 'string') {
+    if (body.description !== undefined) {
       updates.push('description = ?')
-      paramsList.push(body.description.trim() || null)
+      paramsList.push(body.description?.trim() || null)
     }
-    if (typeof body?.ticket_prefix === 'string' || typeof body?.ticketPrefix === 'string') {
+    if (body.ticket_prefix !== undefined || body.ticketPrefix !== undefined) {
       const raw = String(body.ticket_prefix ?? body.ticketPrefix)
       const prefix = normalizePrefix(raw)
       if (!prefix) return NextResponse.json({ error: 'Invalid ticket prefix' }, { status: 400 })
@@ -144,51 +148,89 @@ export async function PATCH(
       updates.push('ticket_prefix = ?')
       paramsList.push(prefix)
     }
-    if (typeof body?.status === 'string') {
-      const status = body.status === 'archived' ? 'archived' : 'active'
+    if (body.status !== undefined) {
       updates.push('status = ?')
-      paramsList.push(status)
+      paramsList.push(body.status)
     }
-    if (body?.github_repo !== undefined) {
+    if (body.github_repo !== undefined) {
       updates.push('github_repo = ?')
-      paramsList.push(typeof body.github_repo === 'string' ? body.github_repo.trim() || null : null)
+      paramsList.push(body.github_repo || null)
     }
-    if (body?.deadline !== undefined) {
+    if (body.deadline !== undefined) {
       updates.push('deadline = ?')
-      paramsList.push(typeof body.deadline === 'number' ? body.deadline : null)
+      paramsList.push(body.deadline)
     }
-    if (body?.color !== undefined) {
+    if (body.color !== undefined) {
       updates.push('color = ?')
-      paramsList.push(typeof body.color === 'string' ? body.color.trim() || null : null)
+      paramsList.push(body.color || null)
     }
-    if (body?.github_sync_enabled !== undefined) {
+    if (body.github_sync_enabled !== undefined) {
       updates.push('github_sync_enabled = ?')
       paramsList.push(body.github_sync_enabled ? 1 : 0)
     }
-    if (body?.github_default_branch !== undefined) {
+    if (body.github_default_branch !== undefined) {
       updates.push('github_default_branch = ?')
-      paramsList.push(typeof body.github_default_branch === 'string' ? body.github_default_branch.trim() || 'main' : 'main')
+      paramsList.push(body.github_default_branch)
     }
-    if (body?.github_labels_initialized !== undefined) {
+    if (body.github_labels_initialized !== undefined) {
       updates.push('github_labels_initialized = ?')
       paramsList.push(body.github_labels_initialized ? 1 : 0)
     }
 
-    if (updates.length === 0) return NextResponse.json({ error: 'No fields to update' }, { status: 400 })
+    const assignedAgents = body.assigned_agents
+    if (assignedAgents?.length) {
+      const placeholders = assignedAgents.map(() => '?').join(', ')
+      const knownAgents = db.prepare(`
+        SELECT name FROM agents
+        WHERE workspace_id = ? AND name IN (${placeholders})
+      `).all(workspaceId, ...assignedAgents) as Array<{ name: string }>
+      const knownNames = new Set(knownAgents.map((agent) => agent.name))
+      const unknownAgents = assignedAgents.filter((name) => !knownNames.has(name))
+      if (unknownAgents.length) {
+        return NextResponse.json({ error: 'Unknown project agents', details: unknownAgents }, { status: 400 })
+      }
+    }
 
     updates.push('updated_at = unixepoch()')
-    db.prepare(`
-      UPDATE projects
-      SET ${updates.join(', ')}
-      WHERE id = ? AND workspace_id = ?
-    `).run(...paramsList, projectId, workspaceId)
+    const updateProject = db.prepare(`
+        UPDATE projects
+        SET ${updates.join(', ')}
+        WHERE id = ? AND workspace_id = ?
+      `)
+    const insertAssignment = db.prepare(`
+      INSERT OR IGNORE INTO project_agent_assignments (project_id, agent_name, role)
+      VALUES (?, ?, 'member')
+    `)
+    const updateTransaction = db.transaction(() => {
+      updateProject.run(...paramsList, projectId, workspaceId)
 
-    const project = db.prepare(`
+      if (assignedAgents !== undefined) {
+        if (assignedAgents.length === 0) {
+          db.prepare('DELETE FROM project_agent_assignments WHERE project_id = ?').run(projectId)
+        } else {
+          const placeholders = assignedAgents.map(() => '?').join(', ')
+          db.prepare(`
+            DELETE FROM project_agent_assignments
+            WHERE project_id = ? AND agent_name NOT IN (${placeholders})
+          `).run(projectId, ...assignedAgents)
+          for (const agentName of assignedAgents) insertAssignment.run(projectId, agentName)
+        }
+      }
+    })
+    updateTransaction()
+
+    const projectRow = db.prepare(`
       SELECT id, workspace_id, name, slug, description, ticket_prefix, ticket_counter, status,
-             github_repo, deadline, color, github_sync_enabled, github_labels_initialized, github_default_branch, created_at, updated_at
+             github_repo, deadline, color, github_sync_enabled, github_labels_initialized, github_default_branch, created_at, updated_at,
+             (SELECT GROUP_CONCAT(paa.agent_name) FROM project_agent_assignments paa WHERE paa.project_id = projects.id) as assigned_agents_csv
       FROM projects
       WHERE id = ? AND workspace_id = ?
-    `).get(projectId, workspaceId)
+    `).get(projectId, workspaceId) as Record<string, unknown>
+    const project = {
+      ...projectRow,
+      assigned_agents: projectRow.assigned_agents_csv ? String(projectRow.assigned_agents_csv).split(',') : [],
+      assigned_agents_csv: undefined,
+    }
 
     return NextResponse.json({ project })
   } catch (error) {

--- a/src/components/modals/project-manager-modal.tsx
+++ b/src/components/modals/project-manager-modal.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useFocusTrap } from '@/lib/use-focus-trap'
 import { Button } from '@/components/ui/button'
+import { apiFetch } from '@/lib/api-client'
 
 interface Project {
   id: number
@@ -25,6 +26,21 @@ interface Agent {
   name: string
   role: string
   status: string
+}
+
+interface ProjectsResponse {
+  projects: Project[]
+}
+
+interface AgentsResponse {
+  agents: Agent[]
+}
+
+async function mutate<T>(path: string, options: RequestInit): Promise<T> {
+  const response = await apiFetch<Response>(path, { ...options, raw: true })
+  const data = await response.json().catch(() => null) as { error?: string } | null
+  if (!response.ok) throw new Error(data?.error || `Request failed (${response.status})`)
+  return data as T
 }
 
 const COLOR_PALETTE = [
@@ -51,6 +67,7 @@ export function ProjectManagerModal({
   const [error, setError] = useState<string | null>(null)
   const [form, setForm] = useState({ name: '', ticket_prefix: '', description: '' })
   const [editingId, setEditingId] = useState<number | null>(null)
+  const [savingId, setSavingId] = useState<number | null>(null)
   const [editForm, setEditForm] = useState<{
     description: string
     github_repo: string
@@ -64,18 +81,12 @@ export function ProjectManagerModal({
   const load = useCallback(async () => {
     try {
       setLoading(true)
-      const [projectsRes, agentsRes] = await Promise.all([
-        fetch('/api/projects?includeArchived=1'),
-        fetch('/api/agents')
+      const [projectsData, agentsData] = await Promise.all([
+        apiFetch<ProjectsResponse>('/api/projects?includeArchived=1'),
+        apiFetch<AgentsResponse>('/api/agents')
       ])
-      const projectsData = await projectsRes.json()
-      if (!projectsRes.ok) throw new Error(projectsData.error || 'Failed to load projects')
       setProjects(projectsData.projects || [])
-
-      if (agentsRes.ok) {
-        const agentsData = await agentsRes.json()
-        setAgents(agentsData.agents || [])
-      }
+      setAgents(agentsData.agents || [])
       setError(null)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load projects')
@@ -92,17 +103,14 @@ export function ProjectManagerModal({
     e.preventDefault()
     if (!form.name.trim()) return
     try {
-      const response = await fetch('/api/projects', {
+      await mutate('/api/projects', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           name: form.name,
           ticket_prefix: form.ticket_prefix,
           description: form.description
         })
       })
-      const data = await response.json()
-      if (!response.ok) throw new Error(data.error || 'Failed to create project')
       setForm({ name: '', ticket_prefix: '', description: '' })
       await load()
       await onChanged?.()
@@ -113,13 +121,10 @@ export function ProjectManagerModal({
 
   const archiveProject = async (project: Project) => {
     try {
-      const response = await fetch(`/api/projects/${project.id}`, {
+      await mutate(`/api/projects/${project.id}`, {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ status: project.status === 'active' ? 'archived' : 'active' })
       })
-      const data = await response.json()
-      if (!response.ok) throw new Error(data.error || 'Failed to update project')
       await load()
       await onChanged?.()
     } catch (err) {
@@ -130,9 +135,7 @@ export function ProjectManagerModal({
   const deleteProject = async (project: Project) => {
     if (!confirm(`Delete project "${project.name}"? Existing tasks will be moved to General.`)) return
     try {
-      const response = await fetch(`/api/projects/${project.id}?mode=delete`, { method: 'DELETE' })
-      const data = await response.json()
-      if (!response.ok) throw new Error(data.error || 'Failed to delete project')
+      await mutate(`/api/projects/${project.id}?mode=delete`, { method: 'DELETE' })
       await load()
       await onChanged?.()
     } catch (err) {
@@ -159,46 +162,28 @@ export function ProjectManagerModal({
 
   const saveEdit = async (project: Project) => {
     try {
+      setSavingId(project.id)
       const body: Record<string, unknown> = {
         description: editForm.description,
         github_repo: editForm.github_repo || null,
         color: editForm.color || null,
         deadline: editForm.deadline ? Math.floor(new Date(editForm.deadline).getTime() / 1000) : null,
-        github_sync_enabled: editForm.github_sync_enabled ? 1 : 0,
+        github_sync_enabled: editForm.github_sync_enabled,
         github_default_branch: editForm.github_default_branch || 'main',
+        assigned_agents: editForm.assigned_agents,
       }
-      const response = await fetch(`/api/projects/${project.id}`, {
+      await mutate(`/api/projects/${project.id}`, {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body)
       })
-      const data = await response.json()
-      if (!response.ok) throw new Error(data.error || 'Failed to update project')
-
-      // Sync agent assignments
-      const currentAgents = project.assigned_agents || []
-      const newAgents = editForm.assigned_agents
-      const toAdd = newAgents.filter(a => !currentAgents.includes(a))
-      const toRemove = currentAgents.filter(a => !newAgents.includes(a))
-
-      for (const agentName of toAdd) {
-        await fetch(`/api/projects/${project.id}/agents`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ agent_name: agentName })
-        })
-      }
-      for (const agentName of toRemove) {
-        await fetch(`/api/projects/${project.id}/agents?agent_name=${encodeURIComponent(agentName)}`, {
-          method: 'DELETE'
-        })
-      }
 
       setEditingId(null)
       await load()
       await onChanged?.()
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to update project')
+    } finally {
+      setSavingId(null)
     }
   }
 
@@ -222,7 +207,7 @@ export function ProjectManagerModal({
             <Button variant="ghost" size="icon-sm" onClick={onClose} className="text-xl">&times;</Button>
           </div>
 
-          {error && <div className="text-sm text-red-400 bg-red-500/10 border border-red-500/20 rounded p-2">{error}</div>}
+          {error && <div role="alert" className="text-sm text-red-400 bg-red-500/10 border border-red-500/20 rounded p-2">{error}</div>}
 
           <form onSubmit={createProject} className="space-y-3">
             <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
@@ -419,8 +404,10 @@ export function ProjectManagerModal({
                       )}
 
                       <div className="flex gap-2 pt-1">
-                        <Button size="sm" onClick={() => saveEdit(project)}>Save</Button>
-                        <Button size="sm" variant="secondary" onClick={() => setEditingId(null)}>Cancel</Button>
+                        <Button size="sm" disabled={savingId === project.id} onClick={() => saveEdit(project)}>
+                          {savingId === project.id ? 'Saving...' : 'Save'}
+                        </Button>
+                        <Button size="sm" variant="secondary" disabled={savingId === project.id} onClick={() => setEditingId(null)}>Cancel</Button>
                       </div>
                     </div>
                   )}

--- a/src/lib/__tests__/validation.test.ts
+++ b/src/lib/__tests__/validation.test.ts
@@ -11,6 +11,7 @@ import {
   createPipelineSchema,
   createWorkflowSchema,
   createMessageSchema,
+  updateProjectSchema,
 } from '@/lib/validation'
 
 describe('createTaskSchema', () => {
@@ -331,5 +332,30 @@ describe('createMessageSchema', () => {
   it('rejects missing message', () => {
     const result = createMessageSchema.safeParse({ to: 'bob' })
     expect(result.success).toBe(false)
+  })
+})
+
+describe('updateProjectSchema', () => {
+  it('accepts an atomic field and assignment update', () => {
+    const result = updateProjectSchema.safeParse({
+      description: 'Updated project',
+      github_sync_enabled: true,
+      assigned_agents: ['builder', 'reviewer'],
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it.each([
+    {},
+    { unexpected: true },
+    { status: 'deleted' },
+    { deadline: -1 },
+    { ticket_prefix: 'MC', ticketPrefix: 'OTHER' },
+    { assigned_agents: ['builder', 'builder'] },
+    { assigned_agents: [''] },
+    { assigned_agents: Array.from({ length: 101 }, (_, index) => `agent-${index}`) },
+  ])('rejects unsafe project update input %#', (input) => {
+    expect(updateProjectSchema.safeParse(input).success).toBe(false)
   })
 })

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -144,6 +144,37 @@ export const updateWorkspaceSchema = z.object({
   isolation: workspaceFields.isolation.optional(),
 })
 
+const projectAssignmentNamesSchema = z.array(
+  z.string().trim().min(1, 'Agent name cannot be empty').max(100)
+).max(100, 'A project can have at most 100 assigned agents').superRefine((names, ctx) => {
+  if (new Set(names).size !== names.length) {
+    ctx.addIssue({ code: 'custom', message: 'Agent assignments must be unique' })
+  }
+})
+
+const booleanFlagSchema = z.union([z.boolean(), z.literal(0), z.literal(1)])
+
+export const updateProjectSchema = z.object({
+  name: z.string().trim().min(1, 'Project name cannot be empty').max(200).optional(),
+  description: z.string().max(5000).nullable().optional(),
+  ticket_prefix: z.string().max(64).optional(),
+  ticketPrefix: z.string().max(64).optional(),
+  status: z.enum(['active', 'archived']).optional(),
+  github_repo: z.string().trim().max(200).nullable().optional(),
+  deadline: z.number().int().min(0).max(4102444800).nullable().optional(),
+  color: z.string().trim().max(32).nullable().optional(),
+  github_sync_enabled: booleanFlagSchema.optional(),
+  github_default_branch: z.string().trim().min(1).max(255).optional(),
+  github_labels_initialized: booleanFlagSchema.optional(),
+  assigned_agents: projectAssignmentNamesSchema.optional(),
+}).strict().superRefine((body, ctx) => {
+  if (body.ticket_prefix !== undefined && body.ticketPrefix !== undefined) {
+    ctx.addIssue({ code: 'custom', message: 'Use only one ticket prefix field' })
+  }
+}).refine((body) => Object.keys(body).length > 0, {
+  message: 'At least one field is required',
+})
+
 export const bulkUpdateTaskStatusSchema = z.object({
   tasks: z.array(z.object({
     id: z.number().int().positive(),

--- a/tests/project-agents.spec.ts
+++ b/tests/project-agents.spec.ts
@@ -211,6 +211,89 @@ test.describe('Project Agent Assignments', () => {
     expect(getBody.project.assigned_agents).toContain(agentName)
   })
 
+  test('PATCH updates project fields and assignment membership atomically', async ({ request }) => {
+    const { id: projectId } = await createTestProject(request)
+    projectCleanup.push(projectId)
+    const { id: existingAgentId, name: existingAgentName } = await createTestAgent(request)
+    const { id: addedAgentId, name: addedAgentName } = await createTestAgent(request)
+    agentCleanup.push(existingAgentId, addedAgentId)
+
+    await request.post(`/api/projects/${projectId}/agents`, {
+      headers: API_KEY_HEADER,
+      data: { agent_name: existingAgentName, role: 'reviewer' },
+    })
+
+    const updateRes = await request.patch(`/api/projects/${projectId}`, {
+      headers: API_KEY_HEADER,
+      data: {
+        description: 'Atomic update',
+        assigned_agents: [existingAgentName, addedAgentName],
+      },
+    })
+    expect(updateRes.status()).toBe(200)
+    const updateBody = await updateRes.json()
+    expect(updateBody.project.description).toBe('Atomic update')
+    expect(updateBody.project.assigned_agents).toEqual(expect.arrayContaining([existingAgentName, addedAgentName]))
+
+    const assignmentsRes = await request.get(`/api/projects/${projectId}/agents`, { headers: API_KEY_HEADER })
+    const assignmentsBody = await assignmentsRes.json()
+    expect(assignmentsBody.assignments).toHaveLength(2)
+    expect(assignmentsBody.assignments.find((item: any) => item.agent_name === existingAgentName)?.role).toBe('reviewer')
+    expect(assignmentsBody.assignments.find((item: any) => item.agent_name === addedAgentName)?.role).toBe('member')
+  })
+
+  test('PATCH rolls back project fields when assignment validation fails', async ({ request }) => {
+    const { id: projectId } = await createTestProject(request)
+    projectCleanup.push(projectId)
+    const { id: agentId, name: agentName } = await createTestAgent(request)
+    agentCleanup.push(agentId)
+
+    await request.patch(`/api/projects/${projectId}`, {
+      headers: API_KEY_HEADER,
+      data: { description: 'Before update' },
+    })
+    await request.post(`/api/projects/${projectId}/agents`, {
+      headers: API_KEY_HEADER,
+      data: { agent_name: agentName },
+    })
+
+    const updateRes = await request.patch(`/api/projects/${projectId}`, {
+      headers: API_KEY_HEADER,
+      data: {
+        description: 'Must not persist',
+        assigned_agents: [agentName, 'missing-agent'],
+      },
+    })
+    expect(updateRes.status()).toBe(400)
+
+    const projectRes = await request.get(`/api/projects/${projectId}`, { headers: API_KEY_HEADER })
+    const projectBody = await projectRes.json()
+    expect(projectBody.project.description).toBe('Before update')
+    expect(projectBody.project.assigned_agents).toEqual([agentName])
+  })
+
+  test('PATCH edits the default project without parsing the body twice', async ({ request }) => {
+    const projectsRes = await request.get('/api/projects?includeArchived=1', { headers: API_KEY_HEADER })
+    const projectsBody = await projectsRes.json()
+    const general = projectsBody.projects.find((project: any) => project.slug === 'general')
+    expect(general).toBeDefined()
+
+    try {
+      const updateRes = await request.patch(`/api/projects/${general.id}`, {
+        headers: API_KEY_HEADER,
+        data: { description: 'Default project edit regression check' },
+      })
+      expect(updateRes.status()).toBe(200)
+      const updateBody = await updateRes.json()
+      expect(updateBody.project.description).toBe('Default project edit regression check')
+    } finally {
+      await request.patch(`/api/projects/${general.id}`, {
+        headers: API_KEY_HEADER,
+        data: { description: general.description ?? null },
+      })
+    }
+  })
+
   // ── Full lifecycle ───────────────────────────
 
   test('full lifecycle: assign multiple → list → unassign one → verify', async ({ request }) => {


### PR DESCRIPTION
## Summary

- validate project PATCH bodies once with a strict, bounded schema
- update project fields and the requested agent membership set in one SQLite transaction
- reject unknown workspace agents before mutation while preserving roles for existing assignments
- remove the default-project double body parse that caused valid edits to return 500
- migrate the project manager to the authenticated API client and one deterministic save request
- add rollback, membership, role-preservation, and default-project regression coverage

## Verification

- pnpm lint
- pnpm test: 107 files, 1,198 tests
- pnpm typecheck
- pnpm build
- pnpm artifact:check
- pnpm exec playwright test tests/project-agents.spec.ts: 18 tests
- strict devgod security scan
- git diff --check