### PR TITLE
security: isolate unowned background dispatch

### DIFF
--- a/src/app/api/scheduler/route.ts
+++ b/src/app/api/scheduler/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireRole } from '@/lib/auth'
 import { getSchedulerStatus, triggerTask } from '@/lib/scheduler'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 
 /**
  * GET /api/scheduler - Get scheduler status
@@ -8,6 +9,8 @@ import { getSchedulerStatus, triggerTask } from '@/lib/scheduler'
 export async function GET(request: NextRequest) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'host_administration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   return NextResponse.json({ tasks: getSchedulerStatus() })
 }
@@ -19,6 +22,8 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'host_administration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   const body = await request.json().catch(() => ({}))
   const taskId = typeof body?.task_id === 'string' ? body.task_id : ''

--- a/src/lib/__tests__/background-dispatch-isolation.test.ts
+++ b/src/lib/__tests__/background-dispatch-isolation.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function handlerBody(source: string, method: string): string {
+  const start = source.indexOf(`export async function ${method}(`)
+  expect(start, `${method} handler`).toBeGreaterThanOrEqual(0)
+  const next = source.indexOf('\nexport async function ', start + 1)
+  return source.slice(start, next === -1 ? source.length : next)
+}
+
+describe('background dispatch workspace isolation', () => {
+  it('filters dispatch and deferred reconciliation at the authoritative workspace join', () => {
+    const source = readFileSync(join(process.cwd(), 'src/lib/task-dispatch.ts'), 'utf8')
+    const dispatchStart = source.indexOf('export async function dispatchAssignedTasks()')
+    const reconciliationStart = source.indexOf('export async function reconcileDeferredTaskCompletions(')
+    const reconciliationEnd = source.indexOf('// Direct Claude API dispatch', reconciliationStart)
+    const dispatchEnd = source.indexOf('// Auto-routing:', dispatchStart)
+    const reconciliation = source.slice(reconciliationStart, reconciliationEnd)
+    const dispatch = source.slice(dispatchStart, dispatchEnd)
+
+    for (const boundary of [reconciliation, dispatch]) {
+      expect(boundary).toContain('JOIN workspaces w ON w.id = t.workspace_id')
+      expect(boundary).toContain("AND w.isolation = 'shared'")
+    }
+  })
+
+  it('guards scheduler reads and triggers before global work', () => {
+    const source = readFileSync(join(process.cwd(), 'src/app/api/scheduler/route.ts'), 'utf8')
+    const cases = [
+      ['GET', 'getSchedulerStatus()'],
+      ['POST', 'request.json()'],
+    ] as const
+
+    for (const [method, sensitiveOperation] of cases) {
+      const handler = handlerBody(source, method)
+      const authIndex = handler.indexOf('requireRole(')
+      const guardIndex = handler.indexOf('denyUnscopedResourceForStrictWorkspace(')
+      const sensitiveIndex = handler.indexOf(sensitiveOperation)
+      expect(guardIndex, `${method} guard after auth`).toBeGreaterThan(authIndex)
+      expect(guardIndex, `${method} guard before work`).toBeLessThan(sensitiveIndex)
+    }
+  })
+})

--- a/src/lib/__tests__/task-dispatch-reconciliation.test.ts
+++ b/src/lib/__tests__/task-dispatch-reconciliation.test.ts
@@ -7,6 +7,7 @@ const mockDbState = vi.hoisted(() => ({
     assigned_to: string | null
     metadata: string | null
     workspace_id: number
+    workspace_isolation?: 'shared' | 'strict'
     ticket_prefix?: string | null
     project_ticket_no?: number | null
   }>,
@@ -44,12 +45,16 @@ vi.mock('../db', () => ({
     prepare: (sql: string) => {
       if (sql.includes('SELECT') && sql.includes('assigned_to') && sql.includes('metadata') && sql.includes('project_ticket_no')) {
         return {
-          all: () => mockDbState.tasks,
+          all: () => sql.includes("w.isolation = 'shared'")
+            ? mockDbState.tasks.filter((task) => task.workspace_isolation !== 'strict')
+            : mockDbState.tasks,
         }
       }
       if (sql.includes('FROM tasks t') && sql.includes('JOIN agents')) {
         return {
-          all: () => mockDbState.tasks,
+          all: () => sql.includes("w.isolation = 'shared'")
+            ? mockDbState.tasks.filter((task) => task.workspace_isolation !== 'strict')
+            : mockDbState.tasks,
         }
       }
       if (sql.includes('SELECT metadata FROM tasks WHERE id = ?')) {
@@ -231,6 +236,25 @@ describe('deferred task completion reconciliation', () => {
     expect(waitForRun).not.toHaveBeenCalled()
     expect(result.promoted).toBe(0)
     expect(mockDbState.updates).toHaveLength(0)
+  })
+
+  it('does not reconcile strict workspace runs or inspect global sessions', async () => {
+    mockDbState.tasks = [{
+      id: 16,
+      title: 'Strict deferred task',
+      assigned_to: 'agent-one',
+      metadata: JSON.stringify({ async_state: 'pending', dispatch_run_id: 'global-run' }),
+      workspace_id: 2,
+      workspace_isolation: 'strict',
+    }]
+    const waitForRun = vi.fn(async () => ({ complete: true, text: null }))
+
+    const result = await reconcileDeferredTaskCompletions({ workspaceId: 2, waitForRun })
+
+    expect(result).toMatchObject({ checked: 0, promoted: 0 })
+    expect(waitForRun).not.toHaveBeenCalled()
+    expect(mockDbState.getAllGatewaySessions).not.toHaveBeenCalled()
+    expect(mockDbState.readSessionJsonl).not.toHaveBeenCalled()
   })
 
   it('leaves tasks in progress when the wait result is not terminal', async () => {
@@ -449,6 +473,34 @@ describe('existing-session deferred dispatch', () => {
       }),
       1,
     )
+  })
+
+  it('does not dispatch strict workspace tasks to named or new global sessions', async () => {
+    mockDbState.tasks = [{
+      id: 23,
+      title: 'Strict session task',
+      description: 'Must remain isolated.',
+      status: 'assigned',
+      priority: 'high',
+      assigned_to: 'agent-one',
+      workspace_id: 2,
+      workspace_isolation: 'strict',
+      agent_name: 'agent-one',
+      agent_id: 7,
+      agent_config: null,
+      ticket_prefix: null,
+      project_ticket_no: null,
+      project_id: null,
+      metadata: JSON.stringify({ target_session: 'global-session' }),
+    } as any]
+
+    const result = await dispatchAssignedTasks()
+
+    expect(result).toEqual({ ok: true, message: 'No assigned tasks to dispatch' })
+    expect(mockDbState.callOpenClawGateway).not.toHaveBeenCalled()
+    expect(mockDbState.runOpenClaw).not.toHaveBeenCalled()
+    expect(mockDbState.statusUpdates).toHaveLength(0)
+    expect(mockDbState.metadataUpdates).toHaveLength(0)
   })
 
   it('does not send heuristic model overrides when the agent has a configured default model', async () => {

--- a/src/lib/__tests__/workspace-isolation-enforcement.test.ts
+++ b/src/lib/__tests__/workspace-isolation-enforcement.test.ts
@@ -233,4 +233,13 @@ describe('direct session API coverage', () => {
       expect(source.match(/["']runtime_configuration["']/g), file).toHaveLength(operations)
     }
   })
+
+  it('fails closed for deployment-global background dispatch and scheduling', () => {
+    const dispatch = readFileSync(join(process.cwd(), 'src/lib/task-dispatch.ts'), 'utf8')
+    const scheduler = readFileSync(join(process.cwd(), 'src/app/api/scheduler/route.ts'), 'utf8')
+
+    expect(dispatch.match(/JOIN workspaces w ON w\.id = t\.workspace_id/g)).toHaveLength(2)
+    expect(dispatch.match(/AND w\.isolation = 'shared'/g)).toHaveLength(2)
+    expect(scheduler.match(/'host_administration'/g)).toHaveLength(2)
+  })
 })

--- a/src/lib/task-dispatch.ts
+++ b/src/lib/task-dispatch.ts
@@ -515,8 +515,10 @@ export async function reconcileDeferredTaskCompletions(options: {
     SELECT t.id, t.title, t.assigned_to, t.metadata, t.workspace_id,
            p.ticket_prefix, t.project_ticket_no
     FROM tasks t
+    JOIN workspaces w ON w.id = t.workspace_id
     LEFT JOIN projects p ON p.id = t.project_id AND p.workspace_id = t.workspace_id
     WHERE t.workspace_id = ?
+      AND w.isolation = 'shared'
       AND t.status = 'in_progress'
       AND t.metadata IS NOT NULL
       AND t.metadata LIKE '%"async_state"%'
@@ -1482,8 +1484,10 @@ export async function dispatchAssignedTasks(): Promise<{ ok: boolean; message: s
            p.ticket_prefix, t.project_ticket_no
     FROM tasks t
     JOIN agents a ON a.name = t.assigned_to AND a.workspace_id = t.workspace_id
+    JOIN workspaces w ON w.id = t.workspace_id
     LEFT JOIN projects p ON p.id = t.project_id AND p.workspace_id = t.workspace_id
     WHERE t.status = 'assigned'
+      AND w.isolation = 'shared'
       AND t.assigned_to IS NOT NULL
     ORDER BY
       CASE t.priority WHEN 'critical' THEN 0 WHEN 'high' THEN 1 WHEN 'medium' THEN 2 ELSE 3 END ASC,


### PR DESCRIPTION
## Summary
- exclude strict-workspace tasks at the authoritative dispatch and deferred-reconciliation query boundaries
- deny strict-workspace administrators access to deployment-global scheduler status and manual triggers
- keep shared-workspace behavior unchanged and leave strict tasks assigned until workspace-owned runtime authority exists

Runtime identifiers such as agent IDs, session keys, run IDs, and working directories are identifiers, not ownership proof. This prevents them from widening a strict workspace boundary into global gateway sessions, transcripts, credentials, CLIs, or host filesystem execution.

## Verification
- 1,302 tests passed across 122 files
- lint passed with 0 errors (existing warnings only)
- TypeScript passed
- production build passed
- standalone artifact integrity passed
- API contract parity passed
- strict devgod security scan passed
- diff check passed

## Tracking
Advances #800 but does not close it; workspace-owned runtime authority, broader negative integration/E2E coverage, and isolation documentation remain outstanding.