### PR TITLE
security: scope audit records by workspace

### DIFF
--- a/src/app/api/agent-runtimes/route.ts
+++ b/src/app/api/agent-runtimes/route.ts
@@ -57,6 +57,7 @@ export async function POST(request: NextRequest) {
       action: 'agent_runtime.install',
       actor: auth.user.username,
       detail: JSON.stringify({ runtime, mode }),
+      workspace_id: auth.user.workspace_id ?? 1,
     })
 
     const job = startInstall(runtime, mode)

--- a/src/app/api/agents/[id]/attribution/route.ts
+++ b/src/app/api/agents/[id]/attribution/route.ts
@@ -152,16 +152,16 @@ function buildAuditTrail(db: any, agentName: string, workspaceId: number, since:
     LIMIT 200
   `).all(agentName, workspaceId, since) as any[];
 
-  // Audit log entries (system-wide, may reference agent)
+  // Audit log entries owned by this workspace that may reference the agent
   let auditEntries: any[] = [];
   try {
     auditEntries = db.prepare(`
       SELECT id, action, actor, detail, created_at
       FROM audit_log
-      WHERE (actor = ? OR detail LIKE ?) AND created_at >= ?
+      WHERE workspace_id = ? AND (actor = ? OR detail LIKE ?) AND created_at >= ?
       ORDER BY created_at DESC
       LIMIT 100
-    `).all(agentName, `%${agentName}%`, since) as any[];
+    `).all(workspaceId, agentName, `%${agentName}%`, since) as any[];
   } catch {
     // audit_log table may not exist
   }

