### PR TITLE
security: isolate scheduler workspace mutations

### DIFF
--- a/src/lib/__tests__/scheduler-workspace-isolation.test.ts
+++ b/src/lib/__tests__/scheduler-workspace-isolation.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function source(path: string): string {
+  return readFileSync(join(process.cwd(), path), 'utf8')
+}
+
+describe('scheduler workspace isolation', () => {
+  it('selects auto-route candidates from the task workspace only', () => {
+    const dispatch = source('src/lib/task-dispatch.ts')
+    const start = dispatch.indexOf('export async function autoRouteInboxTasks()')
+    const route = dispatch.slice(start)
+
+    expect(route).toContain('WHERE workspace_id = ?')
+    expect(route).toContain('.all(task.workspace_id)')
+    expect(route).not.toContain('// Get all non-hidden, non-offline agents')
+    expect(route.match(/WHERE id = \? AND workspace_id = \?/g)).toHaveLength(2)
+    expect(route).toContain("alt.agent.name, now, task.id, task.workspace_id")
+    expect(route).toContain("best.name, now, task.id, task.workspace_id")
+  })
+
+  it('excludes strict tasks before automated reviewer runtime access', () => {
+    const dispatch = source('src/lib/task-dispatch.ts')
+    const start = dispatch.indexOf('export async function runAegisReviews()')
+    const end = dispatch.indexOf('export async function requeueStaleTasks()')
+    const review = dispatch.slice(start, end)
+
+    expect(review).toContain('JOIN workspaces w ON w.id = t.workspace_id')
+    expect(review).toContain("AND w.isolation = 'shared'")
+    expect(review.indexOf("AND w.isolation = 'shared'")).toBeLessThan(review.indexOf("callOpenClawGateway<any>("))
+    expect(review.match(/WHERE id = \? AND workspace_id = \?/g)?.length).toBeGreaterThanOrEqual(6)
+  })
+
+  it('carries agent ownership through every heartbeat side effect', () => {
+    const scheduler = source('src/lib/scheduler.ts')
+    const start = scheduler.indexOf('async function runHeartbeatCheck()')
+    const end = scheduler.indexOf('/** Sync live agent statuses')
+    const heartbeat = scheduler.slice(start, end)
+
+    expect(heartbeat).toContain('SELECT id, name, status, last_seen, workspace_id FROM agents')
+    expect(heartbeat).toContain('WHERE id = ? AND workspace_id = ?')
+    expect(heartbeat).toContain('description, workspace_id)')
+    expect(heartbeat).toContain('source_id, workspace_id)')
+    expect(heartbeat).toContain('agent.id, agent.workspace_id')
+    expect(heartbeat).toContain('marked_offline_count: names.length')
+    expect(heartbeat).not.toContain('detail: { marked_offline: names }')
+  })
+})

--- a/src/lib/__tests__/workspace-isolation-enforcement.test.ts
+++ b/src/lib/__tests__/workspace-isolation-enforcement.test.ts
@@ -252,8 +252,8 @@ describe('direct session API coverage', () => {
     const dispatch = readFileSync(join(process.cwd(), 'src/lib/task-dispatch.ts'), 'utf8')
     const scheduler = readFileSync(join(process.cwd(), 'src/app/api/scheduler/route.ts'), 'utf8')
 
-    expect(dispatch.match(/JOIN workspaces w ON w\.id = t\.workspace_id/g)).toHaveLength(2)
-    expect(dispatch.match(/AND w\.isolation = 'shared'/g)).toHaveLength(2)
+    expect(dispatch.match(/JOIN workspaces w ON w\.id = t\.workspace_id/g)).toHaveLength(3)
+    expect(dispatch.match(/AND w\.isolation = 'shared'/g)).toHaveLength(3)
     expect(scheduler.match(/'host_administration'/g)).toHaveLength(2)
   })
 
