### PR TITLE
security: harden release updates

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -11676,9 +11676,11 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["targetVersion"],
+                "additionalProperties": false,
+                "required": ["targetVersion", "confirmation"],
                 "properties": {
-                  "targetVersion": { "type": "string" }
+                  "targetVersion": { "type": "string", "minLength": 1, "maxLength": 128 },
+                  "confirmation": { "type": "string", "enum": ["update_mission_control"] }
                 }
               }
             }
@@ -11705,7 +11707,10 @@
           "400": { "$ref": "#/components/responses/BadRequest" },
           "401": { "$ref": "#/components/responses/Unauthorized" },
           "403": { "$ref": "#/components/responses/Forbidden" },
-          "409": { "description": "Working tree has uncommitted changes" }
+          "404": { "description": "Release tag not found" },
+          "409": { "description": "Working tree is dirty or release provenance is invalid" },
+          "429": { "description": "Too many update attempts" },
+          "500": { "$ref": "#/components/responses/InternalServerError" }
         }
       }
     }

--- a/src/app/api/releases/update/route.ts
+++ b/src/app/api/releases/update/route.ts
@@ -3,12 +3,16 @@ import { execFileSync } from 'child_process'
 import { readFileSync } from 'fs'
 import { join } from 'path'
 import { requireRole } from '@/lib/auth'
-import { getDatabase } from '@/lib/db'
+import { logAuditEvent } from '@/lib/db'
+import { releaseUpdateLimiter } from '@/lib/rate-limit'
 import { APP_VERSION } from '@/lib/version'
 import { normalizeReleaseTag } from '@/lib/release-update-security'
+import { releaseUpdateSchema, validateBody } from '@/lib/validation'
+import { logger } from '@/lib/logger'
 
 const UPDATE_TIMEOUT = 5 * 60 * 1000 // 5 minutes
 const MAX_BUFFER = 10 * 1024 * 1024 // 10 MB
