### PR TITLE
security: isolate deployment host administration

### DIFF
--- a/src/app/api/backup/route.ts
+++ b/src/app/api/backup/route.ts
@@ -7,6 +7,7 @@ import { readdirSync, statSync, unlinkSync } from 'fs'
 import { heavyLimiter } from '@/lib/rate-limit'
 import { logger } from '@/lib/logger'
 import { runOpenClaw } from '@/lib/command'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 
 const BACKUP_DIR = join(dirname(config.dbPath), 'backups')
 const MAX_BACKUPS = 10
@@ -17,6 +18,8 @@ const MAX_BACKUPS = 10
 export async function GET(request: NextRequest) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'host_administration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   ensureDirExists(BACKUP_DIR)
 
@@ -45,6 +48,8 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'host_administration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   const rateCheck = heavyLimiter(request)
   if (rateCheck) return rateCheck
@@ -135,6 +140,8 @@ export async function POST(request: NextRequest) {
 export async function DELETE(request: NextRequest) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'host_administration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   let body: any
   try { body = await request.json() } catch { return NextResponse.json({ error: 'Request body required' }, { status: 400 }) }

--- a/src/app/api/cleanup/route.ts
+++ b/src/app/api/cleanup/route.ts
@@ -4,6 +4,7 @@ import { getDatabase, logAuditEvent } from '@/lib/db'
 import { config } from '@/lib/config'
 import { heavyLimiter } from '@/lib/rate-limit'
 import { countStaleGatewaySessions, pruneGatewaySessionsOlderThan } from '@/lib/sessions'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 
 interface CleanupResult {
   table: string
@@ -18,6 +19,8 @@ interface CleanupResult {
 export async function GET(request: NextRequest) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'host_administration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   const db = getDatabase()
   const workspaceId = auth.user.workspace_id ?? 1
@@ -84,6 +87,8 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'host_administration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   const rateCheck = heavyLimiter(request)
   if (rateCheck) return rateCheck

--- a/src/app/api/diagnostics/route.ts
+++ b/src/app/api/diagnostics/route.ts
@@ -4,6 +4,7 @@ import { existsSync, statSync } from 'node:fs'
 import { requireRole } from '@/lib/auth'
 import { config } from '@/lib/config'
 import { getDatabase } from '@/lib/db'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 import { runOpenClaw } from '@/lib/command'
 import { logger } from '@/lib/logger'
 import { APP_VERSION } from '@/lib/version'
@@ -19,6 +20,8 @@ const INSECURE_PASSWORDS = new Set([
 export async function GET(request: NextRequest) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'host_administration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   try {
     const [version, security, database, agents, sessions, gateway] = await Promise.all([

--- a/src/app/api/logs/route.ts
+++ b/src/app/api/logs/route.ts
@@ -3,6 +3,7 @@ import { readFile, readdir, stat } from 'fs/promises'
 import { join } from 'path'
 import { config } from '@/lib/config'
 import { requireRole } from '@/lib/auth'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 import { readLimiter, mutationLimiter } from '@/lib/rate-limit'
 import { logger } from '@/lib/logger'
 
@@ -179,6 +180,8 @@ async function readLogFile(filePath: string, source: string, maxLines: number): 
 export async function GET(request: NextRequest) {
   const auth = requireRole(request, 'viewer')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'host_administration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   const rateCheck = readLimiter(request)
   if (rateCheck) return rateCheck
@@ -257,6 +260,8 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   const auth = requireRole(request, 'operator')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'host_administration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   const rateCheck = mutationLimiter(request)
   if (rateCheck) return rateCheck

--- a/src/app/api/system-monitor/route.ts
+++ b/src/app/api/system-monitor/route.ts
@@ -2,11 +2,14 @@ import { NextRequest, NextResponse } from 'next/server'
 import os from 'node:os'
 import { runCommand } from '@/lib/command'
 import { requireRole } from '@/lib/auth'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 import { logger } from '@/lib/logger'
 
 export async function GET(request: NextRequest) {
   const auth = requireRole(request, 'viewer')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'host_administration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   try {
     const [cpu, memory, disk, gpu, network, processes] = await Promise.all([

--- a/src/lib/__tests__/host-administration-isolation.test.ts
+++ b/src/lib/__tests__/host-administration-isolation.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function handlerBody(source: string, method: string): string {
+  const start = source.indexOf(`export async function ${method}(`)
+  expect(start, `${method} handler`).toBeGreaterThanOrEqual(0)
+  const next = source.indexOf('\nexport async function ', start + 1)
+  return source.slice(start, next === -1 ? source.length : next)
+}
+
+function expectGuardBefore(file: string, method: string, sensitiveOperation: string) {
+  const source = readFileSync(join(process.cwd(), file), 'utf8')
+  const handler = handlerBody(source, method)
+  const authIndex = handler.indexOf('requireRole(')
+  const guardIndex = handler.indexOf('denyUnscopedResourceForStrictWorkspace(')
+  const sensitiveIndex = handler.indexOf(sensitiveOperation)
+
+  expect(authIndex, `${file} ${method} authenticates`).toBeGreaterThanOrEqual(0)
+  expect(guardIndex, `${file} ${method} is guarded`).toBeGreaterThan(authIndex)
+  expect(sensitiveIndex, `${file} ${method} sensitive operation exists`).toBeGreaterThanOrEqual(0)
+  expect(guardIndex, `${file} ${method} guard ordering`).toBeLessThan(sensitiveIndex)
+}
+
+describe('deployment host administration isolation', () => {
+  it('guards whole-deployment backup operations before side effects or parsing', () => {
+    const file = 'src/app/api/backup/route.ts'
+    expectGuardBefore(file, 'GET', 'ensureDirExists(BACKUP_DIR)')
+    expectGuardBefore(file, 'POST', 'heavyLimiter(request)')
+    expectGuardBefore(file, 'DELETE', 'request.json()')
+  })
+
+  it('guards global retention operations before database, limiting, or parsing', () => {
+    const file = 'src/app/api/cleanup/route.ts'
+    expectGuardBefore(file, 'GET', 'getDatabase()')
+    expectGuardBefore(file, 'POST', 'heavyLimiter(request)')
+  })
+
+  it('guards deployment observability before host work', () => {
+    expectGuardBefore('src/app/api/diagnostics/route.ts', 'GET', 'Promise.all([')
+    expectGuardBefore('src/app/api/logs/route.ts', 'GET', 'readLimiter(request)')
+    expectGuardBefore('src/app/api/logs/route.ts', 'POST', 'mutationLimiter(request)')
+    expectGuardBefore('src/app/api/system-monitor/route.ts', 'GET', 'Promise.all([')
+  })
+})

--- a/src/lib/__tests__/workspace-isolation-enforcement.test.ts
+++ b/src/lib/__tests__/workspace-isolation-enforcement.test.ts
@@ -182,4 +182,19 @@ describe('direct session API coverage', () => {
     expect(cronRoute.match(/'runtime_configuration'/g)).toHaveLength(2)
     expect(integrationsRoute.match(/'runtime_configuration'/g)).toHaveLength(4)
   })
+
+  it('guards deployment-global host administration operations', () => {
+    const expectedOperations = new Map([
+      ['src/app/api/backup/route.ts', 3],
+      ['src/app/api/cleanup/route.ts', 2],
+      ['src/app/api/diagnostics/route.ts', 1],
+      ['src/app/api/logs/route.ts', 2],
+      ['src/app/api/system-monitor/route.ts', 1],
+    ])
+
+    for (const [file, operations] of expectedOperations) {
+      const source = readFileSync(join(process.cwd(), file), 'utf8')
+      expect(source.match(/'host_administration'/g), file).toHaveLength(operations)
+    }
+  })
 })

--- a/src/lib/workspace-isolation.ts
+++ b/src/lib/workspace-isolation.ts
@@ -9,6 +9,7 @@ export type UnscopedWorkspaceResource =
   | 'agent_filesystem'
   | 'local_sessions'
   | 'gateway_sessions'
+  | 'host_administration'
   | 'runtime_configuration'
   | 'runtime_tasks'
   | 'session_transcripts'


### PR DESCRIPTION
## Summary
- deny strict workspaces access to whole-deployment database and gateway backups
- deny strict workspaces access to global retention cleanup and preview operations
- deny strict workspaces access to deployment diagnostics, logs, and host metrics
- enforce authentication-first and isolation-before-side-effects ordering across all nine operations

## Security rationale
These resources describe or mutate the deployment host and do not carry authoritative workspace ownership. Strict workspaces now fail closed; shared deployments retain existing behavior.

## Verification
- 1,289 unit tests pass across 119 files
- focused isolation and ordering tests pass
- TypeScript passes
- lint passes (existing warnings only)
- API contract parity passes
- devgod strict secret scan passes
- production build passes
- standalone artifact boundaries pass

Part of #800; does not close it.