### PR TITLE
security: fail closed for unscoped events

### DIFF
--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest , NextResponse } from 'next/server'
-import { eventBus, ServerEvent } from '@/lib/event-bus'
+import { eventBelongsToWorkspace, eventBus, ServerEvent } from '@/lib/event-bus'
 import { requireRole } from '@/lib/auth'
 
 export const dynamic = 'force-dynamic'
@@ -28,8 +28,9 @@ export async function GET(request: NextRequest) {
       // Forward workspace-scoped server events to this SSE client
       const userWorkspaceId = auth.user.workspace_id ?? 1
       const handler = (event: ServerEvent) => {
-        // Skip events from other workspaces (if event carries workspace_id)
-        if (event.data?.workspace_id && event.data.workspace_id !== userWorkspaceId) return
+        // Fail closed: unattributed events are not safe to deliver to a
+        // workspace-scoped client.
+        if (!eventBelongsToWorkspace(event, userWorkspaceId)) return
         try {
           controller.enqueue(
             encoder.encode(`data: ${JSON.stringify(event)}\n\n`)

--- a/src/lib/__tests__/event-workspace-isolation.test.ts
+++ b/src/lib/__tests__/event-workspace-isolation.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { eventBelongsToWorkspace, type ServerEvent } from '@/lib/event-bus'
+
+function event(data: unknown): ServerEvent {
+  return { type: 'task.updated', data, timestamp: Date.now() }
+}
+
+describe('event workspace isolation', () => {
+  it('accepts an event only for its explicit workspace owner', () => {
+    expect(eventBelongsToWorkspace(event({ id: 7, workspace_id: 2 }), 2)).toBe(true)
+    expect(eventBelongsToWorkspace(event({ id: 7, workspace_id: 2 }), 1)).toBe(false)
+  })
+
+  it('rejects events with missing or ambiguous workspace ownership', () => {
+    expect(eventBelongsToWorkspace(event({ id: 7 }), 1)).toBe(false)
+    expect(eventBelongsToWorkspace(event({ id: 7, workspace_id: '1' }), 1)).toBe(false)
+    expect(eventBelongsToWorkspace(event(null), 1)).toBe(false)
+  })
+})

--- a/src/lib/event-bus.ts
+++ b/src/lib/event-bus.ts
@@ -11,6 +11,11 @@ export interface ServerEvent {
   timestamp: number
 }
 
+export function eventBelongsToWorkspace(event: ServerEvent, workspaceId: number): boolean {
+  return typeof event.data?.workspace_id === 'number'
+    && event.data.workspace_id === workspaceId
+}
+
 // Event types emitted by the bus
 export type EventType =
   | 'task.created'

--- a/src/lib/webhooks.ts
+++ b/src/lib/webhooks.ts
@@ -1,7 +1,7 @@
 import { createHmac, timingSafeEqual } from 'crypto'
 import { lookup } from 'node:dns/promises'
 import { isIP } from 'node:net'
-import { eventBus, type ServerEvent } from './event-bus'
+import { eventBelongsToWorkspace, eventBus, type ServerEvent } from './event-bus'
 import { logger } from './logger'
 
 interface Webhook {
@@ -147,7 +147,11 @@ export function initWebhookListener() {
 
     // Also fire agent.error for error status specifically
     const isAgentError = event.type === 'agent.status_changed' && event.data?.status === 'error'
-    const workspaceId = typeof event.data?.workspace_id === 'number' ? event.data.workspace_id : 1
+    const workspaceId = event.data?.workspace_id
+    if (typeof workspaceId !== 'number' || !eventBelongsToWorkspace(event, workspaceId)) {
+      logger.warn({ eventType: event.type }, 'Skipping webhook delivery for event without workspace ownership')
+      return
+    }
 
     fireWebhooksAsync(webhookEventType, event.data, workspaceId).catch((err) => {
       logger.error({ err }, 'Webhook dispatch error')


### PR DESCRIPTION
## Security finding\n\nWorkspace-authenticated SSE clients accepted any server event that omitted workspace_id. The webhook listener also assigned unattributed events to workspace 1. That made missing ownership fail open at two outbound boundaries.\n\n## Fix\n\n- require an explicit numeric workspace_id matching the authenticated SSE workspace\n- skip webhook delivery when event ownership is absent or ambiguous\n- share one pure ownership predicate across both boundaries\n- add negative regression coverage for missing, string-valued, and cross-workspace ownership\n\n## Verification\n\n- 1,319 tests across 127 files passed\n- typecheck passed\n- lint passed with 0 errors (100 pre-existing warnings)\n- production build passed\n- standalone artifact check passed\n- API contract parity passed\n- git diff check passed\n\nThis advances #800 but does not close it. Event producers missing explicit ownership will now fail closed and should be corrected in subsequent audited slices.