### PR TITLE
security: isolate indirect session consumers

### DIFF
--- a/src/app/api/chat/messages/route.ts
+++ b/src/app/api/chat/messages/route.ts
@@ -8,6 +8,7 @@ import { logger } from '@/lib/logger'
 import { scanForInjection, sanitizeForPrompt } from '@/lib/injection-guard'
 import { callOpenClawGateway } from '@/lib/openclaw-gateway'
 import { resolveCoordinatorDeliveryTarget } from '@/lib/coordinator-routing'
+import { getWorkspaceIsolation } from '@/lib/workspace-isolation'
 
 type ForwardInfo = {
   attempted: boolean
@@ -331,6 +332,11 @@ export async function POST(request: NextRequest) {
   try {
     const db = getDatabase()
     const workspaceId = auth.user.workspace_id ?? 1
+    const isolation = getWorkspaceIsolation(auth.user)
+    if (!isolation) {
+      return NextResponse.json({ error: 'Workspace isolation context is unavailable' }, { status: 403 })
+    }
+    const strictWorkspace = isolation === 'strict'
     const body = await request.json()
 
     const requestedFrom = typeof body.from === 'string' ? body.from.trim() : ''
@@ -416,17 +422,17 @@ export async function POST(request: NextRequest) {
           .prepare('SELECT * FROM agents WHERE lower(name) = lower(?) AND workspace_id = ?')
           .get(to, workspaceId) as any
 
-        const explicitSessionKey = typeof body.sessionKey === 'string' && body.sessionKey
+        const explicitSessionKey = !strictWorkspace && typeof body.sessionKey === 'string' && body.sessionKey
           ? body.sessionKey
           : null
-        const sessions = getAllGatewaySessions()
+        const sessions = strictWorkspace ? [] : getAllGatewaySessions()
         const isCoordinatorSend = String(to).toLowerCase() === COORDINATOR_AGENT.toLowerCase()
         const allAgents = isCoordinatorSend
           ? (db
               .prepare('SELECT name, session_key, config FROM agents WHERE workspace_id = ?')
               .all(workspaceId) as Array<{ name: string; session_key?: string | null; config?: string | null }>)
           : []
-        const configuredCoordinatorTarget = isCoordinatorSend
+        const configuredCoordinatorTarget = !strictWorkspace && isCoordinatorSend
           ? (db
               .prepare("SELECT value FROM settings WHERE key = 'chat.coordinator_target_agent'")
               .get() as { value?: string } | undefined)?.value || null
@@ -452,7 +458,7 @@ export async function POST(request: NextRequest) {
         let sessionKey: string | null = coordinatorResolution.sessionKey
 
         // Fallback: derive session from on-disk gateway session stores
-        if (!sessionKey) {
+        if (!strictWorkspace && !sessionKey) {
           const match = sessions.find(
             (s) =>
               s.agent.toLowerCase() === String(to).toLowerCase() ||
@@ -464,6 +470,12 @@ export async function POST(request: NextRequest) {
 
         // Prefer configured openclawId when present, fallback to normalized name
         let openclawAgentId: string | null = coordinatorResolution.openclawAgentId
+        if (strictWorkspace && !sessionKey) {
+          // A runtime agent ID is deployment-global and does not prove workspace
+          // ownership. Strict workspaces may forward only through a session key
+          // stored on their workspace-owned agent record.
+          openclawAgentId = null
+        }
 
         if (!sessionKey && !openclawAgentId) {
           forwardInfo.reason = 'no_active_session'

--- a/src/app/api/pty/attach/route.ts
+++ b/src/app/api/pty/attach/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireRole } from '@/lib/auth'
 import { isTmuxAvailable, tmuxSessionExists, listTmuxSessions, listPtySessions } from '@/lib/pty-manager'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 
 /**
  * POST /api/pty/attach — Check if a PTY can be created for a session
@@ -11,6 +12,12 @@ import { isTmuxAvailable, tmuxSessionExists, listTmuxSessions, listPtySessions }
 export async function POST(request: NextRequest) {
   const auth = requireRole(request, 'operator')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(
+    auth.user,
+    'terminal_sessions',
+    new URL(request.url).pathname,
+  )
+  if (isolationDeny) return isolationDeny
 
   try {
     const body = await request.json()
@@ -72,6 +79,12 @@ export async function POST(request: NextRequest) {
 export async function GET(request: NextRequest) {
   const auth = requireRole(request, 'viewer')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(
+    auth.user,
+    'terminal_sessions',
+    new URL(request.url).pathname,
+  )
+  if (isolationDeny) return isolationDeny
 
   return NextResponse.json({
     tmuxAvailable: isTmuxAvailable(),

--- a/src/app/api/status/route.ts
+++ b/src/app/api/status/route.ts
@@ -14,6 +14,7 @@ import { detectProviderSubscriptions, getPrimarySubscription } from '@/lib/provi
 import { APP_VERSION } from '@/lib/version'
 import { isHermesInstalled, scanHermesSessions } from '@/lib/hermes-sessions'
 import { registerMcAsDashboard } from '@/lib/gateway-runtime'
+import { getWorkspaceIsolation } from '@/lib/workspace-isolation'
 
 export async function GET(request: NextRequest) {
   // Docker/Kubernetes health probes must work without auth/cookies.
@@ -25,18 +26,23 @@ export async function GET(request: NextRequest) {
 
   const auth = requireRole(request, 'viewer')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolation = getWorkspaceIsolation(auth.user)
+  if (!isolation) {
+    return NextResponse.json({ error: 'Workspace isolation context is unavailable' }, { status: 403 })
+  }
+  const includeGlobalRuntime = isolation === 'shared'
 
   try {
     const { searchParams } = new URL(request.url)
     const action = searchParams.get('action') || 'overview'
 
     if (action === 'overview') {
-      const status = await getSystemStatus(auth.user.workspace_id ?? 1)
+      const status = await getSystemStatus(auth.user.workspace_id ?? 1, includeGlobalRuntime)
       return NextResponse.json(status)
     }
 
     if (action === 'dashboard') {
-      const data = await getDashboardData(auth.user.workspace_id ?? 1)
+      const data = await getDashboardData(auth.user.workspace_id ?? 1, includeGlobalRuntime)
       return NextResponse.json(data)
     }
 
@@ -56,7 +62,7 @@ export async function GET(request: NextRequest) {
     }
 
     if (action === 'capabilities') {
-      const capabilities = await getCapabilities(request)
+      const capabilities = await getCapabilities(request, includeGlobalRuntime)
       return NextResponse.json(capabilities)
     }
 
@@ -71,9 +77,9 @@ export async function GET(request: NextRequest) {
  * Aggregate all dashboard data in a single request.
  * Combines system health, DB stats, audit summary, and recent activity.
  */
-async function getDashboardData(workspaceId: number) {
+async function getDashboardData(workspaceId: number, includeGlobalRuntime: boolean) {
   const [system, dbStats] = await Promise.all([
-    getSystemStatus(workspaceId),
+    getSystemStatus(workspaceId, includeGlobalRuntime),
     getDbStats(workspaceId),
   ])
 
@@ -247,7 +253,7 @@ function getDbStats(workspaceId: number) {
   }
 }
 
-async function getSystemStatus(workspaceId: number) {
+async function getSystemStatus(workspaceId: number, includeGlobalRuntime: boolean) {
   const status: any = {
     timestamp: Date.now(),
     uptime: 0,
@@ -333,41 +339,43 @@ async function getSystemStatus(workspaceId: number) {
     logger.error({ err: error }, 'Error getting process info')
   }
 
-  try {
-    // Read sessions directly from agent session stores on disk
-    const gatewaySessions = getAllGatewaySessions()
-    status.sessions = {
-      total: gatewaySessions.length,
-      active: gatewaySessions.filter((s) => s.active).length,
-    }
-
-    // Sync agent statuses in DB from live session data
+  if (includeGlobalRuntime) {
     try {
-      const db = getDatabase()
-      const liveStatuses = getAgentLiveStatuses()
-      const now = Math.floor(Date.now() / 1000)
-      // Match by: exact name, lowercase, or normalized (spaces→hyphens)
-      const updateStmt = db.prepare(
-        `UPDATE agents SET status = ?, last_seen = ?, updated_at = ?
-         WHERE workspace_id = ?
-           AND (LOWER(name) = LOWER(?)
-           OR LOWER(REPLACE(name, ' ', '-')) = LOWER(?))`
-      )
-      for (const [agentName, info] of liveStatuses) {
-        updateStmt.run(
-          info.status,
-          Math.floor(info.lastActivity / 1000),
-          now,
-          workspaceId,
-          agentName,
-          agentName
-        )
+      // Read sessions directly from agent session stores on disk
+      const gatewaySessions = getAllGatewaySessions()
+      status.sessions = {
+        total: gatewaySessions.length,
+        active: gatewaySessions.filter((s) => s.active).length,
       }
-    } catch (dbErr) {
-      logger.error({ err: dbErr }, 'Error syncing agent statuses')
+
+      // Sync agent statuses in DB from live session data
+      try {
+        const db = getDatabase()
+        const liveStatuses = getAgentLiveStatuses()
+        const now = Math.floor(Date.now() / 1000)
+        // Match by: exact name, lowercase, or normalized (spaces→hyphens)
+        const updateStmt = db.prepare(
+          `UPDATE agents SET status = ?, last_seen = ?, updated_at = ?
+           WHERE workspace_id = ?
+             AND (LOWER(name) = LOWER(?)
+             OR LOWER(REPLACE(name, ' ', '-')) = LOWER(?))`
+        )
+        for (const [agentName, info] of liveStatuses) {
+          updateStmt.run(
+            info.status,
+            Math.floor(info.lastActivity / 1000),
+            now,
+            workspaceId,
+            agentName,
+            agentName
+          )
+        }
+      } catch (dbErr) {
+        logger.error({ err: dbErr }, 'Error syncing agent statuses')
+      }
+    } catch (error) {
+      logger.error({ err: error }, 'Error reading session stores')
     }
-  } catch (error) {
-    logger.error({ err: error }, 'Error reading session stores')
   }
 
   return status
@@ -604,46 +612,50 @@ async function performHealthCheck() {
   return health
 }
 
-async function getCapabilities(request?: NextRequest) {
+async function getCapabilities(request?: NextRequest, includeGlobalRuntime = true) {
   // Probe configured gateways (if any) or fall back to the default port.
   // A DB row alone isn't enough — the gateway must actually be reachable.
   let gatewayReachable = false
-  try {
-    const db = getDatabase()
-    const table = db.prepare(
-      "SELECT name FROM sqlite_master WHERE type='table' AND name='gateways'"
-    ).get() as { name?: string } | undefined
-    if (table?.name) {
-      const rows = db.prepare('SELECT host, port FROM gateways').all() as { host: string; port: number }[]
-      if (rows.length > 0) {
-        const probes = rows.map(r => isPortOpen(r.host, Number(r.port)))
-        const results = await Promise.all(probes)
-        gatewayReachable = results.some(Boolean)
+  if (includeGlobalRuntime) {
+    try {
+      const db = getDatabase()
+      const table = db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='gateways'"
+      ).get() as { name?: string } | undefined
+      if (table?.name) {
+        const rows = db.prepare('SELECT host, port FROM gateways').all() as { host: string; port: number }[]
+        if (rows.length > 0) {
+          const probes = rows.map(r => isPortOpen(r.host, Number(r.port)))
+          const results = await Promise.all(probes)
+          gatewayReachable = results.some(Boolean)
+        }
       }
+    } catch {
+      // ignore — fall through to default probe
     }
-  } catch {
-    // ignore — fall through to default probe
   }
 
-  const gateway = gatewayReachable || await isPortOpen(config.gatewayHost, config.gatewayPort)
+  const gateway = includeGlobalRuntime && (gatewayReachable || await isPortOpen(config.gatewayHost, config.gatewayPort))
 
-  const openclawHome = Boolean(
+  const openclawHome = includeGlobalRuntime && Boolean(
     (config.openclawStateDir && existsSync(config.openclawStateDir)) ||
     (config.openclawConfigPath && existsSync(config.openclawConfigPath))
   )
 
   const claudeProjectsPath = path.join(config.claudeHome, 'projects')
-  const claudeHome = existsSync(claudeProjectsPath)
+  const claudeHome = includeGlobalRuntime && existsSync(claudeProjectsPath)
 
   let claudeSessions = 0
-  try {
-    const db = getDatabase()
-    const row = db.prepare(
-      "SELECT COUNT(*) as c FROM claude_sessions WHERE is_active = 1"
-    ).get() as { c: number } | undefined
-    claudeSessions = row?.c ?? 0
-  } catch {
-    // claude_sessions table may not exist
+  if (includeGlobalRuntime) {
+    try {
+      const db = getDatabase()
+      const row = db.prepare(
+        "SELECT COUNT(*) as c FROM claude_sessions WHERE is_active = 1"
+      ).get() as { c: number } | undefined
+      claudeSessions = row?.c ?? 0
+    } catch {
+      // claude_sessions table may not exist
+    }
   }
 
   const subscriptions = detectProviderSubscriptions().active
@@ -684,7 +696,7 @@ async function getCapabilities(request?: NextRequest) {
 
   const hermesInstalled = isHermesInstalled()
   let hermesSessions = 0
-  if (hermesInstalled) {
+  if (includeGlobalRuntime && hermesInstalled) {
     try {
       hermesSessions = scanHermesSessions(50).filter(s => s.isActive).length
     } catch { /* ignore */ }
@@ -692,7 +704,7 @@ async function getCapabilities(request?: NextRequest) {
 
   // Auto-register MC as default dashboard when gateway + openclaw home detected
   let dashboardRegistration: { registered: boolean; alreadySet: boolean } | null = null
-  if (gateway && openclawHome) {
+  if (includeGlobalRuntime && gateway && openclawHome) {
     try {
       let mcUrl = process.env.MC_BASE_URL || ''
       if (!mcUrl && request) {

--- a/src/lib/__tests__/pty-websocket-auth.test.ts
+++ b/src/lib/__tests__/pty-websocket-auth.test.ts
@@ -1,10 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const requireRoleMock = vi.fn()
+const isolationDenyMock = vi.fn()
 const wsServers: any[] = []
 
 vi.mock('@/lib/auth', () => ({
   requireRole: requireRoleMock,
+}))
+
+vi.mock('@/lib/workspace-isolation', () => ({
+  denyUnscopedResourceForStrictWorkspace: isolationDenyMock,
 }))
 
 vi.mock('ws', () => {
@@ -44,6 +49,8 @@ describe('handlePtyUpgrade auth and validation', () => {
   beforeEach(() => {
     vi.resetModules()
     requireRoleMock.mockReset()
+    isolationDenyMock.mockReset()
+    isolationDenyMock.mockReturnValue(null)
     wsServers.length = 0
   })
 
@@ -113,6 +120,28 @@ describe('handlePtyUpgrade auth and validation', () => {
     expect(requireRoleMock.mock.calls[0][1]).toBe('operator')
     expect(String(socket.write.mock.calls[0][0])).toContain('403 Forbidden')
     expect(socket.destroy).toHaveBeenCalledOnce()
+  })
+
+  it('rejects a strict workspace before attaching to a global PTY session', async () => {
+    requireRoleMock.mockReturnValue({ user: { role: 'admin', workspace_id: 7, tenant_id: 1 } })
+    isolationDenyMock.mockReturnValue({ status: 403 })
+    const { handlePtyUpgrade } = await import('@/lib/pty-websocket')
+    const socket = makeSocket()
+
+    const handled = handlePtyUpgrade(
+      { url: '/ws/pty?session=s1&kind=claude-code&mode=readonly', headers: { host: 'localhost:3000' }, method: 'GET', socket: {} } as any,
+      socket as any,
+      Buffer.alloc(0),
+    )
+
+    expect(handled).toBe(true)
+    expect(isolationDenyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ workspace_id: 7 }),
+      'terminal_sessions',
+      '/ws/pty',
+    )
+    expect(String(socket.write.mock.calls[0][0])).toContain('403 Forbidden')
+    expect(wsServers).toHaveLength(0)
   })
 
   it('upgrades when auth succeeds and params are valid', async () => {

--- a/src/lib/__tests__/status-route-ollama.test.ts
+++ b/src/lib/__tests__/status-route-ollama.test.ts
@@ -3,6 +3,9 @@ import { NextRequest } from 'next/server'
 
 const runCommandMock = vi.fn()
 const loggerErrorMock = vi.fn()
+const getAllGatewaySessionsMock = vi.fn(() => [])
+const getAgentLiveStatusesMock = vi.fn(() => [])
+const isolationMock = vi.fn(() => 'shared')
 
 vi.mock('@/lib/auth', () => ({
   requireRole: vi.fn(() => ({ user: { role: 'viewer', workspace_id: 1 } })),
@@ -24,7 +27,10 @@ vi.mock('@/lib/config', () => ({
 }))
 
 vi.mock('@/lib/db', () => ({ getDatabase: vi.fn() }))
-vi.mock('@/lib/sessions', () => ({ getAllGatewaySessions: vi.fn(() => []), getAgentLiveStatuses: vi.fn(() => []) }))
+vi.mock('@/lib/sessions', () => ({
+  getAllGatewaySessions: getAllGatewaySessionsMock,
+  getAgentLiveStatuses: getAgentLiveStatusesMock,
+}))
 vi.mock('@/lib/provider-subscriptions', () => ({
   detectProviderSubscriptions: vi.fn(() => ({})),
   getPrimarySubscription: vi.fn(() => null),
@@ -32,6 +38,7 @@ vi.mock('@/lib/provider-subscriptions', () => ({
 vi.mock('@/lib/version', () => ({ APP_VERSION: 'test' }))
 vi.mock('@/lib/hermes-sessions', () => ({ isHermesInstalled: vi.fn(() => false), scanHermesSessions: vi.fn(() => []) }))
 vi.mock('@/lib/gateway-runtime', () => ({ registerMcAsDashboard: vi.fn() }))
+vi.mock('@/lib/workspace-isolation', () => ({ getWorkspaceIsolation: isolationMock }))
 vi.mock('@/lib/logger', () => ({ logger: { error: loggerErrorMock, info: vi.fn(), warn: vi.fn() } }))
 vi.mock('@/lib/models', () => ({
   MODEL_CATALOG: [
@@ -49,6 +56,7 @@ describe('status route Ollama model discovery', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
+    isolationMock.mockReturnValue('shared')
   })
 
   afterEach(() => {
@@ -93,5 +101,18 @@ describe('status route Ollama model discovery', () => {
     expect(response.status).toBe(200)
     expect(payload.models.some((m) => m.name === 'openai/gpt-4.1-mini')).toBe(true)
     expect(loggerErrorMock).toHaveBeenCalled()
+  })
+
+  it('does not inspect deployment-global session stores for a strict workspace', async () => {
+    isolationMock.mockReturnValue('strict')
+    runCommandMock.mockRejectedValue(new Error('unavailable in test'))
+
+    const { GET } = await import('@/app/api/status/route')
+    const response = await GET(new NextRequest('http://localhost/api/status?action=overview'))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({ sessions: { total: 0, active: 0 } })
+    expect(getAllGatewaySessionsMock).not.toHaveBeenCalled()
+    expect(getAgentLiveStatusesMock).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/__tests__/workspace-isolation-enforcement.test.ts
+++ b/src/lib/__tests__/workspace-isolation-enforcement.test.ts
@@ -143,4 +143,19 @@ describe('direct session API coverage', () => {
       expect(source, file).toContain('denyUnscopedResourceForStrictWorkspace')
     }
   })
+
+  it('guards indirect global session consumers', () => {
+    const statusRoute = readFileSync(join(process.cwd(), 'src/app/api/status/route.ts'), 'utf8')
+    const chatRoute = readFileSync(join(process.cwd(), 'src/app/api/chat/messages/route.ts'), 'utf8')
+    const ptyRoute = readFileSync(join(process.cwd(), 'src/app/api/pty/attach/route.ts'), 'utf8')
+    const ptyWebSocket = readFileSync(join(process.cwd(), 'src/lib/pty-websocket.ts'), 'utf8')
+
+    expect(statusRoute).toContain("const includeGlobalRuntime = isolation === 'shared'")
+    expect(statusRoute).toContain('if (includeGlobalRuntime) {')
+    expect(chatRoute).toContain('const sessions = strictWorkspace ? [] : getAllGatewaySessions()')
+    expect(chatRoute).toContain('if (!strictWorkspace && !sessionKey)')
+    expect(chatRoute).toContain('if (strictWorkspace && !sessionKey)')
+    expect(ptyRoute).toContain("'terminal_sessions'")
+    expect(ptyWebSocket).toContain("'terminal_sessions'")
+  })
 })

--- a/src/lib/pty-websocket.ts
+++ b/src/lib/pty-websocket.ts
@@ -10,6 +10,7 @@ import { WebSocketServer, WebSocket } from 'ws'
 import { createPtySession, getPtySession } from './pty-manager'
 import { requireRole } from '@/lib/auth'
 import { logger } from './logger'
+import { denyUnscopedResourceForStrictWorkspace } from './workspace-isolation'
 
 const log = logger.child({ module: 'pty-websocket' })
 
@@ -210,6 +211,17 @@ export function handlePtyUpgrade(req: IncomingMessage, socket: any, head: Buffer
     const message = auth.error || 'Authentication required'
     log.warn({ reason: message, status, minRole }, 'Rejected PTY upgrade: auth failed')
     writeWsHttpError(socket, status, message)
+    return true
+  }
+
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(
+    auth.user,
+    'terminal_sessions',
+    url.pathname,
+  )
+  if (isolationDeny) {
+    log.warn({ status: 403, minRole }, 'Rejected PTY upgrade: workspace isolation denied')
+    writeWsHttpError(socket, 403, 'Terminal sessions are unavailable in this workspace')
     return true
   }
 

--- a/src/lib/workspace-isolation.ts
+++ b/src/lib/workspace-isolation.ts
@@ -10,6 +10,7 @@ export type UnscopedWorkspaceResource =
   | 'gateway_sessions'
   | 'session_transcripts'
   | 'session_preferences'
+  | 'terminal_sessions'
   | 'runtime_memory'
 
 interface IsolationRecord {


### PR DESCRIPTION
## Summary

- keep strict-workspace status responses from reading or syncing deployment-global sessions
- restrict strict-workspace chat forwarding to session keys stored on workspace-owned agent records
- ignore caller-provided and on-disk session fallbacks for strict workspaces
- deny strict-workspace PTY enumeration and attachment over both HTTP and WebSocket

This is the second enforcement slice of #800. It does not close #800.

## Security properties

- missing workspace isolation context fails closed
- strict status responses preserve their schema with zero global-session counts
- a deployment-global runtime agent ID alone cannot authorize strict chat forwarding
- terminal session denials use the minimized workspace isolation audit path
- shared-workspace behavior remains unchanged

## Verification

- 1,276 unit tests passed
- TypeScript passed
- ESLint passed with 0 errors (100 existing warnings)
- API contract parity passed
- strict devgod security scan passed
- production build passed
- standalone artifact check passed
- git diff check passed
