### PR TITLE
security: harden privileged tmux setup

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5443,12 +5443,28 @@
       },
       "post": {
         "tags": ["API"],
-        "summary": "Install tmux (opt-in, admin only)",
+        "summary": "Install tmux (explicitly confirmed, admin only)",
         "operationId": "post_api_pty_setup",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["confirmation"],
+                "properties": {
+                  "confirmation": { "type": "string", "enum": ["install_tmux"] }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": { "description": "OK" },
           "400": { "description": "Bad request" },
           "401": { "description": "Unauthorized" },
+          "429": { "description": "Too many installation attempts" },
           "500": { "description": "Internal server error" }
         }
       }

--- a/src/app/api/pty/setup/route.ts
+++ b/src/app/api/pty/setup/route.ts
@@ -1,10 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { execFileSync } from 'child_process'
+import { execFileSync, type ExecFileSyncOptionsWithStringEncoding } from 'child_process'
 import { requireRole } from '@/lib/auth'
+import { logAuditEvent } from '@/lib/db'
+import { hostPackageInstallLimiter } from '@/lib/rate-limit'
 import { isTmuxAvailable } from '@/lib/pty-manager'
 import { logger } from '@/lib/logger'
+import { installTmuxSchema, validateBody } from '@/lib/validation'
 
 const log = logger.child({ module: 'pty-setup' })
