### PR TITLE
docs: correct runtime and API contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@ loops. It gives operators one place to see and govern the work around those loop
 | Governance | Roles, API keys, security events, trust signals, approvals, audits, and evals |
 | Interfaces | Web UI, CLI, MCP server, OpenAPI-described REST API, WebSocket, and SSE |
 
-![Mission Control system blueprint](docs/mission-control-blueprint.png)
-
-The main runtime is self-hosted and single-tenant. SQLite stores local control-plane state.
-A gateway is optional for task, project, agent, scheduler, webhook, alert, and cost work;
-live session messaging needs a connected runtime gateway.
+The runtime is self-hosted and workspace-aware. SQLite stores local control-plane state.
+Shared workspaces can use deployment-level runtime integrations. Strict workspaces block
+those integrations until the underlying resources carry workspace ownership. A gateway is
+optional for task, project, agent, scheduler, webhook, alert, and cost work; live session
+messaging needs a connected runtime gateway.
 
 ## Operator field notes
 
@@ -162,8 +162,8 @@ claude mcp add mission-control -- \
 ```
 
 Use the [CLI and MCP reference](docs/cli-agent-control.md) for the current command and tool
-surface. The REST contract lives in [`openapi.json`](openapi.json) and is rendered at
-`/api-docs` by a running instance.
+surface. The REST contract lives in [`openapi.json`](openapi.json). A running instance serves
+the interactive reference at `/docs` and the OpenAPI JSON at `/api/docs`.
 
 ## Product surfaces
 

--- a/src/lib/__tests__/readme-runtime-contract.test.ts
+++ b/src/lib/__tests__/readme-runtime-contract.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const root = process.cwd()
+const readme = readFileSync(join(root, 'README.md'), 'utf8')
+
+describe('README runtime contract', () => {
+  it('documents the shipped workspace and OpenAPI routes', () => {
+    expect(readme).toContain('workspace-aware')
+    expect(readme).toContain('Strict workspaces block')
+    expect(readme).toContain('interactive reference at `/docs`')
+    expect(readme).toContain('OpenAPI JSON at `/api/docs`')
+    expect(readme).not.toContain('main runtime is self-hosted and single-tenant')
+    expect(readme).not.toContain('`/api-docs`')
+  })
+
+  it('does not embed the inaccurate single-tenant blueprint', () => {
+    expect(readme).not.toContain('docs/mission-control-blueprint')
+  })
+})


### PR DESCRIPTION
## Summary
- replace the inaccurate single-tenant claim with the shipped workspace-aware contract
- explain that strict workspaces block deployment-global integrations until those resources carry workspace ownership
- correct the interactive API reference path from /api-docs to /docs and identify /api/docs as the OpenAPI JSON endpoint
- stop embedding the blueprint that repeated the inaccurate single-tenant claim
- add a regression test for these public runtime and route contracts

A raster-only blueprint correction was attempted but rejected during visual validation because the saved asset did not reproduce the preview correctly. No broken generated asset is included.

## Verification
- 1,317 tests passed across 126 files
- README contract test passed
- unmachined prose scan: 10/100, passing below threshold 40
- lint passed with 0 errors (existing warnings only)
- TypeScript passed
- production build passed
- standalone artifact integrity passed
- API contract parity passed
- strict devgod security scan passed
- npm bulk-advisory audit: no known vulnerabilities
- diff check passed

## Tracking
Documents the current partial isolation behavior accurately while #800 remains open.