### PR TITLE
security: enforce strict workspace resource isolation

### DIFF
--- a/src/app/api/agents/[id]/memory/route.ts
+++ b/src/app/api/agents/[id]/memory/route.ts
@@ -8,6 +8,7 @@ import { dirname } from 'node:path';
 import { resolveWithin } from '@/lib/paths';
 import { getAgentWorkspaceCandidates, readAgentWorkspaceFile } from '@/lib/agent-workspace';
 import type Database from 'better-sqlite3';
+import { getWorkspaceIsolation } from '@/lib/workspace-isolation';
 
 // 512KB — generous but bounded. Prevents unbounded growth from append mode.
 const MAX_WORKING_MEMORY_SIZE = 512 * 1024;
@@ -49,6 +50,11 @@ export async function GET(
     const { workspaceId } = wsResult;
     const selfDeny = requireAgentSelfAccess(auth.user, agentId);
     if (selfDeny) return selfDeny;
+    const isolation = getWorkspaceIsolation(auth.user);
+    if (!isolation) {
+      return NextResponse.json({ error: 'Workspace isolation context is invalid' }, { status: 403 });
+    }
+    const isStrictWorkspace = isolation === 'strict';
 
     const agent = getAgentByIdOrName(db, agentId, workspaceId);
     if (!agent) {
@@ -68,18 +74,20 @@ export async function GET(
     let workingMemory = '';
     let source: 'workspace' | 'database' | 'none' = 'none';
     try {
-      const agentConfig = agent.config ? JSON.parse(agent.config) : {};
-      const candidates = getAgentWorkspaceCandidates(agentConfig, agent.name);
-      const match = readAgentWorkspaceFile(candidates, ['WORKING.md', 'working.md', 'MEMORY.md', 'memory.md']);
-      if (match.exists && match.path) {
-        const wsMtime = Math.floor(statSync(match.path).mtimeMs / 1000);
-        if (dbUpdatedAt > wsMtime && dbMemory) {
-          // DB is newer — workspace write likely failed on last PUT
-          workingMemory = dbMemory;
-          source = 'database';
-        } else {
-          workingMemory = match.content;
-          source = 'workspace';
+      if (!isStrictWorkspace) {
+        const agentConfig = agent.config ? JSON.parse(agent.config) : {};
+        const candidates = getAgentWorkspaceCandidates(agentConfig, agent.name);
+        const match = readAgentWorkspaceFile(candidates, ['WORKING.md', 'working.md', 'MEMORY.md', 'memory.md']);
+        if (match.exists && match.path) {
+          const wsMtime = Math.floor(statSync(match.path).mtimeMs / 1000);
+          if (dbUpdatedAt > wsMtime && dbMemory) {
+            // DB is newer — workspace write likely failed on last PUT
+            workingMemory = dbMemory;
+            source = 'database';
+          } else {
+            workingMemory = match.content;
+            source = 'workspace';
+          }
         }
       }
     } catch (err) {
@@ -127,6 +135,11 @@ export async function PUT(
     const { workspaceId } = wsResult;
     const selfDeny = requireAgentSelfAccess(auth.user, agentId);
     if (selfDeny) return selfDeny;
+    const isolation = getWorkspaceIsolation(auth.user);
+    if (!isolation) {
+      return NextResponse.json({ error: 'Workspace isolation context is invalid' }, { status: 403 });
+    }
+    const isStrictWorkspace = isolation === 'strict';
     const body = await request.json();
     const { working_memory, append } = body;
 
@@ -163,14 +176,16 @@ export async function PUT(
     // Best effort: sync workspace WORKING.md if agent workspace is configured
     let savedToWorkspace = false;
     try {
-      const agentConfig = agent.config ? JSON.parse(agent.config) : {};
-      const candidates = getAgentWorkspaceCandidates(agentConfig, agent.name);
-      const safeWorkspace = candidates[0];
-      if (safeWorkspace) {
-        const safeWorkingPath = resolveWithin(safeWorkspace, 'WORKING.md');
-        mkdirSync(dirname(safeWorkingPath), { recursive: true });
-        writeFileSync(safeWorkingPath, newContent, 'utf-8');
-        savedToWorkspace = true;
+      if (!isStrictWorkspace) {
+        const agentConfig = agent.config ? JSON.parse(agent.config) : {};
+        const candidates = getAgentWorkspaceCandidates(agentConfig, agent.name);
+        const safeWorkspace = candidates[0];
+        if (safeWorkspace) {
+          const safeWorkingPath = resolveWithin(safeWorkspace, 'WORKING.md');
+          mkdirSync(dirname(safeWorkingPath), { recursive: true });
+          writeFileSync(safeWorkingPath, newContent, 'utf-8');
+          savedToWorkspace = true;
+        }
       }
     } catch (err) {
       logger.warn({ err, agent: agent.name }, 'Failed to write WORKING.md to workspace');
@@ -234,6 +249,11 @@ export async function DELETE(
     const { workspaceId } = wsResult;
     const selfDeny = requireAgentSelfAccess(auth.user, agentId);
     if (selfDeny) return selfDeny;
+    const isolation = getWorkspaceIsolation(auth.user);
+    if (!isolation) {
+      return NextResponse.json({ error: 'Workspace isolation context is invalid' }, { status: 403 });
+    }
+    const isStrictWorkspace = isolation === 'strict';
 
     const agent = getAgentByIdOrName(db, agentId, workspaceId);
     if (!agent) {
@@ -244,13 +264,15 @@ export async function DELETE(
 
     // Best effort: clear workspace WORKING.md if agent workspace is configured
     try {
-      const agentConfig = agent.config ? JSON.parse(agent.config) : {};
-      const candidates = getAgentWorkspaceCandidates(agentConfig, agent.name);
-      const safeWorkspace = candidates[0];
-      if (safeWorkspace) {
-        const safeWorkingPath = resolveWithin(safeWorkspace, 'WORKING.md');
-        mkdirSync(dirname(safeWorkingPath), { recursive: true });
-        writeFileSync(safeWorkingPath, '', 'utf-8');
+      if (!isStrictWorkspace) {
+        const agentConfig = agent.config ? JSON.parse(agent.config) : {};
+        const candidates = getAgentWorkspaceCandidates(agentConfig, agent.name);
+        const safeWorkspace = candidates[0];
+        if (safeWorkspace) {
+          const safeWorkingPath = resolveWithin(safeWorkspace, 'WORKING.md');
+          mkdirSync(dirname(safeWorkingPath), { recursive: true });
+          writeFileSync(safeWorkingPath, '', 'utf-8');
+        }
       }
     } catch (err) {
       logger.warn({ err, agent: agent.name }, 'Failed to clear WORKING.md in workspace');

--- a/src/app/api/chat/session-prefs/route.ts
+++ b/src/app/api/chat/session-prefs/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getDatabase } from '@/lib/db'
 import { requireRole } from '@/lib/auth'
 import { logger } from '@/lib/logger'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 
 const PREFS_KEY = 'chat.session_prefs.v1'
 const ALLOWED_COLORS = new Set(['slate', 'blue', 'green', 'amber', 'red', 'purple', 'pink', 'teal'])
@@ -48,6 +49,8 @@ function savePrefs(prefs: SessionPrefs, username: string) {
 export async function GET(request: NextRequest) {
   const auth = requireRole(request, 'viewer')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDenied = denyUnscopedResourceForStrictWorkspace(auth.user, 'session_preferences', new URL(request.url).pathname)
+  if (isolationDenied) return isolationDenied
 
   try {
     return NextResponse.json({ prefs: loadPrefs() })
@@ -64,6 +67,8 @@ export async function GET(request: NextRequest) {
 export async function PATCH(request: NextRequest) {
   const auth = requireRole(request, 'operator')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDenied = denyUnscopedResourceForStrictWorkspace(auth.user, 'session_preferences', new URL(request.url).pathname)
+  if (isolationDenied) return isolationDenied
 
   try {
     const body = await request.json().catch(() => ({}))

--- a/src/app/api/claude/sessions/route.ts
+++ b/src/app/api/claude/sessions/route.ts
@@ -3,6 +3,7 @@ import { getDatabase } from '@/lib/db'
 import { requireRole } from '@/lib/auth'
 import { syncClaudeSessions } from '@/lib/claude-sessions'
 import { logger } from '@/lib/logger'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 
 /**
  * GET /api/claude/sessions — List discovered local Claude Code sessions
@@ -16,6 +17,8 @@ import { logger } from '@/lib/logger'
 export async function GET(request: NextRequest) {
   const auth = requireRole(request, 'viewer')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDenied = denyUnscopedResourceForStrictWorkspace(auth.user, 'local_sessions', new URL(request.url).pathname)
+  if (isolationDenied) return isolationDenied
 
   try {
     const db = getDatabase()
@@ -91,6 +94,8 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   const auth = requireRole(request, 'operator')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDenied = denyUnscopedResourceForStrictWorkspace(auth.user, 'local_sessions', new URL(request.url).pathname)
+  if (isolationDenied) return isolationDenied
 
   try {
     const result = await syncClaudeSessions()

--- a/src/app/api/hermes/memory/route.ts
+++ b/src/app/api/hermes/memory/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireRole } from '@/lib/auth'
 import { getHermesMemory } from '@/lib/hermes-memory'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 
 /**
  * GET /api/hermes/memory — Returns Hermes memory file contents
@@ -9,6 +10,8 @@ import { getHermesMemory } from '@/lib/hermes-memory'
 export async function GET(request: NextRequest) {
   const auth = requireRole(request, 'viewer')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDenied = denyUnscopedResourceForStrictWorkspace(auth.user, 'runtime_memory', new URL(request.url).pathname)
+  if (isolationDenied) return isolationDenied
 
   const result = getHermesMemory()
 

--- a/src/app/api/memory/context/route.ts
+++ b/src/app/api/memory/context/route.ts
@@ -5,7 +5,8 @@ import { requireRole } from '@/lib/auth'
 import { readLimiter } from '@/lib/rate-limit'
 import { generateContextPayload, ContextPayload } from '@/lib/memory-utils'
 import { logger } from '@/lib/logger'
-import { MEMORY_PATH, MEMORY_ALLOWED_PREFIXES } from '@/lib/memory-path'
+import { MEMORY_ALLOWED_PREFIXES } from '@/lib/memory-path'
+import { resolveWorkspaceMemoryAccess } from '@/lib/workspace-isolation'
 
 function mergeContextPayloads(payloads: ContextPayload[]): ContextPayload {
   return {
@@ -39,7 +40,8 @@ export async function GET(request: NextRequest) {
   const limited = readLimiter(request)
   if (limited) return limited
 
-  if (!MEMORY_PATH) {
+  const memoryAccess = resolveWorkspaceMemoryAccess(auth.user)
+  if (!memoryAccess) {
     return NextResponse.json({ error: 'Memory directory not configured' }, { status: 500 })
   }
 
@@ -48,18 +50,18 @@ export async function GET(request: NextRequest) {
       const payloads: ContextPayload[] = []
       for (const prefix of MEMORY_ALLOWED_PREFIXES) {
         const folder = prefix.replace(/\/$/, '')
-        const fullPath = join(MEMORY_PATH, folder)
+        const fullPath = join(memoryAccess.root, folder)
         if (!existsSync(fullPath)) continue
         payloads.push(await generateContextPayload(fullPath))
       }
       return NextResponse.json(
         payloads.length > 0
           ? mergeContextPayloads(payloads)
-          : await generateContextPayload(MEMORY_PATH)
+          : await generateContextPayload(memoryAccess.root)
       )
     }
 
-    const payload = await generateContextPayload(MEMORY_PATH)
+    const payload = await generateContextPayload(memoryAccess.root)
     return NextResponse.json(payload)
   } catch (err) {
     logger.error({ err }, 'Memory context API error')

--- a/src/app/api/memory/graph/route.ts
+++ b/src/app/api/memory/graph/route.ts
@@ -6,6 +6,7 @@ import { config } from '@/lib/config'
 import { requireRole } from '@/lib/auth'
 import { readLimiter } from '@/lib/rate-limit'
 import { logger } from '@/lib/logger'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 
 interface AgentFileInfo {
   path: string
@@ -80,6 +81,9 @@ export async function GET(request: NextRequest) {
 
   const limited = readLimiter(request)
   if (limited) return limited
+
+  const isolationDenied = denyUnscopedResourceForStrictWorkspace(auth.user, 'runtime_memory', new URL(request.url).pathname)
+  if (isolationDenied) return isolationDenied
 
   if (!memoryDbDir || !existsSync(memoryDbDir)) {
     return NextResponse.json(

--- a/src/app/api/memory/health/route.ts
+++ b/src/app/api/memory/health/route.ts
@@ -1,14 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { existsSync } from 'fs'
 import { join } from 'path'
-import { config } from '@/lib/config'
 import { requireRole } from '@/lib/auth'
 import { readLimiter } from '@/lib/rate-limit'
 import { runHealthDiagnostics } from '@/lib/memory-utils'
 import { logger } from '@/lib/logger'
-
-const MEMORY_PATH = config.memoryDir
-const MEMORY_ALLOWED_PREFIXES = (config.memoryAllowedPrefixes || []).map((p) => p.replace(/\\/g, '/'))
+import { resolveWorkspaceMemoryAccess } from '@/lib/workspace-isolation'
+import { MEMORY_ALLOWED_PREFIXES } from '@/lib/memory-path'
 
 function mergeReports(reports: Awaited<ReturnType<typeof runHealthDiagnostics>>[]) {
   const allCategories = reports.flatMap((report) => report.categories)
@@ -45,7 +43,8 @@ export async function GET(request: NextRequest) {
   const limited = readLimiter(request)
   if (limited) return limited
 
-  if (!MEMORY_PATH) {
+  const memoryAccess = resolveWorkspaceMemoryAccess(auth.user)
+  if (!memoryAccess) {
     return NextResponse.json({ error: 'Memory directory not configured' }, { status: 500 })
   }
 
@@ -54,14 +53,14 @@ export async function GET(request: NextRequest) {
       const reports = []
       for (const prefix of MEMORY_ALLOWED_PREFIXES) {
         const folder = prefix.replace(/\/$/, '')
-        const fullPath = join(MEMORY_PATH, folder)
+        const fullPath = join(memoryAccess.root, folder)
         if (!existsSync(fullPath)) continue
         reports.push(await runHealthDiagnostics(fullPath))
       }
-      return NextResponse.json(reports.length > 0 ? mergeReports(reports) : await runHealthDiagnostics(MEMORY_PATH))
+      return NextResponse.json(reports.length > 0 ? mergeReports(reports) : await runHealthDiagnostics(memoryAccess.root))
     }
 
-    const report = await runHealthDiagnostics(MEMORY_PATH)
+    const report = await runHealthDiagnostics(memoryAccess.root)
     return NextResponse.json(report)
   } catch (err) {
     logger.error({ err }, 'Memory health API error')

--- a/src/app/api/memory/links/route.ts
+++ b/src/app/api/memory/links/route.ts
@@ -4,7 +4,8 @@ import { readLimiter } from '@/lib/rate-limit'
 import { buildLinkGraph, extractWikiLinks } from '@/lib/memory-utils'
 import { readFile } from 'fs/promises'
 import { logger } from '@/lib/logger'
-import { MEMORY_PATH, isPathAllowed, resolveSafeMemoryPath } from '@/lib/memory-path'
+import { isPathAllowed, resolveSafeMemoryPath } from '@/lib/memory-path'
+import { resolveWorkspaceMemoryAccess } from '@/lib/workspace-isolation'
 
 export async function GET(request: NextRequest) {
   const auth = requireRole(request, 'viewer')
@@ -13,7 +14,8 @@ export async function GET(request: NextRequest) {
   const limited = readLimiter(request)
   if (limited) return limited
 
-  if (!MEMORY_PATH) {
+  const memoryAccess = resolveWorkspaceMemoryAccess(auth.user)
+  if (!memoryAccess) {
     return NextResponse.json({ error: 'Memory directory not configured' }, { status: 500 })
   }
 
@@ -25,12 +27,12 @@ export async function GET(request: NextRequest) {
       if (!isPathAllowed(filePath)) {
         return NextResponse.json({ error: 'Path not allowed' }, { status: 403 })
       }
-      const fullPath = await resolveSafeMemoryPath(MEMORY_PATH, filePath)
+      const fullPath = await resolveSafeMemoryPath(memoryAccess.root, filePath)
       const content = await readFile(fullPath, 'utf-8')
       const links = extractWikiLinks(content)
 
       // Also find backlinks from the full graph
-      const graph = await buildLinkGraph(MEMORY_PATH)
+      const graph = await buildLinkGraph(memoryAccess.root)
       const node = graph.nodes[filePath]
       const incoming = node?.incoming ?? []
       const outgoing = node?.outgoing ?? []
@@ -44,7 +46,7 @@ export async function GET(request: NextRequest) {
     }
 
     // Return full link graph
-    const graph = await buildLinkGraph(MEMORY_PATH)
+    const graph = await buildLinkGraph(memoryAccess.root)
 
     // Serialize for the frontend (strip wikiLinks detail for the full graph)
     const nodes = Object.values(graph.nodes).map((n) => ({

--- a/src/app/api/memory/process/route.ts
+++ b/src/app/api/memory/process/route.ts
@@ -1,11 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { config } from '@/lib/config'
 import { requireRole } from '@/lib/auth'
 import { mutationLimiter } from '@/lib/rate-limit'
 import { reflectPass, reweavePass, generateMOCs, gapDetectPass, consolidatePass } from '@/lib/memory-utils'
 import { logger } from '@/lib/logger'
-
-const MEMORY_PATH = config.memoryDir
+import { resolveWorkspaceMemoryAccess } from '@/lib/workspace-isolation'
 
 /**
  * Processing pipeline endpoint — runs knowledge maintenance operations.
@@ -23,7 +21,8 @@ export async function POST(request: NextRequest) {
   const rateCheck = mutationLimiter(request)
   if (rateCheck) return rateCheck
 
-  if (!MEMORY_PATH) {
+  const memoryAccess = resolveWorkspaceMemoryAccess(auth.user)
+  if (!memoryAccess) {
     return NextResponse.json({ error: 'Memory directory not configured' }, { status: 500 })
   }
 
@@ -32,17 +31,17 @@ export async function POST(request: NextRequest) {
     const { action } = body
 
     if (action === 'reflect') {
-      const result = await reflectPass(MEMORY_PATH)
+      const result = await reflectPass(memoryAccess.root)
       return NextResponse.json(result)
     }
 
     if (action === 'reweave') {
-      const result = await reweavePass(MEMORY_PATH)
+      const result = await reweavePass(memoryAccess.root)
       return NextResponse.json(result)
     }
 
     if (action === 'generate-moc') {
-      const mocs = await generateMOCs(MEMORY_PATH)
+      const mocs = await generateMOCs(memoryAccess.root)
       return NextResponse.json({
         action: 'generate-moc',
         groups: mocs,
@@ -52,12 +51,12 @@ export async function POST(request: NextRequest) {
     }
 
     if (action === 'gap-detect') {
-      const result = await gapDetectPass(MEMORY_PATH)
+      const result = await gapDetectPass(memoryAccess.root)
       return NextResponse.json(result)
     }
 
     if (action === 'consolidate') {
-      const result = await consolidatePass(MEMORY_PATH)
+      const result = await consolidatePass(memoryAccess.root)
       return NextResponse.json(result)
     }
 

--- a/src/app/api/memory/route.ts
+++ b/src/app/api/memory/route.ts
@@ -9,6 +9,7 @@ import { logger } from '@/lib/logger'
 import { validateSchema, extractWikiLinks } from '@/lib/memory-utils'
 import { MEMORY_PATH, MEMORY_ALLOWED_PREFIXES, isPathAllowed, resolveSafeMemoryPath } from '@/lib/memory-path'
 import { searchMemory, indexFile, removeFromIndex } from '@/lib/memory-search'
+import { resolveWorkspaceMemoryAccess } from '@/lib/workspace-isolation'
 
 // Ensure memory directory exists on startup
 if (MEMORY_PATH && !existsSync(MEMORY_PATH)) {
@@ -89,6 +90,9 @@ export async function GET(request: NextRequest) {
   const rateCheck = readLimiter(request)
   if (rateCheck) return rateCheck
 
+  const memoryAccess = resolveWorkspaceMemoryAccess(auth.user)
+  const memoryPath = memoryAccess?.root || ''
+
   try {
     const { searchParams } = new URL(request.url)
     const path = searchParams.get('path')
@@ -98,14 +102,14 @@ export async function GET(request: NextRequest) {
 
     if (action === 'tree') {
       // Return the file tree
-      if (!MEMORY_PATH) {
+      if (!memoryPath || !existsSync(memoryPath)) {
         return NextResponse.json({ tree: [] })
       }
       if (path) {
         if (!isPathAllowed(path)) {
           return NextResponse.json({ error: 'Path not allowed' }, { status: 403 })
         }
-        const fullPath = await resolveSafeMemoryPath(MEMORY_PATH, path)
+        const fullPath = await resolveSafeMemoryPath(memoryPath, path)
         const stats = await stat(fullPath).catch(() => null)
         if (!stats?.isDirectory()) {
           return NextResponse.json({ error: 'Directory not found' }, { status: 404 })
@@ -117,7 +121,7 @@ export async function GET(request: NextRequest) {
         const tree: MemoryFile[] = []
         for (const prefix of MEMORY_ALLOWED_PREFIXES) {
           const folder = prefix.replace(/\/$/, '')
-          const fullPath = join(MEMORY_PATH, folder)
+          const fullPath = join(memoryPath, folder)
           if (!existsSync(fullPath)) continue
           try {
             const stats = await stat(fullPath)
@@ -135,7 +139,7 @@ export async function GET(request: NextRequest) {
         }
         return NextResponse.json({ tree })
       }
-      const tree = await buildFileTree(MEMORY_PATH, '', maxDepth)
+      const tree = await buildFileTree(memoryPath, '', maxDepth)
       return NextResponse.json({ tree })
     }
 
@@ -144,10 +148,10 @@ export async function GET(request: NextRequest) {
       if (!isPathAllowed(path)) {
         return NextResponse.json({ error: 'Path not allowed' }, { status: 403 })
       }
-      if (!MEMORY_PATH) {
+      if (!memoryPath || !existsSync(memoryPath)) {
         return NextResponse.json({ error: 'Memory directory not configured' }, { status: 500 })
       }
-      const fullPath = await resolveSafeMemoryPath(MEMORY_PATH, path)
+      const fullPath = await resolveSafeMemoryPath(memoryPath, path)
       
       try {
         const content = await readFile(fullPath, 'utf-8')
@@ -176,12 +180,12 @@ export async function GET(request: NextRequest) {
       if (!query) {
         return NextResponse.json({ error: 'Query required' }, { status: 400 })
       }
-      if (!MEMORY_PATH) {
+      if (!memoryPath || !existsSync(memoryPath)) {
         return NextResponse.json({ query, results: [] })
       }
 
       // FTS5-powered full-text search with BM25 ranking and snippets
-      const response = await searchMemory(MEMORY_PATH, MEMORY_ALLOWED_PREFIXES, query)
+      const response = await searchMemory(memoryPath, MEMORY_ALLOWED_PREFIXES, query, { scope: memoryAccess!.scope })
       return NextResponse.json(response)
     }
 
@@ -199,6 +203,9 @@ export async function POST(request: NextRequest) {
   const rateCheck = mutationLimiter(request)
   if (rateCheck) return rateCheck
 
+  const memoryAccess = resolveWorkspaceMemoryAccess(auth.user)
+  const memoryPath = memoryAccess?.root || ''
+
   try {
     const body = await request.json()
     const { action, path, content } = body
@@ -210,10 +217,11 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Path not allowed' }, { status: 403 })
     }
 
-    if (!MEMORY_PATH) {
+    if (!memoryPath) {
       return NextResponse.json({ error: 'Memory directory not configured' }, { status: 500 })
     }
-    const fullPath = await resolveSafeMemoryPath(MEMORY_PATH, path)
+    await mkdir(memoryPath, { recursive: true })
+    const fullPath = await resolveSafeMemoryPath(memoryPath, path)
 
     if (action === 'save') {
       // Save file content
@@ -227,7 +235,7 @@ export async function POST(request: NextRequest) {
 
       await writeFile(fullPath, content, 'utf-8')
       // Incrementally update FTS index
-      try { indexFile(getDatabase(), MEMORY_PATH, path) } catch { /* best-effort */ }
+      try { indexFile(getDatabase(), memoryPath, path, memoryAccess!.scope) } catch { /* best-effort */ }
       try {
         db_helpers.logActivity('memory_file_saved', 'memory', 0, auth.user.username || 'unknown', `Updated ${path}`, { path, size: content.length })
       } catch { /* best-effort */ }
@@ -258,7 +266,7 @@ export async function POST(request: NextRequest) {
       }
 
       await writeFile(fullPath, content || '', 'utf-8')
-      try { indexFile(getDatabase(), MEMORY_PATH, path) } catch { /* best-effort */ }
+      try { indexFile(getDatabase(), memoryPath, path, memoryAccess!.scope) } catch { /* best-effort */ }
       try {
         db_helpers.logActivity('memory_file_created', 'memory', 0, auth.user.username || 'unknown', `Created ${path}`, { path })
       } catch { /* best-effort */ }
@@ -279,6 +287,9 @@ export async function DELETE(request: NextRequest) {
   const rateCheck = mutationLimiter(request)
   if (rateCheck) return rateCheck
 
+  const memoryAccess = resolveWorkspaceMemoryAccess(auth.user)
+  const memoryPath = memoryAccess?.root || ''
+
   try {
     const body = await request.json()
     const { action, path } = body
@@ -290,10 +301,10 @@ export async function DELETE(request: NextRequest) {
       return NextResponse.json({ error: 'Path not allowed' }, { status: 403 })
     }
 
-    if (!MEMORY_PATH) {
+    if (!memoryPath || !existsSync(memoryPath)) {
       return NextResponse.json({ error: 'Memory directory not configured' }, { status: 500 })
     }
-    const fullPath = await resolveSafeMemoryPath(MEMORY_PATH, path)
+    const fullPath = await resolveSafeMemoryPath(memoryPath, path)
 
     if (action === 'delete') {
       // Check if file exists
@@ -304,7 +315,7 @@ export async function DELETE(request: NextRequest) {
       }
 
       await unlink(fullPath)
-      try { removeFromIndex(getDatabase(), path) } catch { /* best-effort */ }
+      try { removeFromIndex(getDatabase(), path, memoryAccess!.scope) } catch { /* best-effort */ }
       try {
         db_helpers.logActivity('memory_file_deleted', 'memory', 0, auth.user.username || 'unknown', `Deleted ${path}`, { path })
       } catch { /* best-effort */ }

--- a/src/app/api/memory/search/route.ts
+++ b/src/app/api/memory/search/route.ts
@@ -2,9 +2,10 @@ import { NextRequest, NextResponse } from 'next/server'
 import { requireRole } from '@/lib/auth'
 import { readLimiter, mutationLimiter } from '@/lib/rate-limit'
 import { logger } from '@/lib/logger'
-import { MEMORY_PATH, MEMORY_ALLOWED_PREFIXES } from '@/lib/memory-path'
+import { MEMORY_ALLOWED_PREFIXES } from '@/lib/memory-path'
 import { searchMemory, rebuildIndex } from '@/lib/memory-search'
 import { getDatabase } from '@/lib/db'
+import { resolveWorkspaceMemoryAccess } from '@/lib/workspace-isolation'
 
 /**
  * GET /api/memory/search?q=query&limit=20
@@ -20,7 +21,8 @@ export async function GET(request: NextRequest) {
   const limited = readLimiter(request)
   if (limited) return limited
 
-  if (!MEMORY_PATH) {
+  const memoryAccess = resolveWorkspaceMemoryAccess(auth.user)
+  if (!memoryAccess) {
     return NextResponse.json({ error: 'Memory directory not configured' }, { status: 500 })
   }
 
@@ -34,7 +36,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const response = await searchMemory(MEMORY_PATH, MEMORY_ALLOWED_PREFIXES, query, { limit })
+    const response = await searchMemory(memoryAccess.root, MEMORY_ALLOWED_PREFIXES, query, { limit, scope: memoryAccess.scope })
     return NextResponse.json(response)
   } catch (err) {
     logger.error({ err }, 'Memory search API error')
@@ -54,7 +56,8 @@ export async function POST(request: NextRequest) {
   const rateCheck = mutationLimiter(request)
   if (rateCheck) return rateCheck
 
-  if (!MEMORY_PATH) {
+  const memoryAccess = resolveWorkspaceMemoryAccess(auth.user)
+  if (!memoryAccess) {
     return NextResponse.json({ error: 'Memory directory not configured' }, { status: 500 })
   }
 
@@ -62,7 +65,7 @@ export async function POST(request: NextRequest) {
     const body = await request.json()
 
     if (body.action === 'rebuild') {
-      const result = await rebuildIndex(MEMORY_PATH, MEMORY_ALLOWED_PREFIXES)
+      const result = await rebuildIndex(memoryAccess.root, MEMORY_ALLOWED_PREFIXES, memoryAccess.scope)
       return NextResponse.json({
         success: true,
         message: `Rebuilt FTS index: ${result.indexed} files in ${result.duration}ms`,

--- a/src/app/api/sessions/[id]/control/route.ts
+++ b/src/app/api/sessions/[id]/control/route.ts
@@ -4,6 +4,7 @@ import { callOpenClawGateway } from '@/lib/openclaw-gateway'
 import { db_helpers } from '@/lib/db'
 import { mutationLimiter } from '@/lib/rate-limit'
 import { logger } from '@/lib/logger'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 
 // Only allow alphanumeric, hyphens, and underscores in session IDs
 const SESSION_ID_RE = /^[a-zA-Z0-9_-]+$/
@@ -14,6 +15,8 @@ export async function POST(
 ) {
   const auth = requireRole(request, 'operator')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDenied = denyUnscopedResourceForStrictWorkspace(auth.user, 'gateway_sessions', new URL(request.url).pathname)
+  if (isolationDenied) return isolationDenied
 
   const rateCheck = mutationLimiter(request)
   if (rateCheck) return rateCheck

--- a/src/app/api/sessions/__tests__/continue-route-opencode.test.ts
+++ b/src/app/api/sessions/__tests__/continue-route-opencode.test.ts
@@ -9,6 +9,10 @@ vi.mock('@/lib/auth', () => ({
   requireRole: vi.fn(() => ({ user: { role: 'operator', username: 'tester' } })),
 }))
 
+vi.mock('@/lib/workspace-isolation', () => ({
+  denyUnscopedResourceForStrictWorkspace: vi.fn(() => null),
+}))
+
 vi.mock('@/lib/command', () => ({
   runCommand: mocks.runCommand,
 }))

--- a/src/app/api/sessions/continue/route.ts
+++ b/src/app/api/sessions/continue/route.ts
@@ -4,6 +4,7 @@ import os from 'node:os'
 import { NextRequest, NextResponse } from 'next/server'
 import { requireRole } from '@/lib/auth'
 import { logger } from '@/lib/logger'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 import { runCommand } from '@/lib/command'
 import { getOpenCodeExecutable } from '@/lib/opencode-sessions'
 
@@ -171,6 +172,8 @@ async function getSessionJsonlMtime(sessionId: string): Promise<number | null> {
 export async function POST(request: NextRequest) {
   const auth = requireRole(request, 'operator')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDenied = denyUnscopedResourceForStrictWorkspace(auth.user, 'local_sessions', new URL(request.url).pathname)
+  if (isolationDenied) return isolationDenied
 
   try {
     const body = await request.json().catch(() => ({}))

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -9,6 +9,7 @@ import { requireRole } from '@/lib/auth'
 import { callOpenClawGateway } from '@/lib/openclaw-gateway'
 import { mutationLimiter } from '@/lib/rate-limit'
 import { logger } from '@/lib/logger'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 
 // Upstream default 90 minutes was too lax (every recently-touched jsonl
 // stayed "active"); 2 minutes was too tight. 15 minutes matches the
@@ -18,6 +19,8 @@ const LOCAL_SESSION_ACTIVE_WINDOW_MS = 15 * 60 * 1000
 export async function GET(request: NextRequest) {
   const auth = requireRole(request, 'viewer')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDenied = denyUnscopedResourceForStrictWorkspace(auth.user, 'local_sessions', new URL(request.url).pathname)
+  if (isolationDenied) return isolationDenied
 
   try {
     const gatewaySessions = getAllGatewaySessions()
@@ -51,6 +54,8 @@ const SESSION_KEY_RE = /^[a-zA-Z0-9:_.-]+$/
 export async function POST(request: NextRequest) {
   const auth = requireRole(request, 'operator')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDenied = denyUnscopedResourceForStrictWorkspace(auth.user, 'gateway_sessions', new URL(request.url).pathname)
+  if (isolationDenied) return isolationDenied
 
   const rateCheck = mutationLimiter(request)
   if (rateCheck) return rateCheck
@@ -135,6 +140,8 @@ export async function POST(request: NextRequest) {
 export async function DELETE(request: NextRequest) {
   const auth = requireRole(request, 'operator')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDenied = denyUnscopedResourceForStrictWorkspace(auth.user, 'gateway_sessions', new URL(request.url).pathname)
+  if (isolationDenied) return isolationDenied
 
   const rateCheck = mutationLimiter(request)
   if (rateCheck) return rateCheck

--- a/src/app/api/sessions/transcript/aggregate/route.ts
+++ b/src/app/api/sessions/transcript/aggregate/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireRole } from '@/lib/auth'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 import { config } from '@/lib/config'
 import { getAllGatewaySessions } from '@/lib/sessions'
 import { parseJsonlTranscript, readSessionJsonl, type TranscriptMessage, type MessageContentPart } from '@/lib/transcript-parser'
@@ -24,6 +25,8 @@ export interface AggregateEvent {
 export async function GET(request: NextRequest) {
   const auth = requireRole(request, 'viewer')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDenied = denyUnscopedResourceForStrictWorkspace(auth.user, 'session_transcripts', new URL(request.url).pathname)
+  if (isolationDenied) return isolationDenied
 
   const { searchParams } = new URL(request.url)
   const limit = Math.min(Math.max(parseInt(searchParams.get('limit') || '100', 10), 1), 500)

--- a/src/app/api/sessions/transcript/gateway/route.ts
+++ b/src/app/api/sessions/transcript/gateway/route.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import { requireRole } from '@/lib/auth'
 import { config } from '@/lib/config'
 import { logger } from '@/lib/logger'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 import { parseGatewayHistoryTranscript, parseJsonlTranscript } from '@/lib/transcript-parser'
 import { callOpenClawGateway } from '@/lib/openclaw-gateway'
 
@@ -20,6 +21,8 @@ import { callOpenClawGateway } from '@/lib/openclaw-gateway'
 export async function GET(request: NextRequest) {
   const auth = requireRole(request, 'viewer')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDenied = denyUnscopedResourceForStrictWorkspace(auth.user, 'session_transcripts', new URL(request.url).pathname)
+  if (isolationDenied) return isolationDenied
 
   const { searchParams } = new URL(request.url)
   const sessionKey = searchParams.get('key') || ''

--- a/src/lib/__tests__/agent-memory-route-security.test.ts
+++ b/src/lib/__tests__/agent-memory-route-security.test.ts
@@ -46,6 +46,12 @@ describe('agent memory route security', () => {
 
   it('GET allows an agent key to access its own memory route', async () => {
     prepareMock.mockImplementation((sql: string) => {
+      if (sql.includes('FROM workspaces')) {
+        return {
+          get: vi.fn(() => ({ id: 7, tenant_id: 1, isolation: 'shared' })),
+        }
+      }
+
       if (sql.includes('SELECT * FROM agents')) {
         return {
           get: vi.fn(() => ({
@@ -75,6 +81,7 @@ describe('agent memory route security', () => {
         username: 'agent-a',
         role: 'viewer',
         workspace_id: 7,
+        tenant_id: 1,
         agent_name: 'agent-a',
         agent_id: 42,
       },

--- a/src/lib/__tests__/workspace-isolation-enforcement.test.ts
+++ b/src/lib/__tests__/workspace-isolation-enforcement.test.ts
@@ -1,0 +1,146 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import Database from 'better-sqlite3'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+
+const state = vi.hoisted(() => ({
+  db: null as InstanceType<typeof Database> | null,
+  memoryDir: '/tmp/mission-control-isolation-test',
+  auditEvents: [] as unknown[],
+}))
+
+vi.mock('@/lib/config', () => ({
+  config: {
+    get memoryDir() { return state.memoryDir },
+  },
+}))
+
+vi.mock('@/lib/db', () => ({
+  getDatabase: () => state.db,
+  logAuditEvent: (event: unknown) => state.auditEvents.push(event),
+}))
+
+import type { User } from '@/lib/auth'
+import { rebuildIndex, searchMemory } from '@/lib/memory-search'
+import {
+  denyUnscopedResourceForStrictWorkspace,
+  resolveWorkspaceMemoryAccess,
+} from '@/lib/workspace-isolation'
+
+const sharedUser = {
+  id: 1,
+  username: 'shared-user',
+  role: 'admin',
+  workspace_id: 1,
+  tenant_id: 10,
+} as User
+
+const strictUser = {
+  id: 2,
+  username: 'strict-user',
+  role: 'admin',
+  workspace_id: 2,
+  tenant_id: 10,
+} as User
+
+let tempRoot = ''
+
+beforeAll(() => {
+  tempRoot = mkdtempSync(join(tmpdir(), 'mc-isolation-'))
+  state.memoryDir = tempRoot
+  state.db = new Database(':memory:')
+  state.db.exec(`
+    CREATE TABLE workspaces (id INTEGER PRIMARY KEY, tenant_id INTEGER NOT NULL, isolation TEXT NOT NULL);
+    INSERT INTO workspaces (id, tenant_id, isolation) VALUES (1, 10, 'shared'), (2, 10, 'strict');
+  `)
+})
+
+afterAll(() => {
+  state.db?.close()
+  rmSync(tempRoot, { recursive: true, force: true })
+})
+
+describe('workspace isolation policy', () => {
+  it('keeps shared memory on the common root and scopes strict memory by workspace', () => {
+    expect(resolveWorkspaceMemoryAccess(sharedUser)).toEqual({
+      isolation: 'shared',
+      root: tempRoot,
+      scope: 'shared',
+    })
+    expect(resolveWorkspaceMemoryAccess(strictUser)).toEqual({
+      isolation: 'strict',
+      root: join(tempRoot + '-workspaces', '2'),
+      scope: 'workspace:2',
+    })
+  })
+
+  it('allows shared workspaces but denies unowned resources to strict workspaces', async () => {
+    expect(denyUnscopedResourceForStrictWorkspace(sharedUser, 'local_sessions', '/api/sessions')).toBeNull()
+
+    const denied = denyUnscopedResourceForStrictWorkspace(strictUser, 'local_sessions', '/api/sessions')
+    expect(denied?.status).toBe(403)
+    expect(await denied?.json()).toEqual(expect.objectContaining({
+      error: expect.stringContaining('no workspace ownership metadata'),
+    }))
+    expect(state.auditEvents).toContainEqual(expect.objectContaining({
+      action: 'workspace_isolation_denied',
+      target_id: 2,
+      detail: expect.objectContaining({
+        resource: 'local_sessions',
+        route: '/api/sessions',
+      }),
+    }))
+  })
+
+  it('fails closed when workspace and tenant context do not match', () => {
+    const mismatched = { ...strictUser, tenant_id: 999 }
+    const denied = denyUnscopedResourceForStrictWorkspace(mismatched, 'session_transcripts', '/api/sessions/transcript')
+    expect(denied?.status).toBe(403)
+    expect(resolveWorkspaceMemoryAccess(mismatched)).toBeNull()
+  })
+})
+
+describe('workspace-scoped memory search', () => {
+  it('keeps FTS rows and metadata isolated by scope', async () => {
+    const sharedRoot = join(tempRoot, 'shared-fixture')
+    const strictRoot = join(tempRoot, 'strict-fixture')
+    mkdirSync(sharedRoot, { recursive: true })
+    mkdirSync(strictRoot, { recursive: true })
+    writeFileSync(join(sharedRoot, 'shared.md'), '# Shared\n\nsharedonlytoken')
+    writeFileSync(join(strictRoot, 'strict.md'), '# Strict\n\nstrictonlytoken')
+
+    await rebuildIndex(sharedRoot, [], 'shared')
+    await rebuildIndex(strictRoot, [], 'workspace:2')
+
+    const strictOwn = await searchMemory(strictRoot, [], 'strictonlytoken', { scope: 'workspace:2' })
+    const strictLeak = await searchMemory(strictRoot, [], 'sharedonlytoken', { scope: 'workspace:2' })
+    const sharedOwn = await searchMemory(sharedRoot, [], 'sharedonlytoken', { scope: 'shared' })
+
+    expect(strictOwn.results.map((row) => row.path)).toEqual(['strict.md'])
+    expect(strictLeak.results).toEqual([])
+    expect(sharedOwn.results.map((row) => row.path)).toEqual(['shared.md'])
+    expect(strictOwn.indexedFiles).toBe(1)
+    expect(sharedOwn.indexedFiles).toBe(1)
+  })
+})
+
+describe('direct session API coverage', () => {
+  it('guards every deployment-global session route', () => {
+    const files = [
+      'src/app/api/sessions/route.ts',
+      'src/app/api/sessions/continue/route.ts',
+      'src/app/api/sessions/[id]/control/route.ts',
+      'src/lib/session-transcript-route.ts',
+      'src/app/api/sessions/transcript/gateway/route.ts',
+      'src/app/api/sessions/transcript/aggregate/route.ts',
+      'src/app/api/claude/sessions/route.ts',
+      'src/app/api/chat/session-prefs/route.ts',
+    ]
+
+    for (const file of files) {
+      const source = readFileSync(join(process.cwd(), file), 'utf8')
+      expect(source, file).toContain('denyUnscopedResourceForStrictWorkspace')
+    }
+  })
+})

--- a/src/lib/memory-search.ts
+++ b/src/lib/memory-search.ts
@@ -21,7 +21,8 @@ import { logger } from '@/lib/logger'
 
 export function ensureFtsTable(db: Database.Database): void {
   db.exec(`
-    CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
+    CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts_v2 USING fts5(
+      scope UNINDEXED,
       path,
       title,
       content,
@@ -29,9 +30,11 @@ export function ensureFtsTable(db: Database.Database): void {
     )
   `)
   db.exec(`
-    CREATE TABLE IF NOT EXISTS memory_fts_meta (
-      key TEXT PRIMARY KEY,
+    CREATE TABLE IF NOT EXISTS memory_fts_meta_v2 (
+      scope TEXT NOT NULL,
+      key TEXT NOT NULL,
       value TEXT
+      ,PRIMARY KEY (scope, key)
     )
   `)
 }
@@ -53,7 +56,7 @@ function stripFrontmatter(content: string): string {
   return content.replace(/^---\n[\s\S]*?\n---\n?/, '')
 }
 
-export async function rebuildIndex(baseDir: string, allowedPrefixes: string[]): Promise<{ indexed: number; duration: number }> {
+export async function rebuildIndex(baseDir: string, allowedPrefixes: string[], scope = 'shared'): Promise<{ indexed: number; duration: number }> {
   const start = Date.now()
   const db = getDatabase()
   ensureFtsTable(db)
@@ -73,18 +76,18 @@ export async function rebuildIndex(baseDir: string, allowedPrefixes: string[]): 
     files.push(...await scanMemoryFiles(baseDir, { extensions: ['.md', '.txt'] }))
   }
 
-  const insertStmt = db.prepare('INSERT INTO memory_fts (path, title, content) VALUES (?, ?, ?)')
+  const insertStmt = db.prepare('INSERT INTO memory_fts_v2 (scope, path, title, content) VALUES (?, ?, ?, ?)')
 
   let indexed = 0
   db.transaction(() => {
-    db.exec('DELETE FROM memory_fts')
+    db.prepare('DELETE FROM memory_fts_v2 WHERE scope = ?').run(scope)
 
     for (const file of files) {
       try {
         const content = readFileSync(join(baseDir, file.path), 'utf-8')
         const title = extractTitle(content, file.name)
         const body = stripFrontmatter(content)
-        insertStmt.run(file.path, title, body)
+        insertStmt.run(scope, file.path, title, body)
         indexed++
       } catch {
         // Skip unreadable files
@@ -92,11 +95,11 @@ export async function rebuildIndex(baseDir: string, allowedPrefixes: string[]): 
     }
 
     db.prepare(
-      'INSERT OR REPLACE INTO memory_fts_meta (key, value) VALUES (?, ?)'
-    ).run('last_rebuild', new Date().toISOString())
+      'INSERT OR REPLACE INTO memory_fts_meta_v2 (scope, key, value) VALUES (?, ?, ?)'
+    ).run(scope, 'last_rebuild', new Date().toISOString())
     db.prepare(
-      'INSERT OR REPLACE INTO memory_fts_meta (key, value) VALUES (?, ?)'
-    ).run('file_count', String(indexed))
+      'INSERT OR REPLACE INTO memory_fts_meta_v2 (scope, key, value) VALUES (?, ?, ?)'
+    ).run(scope, 'file_count', String(indexed))
   })()
 
   const duration = Date.now() - start
@@ -107,7 +110,7 @@ export async function rebuildIndex(baseDir: string, allowedPrefixes: string[]): 
 /**
  * Index a single file (for incremental updates after saves).
  */
-export function indexFile(db: Database.Database, baseDir: string, relativePath: string): void {
+export function indexFile(db: Database.Database, baseDir: string, relativePath: string, scope = 'shared'): void {
   ensureFtsTable(db)
   try {
     const content = readFileSync(join(baseDir, relativePath), 'utf-8')
@@ -116,8 +119,8 @@ export function indexFile(db: Database.Database, baseDir: string, relativePath: 
     const body = stripFrontmatter(content)
 
     db.transaction(() => {
-      db.prepare('DELETE FROM memory_fts WHERE path = ?').run(relativePath)
-      db.prepare('INSERT INTO memory_fts (path, title, content) VALUES (?, ?, ?)').run(relativePath, title, body)
+      db.prepare('DELETE FROM memory_fts_v2 WHERE scope = ? AND path = ?').run(scope, relativePath)
+      db.prepare('INSERT INTO memory_fts_v2 (scope, path, title, content) VALUES (?, ?, ?, ?)').run(scope, relativePath, title, body)
     })()
   } catch (err) {
     logger.warn({ err, path: relativePath }, 'Failed to index file for FTS')
@@ -127,9 +130,9 @@ export function indexFile(db: Database.Database, baseDir: string, relativePath: 
 /**
  * Remove a file from the index.
  */
-export function removeFromIndex(db: Database.Database, relativePath: string): void {
+export function removeFromIndex(db: Database.Database, relativePath: string, scope = 'shared'): void {
   try {
-    db.prepare('DELETE FROM memory_fts WHERE path = ?').run(relativePath)
+    db.prepare('DELETE FROM memory_fts_v2 WHERE scope = ? AND path = ?').run(scope, relativePath)
   } catch {
     // Index may not exist yet
   }
@@ -152,16 +155,16 @@ export interface SearchResponse {
   indexedAt: string | null
 }
 
-async function ensureIndex(baseDir: string, allowedPrefixes: string[]): Promise<void> {
+async function ensureIndex(baseDir: string, allowedPrefixes: string[], scope: string): Promise<void> {
   const db = getDatabase()
   ensureFtsTable(db)
 
   const meta = db.prepare(
-    "SELECT value FROM memory_fts_meta WHERE key = 'last_rebuild'"
-  ).get() as { value: string } | undefined
+    "SELECT value FROM memory_fts_meta_v2 WHERE scope = ? AND key = 'last_rebuild'"
+  ).get(scope) as { value: string } | undefined
 
   if (!meta) {
-    await rebuildIndex(baseDir, allowedPrefixes)
+    await rebuildIndex(baseDir, allowedPrefixes, scope)
   }
 }
 
@@ -169,9 +172,10 @@ export async function searchMemory(
   baseDir: string,
   allowedPrefixes: string[],
   query: string,
-  opts?: { limit?: number }
+  opts?: { limit?: number; scope?: string }
 ): Promise<SearchResponse> {
-  await ensureIndex(baseDir, allowedPrefixes)
+  const scope = opts?.scope ?? 'shared'
+  await ensureIndex(baseDir, allowedPrefixes, scope)
 
   const db = getDatabase()
   const limit = opts?.limit ?? 20
@@ -186,13 +190,13 @@ export async function searchMemory(
       SELECT
         path,
         title,
-        snippet(memory_fts, 2, '<mark>', '</mark>', '...', 40) as snippet,
-        bm25(memory_fts, 1.0, 5.0, 1.0) as rank
-      FROM memory_fts
-      WHERE memory_fts MATCH ?
+        snippet(memory_fts_v2, 3, '<mark>', '</mark>', '...', 40) as snippet,
+        bm25(memory_fts_v2, 0.0, 1.0, 5.0, 1.0) as rank
+      FROM memory_fts_v2
+      WHERE memory_fts_v2 MATCH ? AND scope = ?
       ORDER BY rank
       LIMIT ?
-    `).all(sanitized, limit) as Array<{ path: string; title: string; snippet: string; rank: number }>
+    `).all(sanitized, scope, limit) as Array<{ path: string; title: string; snippet: string; rank: number }>
 
     results = rows.map((r) => ({
       path: r.path,
@@ -202,8 +206,8 @@ export async function searchMemory(
     }))
 
     const countRow = db.prepare(
-      'SELECT count(*) as cnt FROM memory_fts WHERE memory_fts MATCH ?'
-    ).get(sanitized) as { cnt: number }
+      'SELECT count(*) as cnt FROM memory_fts_v2 WHERE memory_fts_v2 MATCH ? AND scope = ?'
+    ).get(sanitized, scope) as { cnt: number }
     total = countRow.cnt
   } catch (err) {
     logger.warn({ err, query: sanitized }, 'FTS5 query failed, falling back to phrase search')
@@ -211,10 +215,10 @@ export async function searchMemory(
       const fallbackQuery = `"${query.replace(/"/g, '""')}"`
       const rows = db.prepare(`
         SELECT path, title,
-          snippet(memory_fts, 2, '<mark>', '</mark>', '...', 40) as snippet,
-          bm25(memory_fts, 1.0, 5.0, 1.0) as rank
-        FROM memory_fts WHERE memory_fts MATCH ? ORDER BY rank LIMIT ?
-      `).all(fallbackQuery, limit) as Array<{ path: string; title: string; snippet: string; rank: number }>
+          snippet(memory_fts_v2, 3, '<mark>', '</mark>', '...', 40) as snippet,
+          bm25(memory_fts_v2, 0.0, 1.0, 5.0, 1.0) as rank
+        FROM memory_fts_v2 WHERE memory_fts_v2 MATCH ? AND scope = ? ORDER BY rank LIMIT ?
+      `).all(fallbackQuery, scope, limit) as Array<{ path: string; title: string; snippet: string; rank: number }>
       results = rows.map((r) => ({ path: r.path, title: r.title, snippet: r.snippet, rank: Math.abs(r.rank) }))
       total = results.length
     } catch {
@@ -223,11 +227,11 @@ export async function searchMemory(
   }
 
   const meta = db.prepare(
-    "SELECT value FROM memory_fts_meta WHERE key = 'last_rebuild'"
-  ).get() as { value: string } | undefined
+    "SELECT value FROM memory_fts_meta_v2 WHERE scope = ? AND key = 'last_rebuild'"
+  ).get(scope) as { value: string } | undefined
   const fileCountMeta = db.prepare(
-    "SELECT value FROM memory_fts_meta WHERE key = 'file_count'"
-  ).get() as { value: string } | undefined
+    "SELECT value FROM memory_fts_meta_v2 WHERE scope = ? AND key = 'file_count'"
+  ).get(scope) as { value: string } | undefined
 
   return {
     query,

--- a/src/lib/session-transcript-route.ts
+++ b/src/lib/session-transcript-route.ts
@@ -6,6 +6,7 @@ import { config } from '@/lib/config'
 import { requireRole } from '@/lib/auth'
 import { logger } from '@/lib/logger'
 import { getOpenCodeDbCandidates, epochMsToIso } from '@/lib/opencode-sessions'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 
 type MessageContentPart =
   | { type: 'text'; text: string }
@@ -460,6 +461,8 @@ function readHermesTranscript(sessionId: string, limit: number): TranscriptMessa
 export async function GET(request: NextRequest) {
   const auth = requireRole(request, 'viewer')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDenied = denyUnscopedResourceForStrictWorkspace(auth.user, 'session_transcripts', new URL(request.url).pathname)
+  if (isolationDenied) return isolationDenied
 
   try {
     const { searchParams } = new URL(request.url)

--- a/src/lib/workspace-isolation.ts
+++ b/src/lib/workspace-isolation.ts
@@ -1,0 +1,105 @@
+import { basename, dirname, join } from 'node:path'
+import { NextResponse } from 'next/server'
+import type { User } from '@/lib/auth'
+import { config } from '@/lib/config'
+import { getDatabase, logAuditEvent } from '@/lib/db'
+import type { WorkspaceIsolation } from '@/lib/workspaces'
+
+export type UnscopedWorkspaceResource =
+  | 'local_sessions'
+  | 'gateway_sessions'
+  | 'session_transcripts'
+  | 'session_preferences'
+  | 'runtime_memory'
+
+interface IsolationRecord {
+  id: number
+  tenant_id: number
+  isolation: WorkspaceIsolation
+}
+
+export interface WorkspaceMemoryAccess {
+  isolation: WorkspaceIsolation
+  root: string
+  scope: string
+}
+
+function readIsolation(user: User): IsolationRecord | null {
+  return getDatabase().prepare(`
+    SELECT id, tenant_id, isolation
+    FROM workspaces
+    WHERE id = ? AND tenant_id = ?
+    LIMIT 1
+  `).get(user.workspace_id, user.tenant_id) as IsolationRecord | undefined || null
+}
+
+export function getWorkspaceIsolation(user: User): WorkspaceIsolation | null {
+  return readIsolation(user)?.isolation ?? null
+}
+
+function auditDenial(user: User, resource: UnscopedWorkspaceResource, route: string): void {
+  try {
+    logAuditEvent({
+      action: 'workspace_isolation_denied',
+      actor: user.username || 'unknown',
+      actor_id: user.id,
+      target_type: 'workspace',
+      target_id: user.workspace_id,
+      detail: {
+        resource,
+        route,
+        tenant_id: user.tenant_id,
+        reason: 'resource_has_no_workspace_ownership',
+      },
+    })
+  } catch {
+    // Access control must not depend on audit availability.
+  }
+}
+
+/**
+ * Deployment-global resources cannot be safely filtered for a strict workspace
+ * until they carry authoritative workspace ownership. Fail closed and record a
+ * minimized decision event; never include session IDs, prompts, or file paths.
+ */
+export function denyUnscopedResourceForStrictWorkspace(
+  user: User,
+  resource: UnscopedWorkspaceResource,
+  route: string,
+): NextResponse | null {
+  const workspace = readIsolation(user)
+  if (workspace?.isolation !== 'strict') {
+    if (workspace) return null
+    auditDenial(user, resource, route)
+    return NextResponse.json({ error: 'Workspace isolation context is unavailable' }, { status: 403 })
+  }
+
+  auditDenial(user, resource, route)
+  return NextResponse.json(
+    { error: 'This resource is unavailable in strict workspaces because it has no workspace ownership metadata' },
+    { status: 403 },
+  )
+}
+
+/**
+ * Shared workspaces intentionally use the configured common memory root.
+ * Strict workspaces receive a deterministic workspace-owned subtree and FTS
+ * namespace, so file paths and search rows cannot cross workspace boundaries.
+ */
+export function resolveWorkspaceMemoryAccess(user: User): WorkspaceMemoryAccess | null {
+  const base = config.memoryDir
+  if (!base) return null
+
+  const workspace = readIsolation(user)
+  if (!workspace) return null
+  if (workspace.isolation === 'strict') {
+    const strictRoot = join(dirname(base), `${basename(base)}-workspaces`, String(workspace.id))
+    return {
+      isolation: 'strict',
+      root: strictRoot,
+      scope: `workspace:${workspace.id}`,
+    }
+  }
+
+  return { isolation: 'shared', root: base, scope: 'shared' }
+}


### PR DESCRIPTION
## Summary

- enforce strict-workspace memory roots and search-index namespaces
- deny strict workspaces access to deployment-global local/gateway sessions that lack authoritative workspace ownership
- preserve shared-workspace behavior while making missing or mismatched isolation context fail closed
- add minimized audit events and regression coverage for cross-scope memory search

This is the first direct-resource enforcement slice of #800. It intentionally does not close #800; indirect global session consumers will be handled in follow-up slices.

## Security properties

- strict memory lives outside the shared memory tree
- FTS rows and index metadata are filtered by workspace scope
- global session/transcript/preferences APIs return 403 for strict workspaces
- tenant/workspace mismatch fails closed
- audit details exclude session IDs, prompts, and file paths
- no existing shared files are moved or deleted

## Verification

- 1,273 unit tests passed
- TypeScript passed
- ESLint passed with 0 errors (100 existing warnings)
- API contract parity passed
- strict devgod security scan passed
- production build passed
- standalone artifact check passed
- git diff check passed
