### PR TITLE
security: harden OpenClaw maintenance

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -9941,16 +9941,24 @@
           "404": {
             "description": "Not found"
           },
+          "429": {
+            "description": "Too many maintenance attempts"
+          },
           "500": {
             "description": "Internal server error"
           }
         },
         "requestBody": {
-          "required": false,
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object"
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["confirmation"],
+                "properties": {
+                  "confirmation": { "type": "string", "enum": ["fix_openclaw"] }
+                }
               }
             }
           }
@@ -10009,16 +10017,24 @@
           "404": {
             "description": "Not found"
           },
+          "429": {
+            "description": "Too many maintenance attempts"
+          },
           "500": {
             "description": "Internal server error"
           }
         },
         "requestBody": {
-          "required": false,
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object"
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["confirmation"],
+                "properties": {
+                  "confirmation": { "type": "string", "enum": ["update_openclaw"] }
+                }
               }
             }
           }

--- a/src/app/api/openclaw/doctor/route.ts
+++ b/src/app/api/openclaw/doctor/route.ts
@@ -2,10 +2,12 @@ import { NextResponse } from 'next/server'
 import { requireRole } from '@/lib/auth'
 import { runOpenClaw } from '@/lib/command'
 import { config } from '@/lib/config'
-import { getDatabase } from '@/lib/db'
+import { logAuditEvent } from '@/lib/db'
 import { logger } from '@/lib/logger'
 import { archiveOrphanTranscriptsForStateDir } from '@/lib/openclaw-doctor-fix'
 import { parseOpenClawDoctorOutput } from '@/lib/openclaw-doctor'
+import { openClawMaintenanceLimiter } from '@/lib/rate-limit'
+import { openClawDoctorFixSchema, validateBody } from '@/lib/validation'
 
 function getCommandDetail(error: unknown): { detail: string; code: number | null } {
   const err = error as {
@@ -144,18 +146,24 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: auth.error }, { status: auth.status })
   }
 
