### PR TITLE
security: isolate global execution routes

### DIFF
--- a/src/app/api/agents/sync/route.ts
+++ b/src/app/api/agents/sync/route.ts
@@ -3,6 +3,7 @@ import { requireRole } from '@/lib/auth'
 import { syncAgentsFromConfig, previewSyncDiff } from '@/lib/agent-sync'
 import { syncLocalAgents } from '@/lib/local-agent-sync'
 import { logger } from '@/lib/logger'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 
 /**
  * POST /api/agents/sync - Trigger agent config sync
@@ -12,6 +13,8 @@ import { logger } from '@/lib/logger'
 export async function POST(request: NextRequest) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'runtime_configuration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   const { searchParams } = new URL(request.url)
   const source = searchParams.get('source')
@@ -42,6 +45,8 @@ export async function POST(request: NextRequest) {
 export async function GET(request: NextRequest) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'runtime_configuration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   try {
     const diff = await previewSyncDiff()

--- a/src/app/api/pipelines/run/route.ts
+++ b/src/app/api/pipelines/run/route.ts
@@ -3,6 +3,7 @@ import { getDatabase, db_helpers } from '@/lib/db'
 import { requireRole } from '@/lib/auth'
 import { eventBus } from '@/lib/event-bus'
 import { logger } from '@/lib/logger'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 
 interface PipelineStep {
   template_id: number
@@ -100,6 +101,11 @@ export async function POST(request: NextRequest) {
     const workspaceId = auth.user.workspace_id ?? 1
     const body = await request.json()
     const { action, pipeline_id, run_id } = body
+
+    if (action === 'start' || action === 'advance') {
+      const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'runtime_tasks', new URL(request.url).pathname)
+      if (isolationDeny) return isolationDeny
+    }
 
     if (action === 'start') {
       return startPipeline(db, pipeline_id, auth.user?.username || 'system', workspaceId)

--- a/src/app/api/spawn/route.ts
+++ b/src/app/api/spawn/route.ts
@@ -9,6 +9,7 @@ import { logger } from '@/lib/logger'
 import { validateBody, spawnAgentSchema } from '@/lib/validation'
 import { scanForInjection } from '@/lib/injection-guard'
 import { logAuditEvent } from '@/lib/db'
+import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 
 function getPreferredToolsProfile(): string {
   return String(process.env.OPENCLAW_TOOLS_PROFILE || 'coding').trim() || 'coding'
@@ -17,6 +18,8 @@ function getPreferredToolsProfile(): string {
 export async function POST(request: NextRequest) {
   const auth = requireRole(request, 'operator')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'runtime_tasks', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   const rateCheck = heavyLimiter(request)
   if (rateCheck) return rateCheck
@@ -171,6 +174,8 @@ export async function POST(request: NextRequest) {
 export async function GET(request: NextRequest) {
   const auth = requireRole(request, 'viewer')
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status })
+  const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'host_administration', new URL(request.url).pathname)
+  if (isolationDeny) return isolationDeny
 
   const rateCheck = heavyLimiter(request)
   if (rateCheck) return rateCheck

--- a/src/lib/__tests__/runtime-execution-isolation.test.ts
+++ b/src/lib/__tests__/runtime-execution-isolation.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function source(path: string): string {
+  return readFileSync(join(process.cwd(), path), 'utf8')
+}
+
+describe('deployment-global runtime execution isolation', () => {
+  it('denies spawn execution and host-log history before global resource access', () => {
+    const route = source('src/app/api/spawn/route.ts')
+    const post = route.slice(route.indexOf('export async function POST'), route.indexOf('// Get spawn history'))
+    const get = route.slice(route.indexOf('export async function GET'))
+
+    expect(post.indexOf("'runtime_tasks'")).toBeGreaterThan(-1)
+    expect(post.indexOf("'runtime_tasks'")).toBeLessThan(post.indexOf('heavyLimiter(request)'))
+    expect(post.indexOf("'runtime_tasks'")).toBeLessThan(post.indexOf('validateBody(request'))
+    expect(post.indexOf("'runtime_tasks'")).toBeLessThan(post.indexOf("callOpenClawGateway('sessions_spawn'"))
+    expect(get.indexOf("'host_administration'")).toBeGreaterThan(-1)
+    expect(get.indexOf("'host_administration'")).toBeLessThan(get.indexOf('heavyLimiter(request)'))
+    expect(get.indexOf("'host_administration'")).toBeLessThan(get.indexOf('readdir(config.logsDir)'))
+  })
+
+  it('denies only pipeline actions that invoke the global CLI', () => {
+    const route = source('src/app/api/pipelines/run/route.ts')
+    const post = route.slice(route.indexOf('export async function POST'), route.indexOf('/** Spawn a single pipeline step'))
+
+    expect(post).toContain("action === 'start' || action === 'advance'")
+    expect(post).toContain("'runtime_tasks'")
+    expect(post.indexOf("'runtime_tasks'")).toBeLessThan(post.indexOf("if (action === 'start')"))
+    expect(post).toContain("action === 'cancel'")
+    expect(route).toContain("SELECT * FROM pipeline_runs WHERE id = ? AND workspace_id = ?")
+  })
+
+  it('denies agent synchronization before global config or disk access', () => {
+    const route = source('src/app/api/agents/sync/route.ts')
+    const post = route.slice(route.indexOf('export async function POST'), route.indexOf('/**\n * GET'))
+    const get = route.slice(route.indexOf('export async function GET'))
+
+    expect(post.indexOf("'runtime_configuration'")).toBeGreaterThan(-1)
+    expect(post.indexOf("'runtime_configuration'")).toBeLessThan(post.indexOf('syncLocalAgents()'))
+    expect(post.indexOf("'runtime_configuration'")).toBeLessThan(post.indexOf('syncAgentsFromConfig('))
+    expect(get.indexOf("'runtime_configuration'")).toBeGreaterThan(-1)
+    expect(get.indexOf("'runtime_configuration'")).toBeLessThan(get.indexOf('previewSyncDiff()'))
+  })
+})

--- a/src/lib/__tests__/workspace-isolation-enforcement.test.ts
+++ b/src/lib/__tests__/workspace-isolation-enforcement.test.ts
@@ -242,4 +242,16 @@ describe('direct session API coverage', () => {
     expect(dispatch.match(/AND w\.isolation = 'shared'/g)).toHaveLength(2)
     expect(scheduler.match(/'host_administration'/g)).toHaveLength(2)
   })
+
+  it('guards deployment-global spawn, pipeline execution, and agent sync', () => {
+    const spawn = readFileSync(join(process.cwd(), 'src/app/api/spawn/route.ts'), 'utf8')
+    const pipelines = readFileSync(join(process.cwd(), 'src/app/api/pipelines/run/route.ts'), 'utf8')
+    const agentSync = readFileSync(join(process.cwd(), 'src/app/api/agents/sync/route.ts'), 'utf8')
+
+    expect(spawn).toContain("'runtime_tasks'")
+    expect(spawn).toContain("'host_administration'")
+    expect(pipelines).toContain("action === 'start' || action === 'advance'")
+    expect(pipelines).toContain("'runtime_tasks'")
+    expect(agentSync.match(/'runtime_configuration'/g)).toHaveLength(2)
+  })
 })


### PR DESCRIPTION
## Summary
- deny strict workspaces access to global gateway spawning and host-log spawn history
- deny strict pipeline start/advance actions before host CLI execution while preserving workspace-scoped reads and cancellation
- deny strict agent sync and preview operations before global configuration or local-disk access
- add negative boundary coverage and extend the isolation enforcement inventory

Workspace-scoped database IDs do not establish ownership of deployment-global gateways, credentials, CLIs, filesystems, or process state.

## Verification
- 1,306 tests passed across 123 files
- lint passed with 0 errors (existing warnings only)
- TypeScript passed
- production build passed
- standalone artifact integrity passed
- API contract parity passed
- strict devgod security scan passed
- diff check passed

## Tracking
Advances #800 but does not close it; authoritative workspace-owned runtimes, remaining automatic background sync boundaries, broader integration/E2E coverage, and documentation remain outstanding.