### PR TITLE
security: isolate deployment runtime configuration

### DIFF
--- a/src/app/api/cron/route.ts
+++ b/src/app/api/cron/route.ts
@@ -4,6 +4,7 @@ import { config } from '@/lib/config'
 import { logger } from '@/lib/logger'
 import { readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 
 interface CronJob {
   name: string
@@ -134,6 +135,8 @@ function mapOpenClawJob(job: OpenClawCronJob): CronJob {
 export async function GET(request: NextRequest) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'runtime_configuration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   try {
     const { searchParams } = new URL(request.url)
@@ -263,6 +266,8 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'runtime_configuration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   try {
     const body = await request.json()

--- a/src/app/api/integrations/route.ts
+++ b/src/app/api/integrations/route.ts
@@ -12,6 +12,7 @@ import { mutationLimiter } from '@/lib/rate-limit'
 import { detectProviderSubscriptions } from '@/lib/provider-subscriptions'
 import { getPluginIntegrations, getPluginCategories } from '@/lib/plugins'
 import type { PluginIntegrationDef } from '@/lib/plugins'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 
 // ---------------------------------------------------------------------------
 // Integration registry
@@ -311,6 +312,8 @@ async function getOpEnv(): Promise<NodeJS.ProcessEnv> {
 export async function GET(request: NextRequest) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'runtime_configuration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   const envData = await readEnvFile()
   if (!envData) {
@@ -469,6 +472,8 @@ export async function GET(request: NextRequest) {
 export async function PUT(request: NextRequest) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'runtime_configuration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   const body = await request.json().catch(() => null)
   if (!body?.vars || typeof body.vars !== 'object') {
@@ -528,6 +533,8 @@ export async function PUT(request: NextRequest) {
 export async function DELETE(request: NextRequest) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'runtime_configuration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   let body: any
   try { body = await request.json() } catch { return NextResponse.json({ error: 'Request body required' }, { status: 400 }) }
@@ -585,6 +592,8 @@ export async function DELETE(request: NextRequest) {
 export async function POST(request: NextRequest) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'runtime_configuration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   const rateCheck = mutationLimiter(request)
   if (rateCheck) return rateCheck

--- a/src/lib/__tests__/runtime-configuration-isolation.test.ts
+++ b/src/lib/__tests__/runtime-configuration-isolation.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function handlerBody(source: string, method: string): string {
+  const start = source.indexOf(`export async function ${method}(`)
+  expect(start, `${method} handler`).toBeGreaterThanOrEqual(0)
+  const next = source.indexOf('\nexport async function ', start + 1)
+  return source.slice(start, next === -1 ? source.length : next)
+}
+
+function expectGuardBefore(source: string, method: string, firstSensitiveOperation: string) {
+  const handler = handlerBody(source, method)
+  const authIndex = handler.indexOf('requireRole(')
+  const guardIndex = handler.indexOf('denyUnscopedResourceForStrictWorkspace(')
+  const sensitiveIndex = handler.indexOf(firstSensitiveOperation)
+
+  expect(authIndex, `${method} authenticates first`).toBeGreaterThanOrEqual(0)
+  expect(guardIndex, `${method} has an isolation guard`).toBeGreaterThan(authIndex)
+  expect(sensitiveIndex, `${method} sensitive operation`).toBeGreaterThanOrEqual(0)
+  expect(guardIndex, `${method} guard precedes sensitive work`).toBeLessThan(sensitiveIndex)
+}
+
+describe('deployment runtime configuration isolation', () => {
+  it('guards cron reads and mutations before global state access or body parsing', () => {
+    const source = readFileSync(join(process.cwd(), 'src/app/api/cron/route.ts'), 'utf8')
+
+    expectGuardBefore(source, 'GET', 'const { searchParams }')
+    expectGuardBefore(source, 'POST', 'request.json()')
+  })
+
+  it('guards integration reads and mutations before probes, parsing, or limiting', () => {
+    const source = readFileSync(join(process.cwd(), 'src/app/api/integrations/route.ts'), 'utf8')
+
+    expectGuardBefore(source, 'GET', 'readEnvFile()')
+    expectGuardBefore(source, 'PUT', 'request.json()')
+    expectGuardBefore(source, 'DELETE', 'request.json()')
+    expectGuardBefore(source, 'POST', 'mutationLimiter(request)')
+  })
+})

--- a/src/lib/__tests__/workspace-isolation-enforcement.test.ts
+++ b/src/lib/__tests__/workspace-isolation-enforcement.test.ts
@@ -174,4 +174,12 @@ describe('direct session API coverage', () => {
     expect(hermesRoute.match(/'runtime_configuration'/g)).toHaveLength(2)
     expect(claudeTasksRoute).toContain("'runtime_tasks'")
   })
+
+  it('guards deployment-global runtime configuration operations', () => {
+    const cronRoute = readFileSync(join(process.cwd(), 'src/app/api/cron/route.ts'), 'utf8')
+    const integrationsRoute = readFileSync(join(process.cwd(), 'src/app/api/integrations/route.ts'), 'utf8')
+
+    expect(cronRoute.match(/'runtime_configuration'/g)).toHaveLength(2)
+    expect(integrationsRoute.match(/'runtime_configuration'/g)).toHaveLength(4)
+  })
 })


### PR DESCRIPTION
## Summary
- deny strict workspaces access to deployment-global cron state and triggers
- deny strict workspaces access to deployment-global integration credentials and host probes
- enforce authentication-first, isolation-before-side-effects ordering with regression coverage

## Security rationale
Cron files, integration environment variables, credential probes, and runtime commands have no authoritative workspace ownership metadata. Strict workspaces now fail closed while shared deployments retain existing behavior.

## Verification
- 1,285 unit tests pass across 118 files
- focused isolation tests pass
- TypeScript passes
- lint passes (existing warnings only)
- API contract parity passes
- devgod strict secret scan passes
- production build passes
- standalone artifact check passes

Part of #800; does not close it.