### PR TITLE
security: harden OS user provisioning

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -11566,11 +11566,15 @@
               "schema": {
                 "type": "object",
                 "required": ["username", "display_name"],
+                "additionalProperties": false,
                 "properties": {
-                  "username": { "type": "string" },
-                  "display_name": { "type": "string" },
-                  "password": { "type": "string" },
+                  "username": { "type": "string", "pattern": "^[a-z][a-z0-9_-]{1,30}[a-z0-9]$" },
+                  "display_name": { "type": "string", "minLength": 1, "maxLength": 100 },
+                  "password": { "type": "string", "minLength": 12, "maxLength": 128 },
                   "gateway_mode": { "type": "boolean" },
+                  "gateway_port": { "type": "integer", "minimum": 1024, "maximum": 65535 },
+                  "owner_gateway": { "type": "string", "minLength": 1, "maxLength": 120 },
+                  "dry_run": { "type": "boolean" },
                   "install_openclaw": { "type": "boolean" },
                   "install_claude": { "type": "boolean" },
                   "install_codex": { "type": "boolean" }
@@ -11587,7 +11591,8 @@
           "400": { "$ref": "#/components/responses/BadRequest" },
           "401": { "$ref": "#/components/responses/Unauthorized" },
           "403": { "$ref": "#/components/responses/Forbidden" },
-          "409": { "description": "User already exists" }
+          "409": { "description": "User already exists" },
+          "429": { "description": "Provisioning rate limit exceeded" }
         }
       }
     },

--- a/src/app/api/super/os-users/route.ts
+++ b/src/app/api/super/os-users/route.ts
@@ -1,13 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { execFileSync } from 'child_process'
+import { randomBytes } from 'crypto'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { requireRole, getUserFromRequest } from '@/lib/auth'
+import { requireRole } from '@/lib/auth'
 import { getDatabase, logAuditEvent } from '@/lib/db'
 import { logger } from '@/lib/logger'
+import { osUserProvisionLimiter } from '@/lib/rate-limit'
 import { resolvePinnedUserToolSpec, runtimeInstallsEnabled } from '@/lib/runtime-install-security'
 import type { UserRuntimeTool } from '@/lib/runtime-install-security'
+import { createOsUserSchema, validateBody } from '@/lib/validation'
 
 export interface OsUser {
   username: string
@@ -258,21 +261,21 @@ export async function POST(request: NextRequest) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
 
-  const currentUser = getUserFromRequest(request)
-  const actor = currentUser?.username || 'system'
+  const rateCheck = osUserProvisionLimiter(`${auth.user.tenant_id ?? 1}:${auth.user.workspace_id ?? 1}:${auth.user.id}`)
+  if (rateCheck) return rateCheck
 
-  let body: any
-  try { body = await request.json() } catch {
-    return NextResponse.json({ error: 'Request body required' }, { status: 400 })
-  }
+  const validated = await validateBody(request, createOsUserSchema)
+  if ('error' in validated) return validated.error
+  const body = validated.data
+  const actor = auth.user.username
 
-  const username = String(body.username || '').trim().toLowerCase()
-  const displayName = String(body.display_name || '').trim()
-  const password = body.password ? String(body.password) : undefined
-  const gatewayMode = !!body.gateway_mode
-  const installOpenclaw = !!body.install_openclaw
-  const installClaude = !!body.install_claude
-  const installCodex = !!body.install_codex
+  const username = body.username
+  const displayName = body.display_name
+  const password = body.password
+  const gatewayMode = body.gateway_mode ?? false
+  const installOpenclaw = body.install_openclaw ?? false
+  const installClaude = body.install_claude ?? false
+  const installCodex = body.install_codex ?? false
   const toolsToInstall: UserRuntimeTool[] = []
   if (installOpenclaw) toolsToInstall.push('openclaw')
   // When OpenClaw is selected, Claude and Codex are bundled.
@@ -295,13 +298,6 @@ export async function POST(request: NextRequest) {
     }
   }
 
-  // Validate username (safe for OS user creation — alphanumeric + dash/underscore)
-  if (!/^[a-z][a-z0-9_-]{1,30}[a-z0-9]$/.test(username)) {
-    return NextResponse.json({ error: 'Invalid username. Use lowercase letters, numbers, dashes, and underscores (3-32 chars).' }, { status: 400 })
-  }
-  if (!displayName) {
-    return NextResponse.json({ error: 'display_name is required' }, { status: 400 })
-  }
   if (SERVICE_ACCOUNTS.has(username)) {
     return NextResponse.json({ error: 'Cannot use a reserved service account name' }, { status: 400 })
   }