+  const limitKey = `${auth.user.tenant_id ?? 1}:${auth.user.workspace_id ?? 1}:${auth.user.id}`
+  const limited = openClawMaintenanceLimiter(limitKey)
+  if (limited) return limited
+
+  const validated = await validateBody(request, openClawDoctorFixSchema)
+  if ('error' in validated) return validated.error
+
   try {
     const progress: Array<{ step: string; detail: string }> = []
 
-    const fixResult = await runOpenClaw(['doctor', '--fix'], { timeoutMs: 120000 })
+    await runOpenClaw(['doctor', '--fix'], { timeoutMs: 120000 })
     progress.push({ step: 'doctor', detail: 'Applied OpenClaw doctor config fixes.' })
 
     try {
       await runOpenClaw(['sessions', 'cleanup', '--all-agents', '--enforce', '--fix-missing'], { timeoutMs: 120000 })
       progress.push({ step: 'sessions', detail: 'Pruned missing transcript entries from session stores.' })
-    } catch (error) {
-      const { detail } = getCommandDetail(error)
-      progress.push({ step: 'sessions', detail: detail || 'Session cleanup skipped.' })
+    } catch {
+      progress.push({ step: 'sessions', detail: 'Session cleanup could not complete.' })
     }
 
     const orphanFix = archiveOrphanTranscriptsForStateDir(config.openclawStateDir)
@@ -171,46 +179,41 @@ export async function POST(request: Request) {
     const status = parseOpenClawDoctorOutput(`${postFix.stdout}\n${postFix.stderr}`, postFix.code ?? 0, {
       stateDir: config.openclawStateDir,
     })
+    const safeStatus = Object.fromEntries(
+      Object.entries(status).filter(([key]) => key !== 'raw'),
+    )
 
     // The fix changed state on disk — drop the GET cache so the next poll
     // sees the fresh status immediately rather than waiting out the TTL.
     invalidateDoctorCache()
 
     try {
-      const db = getDatabase()
-      db.prepare(
-        'INSERT INTO audit_log (action, actor, detail) VALUES (?, ?, ?)'
-      ).run(
-        'openclaw.doctor.fix',
-        auth.user.username,
-        JSON.stringify({ level: status.level, healthy: status.healthy, issues: status.issues })
-      )
+      logAuditEvent({
+        action: 'openclaw.doctor.fix',
+        actor: auth.user.username,
+        actor_id: auth.user.id,
+        target_type: 'runtime',
+        detail: { level: status.level, healthy: status.healthy, issues: status.issues },
+      })
     } catch {
       // Non-critical.
     }
 
     return NextResponse.json({
       success: true,
-      output: `${fixResult.stdout}\n${fixResult.stderr}`.trim(),
       progress,
-      status,
+      status: safeStatus,
     })
   } catch (error) {
-    const { detail, code } = getCommandDetail(error)
+    const { detail } = getCommandDetail(error)
     if (isMissingOpenClaw(detail)) {
       return NextResponse.json({ error: 'OpenClaw is not installed or not reachable' }, { status: 400 })
     }
 
-    logger.error({ err: error }, 'OpenClaw doctor fix failed')
+    logger.error({ actor: auth.user.username }, 'OpenClaw doctor fix failed')
 
     return NextResponse.json(
-      {
-        error: 'OpenClaw doctor fix failed',
-        detail,
-        status: parseOpenClawDoctorOutput(detail, code ?? 1, {
-          stateDir: config.openclawStateDir,
-        }),
-      },
+      { error: 'OpenClaw doctor fix failed' },
       { status: 500 }
     )
   }

--- a/src/app/api/openclaw/update/route.ts
+++ b/src/app/api/openclaw/update/route.ts
@@ -1,14 +1,23 @@
 import { NextResponse } from 'next/server'
 import { requireRole } from '@/lib/auth'
 import { runOpenClaw } from '@/lib/command'
-import { getDatabase } from '@/lib/db'
+import { logAuditEvent } from '@/lib/db'
 import { logger } from '@/lib/logger'
+import { openClawMaintenanceLimiter } from '@/lib/rate-limit'
+import { openClawUpdateSchema, validateBody } from '@/lib/validation'
 
 export async function POST(request: Request) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) {
     return NextResponse.json({ error: auth.error }, { status: auth.status })
   }
+
+  const limitKey = `${auth.user.tenant_id ?? 1}:${auth.user.workspace_id ?? 1}:${auth.user.id}`
+  const limited = openClawMaintenanceLimiter(limitKey)
+  if (limited) return limited
+
+  const validated = await validateBody(request, openClawUpdateSchema)
+  if ('error' in validated) return validated.error
 
   let installedBefore: string | null = null
 
