### PR TITLE
security: isolate deployment gateway registry

### DIFF
--- a/src/app/api/gateways/connect/route.ts
+++ b/src/app/api/gateways/connect/route.ts
@@ -3,6 +3,7 @@ import { requireRole, ROLE_LEVELS } from '@/lib/auth'
 import { getDatabase } from '@/lib/db'
 import { buildGatewayWebSocketUrl } from '@/lib/gateway-url'
 import { getDetectedGatewayToken } from '@/lib/gateway-runtime'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 import {
   isTailscaleServe,
   refreshTailscaleCache,
@@ -129,6 +130,8 @@ export async function POST(request: NextRequest) {
   // which then fails as "device identity required".
   const auth = requireRole(request, 'viewer')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'runtime_configuration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   const db = getDatabase()
   ensureTable(db)

--- a/src/app/api/gateways/health/history/route.ts
+++ b/src/app/api/gateways/health/history/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 import { requireRole } from "@/lib/auth"
 import { getDatabase } from "@/lib/db"
+import { denyUnscopedResourceForStrictWorkspace } from "@/lib/workspace-isolation"
 
 interface GatewayHealthLogRow {
   gateway_id: number
@@ -27,6 +28,8 @@ interface GatewayHistory {
 export async function GET(request: NextRequest) {
   const auth = requireRole(request, "viewer")
   if ("error" in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, "runtime_configuration", new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   const db = getDatabase()
   const rows = db.prepare(`

--- a/src/app/api/gateways/health/route.ts
+++ b/src/app/api/gateways/health/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 import { requireRole } from "@/lib/auth"
 import { getDatabase } from "@/lib/db"
+import { denyUnscopedResourceForStrictWorkspace } from "@/lib/workspace-isolation"
 
 function ensureGatewaysTable(db: ReturnType<typeof getDatabase>) {
   db.exec(`
@@ -162,6 +163,8 @@ function buildGatewayProbeUrl(host: string, port: number): string | null {
 export async function POST(request: NextRequest) {
   const auth = requireRole(request, "viewer")
   if ("error" in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, "runtime_configuration", new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   const db = getDatabase()
   ensureGatewaysTable(db)

--- a/src/app/api/gateways/route.ts
+++ b/src/app/api/gateways/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { requireRole } from '@/lib/auth'
 import { getDatabase } from '@/lib/db'
 import { getDetectedGatewayPort, getDetectedGatewayToken } from '@/lib/gateway-runtime'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 
 interface GatewayEntry {
   id: number
@@ -45,6 +46,8 @@ function ensureTable(db: ReturnType<typeof getDatabase>) {
 export async function GET(request: NextRequest) {
   const auth = requireRole(request, 'viewer')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'runtime_configuration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   const db = getDatabase()
   ensureTable(db)
@@ -75,6 +78,8 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'runtime_configuration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   const db = getDatabase()
   ensureTable(db)
@@ -141,6 +146,8 @@ export async function POST(request: NextRequest) {
 export async function PUT(request: NextRequest) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'runtime_configuration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   const db = getDatabase()
   ensureTable(db)
@@ -209,6 +216,8 @@ export async function PUT(request: NextRequest) {
 export async function DELETE(request: NextRequest) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'runtime_configuration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   const db = getDatabase()
   ensureTable(db)

--- a/src/lib/__tests__/gateway-registry-isolation.test.ts
+++ b/src/lib/__tests__/gateway-registry-isolation.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function handlerBody(source: string, method: string): string {
+  const start = source.indexOf(`export async function ${method}(`)
+  expect(start, `${method} handler`).toBeGreaterThanOrEqual(0)
+  const next = source.indexOf('\nexport async function ', start + 1)
+  return source.slice(start, next === -1 ? source.length : next)
+}
+
+function expectGuardBefore(file: string, method: string, sensitiveOperation: string) {
+  const source = readFileSync(join(process.cwd(), file), 'utf8')
+  const handler = handlerBody(source, method)
+  const authIndex = handler.indexOf('requireRole(')
+  const guardIndex = handler.indexOf('denyUnscopedResourceForStrictWorkspace(')
+  const sensitiveIndex = handler.indexOf(sensitiveOperation)
+
+  expect(authIndex, `${file} ${method} authenticates`).toBeGreaterThanOrEqual(0)
+  expect(guardIndex, `${file} ${method} is guarded`).toBeGreaterThan(authIndex)
+  expect(sensitiveIndex, `${file} ${method} sensitive operation exists`).toBeGreaterThanOrEqual(0)
+  expect(guardIndex, `${file} ${method} guard ordering`).toBeLessThan(sensitiveIndex)
+}
+
+describe('deployment gateway registry isolation', () => {
+  it('guards gateway registry CRUD before database access or default seeding', () => {
+    const file = 'src/app/api/gateways/route.ts'
+    for (const method of ['GET', 'POST', 'PUT', 'DELETE']) {
+      expectGuardBefore(file, method, 'getDatabase()')
+    }
+  })
+
+  it('guards gateway credential resolution before database and body access', () => {
+    expectGuardBefore('src/app/api/gateways/connect/route.ts', 'POST', 'getDatabase()')
+  })
+
+  it('guards probes and health history before global database access', () => {
+    expectGuardBefore('src/app/api/gateways/health/route.ts', 'POST', 'getDatabase()')
+    expectGuardBefore('src/app/api/gateways/health/history/route.ts', 'GET', 'getDatabase()')
+  })
+})

--- a/src/lib/__tests__/workspace-isolation-enforcement.test.ts
+++ b/src/lib/__tests__/workspace-isolation-enforcement.test.ts
@@ -219,4 +219,18 @@ describe('direct session API coverage', () => {
       expect(source.match(/'host_administration'/g), file).toHaveLength(operations)
     }
   })
+
+  it('guards the deployment-global gateway registry and health data', () => {
+    const expectedOperations = new Map([
+      ['src/app/api/gateways/route.ts', 4],
+      ['src/app/api/gateways/connect/route.ts', 1],
+      ['src/app/api/gateways/health/route.ts', 1],
+      ['src/app/api/gateways/health/history/route.ts', 1],
+    ])
+
+    for (const [file, operations] of expectedOperations) {
+      const source = readFileSync(join(process.cwd(), file), 'utf8')
+      expect(source.match(/["']runtime_configuration["']/g), file).toHaveLength(operations)
+    }
+  })
 })


### PR DESCRIPTION
## Summary
- deny strict workspaces access to deployment-global gateway CRUD and default seeding
- deny strict workspaces access to gateway connection metadata and bearer-token resolution
- deny strict workspaces access to global gateway probes and health history
- enforce authentication-first and isolation-before-database/network/credential work across seven operations

## Security rationale
The gateway registry and health-log tables have no workspace or tenant ownership fields. The connect route can also return and persist the deployment gateway token for operator roles. Strict workspaces now fail closed while shared deployments retain existing behavior.

## Verification
- 1,297 unit tests pass across 121 files
- focused isolation and ordering tests pass
- TypeScript passes
- lint passes (existing warnings only)
- API contract parity passes
- devgod strict secret scan passes
- production build passes
- standalone artifact boundaries pass

Part of #800; does not close it.