@@ -280,5 +280,16 @@ describe('direct session API coverage', () => {
     expect(localSync.match(/workspace_id/g)?.length).toBeGreaterThanOrEqual(4)
     expect(scheduler).toContain('resolveSharedRuntimeWorkspaceId(requestedWorkspaceId)')
     expect(scheduler).toContain("if (r.error) return { ok: false, message: r.error }")
+  })
+
+  it('keeps scheduler routing, review, and heartbeat mutations workspace-scoped', () => {
+    const dispatch = readFileSync(join(process.cwd(), 'src/lib/task-dispatch.ts'), 'utf8')
+    const scheduler = readFileSync(join(process.cwd(), 'src/lib/scheduler.ts'), 'utf8')
+
+    expect(dispatch).toContain("WHERE workspace_id = ?\n        AND hidden = 0")
+    expect(dispatch).toContain("WHERE t.status = 'review'\n      AND w.isolation = 'shared'")
+    expect(scheduler).toContain('SELECT id, name, status, last_seen, workspace_id FROM agents')
+    expect(scheduler).toContain("VALUES ('agent_status_change', 'agent', ?, 'heartbeat', ?, ?)")
+    expect(scheduler).toContain("VALUES ('system', 'heartbeat', ?, ?, 'agent', ?, ?)")
   })
 })

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -182,37 +182,38 @@ async function runHeartbeatCheck(): Promise<{ ok: boolean; message: string }> {
 
     // Find agents that are not offline but haven't been seen recently
     const staleAgents = db.prepare(`
-      SELECT id, name, status, last_seen FROM agents
+      SELECT id, name, status, last_seen, workspace_id FROM agents
       WHERE status != 'offline' AND (last_seen IS NULL OR last_seen < ?)
-    `).all(threshold) as Array<{ id: number; name: string; status: string; last_seen: number | null }>
+    `).all(threshold) as Array<{ id: number; name: string; status: string; last_seen: number | null; workspace_id: number }>
 
     if (staleAgents.length === 0) {
       return { ok: true, message: 'All agents healthy' }
     }
 
     // Mark stale agents as offline
-    const markOffline = db.prepare('UPDATE agents SET status = ?, updated_at = ? WHERE id = ?')
+    const markOffline = db.prepare('UPDATE agents SET status = ?, updated_at = ? WHERE id = ? AND workspace_id = ?')
     const logActivity = db.prepare(`
-      INSERT INTO activities (type, entity_type, entity_id, actor, description)
-      VALUES ('agent_status_change', 'agent', ?, 'heartbeat', ?)
+      INSERT INTO activities (type, entity_type, entity_id, actor, description, workspace_id)
+      VALUES ('agent_status_change', 'agent', ?, 'heartbeat', ?, ?)
     `)
 
     const names: string[] = []
     db.transaction(() => {
       for (const agent of staleAgents) {
-        markOffline.run('offline', now, agent.id)
-        logActivity.run(agent.id, `Agent "${agent.name}" marked offline (no heartbeat for ${timeoutMinutes}m)`)
+        markOffline.run('offline', now, agent.id, agent.workspace_id)
+        logActivity.run(agent.id, `Agent "${agent.name}" marked offline (no heartbeat for ${timeoutMinutes}m)`, agent.workspace_id)
         names.push(agent.name)
 
         // Create notification for each stale agent
         try {
           db.prepare(`
-            INSERT INTO notifications (recipient, type, title, message, source_type, source_id)
-            VALUES ('system', 'heartbeat', ?, ?, 'agent', ?)
+            INSERT INTO notifications (recipient, type, title, message, source_type, source_id, workspace_id)
+            VALUES ('system', 'heartbeat', ?, ?, 'agent', ?, ?)
           `).run(
             `Agent offline: ${agent.name}`,
             `Agent "${agent.name}" was marked offline after ${timeoutMinutes} minutes without heartbeat`,
-            agent.id
+            agent.id,
+            agent.workspace_id,
           )
         } catch { /* notification creation failed */ }
       }
@@ -221,7 +222,7 @@ async function runHeartbeatCheck(): Promise<{ ok: boolean; message: string }> {
     logAuditEvent({
       action: 'heartbeat_check',
       actor: 'scheduler',
-      detail: { marked_offline: names },
+      detail: { marked_offline_count: names.length },
     })
 
     return { ok: true, message: `Marked ${staleAgents.length} agent(s) offline: ${names.join(', ')}` }

--- a/src/lib/task-dispatch.ts
+++ b/src/lib/task-dispatch.ts
@@ -1221,9 +1221,11 @@ export async function runAegisReviews(): Promise<{ ok: boolean; message: string 
     SELECT t.id, t.title, t.description, t.status, t.priority, t.resolution, t.assigned_to, t.workspace_id,
            t.project_id, p.ticket_prefix, t.project_ticket_no, a.config as agent_config
     FROM tasks t
+    JOIN workspaces w ON w.id = t.workspace_id
     LEFT JOIN projects p ON p.id = t.project_id AND p.workspace_id = t.workspace_id
     LEFT JOIN agents a ON a.name = t.assigned_to AND a.workspace_id = t.workspace_id
     WHERE t.status = 'review'
+      AND w.isolation = 'shared'
     ORDER BY t.updated_at ASC
     LIMIT 3
   `).all() as ReviewableTask[]