@@ -24,7 +33,7 @@ export async function POST(request: Request) {
   }
 
   try {
-    const result = await runOpenClaw(['update', '--channel', 'stable'], {
+    await runOpenClaw(['update', '--channel', 'stable'], {
       timeoutMs: 5 * 60 * 1000,
     })
 
@@ -38,33 +47,25 @@ export async function POST(request: Request) {
 
     // Audit log
     try {
-      const db = getDatabase()
-      db.prepare(
-        'INSERT INTO audit_log (action, actor, detail) VALUES (?, ?, ?)'
-      ).run(
-        'openclaw.update',
-        auth.user.username,
-        JSON.stringify({ previousVersion: installedBefore, newVersion: installedAfter })
-      )
+      logAuditEvent({
+        action: 'openclaw.update',
+        actor: auth.user.username,
+        actor_id: auth.user.id,
+        target_type: 'runtime',
+        detail: { previousVersion: installedBefore, newVersion: installedAfter, channel: 'stable' },
+      })
     } catch { /* non-critical */ }
 
     return NextResponse.json({
       success: true,
       previousVersion: installedBefore,
       newVersion: installedAfter,
-      output: result.stdout,
     })
-  } catch (err: any) {
-    const detail =
-      err?.stderr?.toString?.()?.trim() ||
-      err?.stdout?.toString?.()?.trim() ||
-      err?.message ||
-      'Unknown error during OpenClaw update'
-
-    logger.error({ err }, 'OpenClaw update failed')
+  } catch {
+    logger.error({ actor: auth.user.username }, 'OpenClaw update failed')
 
     return NextResponse.json(
-      { error: 'OpenClaw update failed', detail },
+      { error: 'OpenClaw update failed' },
       { status: 500 }
     )
   }

--- a/src/components/layout/openclaw-doctor-banner.tsx
+++ b/src/components/layout/openclaw-doctor-banner.tsx
@@ -78,6 +78,7 @@ export function OpenClawDoctorBanner() {
     try {
       const res = await apiFetch<Response>('/api/openclaw/doctor', {
         method: 'POST',
+        body: JSON.stringify({ confirmation: 'fix_openclaw' }),
         raw: true,
       })
       const data = await res.json()
@@ -85,10 +86,7 @@ export function OpenClawDoctorBanner() {
 
       if (!res.ok) {
         setState('error')
-        setErrorMsg(data.detail || data.error || t('fixFailed'))
-        if (data.status) {
-          setDoctor(data.status)
-        }
+        setErrorMsg(data.error || t('fixFailed'))
         setFixProgress('')
         return
       }
@@ -102,13 +100,7 @@ export function OpenClawDoctorBanner() {
       window.clearInterval(progressTimer)
       setState('error')
       if (error instanceof ApiError && error.code !== 'NETWORK_ERROR') {
-        const payload = error.payload
-        const detail = payload && typeof payload === 'object' && 'detail' in payload
-          && typeof payload.detail === 'string' ? payload.detail : null
-        const status = payload && typeof payload === 'object' && 'status' in payload
-          ? payload.status as OpenClawDoctorStatus : null
-        setErrorMsg(detail || error.message || t('fixFailed'))
-        if (status) setDoctor(status)
+        setErrorMsg(error.message || t('fixFailed'))
       } else {
         setErrorMsg(t('networkError'))
       }

--- a/src/components/layout/openclaw-update-banner.tsx
+++ b/src/components/layout/openclaw-update-banner.tsx
@@ -35,13 +35,14 @@ export function OpenClawUpdateBanner() {
     try {
       const res = await apiFetch<Response>('/api/openclaw/update', {
         method: 'POST',
+        body: JSON.stringify({ confirmation: 'update_openclaw' }),
         raw: true,
       })
       const data = await res.json()
 
       if (!res.ok) {
         setState('error')
-        setErrorMsg(data.detail || data.error || t('updateFailed'))
+        setErrorMsg(data.error || t('updateFailed'))
         return
       }
 
@@ -52,10 +53,7 @@ export function OpenClawUpdateBanner() {
     } catch (error) {
       setState('error')
       if (error instanceof ApiError && error.code !== 'NETWORK_ERROR') {
-        const payload = error.payload
-        const detail = payload && typeof payload === 'object' && 'detail' in payload
-          && typeof payload.detail === 'string' ? payload.detail : null
-        setErrorMsg(detail || error.message || t('updateFailed'))
+        setErrorMsg(error.message || t('updateFailed'))
       } else {
         setErrorMsg(t('networkError'))
       }

--- a/src/components/onboarding/runtime-setup-modal.tsx
+++ b/src/components/onboarding/runtime-setup-modal.tsx
@@ -107,12 +107,15 @@ function OpenClawSetup({ onClose, onComplete }: { onClose: () => void; onComplet
     setRunning(true)
     setError(null)
     try {
-      const data = await apiFetch<{ success?: boolean; output?: string }>('/api/openclaw/doctor', { method: 'POST' })
+      const data = await apiFetch<{ success?: boolean }>('/api/openclaw/doctor', {
+        method: 'POST',
+        body: JSON.stringify({ confirmation: 'fix_openclaw' }),
+      })
       if (data.success) {
         setStep('done')
         setOutput('All issues resolved')
       } else {
-        setOutput(data.output || 'Fix attempt completed with warnings')
+        setOutput('Fix attempt completed with warnings')
       }
     } catch (err) {
       // Preserve graceful degradation: a non-ok response previously did

--- a/src/lib/__tests__/openclaw-doctor-route.test.ts
+++ b/src/lib/__tests__/openclaw-doctor-route.test.ts
@@ -4,12 +4,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const requireRole = vi.fn()
 const runOpenClaw = vi.fn()
 const archiveOrphanTranscriptsForStateDir = vi.fn()
+const openClawMaintenanceLimiter = vi.fn()
 
 vi.mock('@/lib/auth', () => ({ requireRole }))
 vi.mock('@/lib/command', () => ({ runOpenClaw }))
 vi.mock('@/lib/db', () => ({
-  getDatabase: vi.fn(() => ({ prepare: () => ({ run: vi.fn() }) })),
+  logAuditEvent: vi.fn(),
 }))
+vi.mock('@/lib/rate-limit', () => ({ openClawMaintenanceLimiter }))
 vi.mock('@/lib/logger', () => ({
   logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
 }))
@@ -27,6 +29,11 @@ vi.mock('@/lib/config', () => ({
 }))
 
 const fakeRequest = () => new Request('http://localhost/api/openclaw/doctor')
+const fakeFixRequest = () => new Request('http://localhost/api/openclaw/doctor', {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ confirmation: 'fix_openclaw' }),
+})
 
 describe('GET /api/openclaw/doctor — single-flight + TTL cache (issue #613)', () => {
   beforeEach(() => {
@@ -34,6 +41,8 @@ describe('GET /api/openclaw/doctor — single-flight + TTL cache (issue #613)', 
     vi.resetModules()
     requireRole.mockReturnValue({ user: { id: 1, username: 'admin', role: 'admin', workspace_id: 1 } })
     runOpenClaw.mockReset()
+    openClawMaintenanceLimiter.mockReset()
+    openClawMaintenanceLimiter.mockReturnValue(null)
     // Default TTL — long enough that the cache hit test is reliable.
     process.env.MC_DOCTOR_TTL_MS = '30000'
   })
@@ -129,7 +138,7 @@ describe('GET /api/openclaw/doctor — single-flight + TTL cache (issue #613)', 
     await route.GET(fakeRequest())
     expect(runOpenClaw).toHaveBeenCalledTimes(1)
 
-    await route.POST(fakeRequest())
+    await route.POST(fakeFixRequest())
     expect(runOpenClaw).toHaveBeenCalledTimes(4)
 
     // POST invalidates the cache, so the next GET re-runs doctor.

--- a/src/lib/__tests__/openclaw-maintenance-client-security.test.ts
+++ b/src/lib/__tests__/openclaw-maintenance-client-security.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('OpenClaw maintenance client contracts', () => {
+  it('sends explicit confirmations from every maintenance action', () => {
+    const root = process.cwd()
+    const updateBanner = readFileSync(join(root, 'src/components/layout/openclaw-update-banner.tsx'), 'utf8')
+    const doctorBanner = readFileSync(join(root, 'src/components/layout/openclaw-doctor-banner.tsx'), 'utf8')
+    const runtimeSetup = readFileSync(join(root, 'src/components/onboarding/runtime-setup-modal.tsx'), 'utf8')
+
+    expect(updateBanner).toContain("confirmation: 'update_openclaw'")
+    expect(doctorBanner).toContain("confirmation: 'fix_openclaw'")
+    expect(runtimeSetup).toContain("confirmation: 'fix_openclaw'")
+  })
+})

--- a/src/lib/__tests__/openclaw-maintenance-route-security.test.ts
+++ b/src/lib/__tests__/openclaw-maintenance-route-security.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextResponse } from 'next/server'
+
+const {
+  archiveOrphanTranscriptsForStateDirMock,
+  logAuditEventMock,
+  openClawMaintenanceLimiterMock,
+  requireRoleMock,
+  runOpenClawMock,
+} = vi.hoisted(() => ({
+  archiveOrphanTranscriptsForStateDirMock: vi.fn(),
+  logAuditEventMock: vi.fn(),
+  openClawMaintenanceLimiterMock: vi.fn(),
+  requireRoleMock: vi.fn(),
+  runOpenClawMock: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({ requireRole: requireRoleMock }))
+vi.mock('@/lib/command', () => ({ runOpenClaw: runOpenClawMock }))
+vi.mock('@/lib/db', () => ({ logAuditEvent: logAuditEventMock }))
+vi.mock('@/lib/rate-limit', () => ({ openClawMaintenanceLimiter: openClawMaintenanceLimiterMock }))
+vi.mock('@/lib/config', () => ({ config: { openclawStateDir: '/tmp/openclaw-state' } }))
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), child: () => ({ error: vi.fn() }) },
+}))
+vi.mock('@/lib/openclaw-doctor-fix', () => ({
+  archiveOrphanTranscriptsForStateDir: archiveOrphanTranscriptsForStateDirMock,
+}))
+vi.mock('@/lib/openclaw-doctor', () => ({
+  parseOpenClawDoctorOutput: (raw: string) => ({
+    healthy: true,
+    level: 'ok',
+    issues: [],
+    raw,
+  }),
+}))
+
+const admin = {
+  user: { id: 7, username: 'admin', role: 'admin', workspace_id: 3, tenant_id: 9 },
+}
+
+function request(path: string, body: string) {
+  return new Request(`http://localhost${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body,
+  })
+}
+
+describe('OpenClaw maintenance route security', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    requireRoleMock.mockReturnValue(admin)
+    openClawMaintenanceLimiterMock.mockReturnValue(null)
+    archiveOrphanTranscriptsForStateDirMock.mockReturnValue({ archivedOrphans: 0, storesScanned: 1 })
+  })
+
+  it.each([
+    ['update', '/api/openclaw/update', 'update_openclaw'],
+    ['doctor fix', '/api/openclaw/doctor', 'fix_openclaw'],
+  ])('authenticates before limiting, parsing, or executing %s', async (kind, path, confirmation) => {
+    requireRoleMock.mockReturnValue({ error: 'Authentication required', status: 401 })
+    const route = kind === 'update'
+      ? await import('@/app/api/openclaw/update/route')
+      : await import('@/app/api/openclaw/doctor/route')
+
+    const response = await route.POST(request(path, JSON.stringify({ confirmation })))
+
+    expect(response.status).toBe(401)
+    expect(openClawMaintenanceLimiterMock).not.toHaveBeenCalled()
+    expect(runOpenClawMock).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['update', '/api/openclaw/update'],
+    ['doctor fix', '/api/openclaw/doctor'],
+  ])('shares a critical identity limiter before parsing %s', async (kind, path) => {
+    openClawMaintenanceLimiterMock.mockReturnValue(
+      NextResponse.json({ error: 'Too many maintenance attempts' }, { status: 429 }),
+    )
+    const route = kind === 'update'
+      ? await import('@/app/api/openclaw/update/route')
+      : await import('@/app/api/openclaw/doctor/route')
+
+    const response = await route.POST(request(path, '{not-json'))
+
+    expect(response.status).toBe(429)
+    expect(openClawMaintenanceLimiterMock).toHaveBeenCalledWith('9:3:7')
+    expect(runOpenClawMock).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['update', '/api/openclaw/update'],
+    ['doctor fix', '/api/openclaw/doctor'],
+  ])('rejects malformed and unconfirmed %s requests without commands', async (kind, path) => {
+    const route = kind === 'update'
+      ? await import('@/app/api/openclaw/update/route')
+      : await import('@/app/api/openclaw/doctor/route')
+
+    const malformed = await route.POST(request(path, '{not-json'))
+    const unconfirmed = await route.POST(request(path, '{}'))
+
+    expect(malformed.status).toBe(400)
+    expect(unconfirmed.status).toBe(400)
+    expect(runOpenClawMock).not.toHaveBeenCalled()
+  })
+
+  it('updates stable OpenClaw without returning command output', async () => {
+    runOpenClawMock
+      .mockResolvedValueOnce({ stdout: 'OpenClaw 1.2.3', stderr: '', code: 0 })
+      .mockResolvedValueOnce({ stdout: 'SENSITIVE_UPDATE_OUTPUT', stderr: '', code: 0 })
+      .mockResolvedValueOnce({ stdout: 'OpenClaw 1.2.4', stderr: '', code: 0 })
+    const { POST } = await import('@/app/api/openclaw/update/route')
+
+    const response = await POST(request('/api/openclaw/update', JSON.stringify({ confirmation: 'update_openclaw' })))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual({ success: true, previousVersion: '1.2.3', newVersion: '1.2.4' })
+    expect(JSON.stringify(body)).not.toContain('SENSITIVE_UPDATE_OUTPUT')
+    expect(logAuditEventMock).toHaveBeenCalledWith(expect.objectContaining({ action: 'openclaw.update' }))
+  })
+
+  it('sanitizes OpenClaw update failures', async () => {
+    runOpenClawMock
+      .mockResolvedValueOnce({ stdout: 'OpenClaw 1.2.3', stderr: '', code: 0 })
+      .mockRejectedValueOnce(Object.assign(new Error('secret path'), { stderr: '/private/operator/token' }))
+    const { POST } = await import('@/app/api/openclaw/update/route')
+
+    const response = await POST(request('/api/openclaw/update', JSON.stringify({ confirmation: 'update_openclaw' })))
+    const body = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(body).toEqual({ error: 'OpenClaw update failed' })
+    expect(JSON.stringify(body)).not.toContain('/private/operator/token')
+  })
+
+  it('returns bounded doctor-fix progress without command output', async () => {
+    runOpenClawMock
+      .mockResolvedValueOnce({ stdout: 'SENSITIVE_FIX_OUTPUT', stderr: '', code: 0 })
+      .mockRejectedValueOnce(Object.assign(new Error('cleanup failed'), { stderr: 'SENSITIVE_CLEANUP_ERROR' }))
+      .mockResolvedValueOnce({ stdout: 'SENSITIVE_POST_FIX_OUTPUT', stderr: '', code: 0 })
+    const { POST } = await import('@/app/api/openclaw/doctor/route')
+
+    const response = await POST(request('/api/openclaw/doctor', JSON.stringify({ confirmation: 'fix_openclaw' })))
+    const body = await response.json()
+    const serialized = JSON.stringify(body)
+
+    expect(response.status).toBe(200)
+    expect(body.progress[1]).toEqual({ step: 'sessions', detail: 'Session cleanup could not complete.' })
+    expect(body.status.raw).toBeUndefined()
+    expect(serialized).not.toContain('SENSITIVE_FIX_OUTPUT')
+    expect(serialized).not.toContain('SENSITIVE_CLEANUP_ERROR')
+    expect(serialized).not.toContain('SENSITIVE_POST_FIX_OUTPUT')
+    expect(logAuditEventMock).toHaveBeenCalledWith(expect.objectContaining({ action: 'openclaw.doctor.fix' }))
+  })
+
+  it('sanitizes doctor-fix failures', async () => {
+    runOpenClawMock.mockRejectedValueOnce(
+      Object.assign(new Error('doctor failed'), { stderr: 'SENSITIVE_DOCTOR_ERROR', code: 2 }),
+    )
+    const { POST } = await import('@/app/api/openclaw/doctor/route')
+
+    const response = await POST(request('/api/openclaw/doctor', JSON.stringify({ confirmation: 'fix_openclaw' })))
+    const body = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(body).toEqual({ error: 'OpenClaw doctor fix failed' })
+    expect(JSON.stringify(body)).not.toContain('SENSITIVE_DOCTOR_ERROR')
+  })
+})

--- a/src/lib/__tests__/validation.test.ts
+++ b/src/lib/__tests__/validation.test.ts
@@ -15,6 +15,8 @@ import {
   createOsUserSchema,
   installTmuxSchema,
   releaseUpdateSchema,
+  openClawUpdateSchema,
+  openClawDoctorFixSchema,
 } from '@/lib/validation'
 
 describe('createTaskSchema', () => {
@@ -322,6 +324,22 @@ describe('releaseUpdateSchema', () => {
     { targetVersion: 'v' + '1'.repeat(128), confirmation: 'update_mission_control' },
   ])('rejects unsafe release update input %#', (input) => {
     expect(releaseUpdateSchema.safeParse(input).success).toBe(false)
+  })
+})
+
+describe('OpenClaw maintenance schemas', () => {
+  it('accepts only the matching explicit action confirmations', () => {
+    expect(openClawUpdateSchema.safeParse({ confirmation: 'update_openclaw' }).success).toBe(true)
+    expect(openClawDoctorFixSchema.safeParse({ confirmation: 'fix_openclaw' }).success).toBe(true)
+  })
+
+  it.each([
+    {},
+    { confirmation: 'yes' },
+    { confirmation: 'fix_openclaw', force: true },
+  ])('rejects unsafe OpenClaw maintenance input %#', (input) => {
+    expect(openClawUpdateSchema.safeParse(input).success).toBe(false)
+    expect(openClawDoctorFixSchema.safeParse(input).success).toBe(false)
   })
 })
 

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -273,6 +273,14 @@ export const releaseUpdateLimiter = createKeyedRateLimiter({
   critical: true,
 })
 
+/** OpenClaw runtime updates and repairs: 5 attempts per 10 minutes per admin. */
+export const openClawMaintenanceLimiter = createKeyedRateLimiter({
+  windowMs: 10 * 60_000,
+  maxRequests: 5,
+  message: 'Too many OpenClaw maintenance attempts. Try again later.',
+  critical: true,
+})
+
 /** Self-registration: 5/min per IP (prevent spam registrations) */
 export const selfRegisterLimiter = createRateLimiter({
   windowMs: 60_000,

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -307,6 +307,14 @@ export const releaseUpdateSchema = z.object({
   confirmation: z.literal('update_mission_control'),
 }).strict()
 
+export const openClawUpdateSchema = z.object({
+  confirmation: z.literal('update_openclaw'),
+}).strict()
+
+export const openClawDoctorFixSchema = z.object({
+  confirmation: z.literal('fix_openclaw'),
+}).strict()
+
 export const accessRequestActionSchema = z.object({
   request_id: z.number(),
   action: z.enum(['approve', 'reject']),


### PR DESCRIPTION
## Summary
- require action-specific confirmations for OpenClaw stable updates and doctor repairs
- share a critical per-admin limiter across both mutations
- remove subprocess output, cleanup errors, paths, and raw post-fix diagnostics from mutation responses
- preserve read-only doctor caching and diagnostics
- audit successful runtime maintenance and update all client/OpenAPI contracts

## Verification
- 1,262 tests passed across 113 files
- TypeScript passed
- lint passed with 99 existing warnings and 0 errors
- production build passed
- standalone artifact check passed
- API contract parity passed
- strict security scan passed