--- a/src/app/api/alerts/route.ts
+++ b/src/app/api/alerts/route.ts
@@ -95,10 +95,11 @@ export async function POST(request: NextRequest) {
 
     // Audit log
     try {
-      db.prepare('INSERT INTO audit_log (action, actor, detail) VALUES (?, ?, ?)').run(
+      db.prepare('INSERT INTO audit_log (action, actor, detail, workspace_id) VALUES (?, ?, ?, ?)').run(
         'alert_rule_created',
         auth.user?.username || 'system',
-        `Created alert rule: ${name}`
+        `Created alert rule: ${name}`,
+        workspaceId
       )
     } catch { /* audit table might not exist */ }
 
@@ -177,10 +178,11 @@ export async function DELETE(request: NextRequest) {
   const result = db.prepare('DELETE FROM alert_rules WHERE id = ? AND workspace_id = ?').run(id, workspaceId)
 
   try {
-    db.prepare('INSERT INTO audit_log (action, actor, detail) VALUES (?, ?, ?)').run(
+    db.prepare('INSERT INTO audit_log (action, actor, detail, workspace_id) VALUES (?, ?, ?, ?)').run(
       'alert_rule_deleted',
       auth.user?.username || 'system',
-      `Deleted alert rule #${id}`
+      `Deleted alert rule #${id}`,
+      workspaceId
     )
   } catch { /* audit table might not exist */ }
 

--- a/src/app/api/audit/route.ts
+++ b/src/app/api/audit/route.ts
@@ -22,8 +22,8 @@ export async function GET(request: NextRequest) {
   const since = searchParams.get('since')
   const until = searchParams.get('until')
 
-  const conditions: string[] = []
-  const params: any[] = []
+  const conditions: string[] = ['workspace_id = ?']
+  const params: any[] = [auth.user.workspace_id ?? 1]
 
   if (action) {
     conditions.push('action = ?')

--- a/src/app/api/cleanup/route.ts
+++ b/src/app/api/cleanup/route.ts
@@ -195,7 +195,7 @@ function getRetentionTargets() {
   const ret = config.retention
   return [
     { table: 'activities', column: 'created_at', days: ret.activities, label: 'Activities', scoped: true },
-    { table: 'audit_log', column: 'created_at', days: ret.auditLog, label: 'Audit Log', scoped: false }, // instance-global, admin-only
+    { table: 'audit_log', column: 'created_at', days: ret.auditLog, label: 'Audit Log', scoped: true },
     { table: 'notifications', column: 'created_at', days: ret.notifications, label: 'Notifications', scoped: true },
     { table: 'pipeline_runs', column: 'created_at', days: ret.pipelineRuns, label: 'Pipeline Runs', scoped: true },
   ]

--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -53,9 +53,11 @@ export async function GET(request: NextRequest) {
 
   switch (type) {
     case 'audit': {
-      // audit_log is instance-global (no workspace_id column); export is admin-only so this is safe
-      rows = db.prepare(`SELECT * FROM audit_log ${where} ORDER BY created_at DESC LIMIT ?`).all(...params, limit)
-      headers = ['id', 'action', 'actor', 'actor_id', 'target_type', 'target_id', 'detail', 'ip_address', 'user_agent', 'created_at']
+      conditions.unshift('workspace_id = ?')
+      params.unshift(workspaceId)
+      const scopedWhere = `WHERE ${conditions.join(' AND ')}`
+      rows = db.prepare(`SELECT * FROM audit_log ${scopedWhere} ORDER BY created_at DESC LIMIT ?`).all(...params, limit)
+      headers = ['id', 'action', 'actor', 'actor_id', 'target_type', 'target_id', 'detail', 'ip_address', 'user_agent', 'workspace_id', 'created_at']
       filename = 'audit-log'
       break
     }
@@ -96,6 +98,7 @@ export async function GET(request: NextRequest) {
     actor_id: auth.user.id,
     detail: { type, format, row_count: rows.length },
     ip_address: ipAddress,
+    workspace_id: workspaceId,
   })
 
   const dateStr = new Date().toISOString().split('T')[0]

--- a/src/app/api/gateways/route.ts
+++ b/src/app/api/gateways/route.ts
@@ -125,8 +125,8 @@ export async function POST(request: NextRequest) {
     }
 
     try {
-      db.prepare('INSERT INTO audit_log (action, actor, detail) VALUES (?, ?, ?)').run(
-        'gateway_added', auth.user?.username || 'system', `Added gateway: ${name} (${host}:${port})${agentsRegistered ? `, registered ${agentsRegistered} agent(s)` : ''}`
+      db.prepare('INSERT INTO audit_log (action, actor, detail, workspace_id) VALUES (?, ?, ?, ?)').run(
+        'gateway_added', auth.user?.username || 'system', `Added gateway: ${name} (${host}:${port})${agentsRegistered ? `, registered ${agentsRegistered} agent(s)` : ''}`, auth.user.workspace_id ?? 1
       )
     } catch { /* audit might not exist */ }
 
@@ -234,8 +234,8 @@ export async function DELETE(request: NextRequest) {
   const result = db.prepare('DELETE FROM gateways WHERE id = ?').run(id)
 
   try {
-    db.prepare('INSERT INTO audit_log (action, actor, detail) VALUES (?, ?, ?)').run(
-      'gateway_removed', auth.user?.username || 'system', `Removed gateway: ${gw?.name}`
+    db.prepare('INSERT INTO audit_log (action, actor, detail, workspace_id) VALUES (?, ?, ?, ?)').run(
+      'gateway_removed', auth.user?.username || 'system', `Removed gateway: ${gw?.name}`, auth.user.workspace_id ?? 1
     )
   } catch { /* audit might not exist */ }
 

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -103,14 +103,15 @@ export async function GET(request: NextRequest) {
     } catch { /* table might not exist */ }
   }
 
-  // Search audit log (admin-only — audit_log is instance-global)
+  // Search audit log (admin-only and workspace-scoped)
   if ((!typeFilter || typeFilter === 'audit') && auth.user.role === 'admin') {
     try {
       const audits = db.prepare(`
         SELECT id, action, actor, detail, created_at
-        FROM audit_log WHERE action LIKE ? OR actor LIKE ? OR detail LIKE ?
+        FROM audit_log
+        WHERE workspace_id = ? AND (action LIKE ? OR actor LIKE ? OR detail LIKE ?)
         ORDER BY created_at DESC LIMIT ?
-      `).all(likeQ, likeQ, likeQ, limit) as any[]
+      `).all(workspaceId, likeQ, likeQ, likeQ, limit) as any[]
       for (const a of audits) {
         results.push({
           type: 'audit',

--- a/src/app/api/security-scan/fix/route.ts
+++ b/src/app/api/security-scan/fix/route.ts
@@ -366,8 +366,8 @@ export async function POST(request: NextRequest) {
   try {
     const db = getDatabase()
     db.prepare(
-      'INSERT INTO audit_log (action, actor, detail) VALUES (?, ?, ?)'
-    ).run('security.auto_fix', auth.user.username, JSON.stringify({ fixes: results.filter(r => r.fixed).map(r => r.id) }))
+      'INSERT INTO audit_log (action, actor, detail, workspace_id) VALUES (?, ?, ?, ?)'
+    ).run('security.auto_fix', auth.user.username, JSON.stringify({ fixes: results.filter(r => r.fixed).map(r => r.id) }), auth.user.workspace_id ?? 1)
   } catch { /* non-critical */ }
 
   const fixed = results.filter(r => r.fixed).length

--- a/src/app/api/status/route.ts
+++ b/src/app/api/status/route.ts
@@ -168,13 +168,13 @@ function getDbStats(workspaceId: number) {
     }
 
     // Audit events (24h / 7d)
-    const auditDay = (db.prepare('SELECT COUNT(*) as c FROM audit_log WHERE created_at > ?').get(day) as any).c
-    const auditWeek = (db.prepare('SELECT COUNT(*) as c FROM audit_log WHERE created_at > ?').get(week) as any).c
+    const auditDay = (db.prepare('SELECT COUNT(*) as c FROM audit_log WHERE created_at > ? AND workspace_id = ?').get(day, workspaceId) as any).c
+    const auditWeek = (db.prepare('SELECT COUNT(*) as c FROM audit_log WHERE created_at > ? AND workspace_id = ?').get(week, workspaceId) as any).c
 
     // Security events (login failures in last 24h)
     const loginFailures = (db.prepare(
-      "SELECT COUNT(*) as c FROM audit_log WHERE action = 'login_failed' AND created_at > ?"
-    ).get(day) as any).c
+      "SELECT COUNT(*) as c FROM audit_log WHERE action = 'login_failed' AND created_at > ? AND workspace_id = ?"
+    ).get(day, workspaceId) as any).c
 
     // Activities (24h)
     const activityDay = (

--- a/src/lib/__tests__/audit-workspace-isolation.test.ts
+++ b/src/lib/__tests__/audit-workspace-isolation.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import Database from 'better-sqlite3'
+import { NextRequest } from 'next/server'
+import { runMigrations } from '@/lib/migrations'
+
+let db: InstanceType<typeof Database>
+const requireRole = vi.fn()
+const logAuditEvent = vi.fn()
+
+vi.mock('@/lib/db', () => ({
+  getDatabase: () => db,
+  logAuditEvent,
+}))
+
+vi.mock('@/lib/auth', () => ({ requireRole }))
+vi.mock('@/lib/rate-limit', () => ({ heavyLimiter: vi.fn(() => null) }))
+
+beforeEach(() => {
+  db = new Database(':memory:')
+  runMigrations(db)
+  requireRole.mockReturnValue({
+    user: { id: 2, username: 'workspace-two-admin', role: 'admin', workspace_id: 2, tenant_id: 1 },
+  })
+  db.prepare("INSERT INTO workspaces (id, slug, name, tenant_id) VALUES (2, 'two', 'Two', 1)").run()
+  db.prepare("INSERT INTO audit_log (action, actor, workspace_id) VALUES ('workspace.one', 'one', 1)").run()
+  db.prepare("INSERT INTO audit_log (action, actor, workspace_id) VALUES ('workspace.two', 'two', 2)").run()
+})
+
+afterEach(() => {
+  db.close()
+  vi.clearAllMocks()
+})
+
+describe('migration 053_audit_log_workspace', () => {
+  it('adds indexed workspace ownership and assigns legacy rows to the default workspace', () => {
+    db.exec(`
+      CREATE TABLE legacy_audit_log AS
+      SELECT id, action, actor, actor_id, target_type, target_id, detail, ip_address, user_agent, created_at
+      FROM audit_log
+    `)
+    db.exec('DROP TABLE audit_log')
+    db.exec('ALTER TABLE legacy_audit_log RENAME TO audit_log')
+    db.prepare("INSERT INTO audit_log (action, actor, created_at) VALUES ('legacy', 'legacy', unixepoch())").run()
+    db.prepare("DELETE FROM schema_migrations WHERE id = '053_audit_log_workspace'").run()
+    runMigrations(db)
+
+    const columns = db.prepare('PRAGMA table_info(audit_log)').all() as Array<{ name: string; notnull: number; dflt_value: string | null }>
+    const workspaceColumn = columns.find((column) => column.name === 'workspace_id')
+    expect(workspaceColumn).toMatchObject({ notnull: 1, dflt_value: '1' })
+
+    const indexes = db.prepare("PRAGMA index_list('audit_log')").all() as Array<{ name: string }>
+    expect(indexes.map((index) => index.name)).toContain('idx_audit_log_workspace_created')
+    expect(db.prepare("SELECT id FROM schema_migrations WHERE id = '053_audit_log_workspace'").get()).toBeDefined()
+    expect(db.prepare("SELECT workspace_id FROM audit_log WHERE action = 'legacy'").get()).toEqual({ workspace_id: 1 })
+  })
+})
+
+describe('audit API workspace isolation', () => {
+  it('lists only records owned by the authenticated workspace', async () => {
+    const { GET } = await import('@/app/api/audit/route')
+    const response = await GET(new NextRequest('http://localhost/api/audit'))
+    expect(response.status).toBe(200)
+    const body = await response.json()
+
+    expect(body.total).toBe(1)
+    expect(body.events.map((event: { action: string }) => event.action)).toEqual(['workspace.two'])
+  })
+
+  it('exports only records owned by the authenticated workspace', async () => {
+    const { GET } = await import('@/app/api/export/route')
+    const response = await GET(new NextRequest('http://localhost/api/export?type=audit&format=json'))
+    expect(response.status).toBe(200)
+    const body = await response.json()
+
+    expect(body.count).toBe(1)
+    expect(body.data.map((event: { action: string }) => event.action)).toEqual(['workspace.two'])
+    expect(logAuditEvent).toHaveBeenCalledWith(expect.objectContaining({ workspace_id: 2 }))
+  })
+
+  it('searches audit records only inside the authenticated workspace', async () => {
+    const { GET } = await import('@/app/api/search/route')
+    const response = await GET(new NextRequest('http://localhost/api/search?q=workspace&type=audit'))
+    expect(response.status).toBe(200)
+    const body = await response.json()
+
+    expect(body.results.map((result: { title: string }) => result.title)).toEqual(['workspace.two'])
+  })
+})

--- a/src/lib/__tests__/db-helpers.test.ts
+++ b/src/lib/__tests__/db-helpers.test.ts
@@ -48,7 +48,39 @@ vi.mock('@/lib/event-bus', () => ({
 }))
 
 // Import after mocks — the real db_helpers will use our mocked getDatabase
-import { db_helpers } from '@/lib/db'
+import { db_helpers, logAuditEvent } from '@/lib/db'
+
+describe('logAuditEvent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('persists explicit workspace ownership and includes it in security broadcasts', () => {
+    logAuditEvent({
+      action: 'password_change',
+      actor: 'admin',
+      workspace_id: 7,
+    })
+
+    expect(mockRun).toHaveBeenCalledWith(
+      'password_change', 'admin', null, null, null, null, null, null, 7,
+    )
+    expect(mockBroadcast).toHaveBeenCalledWith(
+      'audit.security',
+      expect.objectContaining({ action: 'password_change', workspace_id: 7 }),
+    )
+  })
+
+  it('derives workspace ownership from an authenticated actor', () => {
+    mockGet.mockReturnValueOnce({ workspace_id: 9 })
+
+    logAuditEvent({ action: 'profile_update', actor: 'operator', actor_id: 42 })
+
+    expect(mockRun).toHaveBeenCalledWith(
+      'profile_update', 'operator', 42, null, null, null, null, null, 9,
+    )
+  })
+})
 
 describe('parseMentions', () => {
   it('extracts multiple mentions', () => {

--- a/src/lib/agent-sync.ts
+++ b/src/lib/agent-sync.ts
@@ -303,10 +303,11 @@ export async function syncAgentsFromConfig(actor: string = 'system', requestedWo
       action: 'agent_config_sync',
       actor,
       detail: { synced, created, updated, agents: results.filter(a => a.action !== 'unchanged').map(a => a.name) },
+      workspace_id: workspaceId,
     })
 
     // Broadcast sync event
-    eventBus.broadcast('agent.created', { type: 'sync', synced, created, updated })
+    eventBus.broadcast('agent.created', { type: 'sync', synced, created, updated, workspace_id: workspaceId })
   }
 
   logger.info({ synced, created, updated }, 'Agent sync complete')

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -544,11 +544,16 @@ export function logAuditEvent(event: {
   detail?: any
   ip_address?: string
   user_agent?: string
+  workspace_id?: number
 }) {
   const db = getDatabase()
+  const actorWorkspace = event.actor_id
+    ? db.prepare('SELECT workspace_id FROM users WHERE id = ?').get(event.actor_id) as { workspace_id?: number } | undefined
+    : undefined
+  const workspaceId = event.workspace_id ?? actorWorkspace?.workspace_id ?? 1
   db.prepare(`
-    INSERT INTO audit_log (action, actor, actor_id, target_type, target_id, detail, ip_address, user_agent)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO audit_log (action, actor, actor_id, target_type, target_id, detail, ip_address, user_agent, workspace_id)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     event.action,
     event.actor,
@@ -558,6 +563,7 @@ export function logAuditEvent(event: {
     event.detail ? JSON.stringify(event.detail) : null,
     event.ip_address ?? null,
     event.user_agent ?? null,
+    workspaceId,
   )
 
   // Broadcast audit events (webhooks listen here too)
@@ -568,6 +574,7 @@ export function logAuditEvent(event: {
       actor: event.actor,
       target_type: event.target_type ?? null,
       target_id: event.target_id ?? null,
+      workspace_id: workspaceId,
       timestamp: Math.floor(Date.now() / 1000),
     })
   }

--- a/src/lib/local-agent-sync.ts
+++ b/src/lib/local-agent-sync.ts
@@ -296,6 +296,7 @@ export async function syncLocalAgents(requestedWorkspaceId?: number): Promise<{ 
         action: 'local_agent_sync',
         actor: 'scheduler',
         detail: { created, updated, removed, total: diskAgents.length },
+        workspace_id: workspaceId,
       })
     }
     return { ok: true, message: msg }

--- a/src/lib/migrations.ts
+++ b/src/lib/migrations.ts
@@ -1470,6 +1470,18 @@ const migrations: Migration[] = [
         db.exec(`ALTER TABLE workspaces ADD COLUMN isolation TEXT NOT NULL DEFAULT 'shared'`)
       }
     }
+  },
+  {
+    id: '053_audit_log_workspace',
+    up(db: Database.Database) {
+      const cols = db.prepare(`PRAGMA table_info(audit_log)`).all() as Array<{ name: string }>
+      if (!cols.some((column) => column.name === 'workspace_id')) {
+        // Legacy rows predate workspace attribution. Keep them visible only in
+        // the default workspace rather than guessing ownership.
+        db.exec(`ALTER TABLE audit_log ADD COLUMN workspace_id INTEGER NOT NULL DEFAULT 1`)
+      }
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_audit_log_workspace_created ON audit_log(workspace_id, created_at DESC)`)
+    }
   }
 ]
 

--- a/src/lib/workspaces.ts
+++ b/src/lib/workspaces.ts
@@ -48,9 +48,13 @@ function logTenantAccessDenied(
   tenantId: number,
   context: AccessAuditContext
 ) {
+  const actorWorkspace = context.actorId
+    ? db.prepare('SELECT workspace_id FROM users WHERE id = ?').get(context.actorId) as { workspace_id?: number } | undefined
+    : undefined
+  const workspaceId = actorWorkspace?.workspace_id ?? 1
   db.prepare(`
-    INSERT INTO audit_log (action, actor, actor_id, target_type, target_id, detail, ip_address, user_agent)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO audit_log (action, actor, actor_id, target_type, target_id, detail, ip_address, user_agent, workspace_id)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     'tenant_access_denied',
     context.actor || 'unknown',
@@ -62,7 +66,8 @@ function logTenantAccessDenied(
       route: context.route || null,
     }),
     context.ipAddress ?? null,
-    context.userAgent ?? null
+    context.userAgent ?? null,
+    workspaceId
   )
 }
 


### PR DESCRIPTION
## Security finding\n\nAudit records had no workspace ownership. Workspace-bound admins could list, search, export, count, clean up, and include audit records from every workspace. Several direct writers also created unattributed records.\n\n## Fix\n\n- add migration 053 with a non-null workspace_id and a workspace/time index\n- conservatively assign pre-migration records to the default workspace instead of guessing ownership\n- scope audit listing, search, export, dashboard counters, agent attribution, and interactive cleanup\n- persist ownership in the central audit writer and derive it from authenticated actors when not explicit\n- scope direct alert, gateway, and security-fix audit writes\n- include workspace ownership in security audit broadcasts and agent sync events\n- add migration and negative API isolation tests\n\n## Verification\n\n- 1,324 tests across 128 files passed locally; an additional focused writer test passed after the full run\n- typecheck passed\n- lint passed with 0 errors and 100 existing warnings\n- production build passed\n- standalone artifact boundary passed\n- API contract parity passed\n- strict security scan passed\n- modern dependency audit reports no known vulnerabilities\n- private-system firewall and diff checks passed\n\nThis advances #800 but does not close it. Remaining schema uniqueness, producer ownership, and negative integration invariants still require audit.