@@ -327,8 +323,8 @@ export async function POST(request: NextRequest) {
         slug: username,
         display_name: displayName,
         linux_user: username,
-        gateway_port: body.gateway_port ? Number(body.gateway_port) : undefined,
-        owner_gateway: body.owner_gateway || undefined,
+        gateway_port: body.gateway_port,
+        owner_gateway: body.owner_gateway,
         dry_run: body.dry_run !== false,
         config: { install_openclaw: installOpenclaw, install_claude: installClaude, install_codex: installCodex },
       }, actor)
@@ -344,22 +340,21 @@ export async function POST(request: NextRequest) {
       if (platform === 'darwin') {
         // macOS: use sysadminctl to create user (requires admin/sudo)
         const args = ['-addUser', username, '-fullName', displayName, '-home', `/Users/${username}`]
-        if (password) {
-          args.push('-password', password)
-        } else {
-          args.push('-password', '') // empty password, can be set later
-        }
+        // Never create a blank-password account. If the caller omitted a password,
+        // use an unreturned random credential that can be replaced out of band.
+        args.push('-password', password ?? randomBytes(32).toString('base64url'))
         try {
           execFileSync('/usr/sbin/sysadminctl', args, { timeout: 15000, stdio: 'pipe' })
-        } catch (e: any) {
+        } catch {
           // sysadminctl may need sudo — try with sudo
           try {
             execFileSync('/usr/bin/sudo', ['-n', '/usr/sbin/sysadminctl', ...args], { timeout: 15000, stdio: 'pipe' })
-          } catch (sudoErr: any) {
-            const msg = sudoErr?.stderr?.toString?.() || sudoErr?.message || 'Failed to create OS user'
-            logger.error({ err: sudoErr }, 'Failed to create macOS user')
+          } catch {
+            // Do not log or return the subprocess error: spawn arguments can contain
+            // the account password supplied above.
+            logger.error({ username, platform }, 'Failed to create macOS user')
             return NextResponse.json({
-              error: `Failed to create OS user. This requires admin privileges. ${msg}`,
+              error: 'Failed to create OS user. This requires admin privileges.',
               hint: 'Run Mission Control with sudo or grant the current user admin rights.',
             }, { status: 500 })
           }
@@ -438,11 +433,12 @@ export async function POST(request: NextRequest) {
       install_results: Object.keys(installResults).length > 0 ? installResults : undefined,
       message: installSummary ? `${baseMsg} ${installSummary}.` : baseMsg,
     }, { status: 201 })
-  } catch (e: any) {
-    if (String(e?.message || '').includes('UNIQUE')) {
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : ''
+    if (message.includes('UNIQUE')) {
       return NextResponse.json({ error: 'Organization slug or user already exists' }, { status: 409 })
     }
     logger.error({ err: e }, 'POST /api/super/os-users error')
-    return NextResponse.json({ error: e?.message || 'Failed to create organization' }, { status: 500 })
+    return NextResponse.json({ error: 'Failed to create organization' }, { status: 500 })
   }
 }

--- a/src/components/layout/nav-rail.tsx
+++ b/src/components/layout/nav-rail.tsx
@@ -9,6 +9,7 @@ import { useRouter } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import { APP_VERSION } from '@/lib/version'
 import { getPluginNavItems } from '@/lib/plugins'
+import { apiFetch } from '@/lib/api-client'
 
 interface NavItem {
   id: string
@@ -1186,9 +1187,9 @@ function ContextSwitcher({ currentUser, isAdmin, isLocal, isConnected, tenants, 
                             setCreating(true)
                             setCreateError(null)
                             try {
-                              const res = await fetch('/api/super/os-users', {
+                              const res = await apiFetch<Response>('/api/super/os-users', {
                                 method: 'POST',
-                                headers: { 'Content-Type': 'application/json' },
+                                raw: true,
                                 body: JSON.stringify({
                                   username,
                                   display_name,
@@ -1204,8 +1205,8 @@ function ContextSwitcher({ currentUser, isAdmin, isLocal, isConnected, tenants, 
                               setCreateForm({ username: '', display_name: '', gateway_port: '', install_openclaw: true, install_claude: false, install_codex: false })
                               setCreateMode(false)
                               await Promise.all([fetchTenants(), fetchOsUsers()])
-                            } catch (e: any) {
-                              setCreateError(e?.message || 'Failed to create')
+                            } catch (error: unknown) {
+                              setCreateError(error instanceof Error ? error.message : 'Failed to create')
                             } finally {
                               setCreating(false)
                             }

--- a/src/lib/__tests__/os-user-provision-route-security.test.ts
+++ b/src/lib/__tests__/os-user-provision-route-security.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest, NextResponse } from 'next/server'
+
+const {
+  getDatabaseMock,
+  osUserProvisionLimiterMock,
+  requireRoleMock,
+  resolvePinnedUserToolSpecMock,
+  runtimeInstallsEnabledMock,
+} = vi.hoisted(() => ({
+  getDatabaseMock: vi.fn(),
+  osUserProvisionLimiterMock: vi.fn(),
+  requireRoleMock: vi.fn(),
+  resolvePinnedUserToolSpecMock: vi.fn(),
+  runtimeInstallsEnabledMock: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  requireRole: requireRoleMock,
+}))
+
+vi.mock('@/lib/rate-limit', () => ({
+  osUserProvisionLimiter: osUserProvisionLimiterMock,
+}))
+
+vi.mock('@/lib/db', () => ({
+  getDatabase: getDatabaseMock,
+  logAuditEvent: vi.fn(),
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+
+vi.mock('@/lib/runtime-install-security', () => ({
+  resolvePinnedUserToolSpec: resolvePinnedUserToolSpecMock,
+  runtimeInstallsEnabled: runtimeInstallsEnabledMock,
+}))
+
+function request(body: string) {
+  return new NextRequest('http://localhost/api/super/os-users', {
+    method: 'POST',
+    body,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('OS user provisioning route security', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    requireRoleMock.mockReturnValue({
+      user: { id: 7, username: 'admin', role: 'admin', workspace_id: 3, tenant_id: 9 },
+    })
+    osUserProvisionLimiterMock.mockReturnValue(null)
+    runtimeInstallsEnabledMock.mockReturnValue(true)
+  })
+
+  it('authenticates before rate limiting or parsing provisioning input', async () => {
+    requireRoleMock.mockReturnValue({ error: 'Authentication required', status: 401 })
+    const { POST } = await import('@/app/api/super/os-users/route')
+
+    const response = await POST(request('{not-json'))
+
+    expect(response.status).toBe(401)
+    expect(osUserProvisionLimiterMock).not.toHaveBeenCalled()
+    expect(getDatabaseMock).not.toHaveBeenCalled()
+  })
+
+  it('applies the critical identity limiter before parsing or side effects', async () => {
+    osUserProvisionLimiterMock.mockReturnValue(
+      NextResponse.json({ error: 'Too many provisioning attempts' }, { status: 429 }),
+    )
+    const { POST } = await import('@/app/api/super/os-users/route')
+
+    const response = await POST(request('{not-json'))
+
+    expect(response.status).toBe(429)
+    expect(osUserProvisionLimiterMock).toHaveBeenCalledWith('9:3:7')
+    expect(getDatabaseMock).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['malformed JSON', '{not-json'],
+    ['unknown fields', JSON.stringify({ username: 'valid-user', display_name: 'Valid', root: true })],
+    ['invalid username', JSON.stringify({ username: 'root;shutdown', display_name: 'Invalid' })],
+    ['weak password', JSON.stringify({ username: 'valid-user', display_name: 'Valid', password: 'short' })],
+    ['invalid gateway port', JSON.stringify({ username: 'valid-user', display_name: 'Valid', gateway_mode: true, gateway_port: 22 })],
+    ['missing gateway port', JSON.stringify({ username: 'valid-user', display_name: 'Valid', gateway_mode: true })],
+  ])('rejects %s before discovery, database access, or runtime resolution', async (_label, body) => {
+    const { POST } = await import('@/app/api/super/os-users/route')
+
+    const response = await POST(request(body))
+
+    expect(response.status).toBe(400)
+    expect(getDatabaseMock).not.toHaveBeenCalled()
+    expect(runtimeInstallsEnabledMock).not.toHaveBeenCalled()
+    expect(resolvePinnedUserToolSpecMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/__tests__/validation.test.ts
+++ b/src/lib/__tests__/validation.test.ts
@@ -12,6 +12,7 @@ import {
   createWorkflowSchema,
   createMessageSchema,
   updateProjectSchema,
+  createOsUserSchema,
 } from '@/lib/validation'
 
 describe('createTaskSchema', () => {
@@ -244,6 +245,46 @@ describe('createUserSchema', () => {
   it('rejects missing password', () => {
     const result = createUserSchema.safeParse({ username: 'x' })
     expect(result.success).toBe(false)
+  })
+})
+
+describe('createOsUserSchema', () => {
+  it('accepts a bounded local provisioning request', () => {
+    const result = createOsUserSchema.safeParse({
+      username: 'builder-01',
+      display_name: 'Builder 01',
+      password: 'secure-passphrase',
+      install_codex: true,
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('normalizes safe usernames and display names', () => {
+    const result = createOsUserSchema.safeParse({
+      username: '  Builder-01  ',
+      display_name: '  Builder 01  ',
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.username).toBe('builder-01')
+      expect(result.data.display_name).toBe('Builder 01')
+    }
+  })
+
+  it.each([
+    {},
+    { username: 'ab', display_name: 'Too short username' },
+    { username: 'root;shutdown', display_name: 'Unsafe' },
+    { username: 'valid-user', display_name: '' },
+    { username: 'valid-user', display_name: 'x'.repeat(101) },
+    { username: 'valid-user', display_name: 'Valid', password: 'short' },
+    { username: 'valid-user', display_name: 'Valid', gateway_mode: true },
+    { username: 'valid-user', display_name: 'Valid', gateway_mode: true, gateway_port: 22 },
+    { username: 'valid-user', display_name: 'Valid', unexpected: true },
+  ])('rejects unsafe OS user provisioning input %#', (input) => {
+    expect(createOsUserSchema.safeParse(input).success).toBe(false)
   })
 })
 

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -249,6 +249,14 @@ export const securityFixLimiter = createKeyedRateLimiter({
   critical: true,
 })
 
+/** OS account creation and runtime installation: 5 attempts per 10 minutes per admin. */
+export const osUserProvisionLimiter = createKeyedRateLimiter({
+  windowMs: 10 * 60_000,
+  maxRequests: 5,
+  message: 'Too many OS user provisioning attempts. Try again later.',
+  critical: true,
+})
+
 /** Self-registration: 5/min per IP (prevent spam registrations) */
 export const selfRegisterLimiter = createRateLimiter({
   windowMs: 60_000,

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -276,6 +276,28 @@ export const createUserSchema = z.object({
   email: z.string().optional(),
 })
 
+export const createOsUserSchema = z.object({
+  username: z.string().trim().toLowerCase()
+    .regex(/^[a-z][a-z0-9_-]{1,30}[a-z0-9]$/, 'Invalid OS username'),
+  display_name: z.string().trim().min(1, 'Display name is required').max(100),
+  password: z.string().min(12, 'Password must be at least 12 characters').max(128).optional(),
+  gateway_mode: z.boolean().optional(),
+  gateway_port: z.number().int().min(1024).max(65535).optional(),
+  owner_gateway: z.string().trim().min(1).max(120).optional(),
+  dry_run: z.boolean().optional(),
+  install_openclaw: z.boolean().optional(),
+  install_claude: z.boolean().optional(),
+  install_codex: z.boolean().optional(),
+}).strict().superRefine((body, ctx) => {
+  if (body.gateway_mode && body.gateway_port === undefined) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['gateway_port'],
+      message: 'gateway_port is required in gateway mode',
+    })
+  }
+})
+
 export const accessRequestActionSchema = z.object({
   request_id: z.number(),
   action: z.enum(['approve', 'reject']),


### PR DESCRIPTION
## Summary

- add a critical per-admin limiter before OS account or runtime-install provisioning
- validate the request once with a strict bounded schema and reject unknown fields
- require valid gateway ports and strong supplied passwords
- stop creating blank-password macOS accounts by using an unreturned random fallback credential
- redact subprocess failures that could expose password-bearing arguments
- migrate the nav provisioning mutation to the authenticated API client
- align the public OpenAPI contract and add ordering/fail-closed regression tests

## Verification

- pnpm lint
- pnpm test: 108 files, 1,217 tests
- pnpm typecheck
- pnpm build
- pnpm artifact:check
- pnpm api:parity
- strict devgod security scan
- git diff --check