@@ -1236,8 +1238,8 @@ export async function runAegisReviews(): Promise<{ ok: boolean; message: string 
 
   for (const task of tasks) {
     // Move to quality_review to prevent re-processing
-    db.prepare('UPDATE tasks SET status = ?, updated_at = ? WHERE id = ?')
-      .run('quality_review', Math.floor(Date.now() / 1000), task.id)
+    db.prepare('UPDATE tasks SET status = ?, updated_at = ? WHERE id = ? AND workspace_id = ?')
+      .run('quality_review', Math.floor(Date.now() / 1000), task.id, task.workspace_id)
 
     eventBus.broadcast('task.status_changed', {
       id: task.id,
@@ -1295,8 +1297,8 @@ export async function runAegisReviews(): Promise<{ ok: boolean; message: string 
       `).run(task.id, verdict.status, verdict.notes, task.workspace_id)
 
       if (verdict.status === 'approved') {
-        db.prepare('UPDATE tasks SET status = ?, updated_at = ? WHERE id = ?')
-          .run('done', Math.floor(Date.now() / 1000), task.id)
+        db.prepare('UPDATE tasks SET status = ?, updated_at = ? WHERE id = ? AND workspace_id = ?')
+          .run('done', Math.floor(Date.now() / 1000), task.id, task.workspace_id)
 
         eventBus.broadcast('task.status_changed', {
           id: task.id,
@@ -1307,14 +1309,14 @@ export async function runAegisReviews(): Promise<{ ok: boolean; message: string 
       } else {
         // Rejected: check dispatch_attempts to decide next status
         const now = Math.floor(Date.now() / 1000)
-        const currentAttempts = (db.prepare('SELECT dispatch_attempts FROM tasks WHERE id = ?').get(task.id) as { dispatch_attempts: number } | undefined)?.dispatch_attempts ?? 0
+        const currentAttempts = (db.prepare('SELECT dispatch_attempts FROM tasks WHERE id = ? AND workspace_id = ?').get(task.id, task.workspace_id) as { dispatch_attempts: number } | undefined)?.dispatch_attempts ?? 0
         const newAttempts = currentAttempts + 1
         const maxAegisRetries = 3
 
         if (newAttempts >= maxAegisRetries) {
           // Too many rejections — move to failed
-          db.prepare('UPDATE tasks SET status = ?, error_message = ?, dispatch_attempts = ?, updated_at = ? WHERE id = ?')
-            .run('failed', `Aegis rejected ${newAttempts} times. Last: ${verdict.notes}`, newAttempts, now, task.id)
+          db.prepare('UPDATE tasks SET status = ?, error_message = ?, dispatch_attempts = ?, updated_at = ? WHERE id = ? AND workspace_id = ?')
+            .run('failed', `Aegis rejected ${newAttempts} times. Last: ${verdict.notes}`, newAttempts, now, task.id, task.workspace_id)
 
           eventBus.broadcast('task.status_changed', {
             id: task.id,
@@ -1326,8 +1328,8 @@ export async function runAegisReviews(): Promise<{ ok: boolean; message: string 
           syncAndEscalateIfFailed(task, 'failed', `Aegis rejected ${newAttempts} times`, newAttempts)
         } else {
           // Requeue to assigned for re-dispatch with feedback
-          db.prepare('UPDATE tasks SET status = ?, error_message = ?, dispatch_attempts = ?, updated_at = ? WHERE id = ?')
-            .run('assigned', `Aegis rejected: ${verdict.notes}`, newAttempts, now, task.id)
+          db.prepare('UPDATE tasks SET status = ?, error_message = ?, dispatch_attempts = ?, updated_at = ? WHERE id = ? AND workspace_id = ?')
+            .run('assigned', `Aegis rejected: ${verdict.notes}`, newAttempts, now, task.id, task.workspace_id)
 
           eventBus.broadcast('task.status_changed', {
             id: task.id,
@@ -1363,8 +1365,8 @@ export async function runAegisReviews(): Promise<{ ok: boolean; message: string 
       logger.error({ taskId: task.id, err }, 'Aegis review failed')
 
       // Revert to review so it can be retried
-      db.prepare('UPDATE tasks SET status = ?, updated_at = ? WHERE id = ?')
-        .run('review', Math.floor(Date.now() / 1000), task.id)
+      db.prepare('UPDATE tasks SET status = ?, updated_at = ? WHERE id = ? AND workspace_id = ?')
+        .run('review', Math.floor(Date.now() / 1000), task.id, task.workspace_id)
 
       eventBus.broadcast('task.status_changed', {
         id: task.id,
@@ -1901,22 +1903,20 @@ export async function autoRouteInboxTasks(): Promise<{ ok: boolean; message: str
     return { ok: true, message: 'No inbox tasks to route' }
   }
 
-  // Get all non-hidden, non-offline agents
-  const agents = db.prepare(`
-    SELECT id, name, role, status, config
-    FROM agents
-    WHERE hidden = 0 AND status NOT IN ('offline', 'error')
-    LIMIT 50
-  `).all() as Array<{ id: number; name: string; role: string; status: string; config: string | null }>
-
-  if (agents.length === 0) {
-    return { ok: true, message: `${inboxTasks.length} inbox task(s) but no available agents` }
-  }
-
   let routed = 0
   const now = Math.floor(Date.now() / 1000)
 
   for (const task of inboxTasks) {
+    const agents = db.prepare(`
+      SELECT id, name, role, status, config
+      FROM agents
+      WHERE workspace_id = ?
+        AND hidden = 0
+        AND status NOT IN ('offline', 'error')
+      LIMIT 50
+    `).all(task.workspace_id) as Array<{ id: number; name: string; role: string; status: string; config: string | null }>
+    if (agents.length === 0) continue
+
     const taskText = `${task.title} ${task.description || ''}`
     let parsedTags: string[] = []
     if (task.tags) {
@@ -1948,8 +1948,8 @@ export async function autoRouteInboxTasks(): Promise<{ ok: boolean; message: str
         return c < 3
       })
       if (!alt) continue // all agents at capacity
-      db.prepare('UPDATE tasks SET status = ?, assigned_to = ?, updated_at = ? WHERE id = ?')
-        .run('assigned', alt.agent.name, now, task.id)
+      db.prepare('UPDATE tasks SET status = ?, assigned_to = ?, updated_at = ? WHERE id = ? AND workspace_id = ?')
+        .run('assigned', alt.agent.name, now, task.id, task.workspace_id)
 
       db_helpers.logActivity('task_auto_routed', 'task', task.id, 'scheduler',
         `Auto-assigned "${task.title}" to ${alt.agent.name} (${alt.agent.role}, score: ${alt.score})`,
@@ -1962,8 +1962,8 @@ export async function autoRouteInboxTasks(): Promise<{ ok: boolean; message: str
       continue
     }
 
-    db.prepare('UPDATE tasks SET status = ?, assigned_to = ?, updated_at = ? WHERE id = ?')
-      .run('assigned', best.name, now, task.id)
+    db.prepare('UPDATE tasks SET status = ?, assigned_to = ?, updated_at = ? WHERE id = ? AND workspace_id = ?')
+      .run('assigned', best.name, now, task.id, task.workspace_id)
 
     db_helpers.logActivity('task_auto_routed', 'task', task.id, 'scheduler',
       `Auto-assigned "${task.title}" to ${best.name} (${best.role}, score: ${scored[0].score})`,


### PR DESCRIPTION
## Summary
- select auto-routing candidates from the task workspace instead of a deployment-wide agent pool
- exclude strict workspace tasks before automated quality review can invoke global gateway, provider, or CLI state
- scope all automated review transitions and retry reads by workspace
- carry agent workspace ownership through heartbeat status, activity, and notification writes
- minimize heartbeat audit detail to a count rather than agent names

## Verification
- 1,315 tests passed across 125 files
- focused scheduler/isolation suite: 31 tests passed
- lint passed with 0 errors (existing warnings only)
- TypeScript passed
- production build passed
- standalone artifact integrity passed
- API contract parity passed
- strict devgod security scan passed
- npm bulk-advisory audit: no known vulnerabilities
- diff check passed

## Tracking
Advances #800 but does not close it. Remaining work includes other workspace predicates and schema uniqueness constraints, negative integration/E2E coverage, and explicit isolation documentation.