### PR TITLE
security: isolate agent and runtime filesystem access

### DIFF
--- a/src/app/api/agents/[id]/files/route.ts
+++ b/src/app/api/agents/[id]/files/route.ts
@@ -7,6 +7,7 @@ import { dirname, isAbsolute, resolve } from 'node:path'
 import { resolveWithin } from '@/lib/paths'
 import { getAgentWorkspaceCandidates, readAgentWorkspaceFile } from '@/lib/agent-workspace'
 import { logger } from '@/lib/logger'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 
 const ALLOWED_FILES = new Set([
   'agent.md',
@@ -50,6 +51,12 @@ export async function GET(
 ) {
   const auth = requireRole(request, 'viewer')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(
+    auth.user,
+    'agent_filesystem',
+    new URL(request.url).pathname,
+  )
+  if (isolationDeny) return isolationDeny
 
   try {
     const { id } = await params
@@ -96,6 +103,12 @@ export async function PUT(
 ) {
   const auth = requireRole(request, 'operator')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(
+    auth.user,
+    'agent_filesystem',
+    new URL(request.url).pathname,
+  )
+  if (isolationDeny) return isolationDeny
 
   try {
     const { id } = await params

--- a/src/app/api/agents/[id]/soul/route.ts
+++ b/src/app/api/agents/[id]/soul/route.ts
@@ -7,6 +7,7 @@ import { resolveWithin } from '@/lib/paths';
 import { getAgentWorkspaceCandidates, readAgentWorkspaceFile } from '@/lib/agent-workspace';
 import { requireRole } from '@/lib/auth';
 import { logger } from '@/lib/logger';
+import { denyUnscopedResourceForStrictWorkspace, getWorkspaceIsolation } from '@/lib/workspace-isolation';
 
 function resolveAgentWorkspacePath(workspace: string): string {
   if (isAbsolute(workspace)) return resolve(workspace)
@@ -23,6 +24,9 @@ export async function GET(
 ) {
   const auth = requireRole(request, 'viewer')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolation = getWorkspaceIsolation(auth.user)
+  if (!isolation) return NextResponse.json({ error: 'Workspace isolation context is unavailable' }, { status: 403 })
+  const isStrictWorkspace = isolation === 'strict'
 
   try {
     const db = getDatabase();
@@ -46,16 +50,18 @@ export async function GET(
     let soulContent = ''
     let source: 'workspace' | 'database' | 'none' = 'none'
 
-    try {
-      const agentConfig = agent.config ? JSON.parse(agent.config) : {}
-      const candidates = getAgentWorkspaceCandidates(agentConfig, agent.name)
-      const match = readAgentWorkspaceFile(candidates, ['soul.md', 'SOUL.md'])
-      if (match.exists) {
-        soulContent = match.content
-        source = 'workspace'
+    if (!isStrictWorkspace) {
+      try {
+        const agentConfig = agent.config ? JSON.parse(agent.config) : {}
+        const candidates = getAgentWorkspaceCandidates(agentConfig, agent.name)
+        const match = readAgentWorkspaceFile(candidates, ['soul.md', 'SOUL.md'])
+        if (match.exists) {
+          soulContent = match.content
+          source = 'workspace'
+        }
+      } catch (err) {
+        logger.warn({ err, agent: agent.name }, 'Failed to read soul.md from workspace')
       }
-    } catch (err) {
-      logger.warn({ err, agent: agent.name }, 'Failed to read soul.md from workspace')
     }
 
     // Fall back to database value
@@ -67,15 +73,17 @@ export async function GET(
     const templatesPath = config.soulTemplatesDir;
     let availableTemplates: string[] = [];
 
-    try {
-      if (templatesPath && existsSync(templatesPath)) {
-        const files = readdirSync(templatesPath);
-        availableTemplates = files
-          .filter(file => file.endsWith('.md'))
-          .map(file => file.replace('.md', ''));
+    if (!isStrictWorkspace) {
+      try {
+        if (templatesPath && existsSync(templatesPath)) {
+          const files = readdirSync(templatesPath);
+          availableTemplates = files
+            .filter(file => file.endsWith('.md'))
+            .map(file => file.replace('.md', ''));
+        }
+      } catch (error) {
+        logger.warn({ err: error }, 'Could not read soul templates directory');
       }
-    } catch (error) {
-      logger.warn({ err: error }, 'Could not read soul templates directory');
     }
 
     return NextResponse.json({
@@ -104,6 +112,9 @@ export async function PUT(
 ) {
   const auth = requireRole(request, 'operator');
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status });
+  const isolation = getWorkspaceIsolation(auth.user)
+  if (!isolation) return NextResponse.json({ error: 'Workspace isolation context is unavailable' }, { status: 403 })
+  const isStrictWorkspace = isolation === 'strict'
 
   try {
     const db = getDatabase();
@@ -129,6 +140,9 @@ export async function PUT(
     
     // If template_name is provided, load from template
     if (template_name) {
+      if (isStrictWorkspace) {
+        return NextResponse.json({ error: 'Global SOUL templates are unavailable in strict workspaces' }, { status: 403 })
+      }
       if (!config.soulTemplatesDir) {
         return NextResponse.json({ error: 'Templates directory not configured' }, { status: 500 });
       }
@@ -160,18 +174,20 @@ export async function PUT(
 
     // Write to workspace file if available
     let savedToWorkspace = false
-    try {
-      const agentConfig = agent.config ? JSON.parse(agent.config) : {}
-      const candidates = getAgentWorkspaceCandidates(agentConfig, agent.name)
-      const safeWorkspace = candidates[0]
-      if (safeWorkspace) {
-        const safeSoulPath = resolveWithin(safeWorkspace, 'soul.md')
-        mkdirSync(dirname(safeSoulPath), { recursive: true })
-        writeFileSync(safeSoulPath, newSoulContent || '', 'utf-8')
-        savedToWorkspace = true
+    if (!isStrictWorkspace) {
+      try {
+        const agentConfig = agent.config ? JSON.parse(agent.config) : {}
+        const candidates = getAgentWorkspaceCandidates(agentConfig, agent.name)
+        const safeWorkspace = candidates[0]
+        if (safeWorkspace) {
+          const safeSoulPath = resolveWithin(safeWorkspace, 'soul.md')
+          mkdirSync(dirname(safeSoulPath), { recursive: true })
+          writeFileSync(safeSoulPath, newSoulContent || '', 'utf-8')
+          savedToWorkspace = true
+        }
+      } catch (err) {
+        logger.warn({ err, agent: agent.name }, 'Failed to write soul.md to workspace, saving to DB only')
       }
-    } catch (err) {
-      logger.warn({ err, agent: agent.name }, 'Failed to write soul.md to workspace, saving to DB only')
     }
 
     // Update SOUL content in DB
@@ -220,6 +236,15 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const auth = requireRole(request, 'viewer')
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(
+    auth.user,
+    'runtime_configuration',
+    new URL(request.url).pathname,
+  )
+  if (isolationDeny) return isolationDeny
+
   try {
     const { searchParams } = new URL(request.url);
     const templateName = searchParams.get('template');

--- a/src/app/api/claude-tasks/route.ts
+++ b/src/app/api/claude-tasks/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireRole } from '@/lib/auth'
 import { getClaudeCodeTasks } from '@/lib/claude-tasks'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 
 /**
  * GET /api/claude-tasks — Returns Claude Code teams and tasks
@@ -9,6 +10,12 @@ import { getClaudeCodeTasks } from '@/lib/claude-tasks'
 export async function GET(request: NextRequest) {
   const auth = requireRole(request, 'viewer')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(
+    auth.user,
+    'runtime_tasks',
+    new URL(request.url).pathname,
+  )
+  if (isolationDeny) return isolationDeny
 
   const force = request.nextUrl.searchParams.get('force') === 'true'
   const result = getClaudeCodeTasks(force)

--- a/src/app/api/hermes/route.ts
+++ b/src/app/api/hermes/route.ts
@@ -7,6 +7,7 @@ import { isHermesInstalled, isHermesGatewayRunning, scanHermesSessions } from '@
 import { getHermesTasks } from '@/lib/hermes-tasks'
 import { getHermesMemory } from '@/lib/hermes-memory'
 import { logger } from '@/lib/logger'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 
 // In Docker, HOME=/nonexistent — check dataDir first, then homeDir
 import { resolve } from 'node:path'
@@ -22,6 +23,12 @@ const HOOK_DIR = join(HERMES_HOME, 'hooks', 'mission-control')
 export async function GET(request: NextRequest) {
   const auth = requireRole(request, 'viewer')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(
+    auth.user,
+    'runtime_configuration',
+    new URL(request.url).pathname,
+  )
+  if (isolationDeny) return isolationDeny
 
   try {
     const installed = isHermesInstalled()
@@ -67,6 +74,12 @@ function extractDeviceAuth(output: string): { cleanOutput: string; deviceUrl: st
 export async function POST(request: NextRequest) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(
+    auth.user,
+    'runtime_configuration',
+    new URL(request.url).pathname,
+  )
+  if (isolationDeny) return isolationDeny
 
   try {
     const body = await request.json()

--- a/src/app/api/tokens/route.ts
+++ b/src/app/api/tokens/route.ts
@@ -9,6 +9,7 @@ import { getDatabase } from '@/lib/db'
 import { calculateTokenCost } from '@/lib/token-pricing'
 import { getProviderSubscriptionFlags } from '@/lib/provider-subscriptions'
 import { buildTaskCostReport, type TaskCostMetadata } from '@/lib/task-costs'
+import { getWorkspaceIsolation } from '@/lib/workspace-isolation'
 
 const DATA_PATH = config.tokensPath
 
@@ -183,11 +184,11 @@ async function loadTokenDataFromFile(workspaceId: number, providerSubscriptions:
  * Load token data from all sources: DB, file, and gateway session stores.
  * All sources are merged and deduplicated so session-derived data is always included.
  */
-async function loadTokenData(workspaceId: number): Promise<TokenUsageRecord[]> {
+async function loadTokenData(workspaceId: number, includeGlobalRuntime: boolean): Promise<TokenUsageRecord[]> {
   const providerSubscriptions = getProviderSubscriptionFlags()
   const dbRecords = loadTokenDataFromDb(workspaceId, providerSubscriptions)
-  const fileRecords = await loadTokenDataFromFile(workspaceId, providerSubscriptions)
-  const sessionRecords = deriveFromSessions(workspaceId, providerSubscriptions)
+  const fileRecords = includeGlobalRuntime ? await loadTokenDataFromFile(workspaceId, providerSubscriptions) : []
+  const sessionRecords = includeGlobalRuntime ? deriveFromSessions(workspaceId, providerSubscriptions) : []
   return dedupeTokenRecords([...dbRecords, ...fileRecords, ...sessionRecords])
     .sort((a, b) => b.timestamp - a.timestamp)
 }
@@ -322,7 +323,11 @@ export async function GET(request: NextRequest) {
     const format = searchParams.get('format') || 'json'
 
     const workspaceId = auth.user.workspace_id ?? 1
-    const tokenData = await loadTokenData(workspaceId)
+    const isolation = getWorkspaceIsolation(auth.user)
+    if (!isolation) {
+      return NextResponse.json({ error: 'Workspace isolation context is unavailable' }, { status: 403 })
+    }
+    const tokenData = await loadTokenData(workspaceId, isolation === 'shared')
     const filteredData = filterByTimeframe(tokenData, timeframe)
 
     if (action === 'list') {
@@ -569,6 +574,11 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
     const workspaceId = auth.user.workspace_id ?? 1
+    const isolation = getWorkspaceIsolation(auth.user)
+    if (!isolation) {
+      return NextResponse.json({ error: 'Workspace isolation context is unavailable' }, { status: 403 })
+    }
+    const isStrictWorkspace = isolation === 'strict'
     const { model, sessionId, inputTokens, outputTokens, operation = 'chat_completion', duration, taskId } = body
 
     if (!model || !sessionId || typeof inputTokens !== 'number' || typeof outputTokens !== 'number') {
@@ -609,14 +619,16 @@ export async function POST(request: NextRequest) {
     }
 
     // Persist only manually posted usage records in the JSON file.
-    const existingData = await loadTokenDataFromFile(workspaceId, providerSubscriptions)
-    existingData.unshift(record)
+    if (!isStrictWorkspace) {
+      const existingData = await loadTokenDataFromFile(workspaceId, providerSubscriptions)
+      existingData.unshift(record)
 
-    if (existingData.length > 10000) {
-      existingData.splice(10000)
+      if (existingData.length > 10000) {
+        existingData.splice(10000)
+      }
+
+      await saveTokenData(existingData)
     }
-
-    await saveTokenData(existingData)
 
     // Also INSERT into the token_usage SQLite table so by-agent / DB-based
     // aggregations (which read from token_usage, not from the JSON file)
@@ -642,6 +654,7 @@ export async function POST(request: NextRequest) {
         record.agentName,
       )
     } catch (err) {
+      if (isStrictWorkspace) throw err
       logger.warn({ err }, 'token_usage DB insert failed (JSON record persisted)')
     }
 

--- a/src/lib/__tests__/agent-filesystem-isolation.test.ts
+++ b/src/lib/__tests__/agent-filesystem-isolation.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest, NextResponse } from 'next/server'
+
+const requireRoleMock = vi.fn()
+const getDatabaseMock = vi.fn()
+const getWorkspaceIsolationMock = vi.fn()
+const denyUnscopedResourceMock = vi.fn()
+const getAgentWorkspaceCandidatesMock = vi.fn()
+const readAgentWorkspaceFileMock = vi.fn()
+
+vi.mock('@/lib/auth', () => ({ requireRole: requireRoleMock }))
+vi.mock('@/lib/db', () => ({
+  getDatabase: getDatabaseMock,
+  db_helpers: { logActivity: vi.fn() },
+}))
+vi.mock('@/lib/workspace-isolation', () => ({
+  getWorkspaceIsolation: getWorkspaceIsolationMock,
+  denyUnscopedResourceForStrictWorkspace: denyUnscopedResourceMock,
+}))
+vi.mock('@/lib/agent-workspace', () => ({
+  getAgentWorkspaceCandidates: getAgentWorkspaceCandidatesMock,
+  readAgentWorkspaceFile: readAgentWorkspaceFileMock,
+}))
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}))
+
+function authUser(role = 'operator') {
+  return {
+    user: {
+      id: 9,
+      username: 'strict-user',
+      role,
+      workspace_id: 7,
+      tenant_id: 2,
+    },
+  }
+}
+
+describe('strict agent filesystem isolation', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    denyUnscopedResourceMock.mockReturnValue(null)
+    getWorkspaceIsolationMock.mockReturnValue('strict')
+  })
+
+  it('requires authentication before exposing SOUL templates', async () => {
+    requireRoleMock.mockReturnValue({ error: 'Authentication required', status: 401 })
+    const { PATCH } = await import('@/app/api/agents/[id]/soul/route')
+
+    const response = await PATCH(
+      new NextRequest('http://localhost/api/agents/42/soul?template=default', { method: 'PATCH' }),
+      { params: Promise.resolve({ id: '42' }) },
+    )
+
+    expect(response.status).toBe(401)
+    expect(denyUnscopedResourceMock).not.toHaveBeenCalled()
+    expect(getDatabaseMock).not.toHaveBeenCalled()
+  })
+
+  it('denies strict agent-file reads before database or filesystem access', async () => {
+    requireRoleMock.mockReturnValue(authUser('viewer'))
+    denyUnscopedResourceMock.mockReturnValue(
+      NextResponse.json({ error: 'Strict workspace filesystem denied' }, { status: 403 }),
+    )
+    const { GET } = await import('@/app/api/agents/[id]/files/route')
+
+    const response = await GET(
+      new NextRequest('http://localhost/api/agents/42/files'),
+      { params: Promise.resolve({ id: '42' }) },
+    )
+
+    expect(response.status).toBe(403)
+    expect(denyUnscopedResourceMock).toHaveBeenCalledWith(
+      expect.objectContaining({ workspace_id: 7, tenant_id: 2 }),
+      'agent_filesystem',
+      '/api/agents/42/files',
+    )
+    expect(getDatabaseMock).not.toHaveBeenCalled()
+    expect(readAgentWorkspaceFileMock).not.toHaveBeenCalled()
+  })
+
+  it('serves strict SOUL state from the workspace-owned database only', async () => {
+    requireRoleMock.mockReturnValue(authUser('viewer'))
+    const get = vi.fn(() => ({
+      id: 42,
+      name: 'agent-a',
+      role: 'operator',
+      soul_content: 'database soul',
+      updated_at: 123,
+      config: JSON.stringify({ workspace: '/unowned/global/path' }),
+    }))
+    getDatabaseMock.mockReturnValue({ prepare: vi.fn(() => ({ get })) })
+    const { GET } = await import('@/app/api/agents/[id]/soul/route')
+
+    const response = await GET(
+      new NextRequest('http://localhost/api/agents/42/soul'),
+      { params: Promise.resolve({ id: '42' }) },
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      soul_content: 'database soul',
+      source: 'database',
+      available_templates: [],
+    })
+    expect(getAgentWorkspaceCandidatesMock).not.toHaveBeenCalled()
+    expect(readAgentWorkspaceFileMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/__tests__/token-runtime-isolation.test.ts
+++ b/src/lib/__tests__/token-runtime-isolation.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { existsSync } from 'node:fs'
+
+const requireRoleMock = vi.fn()
+const getWorkspaceIsolationMock = vi.fn()
+const getAllGatewaySessionsMock = vi.fn()
+const prepareMock = vi.fn()
+const state = vi.hoisted(() => ({
+  tokenPath: `/tmp/mission-control-strict-token-isolation-${process.pid}.json`,
+}))
+
+vi.mock('@/lib/auth', () => ({ requireRole: requireRoleMock }))
+vi.mock('@/lib/workspace-isolation', () => ({ getWorkspaceIsolation: getWorkspaceIsolationMock }))
+vi.mock('@/lib/sessions', () => ({ getAllGatewaySessions: getAllGatewaySessionsMock }))
+vi.mock('@/lib/db', () => ({ getDatabase: vi.fn(() => ({ prepare: prepareMock })) }))
+vi.mock('@/lib/config', () => ({
+  config: { tokensPath: state.tokenPath },
+  ensureDirExists: vi.fn(),
+}))
+vi.mock('@/lib/provider-subscriptions', () => ({
+  getProviderSubscriptionFlags: vi.fn(() => ({})),
+  getProviderFromModel: vi.fn(() => 'unknown'),
+}))
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}))
+
+const strictUser = {
+  id: 9,
+  username: 'strict-user',
+  role: 'operator',
+  workspace_id: 7,
+  tenant_id: 2,
+}
+
+describe('strict token runtime isolation', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    requireRoleMock.mockReturnValue({ user: strictUser })
+    getWorkspaceIsolationMock.mockReturnValue('strict')
+  })
+
+  it('reads workspace-owned database usage without scanning global sessions or files', async () => {
+    prepareMock.mockReturnValue({
+      all: vi.fn(() => [{
+        id: 1,
+        model: 'test-model',
+        session_id: 'agent-a:main',
+        input_tokens: 10,
+        output_tokens: 5,
+        task_id: null,
+        workspace_id: 7,
+        created_at: 100,
+      }]),
+    })
+    const { GET } = await import('@/app/api/tokens/route')
+
+    const response = await GET(new NextRequest('http://localhost/api/tokens?action=list'))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      total: 1,
+      usage: [expect.objectContaining({ workspaceId: 7, sessionId: 'agent-a:main' })],
+    })
+    expect(getAllGatewaySessionsMock).not.toHaveBeenCalled()
+    expect(existsSync(state.tokenPath)).toBe(false)
+  })
+
+  it('persists strict usage to the scoped database without writing the global JSON file', async () => {
+    const run = vi.fn()
+    prepareMock.mockReturnValue({ run })
+    const { POST } = await import('@/app/api/tokens/route')
+
+    const response = await POST(new NextRequest('http://localhost/api/tokens', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        model: 'test-model',
+        sessionId: 'agent-a:main',
+        inputTokens: 10,
+        outputTokens: 5,
+      }),
+    }))
+
+    expect(response.status).toBe(200)
+    expect(run).toHaveBeenCalledWith(
+      'test-model',
+      'agent-a:main',
+      10,
+      5,
+      expect.any(Number),
+      7,
+      null,
+      expect.any(Number),
+      'agent-a',
+    )
+    expect(existsSync(state.tokenPath)).toBe(false)
+  })
+})

--- a/src/lib/__tests__/workspace-isolation-enforcement.test.ts
+++ b/src/lib/__tests__/workspace-isolation-enforcement.test.ts
@@ -158,4 +158,20 @@ describe('direct session API coverage', () => {
     expect(ptyRoute).toContain("'terminal_sessions'")
     expect(ptyWebSocket).toContain("'terminal_sessions'")
   })
+
+  it('guards remaining runtime filesystem consumers', () => {
+    const filesRoute = readFileSync(join(process.cwd(), 'src/app/api/agents/[id]/files/route.ts'), 'utf8')
+    const soulRoute = readFileSync(join(process.cwd(), 'src/app/api/agents/[id]/soul/route.ts'), 'utf8')
+    const tokensRoute = readFileSync(join(process.cwd(), 'src/app/api/tokens/route.ts'), 'utf8')
+    const hermesRoute = readFileSync(join(process.cwd(), 'src/app/api/hermes/route.ts'), 'utf8')
+    const claudeTasksRoute = readFileSync(join(process.cwd(), 'src/app/api/claude-tasks/route.ts'), 'utf8')
+
+    expect(filesRoute).toContain("'agent_filesystem'")
+    expect(soulRoute).toContain("const auth = requireRole(request, 'viewer')")
+    expect(soulRoute).toContain('if (!isStrictWorkspace)')
+    expect(tokensRoute).toContain("const tokenData = await loadTokenData(workspaceId, isolation === 'shared')")
+    expect(tokensRoute).toContain('if (!isStrictWorkspace)')
+    expect(hermesRoute.match(/'runtime_configuration'/g)).toHaveLength(2)
+    expect(claudeTasksRoute).toContain("'runtime_tasks'")
+  })
 })

--- a/src/lib/workspace-isolation.ts
+++ b/src/lib/workspace-isolation.ts
@@ -6,8 +6,11 @@ import { getDatabase, logAuditEvent } from '@/lib/db'
 import type { WorkspaceIsolation } from '@/lib/workspaces'
 
 export type UnscopedWorkspaceResource =
+  | 'agent_filesystem'
   | 'local_sessions'
   | 'gateway_sessions'
+  | 'runtime_configuration'
+  | 'runtime_tasks'
   | 'session_transcripts'
   | 'session_preferences'
   | 'terminal_sessions'


### PR DESCRIPTION
## Summary

- authenticate the previously unguarded SOUL-template endpoint
- deny strict workspaces access to agent-configured filesystem paths and deployment-global Hermes/Claude runtime state
- keep strict agent SOUL reads and writes database-only
- keep strict token analytics available from workspace-owned database rows while excluding global JSON and gateway-session sources
- require strict token writes to persist to the scoped database instead of silently succeeding on a global-file fallback

This is the third enforcement slice of #800. The issue remains open for the remaining runtime routes, policy documentation, and negative E2E acceptance evidence.

## Security properties

- missing or mismatched isolation context fails closed
- strict agent filesystem denials occur before database/path/filesystem access
- strict SOUL responses expose no global templates or workspace-file contents
- strict token reads never scan global gateway sessions or token files
- strict token writes never modify the global JSON token store
- shared-workspace compatibility remains unchanged

## Verification

- 1,282 unit tests passed across 117 files
- focused negative route tests passed
- TypeScript passed
- ESLint passed with 0 errors (100 existing warnings)
- API contract parity passed
- strict devgod security scan passed
- production build passed
- standalone artifact check passed
- git diff check passed