+const log = logger.child({ module: 'release-update' })
 
 const EXEC_OPTS = {
   timeout: UPDATE_TIMEOUT,
@@ -31,15 +35,20 @@ export async function POST(request: Request) {
   }
 
   const user = auth.user!
+  const limitKey = `${user.tenant_id ?? 1}:${user.workspace_id ?? 1}:${user.id}`
+  const limited = releaseUpdateLimiter(limitKey)
+  if (limited) return limited
+
+  const validated = await validateBody(request, releaseUpdateSchema)
+  if ('error' in validated) return validated.error
+
   const cwd = process.cwd()
-  const steps: { step: string; output: string }[] = []
+  const steps: string[] = []
   let originalRef: string | null = null
   let checkoutPerformed = false
 
   try {
-    // Parse target version from request body
-    const body = await request.json().catch(() => ({}))
-    const tag = normalizeReleaseTag(body.targetVersion)
+    const tag = normalizeReleaseTag(validated.data.targetVersion)
     if (!tag) {
       return NextResponse.json(
         { error: 'targetVersion must be an exact semantic version such as 2.1.0 or v2.1.0' },
@@ -54,7 +63,6 @@ export async function POST(request: Request) {
         {
           error: 'Working tree has uncommitted changes. Please commit or stash them before updating.',
           dirty: true,
-          files: status.split('\n').slice(0, 20),
         },
         { status: 409 }
       )
@@ -67,8 +75,8 @@ export async function POST(request: Request) {
 
     // 2. Fetch the trusted main history and the exact release tag. Fetching an
     // exact ref prevents a stale or unrelated local tag from being accepted.
-    const fetchMainOut = git(['fetch', 'origin', 'refs/heads/main:refs/remotes/origin/main'], cwd)
-    steps.push({ step: 'git fetch origin main', output: fetchMainOut || 'OK' })
+    git(['fetch', 'origin', 'refs/heads/main:refs/remotes/origin/main'], cwd)
+    steps.push('git fetch origin main')
 
     // 3. Verify the tag exists
     try {
@@ -95,17 +103,17 @@ export async function POST(request: Request) {
     }
 
     // 4. Checkout the release tag
-    const checkoutOut = git(['checkout', tag], cwd)
+    git(['checkout', tag], cwd)
     checkoutPerformed = true
-    steps.push({ step: `git checkout ${tag}`, output: checkoutOut })
+    steps.push(`git checkout ${tag}`)
 
     // 5. Install dependencies
-    const installOut = pnpm(['install', '--frozen-lockfile'], cwd)
-    steps.push({ step: 'pnpm install', output: installOut })
+    pnpm(['install', '--frozen-lockfile'], cwd)
+    steps.push('pnpm install')
 
     // 6. Build
-    const buildOut = pnpm(['build'], cwd)
-    steps.push({ step: 'pnpm build', output: buildOut })
+    pnpm(['build'], cwd)
+    steps.push('pnpm build')
 
     // 7. Read new version from package.json
     const newPkg = JSON.parse(readFileSync(join(cwd, 'package.json'), 'utf-8'))
@@ -113,18 +121,17 @@ export async function POST(request: Request) {
 
     // 8. Log to audit_log
     try {
-      const db = getDatabase()
-      db.prepare(
-        'INSERT INTO audit_log (action, actor, detail) VALUES (?, ?, ?)'
-      ).run(
-        'system.update',
-        user.username,
-        JSON.stringify({
+      logAuditEvent({
+        action: 'system.update',
+        actor: user.username,
+        actor_id: user.id,
+        target_type: 'release',
+        detail: {
           previousVersion: APP_VERSION,
           newVersion,
           tag,
-        })
-      )
+        },
+      })
     } catch {
       // Non-critical -- don't fail the update if audit logging fails
     }
@@ -137,14 +144,8 @@ export async function POST(request: Request) {
       steps,
       restartRequired: true,
     })
-  } catch (err: any) {
-    const message =
-      err?.stderr?.toString?.()?.trim() ||
-      err?.stdout?.toString?.()?.trim() ||
-      err?.message ||
-      'Unknown error during update'
-
-    let rollback: { attempted: boolean; restored: boolean; detail?: string } = {
+  } catch {
+    let rollback: { attempted: boolean; restored: boolean } = {
       attempted: false,
       restored: false,
     }
@@ -153,15 +154,14 @@ export async function POST(request: Request) {
       try {
         git(['checkout', originalRef], cwd)
         rollback.restored = true
-      } catch (rollbackErr: any) {
-        rollback.detail = rollbackErr?.stderr?.toString?.()?.trim() || rollbackErr?.message || 'Rollback failed'
-      }
+      } catch { /* response reports restoration state without exposing command output */ }
     }
+
+    log.error({ actor: user.username, rollback }, 'Release update failed')
 
     return NextResponse.json(
       {
         error: 'Update failed',
-        detail: message,
         steps,
         rollback,
       },

--- a/src/components/layout/update-banner.tsx
+++ b/src/components/layout/update-banner.tsx
@@ -25,7 +25,10 @@ export function UpdateBanner() {
     try {
       const res = await apiFetch<Response>('/api/releases/update', {
         method: 'POST',
-        body: JSON.stringify({ targetVersion: updateAvailable!.latestVersion }),
+        body: JSON.stringify({
+          targetVersion: updateAvailable!.latestVersion,
+          confirmation: 'update_mission_control',
+        }),
         raw: true,
       })
       const data = await res.json()

--- a/src/lib/__tests__/release-update-client-security.test.ts
+++ b/src/lib/__tests__/release-update-client-security.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('release update client contract', () => {
+  it('sends the explicit server-side confirmation literal', () => {
+    const source = readFileSync(join(process.cwd(), 'src/components/layout/update-banner.tsx'), 'utf8')
+
+    expect(source).toContain("confirmation: 'update_mission_control'")
+  })
+})

--- a/src/lib/__tests__/release-update-route-security.test.ts
+++ b/src/lib/__tests__/release-update-route-security.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest, NextResponse } from 'next/server'
+
+const {
+  execFileSyncMock,
+  logAuditEventMock,
+  readFileSyncMock,
+  releaseUpdateLimiterMock,
+  requireRoleMock,
+} = vi.hoisted(() => ({
+  execFileSyncMock: vi.fn(),
+  logAuditEventMock: vi.fn(),
+  readFileSyncMock: vi.fn(),
+  releaseUpdateLimiterMock: vi.fn(),
+  requireRoleMock: vi.fn(),
+}))
+
+vi.mock('child_process', () => ({
+  default: { execFileSync: execFileSyncMock },
+  execFileSync: execFileSyncMock,
+}))
+vi.mock('fs', () => ({
+  default: { readFileSync: readFileSyncMock },
+  readFileSync: readFileSyncMock,
+}))
+vi.mock('@/lib/auth', () => ({ requireRole: requireRoleMock }))
+vi.mock('@/lib/db', () => ({ logAuditEvent: logAuditEventMock }))
+vi.mock('@/lib/rate-limit', () => ({ releaseUpdateLimiter: releaseUpdateLimiterMock }))
+vi.mock('@/lib/version', () => ({ APP_VERSION: '2.0.0' }))
+vi.mock('@/lib/logger', () => ({
+  logger: { child: () => ({ error: vi.fn() }) },
+}))
+
+const admin = {
+  user: { id: 7, username: 'admin', role: 'admin', workspace_id: 3, tenant_id: 9 },
+}
+
+function request(body: string) {
+  return new NextRequest('http://localhost/api/releases/update', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body,
+  })
+}
+
+function validBody() {
+  return JSON.stringify({
+    targetVersion: 'v2.1.0',
+    confirmation: 'update_mission_control',
+  })
+}
+
+function commandName(command: string, args: string[]) {
+  return `${command} ${args.join(' ')}`
+}
+
+describe('release update route security', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    requireRoleMock.mockReturnValue(admin)
+    releaseUpdateLimiterMock.mockReturnValue(null)
+    readFileSyncMock.mockReturnValue(JSON.stringify({ version: '2.1.0' }))
+    execFileSyncMock.mockImplementation((command: string, args: string[]) => {
+      const name = commandName(command, args)
+      if (name === 'git symbolic-ref --quiet --short HEAD') return 'main\n'
+      return name === 'git status --porcelain' ? '' : 'SENSITIVE_COMMAND_OUTPUT\n'
+    })
+  })
+
+  it('authenticates before rate limiting, parsing, or executing commands', async () => {
+    requireRoleMock.mockReturnValue({ error: 'Authentication required', status: 401 })
+    const { POST } = await import('@/app/api/releases/update/route')
+
+    const response = await POST(request('{not-json'))
+
+    expect(response.status).toBe(401)
+    expect(releaseUpdateLimiterMock).not.toHaveBeenCalled()
+    expect(execFileSyncMock).not.toHaveBeenCalled()
+  })
+
+  it('applies the critical identity limiter before parsing or commands', async () => {
+    releaseUpdateLimiterMock.mockReturnValue(
+      NextResponse.json({ error: 'Too many update attempts' }, { status: 429 }),
+    )
+    const { POST } = await import('@/app/api/releases/update/route')
+
+    const response = await POST(request('{not-json'))
+
+    expect(response.status).toBe(429)
+    expect(releaseUpdateLimiterMock).toHaveBeenCalledWith('9:3:7')
+    expect(execFileSyncMock).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['malformed JSON', '{not-json'],
+    ['missing confirmation', JSON.stringify({ targetVersion: 'v2.1.0' })],
+    ['wrong confirmation', JSON.stringify({ targetVersion: 'v2.1.0', confirmation: 'yes' })],
+    ['unknown field', JSON.stringify({ targetVersion: 'v2.1.0', confirmation: 'update_mission_control', force: true })],
+  ])('rejects %s before executing commands', async (_label, body) => {
+    const { POST } = await import('@/app/api/releases/update/route')
+
+    const response = await POST(request(body))
+
+    expect(response.status).toBe(400)
+    expect(execFileSyncMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses a release outside the fetched origin/main history', async () => {
+    execFileSyncMock.mockImplementation((command: string, args: string[]) => {
+      const name = commandName(command, args)
+      if (name === 'git status --porcelain') return ''
+      if (name === 'git symbolic-ref --quiet --short HEAD') return 'main\n'
+      if (args[0] === 'merge-base') throw new Error('not an ancestor')
+      return ''
+    })
+    const { POST } = await import('@/app/api/releases/update/route')
+
+    const response = await POST(request(validBody()))
+
+    expect(response.status).toBe(409)
+    expect(execFileSyncMock).not.toHaveBeenCalledWith('pnpm', expect.anything(), expect.anything())
+    expect(logAuditEventMock).not.toHaveBeenCalled()
+  })
+
+  it('returns bounded progress without exposing command output', async () => {
+    const { POST } = await import('@/app/api/releases/update/route')
+
+    const response = await POST(request(validBody()))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.steps).toEqual([
+      'git fetch origin main',
+      'git checkout v2.1.0',
+      'pnpm install',
+      'pnpm build',
+    ])
+    expect(JSON.stringify(body)).not.toContain('SENSITIVE_COMMAND_OUTPUT')
+    expect(logAuditEventMock).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'system.update',
+      actor: 'admin',
+      actor_id: 7,
+      target_type: 'release',
+    }))
+  })
+
+  it('restores the original ref and sanitizes post-checkout failures', async () => {
+    execFileSyncMock.mockImplementation((command: string, args: string[]) => {
+      const name = commandName(command, args)
+      if (name === 'git status --porcelain') return ''
+      if (name === 'git symbolic-ref --quiet --short HEAD') return 'main\n'
+      if (name === 'pnpm install --frozen-lockfile') {
+        const error = new Error('SENSITIVE_UPDATE_FAILURE') as Error & { stderr: Buffer }
+        error.stderr = Buffer.from('/private/operator/repo token=secret')
+        throw error
+      }
+      return ''
+    })
+    const { POST } = await import('@/app/api/releases/update/route')
+
+    const response = await POST(request(validBody()))
+    const body = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(body).toEqual({
+      error: 'Update failed',
+      steps: ['git fetch origin main', 'git checkout v2.1.0'],
+      rollback: { attempted: true, restored: true },
+    })
+    expect(execFileSyncMock).toHaveBeenCalledWith('git', ['checkout', 'main'], expect.anything())
+    expect(JSON.stringify(body)).not.toContain('SENSITIVE_UPDATE_FAILURE')
+    expect(JSON.stringify(body)).not.toContain('/private/operator/repo')
+    expect(logAuditEventMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/__tests__/validation.test.ts
+++ b/src/lib/__tests__/validation.test.ts
@@ -14,6 +14,7 @@ import {
   updateProjectSchema,
   createOsUserSchema,
   installTmuxSchema,
+  releaseUpdateSchema,
 } from '@/lib/validation'
 
 describe('createTaskSchema', () => {
@@ -301,6 +302,26 @@ describe('installTmuxSchema', () => {
     { confirmation: 'install_tmux', package: 'curl' },
   ])('rejects unsafe tmux installation input %#', (input) => {
     expect(installTmuxSchema.safeParse(input).success).toBe(false)
+  })
+})
+
+describe('releaseUpdateSchema', () => {
+  it('accepts a bounded target with the explicit update confirmation', () => {
+    expect(releaseUpdateSchema.safeParse({
+      targetVersion: ' v2.1.0 ',
+      confirmation: 'update_mission_control',
+    }).success).toBe(true)
+  })
+
+  it.each([
+    {},
+    { targetVersion: 'v2.1.0' },
+    { targetVersion: 'v2.1.0', confirmation: true },
+    { targetVersion: 'v2.1.0', confirmation: 'yes' },
+    { targetVersion: 'v2.1.0', confirmation: 'update_mission_control', force: true },
+    { targetVersion: 'v' + '1'.repeat(128), confirmation: 'update_mission_control' },
+  ])('rejects unsafe release update input %#', (input) => {
+    expect(releaseUpdateSchema.safeParse(input).success).toBe(false)
   })
 })
 

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -265,6 +265,14 @@ export const hostPackageInstallLimiter = createKeyedRateLimiter({
   critical: true,
 })
 
+/** Application self-update: 3 attempts per 10 minutes per admin. */
+export const releaseUpdateLimiter = createKeyedRateLimiter({
+  windowMs: 10 * 60_000,
+  maxRequests: 3,
+  message: 'Too many release update attempts. Try again later.',
+  critical: true,
+})
+
 /** Self-registration: 5/min per IP (prevent spam registrations) */
 export const selfRegisterLimiter = createRateLimiter({
   windowMs: 60_000,

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -302,6 +302,11 @@ export const installTmuxSchema = z.object({
   confirmation: z.literal('install_tmux'),
 }).strict()
 
+export const releaseUpdateSchema = z.object({
+  targetVersion: z.string().trim().min(1).max(128),
+  confirmation: z.literal('update_mission_control'),
+}).strict()
+
 export const accessRequestActionSchema = z.object({
   request_id: z.number(),
   action: z.enum(['approve', 'reject']),


### PR DESCRIPTION
## Summary
- require strict explicit confirmation and critical per-admin throttling before self-update commands
- retain exact-tag, origin/main ancestry, frozen-lockfile, and rollback protections
- stop exposing git, install, build, stderr, path, and rollback command output
- return bounded progress labels and audit successful updates
- update the client and OpenAPI contract

## Verification
- 1,247 tests passed across 111 files
- TypeScript passed
- lint passed with 99 existing warnings and 0 errors
- production build passed
- standalone artifact check passed
- API contract parity passed
- strict security scan passed