+const EXEC_OPTIONS: ExecFileSyncOptionsWithStringEncoding = {
+  encoding: 'utf-8' as const,
+  stdio: ['ignore', 'pipe', 'pipe'],
+  timeout: 120_000,
+  maxBuffer: 1024 * 1024,
+}
 
 /**
  * GET /api/pty/setup — Check terminal prerequisites
@@ -55,6 +64,13 @@ export async function POST(request: NextRequest) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
 
+  const limitKey = `${auth.user.tenant_id ?? 1}:${auth.user.workspace_id ?? 1}:${auth.user.id}`
+  const limited = hostPackageInstallLimiter(limitKey)
+  if (limited) return limited
+
+  const validated = await validateBody(request, installTmuxSchema)
+  if ('error' in validated) return validated.error
+
   if (isTmuxAvailable()) {
     return NextResponse.json({ success: true, message: 'tmux is already installed' })
   }
@@ -65,7 +81,7 @@ export async function POST(request: NextRequest) {
   if (platform === 'darwin') {
     // Check if brew is available
     try {
-      execFileSync('brew', ['--version'], { stdio: 'pipe' })
+      execFileSync('brew', ['--version'], EXEC_OPTIONS)
     } catch {
       return NextResponse.json({
         success: false,
@@ -76,11 +92,11 @@ export async function POST(request: NextRequest) {
   } else if (platform === 'linux') {
     // Try apt first, then yum
     try {
-      execFileSync('apt-get', ['--version'], { stdio: 'pipe' })
+      execFileSync('apt-get', ['--version'], EXEC_OPTIONS)
       installCmd = ['sudo', 'apt-get', 'install', '-y', 'tmux']
     } catch {
       try {
-        execFileSync('yum', ['--version'], { stdio: 'pipe' })
+        execFileSync('yum', ['--version'], EXEC_OPTIONS)
         installCmd = ['sudo', 'yum', 'install', '-y', 'tmux']
       } catch {
         return NextResponse.json({
@@ -97,12 +113,8 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    log.info({ cmd: installCmd }, 'Installing tmux')
-    execFileSync(installCmd[0], installCmd.slice(1), {
-      stdio: 'pipe',
-      encoding: 'utf-8',
-      timeout: 120_000,
-    })
+    log.info({ packageManager: installCmd[0], actor: auth.user.username }, 'Installing tmux')
+    execFileSync(installCmd[0], installCmd.slice(1), EXEC_OPTIONS)
 
     // Verify installation
     if (!isTmuxAvailable()) {
@@ -114,9 +126,21 @@ export async function POST(request: NextRequest) {
 
     let version: string | null = null
     try {
-      version = execFileSync('tmux', ['-V'], { encoding: 'utf-8', stdio: 'pipe' }).trim()
+      version = execFileSync('tmux', ['-V'], EXEC_OPTIONS).trim()
     } catch {
       // ignore
+    }
+
+    try {
+      logAuditEvent({
+        action: 'system.package_install',
+        actor: auth.user.username,
+        actor_id: auth.user.id,
+        target_type: 'host_package',
+        detail: { package: 'tmux', package_manager: installCmd[0], platform },
+      })
+    } catch {
+      // Installation succeeded; audit persistence must not corrupt the response.
     }
 
     return NextResponse.json({
@@ -124,12 +148,11 @@ export async function POST(request: NextRequest) {
       message: `tmux installed successfully${version ? ` (${version})` : ''}`,
       version,
     })
-  } catch (error) {
-    const msg = error instanceof Error ? error.message : 'Unknown error'
-    log.error({ err: error }, 'Failed to install tmux')
+  } catch {
+    log.error({ actor: auth.user.username }, 'Failed to install tmux')
     return NextResponse.json({
       success: false,
-      error: `Failed to install tmux: ${msg}`,
+      error: 'Failed to install tmux. Check the server logs and package manager state.',
     }, { status: 500 })
   }
 }

--- a/src/lib/__tests__/pty-setup-route-security.test.ts
+++ b/src/lib/__tests__/pty-setup-route-security.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest, NextResponse } from 'next/server'
+
+const {
+  execFileSyncMock,
+  hostPackageInstallLimiterMock,
+  isTmuxAvailableMock,
+  logAuditEventMock,
+  requireRoleMock,
+} = vi.hoisted(() => ({
+  execFileSyncMock: vi.fn(),
+  hostPackageInstallLimiterMock: vi.fn(),
+  isTmuxAvailableMock: vi.fn(),
+  logAuditEventMock: vi.fn(),
+  requireRoleMock: vi.fn(),
+}))
+
+vi.mock('child_process', () => ({
+  default: { execFileSync: execFileSyncMock },
+  execFileSync: execFileSyncMock,
+}))
+vi.mock('@/lib/auth', () => ({ requireRole: requireRoleMock }))
+vi.mock('@/lib/db', () => ({ logAuditEvent: logAuditEventMock }))
+vi.mock('@/lib/rate-limit', () => ({ hostPackageInstallLimiter: hostPackageInstallLimiterMock }))
+vi.mock('@/lib/pty-manager', () => ({ isTmuxAvailable: isTmuxAvailableMock }))
+vi.mock('@/lib/logger', () => ({
+  logger: { child: () => ({ error: vi.fn(), info: vi.fn() }) },
+}))
+
+function request(body: string) {
+  return new NextRequest('http://localhost/api/pty/setup', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body,
+  })
+}
+
+const admin = {
+  user: { id: 7, username: 'admin', role: 'admin', workspace_id: 3, tenant_id: 9 },
+}
+
+describe('PTY setup route security', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    requireRoleMock.mockReturnValue(admin)
+    hostPackageInstallLimiterMock.mockReturnValue(null)
+    isTmuxAvailableMock.mockReturnValue(false)
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+  })
+
+  it('authenticates before rate limiting, parsing, or subprocess execution', async () => {
+    requireRoleMock.mockReturnValue({ error: 'Authentication required', status: 401 })
+    const { POST } = await import('@/app/api/pty/setup/route')
+
+    const response = await POST(request('{not-json'))
+
+    expect(response.status).toBe(401)
+    expect(hostPackageInstallLimiterMock).not.toHaveBeenCalled()
+    expect(isTmuxAvailableMock).not.toHaveBeenCalled()
+    expect(execFileSyncMock).not.toHaveBeenCalled()
+  })
+
+  it('applies the critical identity limiter before parsing or side effects', async () => {
+    hostPackageInstallLimiterMock.mockReturnValue(
+      NextResponse.json({ error: 'Too many installation attempts' }, { status: 429 }),
+    )
+    const { POST } = await import('@/app/api/pty/setup/route')
+
+    const response = await POST(request('{not-json'))
+
+    expect(response.status).toBe(429)
+    expect(hostPackageInstallLimiterMock).toHaveBeenCalledWith('9:3:7')
+    expect(isTmuxAvailableMock).not.toHaveBeenCalled()
+    expect(execFileSyncMock).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['malformed JSON', '{not-json'],
+    ['missing confirmation', '{}'],
+    ['incorrect confirmation', JSON.stringify({ confirmation: 'yes' })],
+    ['unknown field', JSON.stringify({ confirmation: 'install_tmux', package: 'curl' })],
+  ])('rejects %s before host probes or execution', async (_label, body) => {
+    const { POST } = await import('@/app/api/pty/setup/route')
+
+    const response = await POST(request(body))
+
+    expect(response.status).toBe(400)
+    expect(isTmuxAvailableMock).not.toHaveBeenCalled()
+    expect(execFileSyncMock).not.toHaveBeenCalled()
+  })
+
+  it('executes only the fixed tmux install command and records an audit event', async () => {
+    isTmuxAvailableMock.mockReturnValueOnce(false).mockReturnValueOnce(true)
+    execFileSyncMock.mockImplementation((command: string, args: string[]) => {
+      if (command === 'tmux' && args[0] === '-V') return 'tmux 3.5a\n'
+      return ''
+    })
+    const { POST } = await import('@/app/api/pty/setup/route')
+
+    const response = await POST(request(JSON.stringify({ confirmation: 'install_tmux' })))
+
+    expect(response.status).toBe(200)
+    expect(execFileSyncMock).toHaveBeenCalledWith('brew', ['install', 'tmux'], expect.objectContaining({
+      timeout: 120_000,
+      maxBuffer: 1024 * 1024,
+    }))
+    expect(logAuditEventMock).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'system.package_install',
+      actor: 'admin',
+      actor_id: 7,
+      detail: { package: 'tmux', package_manager: 'brew', platform: 'darwin' },
+    }))
+  })
+
+  it('does not expose subprocess errors to the client', async () => {
+    execFileSyncMock.mockImplementation((command: string, args: string[]) => {
+      if (command === 'brew' && args[0] === 'install') {
+        throw new Error('secret host path: /Users/operator/private')
+      }
+      return ''
+    })
+    const { POST } = await import('@/app/api/pty/setup/route')
+
+    const response = await POST(request(JSON.stringify({ confirmation: 'install_tmux' })))
+    const body = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(body).toEqual({
+      success: false,
+      error: 'Failed to install tmux. Check the server logs and package manager state.',
+    })
+    expect(JSON.stringify(body)).not.toContain('/Users/operator/private')
+    expect(logAuditEventMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/__tests__/validation.test.ts
+++ b/src/lib/__tests__/validation.test.ts
@@ -13,6 +13,7 @@ import {
   createMessageSchema,
   updateProjectSchema,
   createOsUserSchema,
+  installTmuxSchema,
 } from '@/lib/validation'
 
 describe('createTaskSchema', () => {
@@ -285,6 +286,21 @@ describe('createOsUserSchema', () => {
     { username: 'valid-user', display_name: 'Valid', unexpected: true },
   ])('rejects unsafe OS user provisioning input %#', (input) => {
     expect(createOsUserSchema.safeParse(input).success).toBe(false)
+  })
+})
+
+describe('installTmuxSchema', () => {
+  it('accepts only the explicit installation confirmation', () => {
+    expect(installTmuxSchema.safeParse({ confirmation: 'install_tmux' }).success).toBe(true)
+  })
+
+  it.each([
+    {},
+    { confirmation: true },
+    { confirmation: 'yes' },
+    { confirmation: 'install_tmux', package: 'curl' },
+  ])('rejects unsafe tmux installation input %#', (input) => {
+    expect(installTmuxSchema.safeParse(input).success).toBe(false)
   })
 })
 

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -257,6 +257,14 @@ export const osUserProvisionLimiter = createKeyedRateLimiter({
   critical: true,
 })
 
+/** Host package installation: 3 attempts per 10 minutes per admin. */
+export const hostPackageInstallLimiter = createKeyedRateLimiter({
+  windowMs: 10 * 60_000,
+  maxRequests: 3,
+  message: 'Too many host package installation attempts. Try again later.',
+  critical: true,
+})
+
 /** Self-registration: 5/min per IP (prevent spam registrations) */
 export const selfRegisterLimiter = createRateLimiter({
   windowMs: 60_000,

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -298,6 +298,10 @@ export const createOsUserSchema = z.object({
   }
 })
 
+export const installTmuxSchema = z.object({
+  confirmation: z.literal('install_tmux'),
+}).strict()
+
 export const accessRequestActionSchema = z.object({
   request_id: z.number(),
   action: z.enum(['approve', 'reject']),


### PR DESCRIPTION
## Summary
- require an explicit strict confirmation before host package installation
- apply a critical per-admin limiter before parsing or subprocess probes
- bound subprocess buffers/timeouts, sanitize failures, and audit successful installs
- document the request and 429 contract in OpenAPI

## Verification
- 1,230 tests passed across 109 files
- TypeScript passed
- lint passed with 99 existing warnings and 0 errors
- production build passed
- standalone artifact check passed
- API contract parity passed
- strict security scan passed