### PR TITLE
security: scope agent identity uniqueness

### DIFF
--- a/src/app/api/gateways/route.ts
+++ b/src/app/api/gateways/route.ts
@@ -109,7 +109,7 @@ export async function POST(request: NextRequest) {
       const upsertAgent = db.prepare(`
         INSERT INTO agents (name, role, status, last_seen, source, workspace_id, updated_at)
         VALUES (?, ?, 'idle', ?, 'gateway', ?, ?)
-        ON CONFLICT(name) DO UPDATE SET
+        ON CONFLICT(name, workspace_id) DO UPDATE SET
           status = 'idle',
           last_seen = excluded.last_seen,
           source = 'gateway',

--- a/src/lib/__tests__/agent-identity-uniqueness.test.ts
+++ b/src/lib/__tests__/agent-identity-uniqueness.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import Database from 'better-sqlite3'
+import { runMigrations } from '@/lib/migrations'
+
+let db: InstanceType<typeof Database>
+
+beforeEach(() => {
+  db = new Database(':memory:')
+  db.pragma('foreign_keys = ON')
+  runMigrations(db)
+  db.prepare("INSERT INTO workspaces (id, slug, name, tenant_id) VALUES (2, 'two', 'Two', 1)").run()
+})
+
+afterEach(() => db.close())
+
+describe('migration 054_agent_name_workspace_unique', () => {
+  it('allows the same agent name in separate workspaces', () => {
+    db.prepare("INSERT INTO agents (name, role, workspace_id) VALUES ('builder', 'agent', 1)").run()
+    expect(() => {
+      db.prepare("INSERT INTO agents (name, role, workspace_id) VALUES ('builder', 'agent', 2)").run()
+    }).not.toThrow()
+  })
+
+  it('still rejects duplicate names inside one workspace', () => {
+    db.prepare("INSERT INTO agents (name, role, workspace_id) VALUES ('builder', 'agent', 2)").run()
+    expect(() => {
+      db.prepare("INSERT INTO agents (name, role, workspace_id) VALUES ('builder', 'agent', 2)").run()
+    }).toThrow(/UNIQUE constraint failed: agents.name, agents.workspace_id/)
+  })
+
+  it('keeps external session keys globally unique', () => {
+    db.prepare("INSERT INTO agents (name, role, session_key, workspace_id) VALUES ('one', 'agent', 'shared-session', 1)").run()
+    expect(() => {
+      db.prepare("INSERT INTO agents (name, role, session_key, workspace_id) VALUES ('two', 'agent', 'shared-session', 2)").run()
+    }).toThrow(/UNIQUE constraint failed: agents.session_key/)
+  })
+
+  it('preserves agent ids and foreign-key children across a migration replay', () => {
+    const agent = db.prepare("INSERT INTO agents (name, role, workspace_id) VALUES ('key-owner', 'agent', 1)").run()
+    db.prepare("INSERT INTO direct_connections (agent_id, tool_name, connection_id) VALUES (?, 'tool', 'connection')").run(agent.lastInsertRowid)
+    db.prepare("DELETE FROM schema_migrations WHERE id = '054_agent_name_workspace_unique'").run()
+    runMigrations(db)
+
+    expect(db.pragma('foreign_key_check')).toEqual([])
+    expect(db.prepare('SELECT agent_id FROM direct_connections WHERE connection_id = ?').get('connection')).toEqual({ agent_id: agent.lastInsertRowid })
+
+    const foreignKeys = db.pragma("foreign_key_list('direct_connections')") as Array<{ table: string }>
+    expect(foreignKeys.map((foreignKey) => foreignKey.table)).toContain('agents')
+    expect(db.pragma('foreign_keys', { simple: true })).toBe(1)
+    expect(db.prepare("SELECT id FROM schema_migrations WHERE id = '054_agent_name_workspace_unique'").get()).toBeDefined()
+  })
+})

--- a/src/lib/migrations.ts
+++ b/src/lib/migrations.ts
@@ -6,6 +6,7 @@ import type Database from 'better-sqlite3'
 export type Migration = {
   id: string
   up: (db: Database.Database) => void
+  foreignKeysOff?: boolean
 }
 
 // Plugin hook: extensions can register additional migrations without modifying this file.
@@ -1482,6 +1483,58 @@ const migrations: Migration[] = [
       }
       db.exec(`CREATE INDEX IF NOT EXISTS idx_audit_log_workspace_created ON audit_log(workspace_id, created_at DESC)`)
     }
+  },
+  {
+    id: '054_agent_name_workspace_unique',
+    foreignKeysOff: true,
+    up(db: Database.Database) {
+      // The original schema made agent names globally unique even after agents
+      // gained workspace ownership. Rebuild the table so names are unique only
+      // within a workspace. Session keys remain globally unique because they
+      // address an external runtime session, not an application-local identity.
+      db.exec(`
+        CREATE TABLE agents_workspace_unique (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          name TEXT NOT NULL,
+          role TEXT NOT NULL,
+          session_key TEXT UNIQUE,
+          soul_content TEXT,
+          status TEXT NOT NULL DEFAULT 'offline',
+          last_seen INTEGER,
+          last_activity TEXT,
+          created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+          updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+          config TEXT,
+          workspace_id INTEGER NOT NULL DEFAULT 1,
+          source TEXT DEFAULT 'manual',
+          content_hash TEXT,
+          workspace_path TEXT,
+          hidden INTEGER NOT NULL DEFAULT 0,
+          working_memory TEXT DEFAULT '',
+          runtime_type TEXT DEFAULT NULL,
+          UNIQUE(name, workspace_id)
+        );
+
+        INSERT INTO agents_workspace_unique (
+          id, name, role, session_key, soul_content, status, last_seen,
+          last_activity, created_at, updated_at, config, workspace_id, source,
+          content_hash, workspace_path, hidden, working_memory, runtime_type
+        )
+        SELECT
+          id, name, role, session_key, soul_content, status, last_seen,
+          last_activity, created_at, updated_at, config, workspace_id, source,
+          content_hash, workspace_path, hidden, working_memory, runtime_type
+        FROM agents;
+
+        DROP TABLE agents;
+        ALTER TABLE agents_workspace_unique RENAME TO agents;
+
+        CREATE INDEX idx_agents_session_key ON agents(session_key);
+        CREATE INDEX idx_agents_status ON agents(status);
+        CREATE INDEX idx_agents_workspace_id ON agents(workspace_id);
+        CREATE INDEX idx_agents_source ON agents(source);
+      `)
+    }
   }
 ]
 
@@ -1499,9 +1552,22 @@ export function runMigrations(db: Database.Database) {
 
   for (const migration of [...migrations, ...extraMigrations]) {
     if (applied.has(migration.id)) continue
-    db.transaction(() => {
-      migration.up(db)
-      db.prepare('INSERT OR IGNORE INTO schema_migrations (id) VALUES (?)').run(migration.id)
-    })()
+    const restoreForeignKeys = migration.foreignKeysOff
+      && db.pragma('foreign_keys', { simple: true }) === 1
+    if (restoreForeignKeys) db.pragma('foreign_keys = OFF')
+    try {
+      db.transaction(() => {
+        migration.up(db)
+        if (migration.foreignKeysOff) {
+          const violations = db.pragma('foreign_key_check') as unknown[]
+          if (violations.length > 0) {
+            throw new Error(`Migration ${migration.id} left ${violations.length} foreign-key violation(s)`)
+          }
+        }
+        db.prepare('INSERT OR IGNORE INTO schema_migrations (id) VALUES (?)').run(migration.id)
+      })()
+    } finally {
+      if (restoreForeignKeys) db.pragma('foreign_keys = ON')
+    }
   }
 }


### PR DESCRIPTION
## Confirmed schema mismatch\n\nAgent APIs already scope identity by name plus workspace_id, but the original agents table retained global UNIQUE(name). A same-name agent in another workspace therefore failed at the database boundary. Gateway POST also retained a stale ON CONFLICT(name) target.\n\n## Fix\n\n- migration 054 rebuilds agents with UNIQUE(name, workspace_id)\n- globally unique session_key is deliberately retained because it addresses an external runtime session\n- migration runner can temporarily disable foreign-key enforcement for declared table rebuilds, validates foreign_key_check inside the transaction, rolls back on violations, and restores the caller's prior enforcement state\n- gateway agent registration now upserts on name plus workspace_id\n- regression coverage proves cross-workspace same names, same-workspace rejection, global session-key protection, preserved ids/children, and restored foreign-key enforcement\n\n## Verification\n\n- full unit suite passed locally\n- typecheck passed\n- lint passed with 0 errors and 100 existing warnings\n- production build passed\n- standalone artifact boundary passed\n- API contract parity passed\n- strict security scan passed\n- modern dependency audit reports no known vulnerabilities\n- private-system firewall and diff checks passed\n\nThis advances #800 but does not close it. Remaining event-producer ownership and negative integration invariants still require audit.