### PR TITLE
security: isolate gateway and local host runtime

### DIFF
--- a/src/app/api/gateway-config/route.ts
+++ b/src/app/api/gateway-config/route.ts
@@ -7,6 +7,7 @@ import { validateBody, gatewayConfigUpdateSchema } from '@/lib/validation'
 import { mutationLimiter } from '@/lib/rate-limit'
 import { getDetectedGatewayToken } from '@/lib/gateway-runtime'
 import { parseJsonRelaxed } from '@/lib/json-relaxed'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 
 function getConfigPath(): string | null {
   return config.openclawConfigPath || null
@@ -34,6 +35,8 @@ function computeHash(raw: string): string {
 export async function GET(request: NextRequest) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'runtime_configuration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   const action = request.nextUrl.searchParams.get('action')
 
@@ -105,6 +108,8 @@ async function getSchema(): Promise<NextResponse> {
 export async function PUT(request: NextRequest) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'runtime_configuration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   const rateCheck = mutationLimiter(request)
   if (rateCheck) return rateCheck

--- a/src/app/api/gateways/control/route.ts
+++ b/src/app/api/gateways/control/route.ts
@@ -6,6 +6,7 @@ import { isHermesGatewayRunning } from '@/lib/hermes-sessions'
 import { existsSync, readFileSync, writeFileSync, mkdirSync, openSync } from 'node:fs'
 import { join } from 'node:path'
 import { spawn } from 'node:child_process'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 
 /** True when MC is running inside a Docker container without systemd. */
 function isDockerEnvironment(): boolean {
@@ -149,6 +150,8 @@ function getOpenClawGatewayStatus(): GatewayStatus {
 export async function GET(request: NextRequest) {
   const auth = requireRole(request, 'viewer')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'runtime_configuration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   const gateways: GatewayStatus[] = []
   gateways.push(getHermesGatewayStatus())
@@ -164,6 +167,8 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'runtime_configuration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   try {
     const body = await request.json()

--- a/src/app/api/gateways/discover/route.ts
+++ b/src/app/api/gateways/discover/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { readFileSync } from 'node:fs'
 import { execFileSync } from 'node:child_process'
 import { requireRole } from '@/lib/auth'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 
 interface DiscoveredGateway {
   user: string
@@ -18,6 +19,8 @@ interface DiscoveredGateway {
 export async function GET(request: NextRequest) {
   const auth = requireRole(request, 'viewer')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'runtime_configuration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   const discovered: DiscoveredGateway[] = []
 

--- a/src/app/api/local/agents-doc/route.ts
+++ b/src/app/api/local/agents-doc/route.ts
@@ -4,6 +4,7 @@ import { constants } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { requireRole } from '@/lib/auth'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 
 async function findFirstReadable(paths: string[]): Promise<string | null> {
   for (const p of paths) {
@@ -20,6 +21,8 @@ async function findFirstReadable(paths: string[]): Promise<string | null> {
 export async function GET(request: NextRequest) {
   const auth = requireRole(request, 'viewer')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'host_administration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   const cwd = process.cwd()
   const home = homedir()

--- a/src/app/api/local/flight-deck/route.ts
+++ b/src/app/api/local/flight-deck/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { existsSync, statSync } from 'node:fs'
 import { requireRole } from '@/lib/auth'
 import { runCommand } from '@/lib/command'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 
 const DEFAULT_DOWNLOAD_URL = 'https://flightdeck.example.com/download'
 const DEFAULT_INSTALL_PATHS = [
@@ -50,6 +51,8 @@ function resolveFlightDeckInstallPath(): string | null {
 export async function GET(request: NextRequest) {
   const auth = requireRole(request, 'viewer')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'host_administration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   const installPath = resolveFlightDeckInstallPath()
   const installed = installPath ? isInstalled(installPath) : false
@@ -69,6 +72,8 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   const auth = requireRole(request, 'operator')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'host_administration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   const installPath = resolveFlightDeckInstallPath()
   const installed = installPath ? isInstalled(installPath) : false

--- a/src/app/api/local/terminal/route.ts
+++ b/src/app/api/local/terminal/route.ts
@@ -3,6 +3,7 @@ import { existsSync, statSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { requireRole } from '@/lib/auth'
 import { runCommand } from '@/lib/command'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 
 function isAllowedDirectory(input: string): boolean {
   const cwd = resolve(input)
@@ -26,6 +27,8 @@ function isAllowedDirectory(input: string): boolean {
 export async function POST(request: NextRequest) {
   const auth = requireRole(request, 'operator')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'host_administration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   const body = await request.json().catch(() => ({}))
   const cwd = typeof body?.cwd === 'string' ? body.cwd.trim() : ''

--- a/src/lib/__tests__/gateway-local-runtime-isolation.test.ts
+++ b/src/lib/__tests__/gateway-local-runtime-isolation.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function handlerBody(source: string, method: string): string {
+  const start = source.indexOf(`export async function ${method}(`)
+  expect(start, `${method} handler`).toBeGreaterThanOrEqual(0)
+  const next = source.indexOf('\nexport async function ', start + 1)
+  return source.slice(start, next === -1 ? source.length : next)
+}
+
+function expectGuardBefore(file: string, method: string, sensitiveOperation: string) {
+  const source = readFileSync(join(process.cwd(), file), 'utf8')
+  const handler = handlerBody(source, method)
+  const authIndex = handler.indexOf('requireRole(')
+  const guardIndex = handler.indexOf('denyUnscopedResourceForStrictWorkspace(')
+  const sensitiveIndex = handler.indexOf(sensitiveOperation)
+
+  expect(authIndex, `${file} ${method} authenticates`).toBeGreaterThanOrEqual(0)
+  expect(guardIndex, `${file} ${method} is guarded`).toBeGreaterThan(authIndex)
+  expect(sensitiveIndex, `${file} ${method} sensitive operation exists`).toBeGreaterThanOrEqual(0)
+  expect(guardIndex, `${file} ${method} guard ordering`).toBeLessThan(sensitiveIndex)
+}
+
+describe('gateway and local host runtime isolation', () => {
+  it('guards deployment gateway configuration before reads, RPC, or mutation work', () => {
+    const file = 'src/app/api/gateway-config/route.ts'
+    expectGuardBefore(file, 'GET', 'request.nextUrl.searchParams')
+    expectGuardBefore(file, 'PUT', 'mutationLimiter(request)')
+  })
+
+  it('guards gateway status, control, and discovery before host access', () => {
+    expectGuardBefore('src/app/api/gateways/control/route.ts', 'GET', 'const gateways:')
+    expectGuardBefore('src/app/api/gateways/control/route.ts', 'POST', 'request.json()')
+    expectGuardBefore('src/app/api/gateways/discover/route.ts', 'GET', 'execFileSync(')
+  })
+
+  it('guards local apps and instruction files before host access or parsing', () => {
+    expectGuardBefore('src/app/api/local/terminal/route.ts', 'POST', 'request.json()')
+    expectGuardBefore('src/app/api/local/flight-deck/route.ts', 'GET', 'resolveFlightDeckInstallPath()')
+    expectGuardBefore('src/app/api/local/flight-deck/route.ts', 'POST', 'resolveFlightDeckInstallPath()')
+    expectGuardBefore('src/app/api/local/agents-doc/route.ts', 'GET', 'process.cwd()')
+  })
+})

--- a/src/lib/__tests__/workspace-isolation-enforcement.test.ts
+++ b/src/lib/__tests__/workspace-isolation-enforcement.test.ts
@@ -197,4 +197,26 @@ describe('direct session API coverage', () => {
       expect(source.match(/'host_administration'/g), file).toHaveLength(operations)
     }
   })
+
+  it('guards deployment-global gateway and local host operations', () => {
+    const runtimeFiles = new Map([
+      ['src/app/api/gateway-config/route.ts', 2],
+      ['src/app/api/gateways/control/route.ts', 2],
+      ['src/app/api/gateways/discover/route.ts', 1],
+    ])
+    const hostFiles = new Map([
+      ['src/app/api/local/terminal/route.ts', 1],
+      ['src/app/api/local/flight-deck/route.ts', 2],
+      ['src/app/api/local/agents-doc/route.ts', 1],
+    ])
+
+    for (const [file, operations] of runtimeFiles) {
+      const source = readFileSync(join(process.cwd(), file), 'utf8')
+      expect(source.match(/'runtime_configuration'/g), file).toHaveLength(operations)
+    }
+    for (const [file, operations] of hostFiles) {
+      const source = readFileSync(join(process.cwd(), file), 'utf8')
+      expect(source.match(/'host_administration'/g), file).toHaveLength(operations)
+    }
+  })
 })


### PR DESCRIPTION
## Summary
- deny strict workspaces access to deployment gateway config and lifecycle control
- deny strict workspaces access to host-level gateway discovery
- deny strict workspaces access to local Terminal and Flight Deck launching
- deny strict workspaces access to host instruction-file discovery
- enforce authentication-first and isolation-before-side-effects ordering across nine operations

## Security rationale
These routes operate on deployment-global gateway processes/configuration or the server host filesystem and desktop. They have no authoritative workspace ownership metadata, so strict workspaces now fail closed while shared deployments retain existing behavior.

Gateway health is intentionally unchanged in this PR because it evaluates caller-supplied targets and requires separate ownership validation.

## Verification
- 1,293 unit tests pass across 120 files
- focused isolation and ordering tests pass
- TypeScript passes
- lint passes (existing warnings only)
- API contract parity passes
- devgod strict secret scan passes
- production build passes
- standalone artifact boundaries pass

Part of #800; does not close it.