### PR TITLE
security: attribute live events by workspace

### DIFF
--- a/src/app/api/adapters/route.ts
+++ b/src/app/api/adapters/route.ts
@@ -43,6 +43,7 @@ export async function POST(request: NextRequest) {
   const framework = typeof body?.framework === 'string' ? body.framework.trim() : ''
   const action = typeof body?.action === 'string' ? body.action.trim() : ''
   const payload = body?.payload ?? {}
+  const workspaceId = auth.user.workspace_id ?? 1
 
   if (!framework || !action) {
     return NextResponse.json({ error: 'framework and action are required' }, { status: 400 })
@@ -64,7 +65,7 @@ export async function POST(request: NextRequest) {
         if (!agentId || !name) {
           return NextResponse.json({ error: 'payload.agentId and payload.name required' }, { status: 400 })
         }
-        await adapter.register({ agentId, name, framework, metadata })
+        await adapter.register({ agentId, name, framework, metadata, workspaceId })
         return NextResponse.json({ ok: true, action: 'register', framework })
       }
 
@@ -73,7 +74,7 @@ export async function POST(request: NextRequest) {
         if (!agentId) {
           return NextResponse.json({ error: 'payload.agentId required' }, { status: 400 })
         }
-        await adapter.heartbeat({ agentId, status: status || 'online', metrics })
+        await adapter.heartbeat({ agentId, status: status || 'online', metrics, workspaceId })
         return NextResponse.json({ ok: true, action: 'heartbeat', framework })
       }
 
@@ -82,7 +83,7 @@ export async function POST(request: NextRequest) {
         if (!taskId || !agentId) {
           return NextResponse.json({ error: 'payload.taskId and payload.agentId required' }, { status: 400 })
         }
-        await adapter.reportTask({ taskId, agentId, progress: progress ?? 0, status: taskStatus || 'in_progress', output })
+        await adapter.reportTask({ taskId, agentId, progress: progress ?? 0, status: taskStatus || 'in_progress', output, workspaceId })
         return NextResponse.json({ ok: true, action: 'report', framework })
       }
 
@@ -91,7 +92,7 @@ export async function POST(request: NextRequest) {
         if (!agentId) {
           return NextResponse.json({ error: 'payload.agentId required' }, { status: 400 })
         }
-        const assignments = await adapter.getAssignments(agentId)
+        const assignments = await adapter.getAssignments(agentId, workspaceId)
         return NextResponse.json({ assignments, framework })
       }
 
@@ -100,7 +101,7 @@ export async function POST(request: NextRequest) {
         if (!agentId) {
           return NextResponse.json({ error: 'payload.agentId required' }, { status: 400 })
         }
-        await adapter.disconnect(agentId)
+        await adapter.disconnect(agentId, workspaceId)
         return NextResponse.json({ ok: true, action: 'disconnect', framework })
       }
 

--- a/src/app/api/agents/[id]/route.ts
+++ b/src/app/api/agents/[id]/route.ts
@@ -191,6 +191,7 @@ export async function PUT(
 
     // Broadcast update
     eventBus.broadcast('agent.updated', {
+      workspace_id: workspaceId,
       id: agent.id,
       name: agent.name,
       config: newConfig,
@@ -286,7 +287,7 @@ export async function DELETE(
       workspaceId
     )
 
-    eventBus.broadcast('agent.deleted', { id: agent.id, name: agent.name })
+    eventBus.broadcast('agent.deleted', { id: agent.id, name: agent.name, workspace_id: workspaceId })
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/agents/register/route.ts
+++ b/src/app/api/agents/register/route.ts
@@ -111,7 +111,7 @@ export async function POST(request: NextRequest) {
       ip_address: request.headers.get('x-forwarded-for') || request.headers.get('x-real-ip') || 'unknown',
     })
 
-    eventBus.broadcast('agent.created', { id: agentId, name, role, status: 'idle' })
+    eventBus.broadcast('agent.created', { id: agentId, name, role, status: 'idle', workspace_id: workspaceId })
 
     return NextResponse.json({
       agent: {

--- a/src/app/api/agents/route.ts
+++ b/src/app/api/agents/route.ts
@@ -327,7 +327,7 @@ export async function POST(request: NextRequest) {
     };
 
     // Broadcast to SSE clients
-    eventBus.broadcast('agent.created', parsedAgent);
+    eventBus.broadcast('agent.created', { ...parsedAgent, workspace_id: workspaceId });
 
     // Write to gateway config if requested
     if (write_to_gateway && finalConfig) {
@@ -470,6 +470,7 @@ export async function PUT(request: NextRequest) {
 
       // Broadcast update to SSE clients
       eventBus.broadcast('agent.updated', {
+        workspace_id: workspaceId,
         id: agent.id,
         name,
         ...(status !== undefined && { status }),

--- a/src/app/api/chat/messages/route.ts
+++ b/src/app/api/chat/messages/route.ts
@@ -107,6 +107,7 @@ function createChatReply(
     .get(replyInsert.lastInsertRowid, workspaceId) as Message
 
   eventBus.broadcast('chat.message', {
+    workspace_id: workspaceId,
     ...row,
     metadata: safeParseMetadata(row.metadata),
   })
@@ -742,7 +743,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Broadcast to SSE clients
-    eventBus.broadcast('chat.message', parsedMessage)
+    eventBus.broadcast('chat.message', { ...parsedMessage, workspace_id: workspaceId })
 
     return NextResponse.json({ message: parsedMessage, forward: forwardInfo }, { status: 201 })
   } catch (error) {

--- a/src/app/api/connect/route.ts
+++ b/src/app/api/connect/route.ts
@@ -33,12 +33,12 @@ export async function POST(request: NextRequest) {
     agent = { id: result.lastInsertRowid, name: agent_name }
     db_helpers.logActivity('agent_created', 'agent', agent.id as number, 'system',
       `Auto-created agent "${agent_name}" via direct CLI connection`, undefined, workspaceId)
-    eventBus.broadcast('agent.created', { id: agent.id, name: agent_name })
+    eventBus.broadcast('agent.created', { id: agent.id, name: agent_name, workspace_id: workspaceId })
   } else {
     // Set agent online
     db.prepare('UPDATE agents SET status = ?, updated_at = ? WHERE id = ? AND workspace_id = ?')
       .run('online', now, agent.id, workspaceId)
-    eventBus.broadcast('agent.status_changed', { id: agent.id, name: agent.name, status: 'online' })
+    eventBus.broadcast('agent.status_changed', { id: agent.id, name: agent.name, status: 'online', workspace_id: workspaceId })
   }
 
   // Deactivate previous connections for this agent
@@ -57,6 +57,7 @@ export async function POST(request: NextRequest) {
     `CLI connection established via ${tool_name}${tool_version ? ` v${tool_version}` : ''}`, undefined, workspaceId)
 
   eventBus.broadcast('connection.created', {
+    workspace_id: workspaceId,
     connection_id: connectionId,
     agent_id: agent.id,
     agent_name,
@@ -144,6 +145,7 @@ export async function DELETE(request: NextRequest) {
     `CLI connection disconnected (${conn.tool_name})`, undefined, workspaceId)
 
   eventBus.broadcast('connection.disconnected', {
+    workspace_id: workspaceId,
     connection_id,
     agent_id: conn.agent_id,
     agent_name: agent?.name,

--- a/src/app/api/github/route.ts
+++ b/src/app/api/github/route.ts
@@ -195,7 +195,7 @@ async function handleSync(
         metadata: JSON.parse(createdTask.metadata || '{}'),
       }
 
-      eventBus.broadcast('task.created', parsedTask)
+      eventBus.broadcast('task.created', { ...parsedTask, workspace_id: workspaceId })
       createdTasks.push(parsedTask)
       imported++
     } catch (err: any) {
@@ -234,6 +234,7 @@ async function handleSync(
   }
 
   eventBus.broadcast('github.synced', {
+    workspace_id: workspaceId,
     repo,
     imported,
     skipped,

--- a/src/app/api/hermes/events/route.ts
+++ b/src/app/api/hermes/events/route.ts
@@ -38,6 +38,7 @@ export async function POST(request: NextRequest) {
 
     // Broadcast to SSE clients
     eventBus.broadcast('session.updated', {
+      workspace_id: workspaceId,
       source: 'hermes',
       event,
       session_id,

--- a/src/app/api/pipelines/run/route.ts
+++ b/src/app/api/pipelines/run/route.ts
@@ -206,6 +206,7 @@ async function startPipeline(db: ReturnType<typeof getDatabase>, pipelineId: num
   db_helpers.logActivity('pipeline_started', 'pipeline', pipelineId, triggeredBy, `Started pipeline: ${pipeline.name}`, { run_id: runId }, workspaceId)
 
   eventBus.broadcast('activity.created', {
+    workspace_id: workspaceId,
     type: 'pipeline_started',
     entity_type: 'pipeline',
     entity_id: pipelineId,
@@ -260,6 +261,7 @@ async function advanceRun(db: ReturnType<typeof getDatabase>, runId: number, suc
       .run(finalStatus, currentIdx, JSON.stringify(steps), now, runId, workspaceId)
 
     eventBus.broadcast('activity.created', {
+      workspace_id: workspaceId,
       type: 'pipeline_completed',
       entity_type: 'pipeline',
       entity_id: run.pipeline_id,

--- a/src/app/api/quality-review/route.ts
+++ b/src/app/api/quality-review/route.ts
@@ -109,6 +109,7 @@ export async function POST(request: NextRequest) {
       db.prepare('UPDATE tasks SET status = ?, updated_at = unixepoch() WHERE id = ? AND workspace_id = ?')
         .run('done', taskId, workspaceId)
       eventBus.broadcast('task.status_changed', {
+        workspace_id: workspaceId,
         id: taskId,
         status: 'done',
         previous_status: 'review',
@@ -119,6 +120,7 @@ export async function POST(request: NextRequest) {
       db.prepare('UPDATE tasks SET status = ?, error_message = ?, updated_at = unixepoch() WHERE id = ? AND workspace_id = ?')
         .run('in_progress', `Quality review rejected by ${reviewer}: ${notes}`, taskId, workspaceId)
       eventBus.broadcast('task.status_changed', {
+        workspace_id: workspaceId,
         id: taskId,
         status: 'in_progress',
         previous_status: 'review',

--- a/src/app/api/tasks/[id]/branch/route.ts
+++ b/src/app/api/tasks/[id]/branch/route.ts
@@ -170,6 +170,7 @@ export async function POST(
       )
 
       eventBus.broadcast('task.updated', {
+        workspace_id: workspaceId,
         id: taskId,
         github_pr_number: pr.number,
         github_pr_state: 'open',
@@ -225,6 +226,7 @@ export async function POST(
     )
 
     eventBus.broadcast('task.updated', {
+      workspace_id: workspaceId,
       id: taskId,
       github_branch: branchName,
     })

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -415,7 +415,7 @@ export async function PUT(
     }
 
     // Broadcast to SSE clients
-    eventBus.broadcast('task.updated', parsedTask);
+    eventBus.broadcast('task.updated', { ...parsedTask, workspace_id: workspaceId });
 
     return NextResponse.json({ task: parsedTask });
   } catch (error) {
@@ -487,7 +487,7 @@ export async function DELETE(
     }
 
     // Broadcast to SSE clients
-    eventBus.broadcast('task.deleted', { id: taskId, title: task.title });
+    eventBus.broadcast('task.deleted', { id: taskId, title: task.title, workspace_id: workspaceId });
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -353,7 +353,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Broadcast to SSE clients
-    eventBus.broadcast('task.created', parsedTask);
+    eventBus.broadcast('task.created', { ...parsedTask, workspace_id: workspaceId });
 
     return NextResponse.json({ task: parsedTask }, { status: 201 });
   } catch (error) {
@@ -431,6 +431,7 @@ export async function PUT(request: NextRequest) {
     // Broadcast status changes to SSE clients + outbound sync
     for (const task of tasks) {
       eventBus.broadcast('task.status_changed', {
+        workspace_id: workspaceId,
         id: task.id,
         status: task.status,
         updated_at: Math.floor(Date.now() / 1000),

--- a/src/lib/__tests__/event-workspace-isolation.test.ts
+++ b/src/lib/__tests__/event-workspace-isolation.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { eventBelongsToWorkspace, type ServerEvent } from '@/lib/event-bus'
 
 function event(data: unknown): ServerEvent {
-  return { type: 'task.updated', data, timestamp: Date.now() }
+  return { type: 'task.updated', data: data as Record<string, unknown>, timestamp: Date.now() }
 }
 
 describe('event workspace isolation', () => {

--- a/src/lib/adapters/__tests__/adapter-api.test.ts
+++ b/src/lib/adapters/__tests__/adapter-api.test.ts
@@ -35,6 +35,7 @@ async function simulateAdapterAction(
   action: string,
   payload: Record<string, unknown>
 ): Promise<{ ok?: boolean; assignments?: unknown[]; error?: string }> {
+  const workspaceId = 7
   let adapter
   try {
     adapter = getAdapter(framework)
@@ -51,6 +52,7 @@ async function simulateAdapterAction(
         name: name as string,
         framework,
         metadata: metadata as Record<string, unknown>,
+        workspaceId,
       })
       return { ok: true }
     }
@@ -61,6 +63,7 @@ async function simulateAdapterAction(
         agentId: agentId as string,
         status: (status as string) || 'online',
         metrics: metrics as Record<string, unknown>,
+        workspaceId,
       })
       return { ok: true }
     }
@@ -73,19 +76,20 @@ async function simulateAdapterAction(
         progress: (progress as number) ?? 0,
         status: (status as string) || 'in_progress',
         output,
+        workspaceId,
       })
       return { ok: true }
     }
     case 'assignments': {
       const { agentId } = payload
       if (!agentId) return { error: 'payload.agentId required' }
-      const assignments = await adapter.getAssignments(agentId as string)
+      const assignments = await adapter.getAssignments(agentId as string, workspaceId)
       return { assignments }
     }
     case 'disconnect': {
       const { agentId } = payload
       if (!agentId) return { error: 'payload.agentId required' }
-      await adapter.disconnect(agentId as string)
+      await adapter.disconnect(agentId as string, workspaceId)
       return { ok: true }
     }
     default:

--- a/src/lib/adapters/__tests__/adapter-assignment-isolation.test.ts
+++ b/src/lib/adapters/__tests__/adapter-assignment-isolation.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const all = vi.fn()
+const prepare = vi.fn(() => ({ all }))
+
+vi.mock('@/lib/db', () => ({
+  getDatabase: () => ({ prepare }),
+}))
+
+import { queryPendingAssignments } from '../adapter'
+
+describe('adapter assignment isolation', () => {
+  beforeEach(() => {
+    all.mockReset()
+    prepare.mockClear()
+  })
+
+  it('binds the authenticated workspace in the assignment query', () => {
+    all.mockReturnValue([])
+
+    queryPendingAssignments('agent-1', 42)
+
+    expect(prepare).toHaveBeenCalledOnce()
+    expect(prepare.mock.calls[0][0]).toContain('AND workspace_id = ?')
+    expect(all).toHaveBeenCalledWith('agent-1', 42)
+  })
+})

--- a/src/lib/adapters/__tests__/adapter-assignment-isolation.test.ts
+++ b/src/lib/adapters/__tests__/adapter-assignment-isolation.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const all = vi.fn()
-const prepare = vi.fn(() => ({ all }))
+const prepare = vi.fn((_sql: string) => ({ all }))
 
 vi.mock('@/lib/db', () => ({
   getDatabase: () => ({ prepare }),

--- a/src/lib/adapters/__tests__/adapter-compliance.test.ts
+++ b/src/lib/adapters/__tests__/adapter-compliance.test.ts
@@ -34,17 +34,21 @@ vi.mock('../adapter', async (importOriginal) => {
 
 // ─── Test Data ───────────────────────────────────────────────────────────────
 
+const TEST_WORKSPACE_ID = 42
+
 const testAgent: AgentRegistration = {
   agentId: 'test-agent-001',
   name: 'Test Agent',
   framework: 'test-framework',
   metadata: { version: '1.0', runtime: 'node' },
+  workspaceId: TEST_WORKSPACE_ID,
 }
 
 const testHeartbeat: HeartbeatPayload = {
   agentId: 'test-agent-001',
   status: 'busy',
   metrics: { cpu: 42, memory: 1024, tasksCompleted: 5 },
+  workspaceId: TEST_WORKSPACE_ID,
 }
 
 const testReport: TaskReport = {
@@ -53,6 +57,7 @@ const testReport: TaskReport = {
   progress: 75,
   status: 'in_progress',
   output: { summary: 'Processing step 3 of 4' },
+  workspaceId: TEST_WORKSPACE_ID,
 }
 
 // ─── Shared Compliance Tests ─────────────────────────────────────────────────
@@ -111,8 +116,8 @@ describe.each(ALL_FRAMEWORKS)('FrameworkAdapter compliance: %s', (framework) => 
         adapter.register(testAgent),
         adapter.heartbeat(testHeartbeat),
         adapter.reportTask(testReport),
-        adapter.getAssignments('any-id'),
-        adapter.disconnect('any-id'),
+        adapter.getAssignments('any-id', TEST_WORKSPACE_ID),
+        adapter.disconnect('any-id', TEST_WORKSPACE_ID),
       ]
 
       // All should be thenables
@@ -163,6 +168,7 @@ describe.each(ALL_FRAMEWORKS)('FrameworkAdapter compliance: %s', (framework) => 
         agentId: 'minimal-agent',
         name: 'Minimal',
         framework,
+        workspaceId: TEST_WORKSPACE_ID,
       })
 
       expect(mockBroadcast).toHaveBeenCalledWith(
@@ -202,6 +208,7 @@ describe.each(ALL_FRAMEWORKS)('FrameworkAdapter compliance: %s', (framework) => 
       await adapter.heartbeat({
         agentId: 'test-agent-001',
         status: 'idle',
+        workspaceId: TEST_WORKSPACE_ID,
       })
 
       expect(mockBroadcast).toHaveBeenCalledWith(
@@ -243,6 +250,7 @@ describe.each(ALL_FRAMEWORKS)('FrameworkAdapter compliance: %s', (framework) => 
         agentId: 'test-agent-001',
         progress: 100,
         status: 'completed',
+        workspaceId: TEST_WORKSPACE_ID,
       })
 
       expect(mockBroadcast).toHaveBeenCalledWith(
@@ -264,16 +272,16 @@ describe.each(ALL_FRAMEWORKS)('FrameworkAdapter compliance: %s', (framework) => 
       ]
       mockQuery.mockResolvedValue(mockAssignments)
 
-      const result = await adapter.getAssignments('test-agent-001')
+      const result = await adapter.getAssignments('test-agent-001', TEST_WORKSPACE_ID)
 
-      expect(mockQuery).toHaveBeenCalledWith('test-agent-001')
+      expect(mockQuery).toHaveBeenCalledWith('test-agent-001', TEST_WORKSPACE_ID)
       expect(result).toEqual(mockAssignments)
     })
 
     it('returns empty array when no assignments', async () => {
       mockQuery.mockResolvedValue([])
 
-      const result = await adapter.getAssignments('idle-agent')
+      const result = await adapter.getAssignments('idle-agent', TEST_WORKSPACE_ID)
 
       expect(result).toEqual([])
     })
@@ -281,7 +289,7 @@ describe.each(ALL_FRAMEWORKS)('FrameworkAdapter compliance: %s', (framework) => 
     it('does not broadcast events', async () => {
       mockQuery.mockResolvedValue([])
 
-      await adapter.getAssignments('test-agent-001')
+      await adapter.getAssignments('test-agent-001', TEST_WORKSPACE_ID)
 
       expect(mockBroadcast).not.toHaveBeenCalled()
     })
@@ -289,7 +297,7 @@ describe.each(ALL_FRAMEWORKS)('FrameworkAdapter compliance: %s', (framework) => 
 
   describe('disconnect()', () => {
     it('broadcasts agent.status_changed with offline status', async () => {
-      await adapter.disconnect('test-agent-001')
+      await adapter.disconnect('test-agent-001', TEST_WORKSPACE_ID)
 
       expect(mockBroadcast).toHaveBeenCalledTimes(1)
       expect(mockBroadcast).toHaveBeenCalledWith(
@@ -302,7 +310,7 @@ describe.each(ALL_FRAMEWORKS)('FrameworkAdapter compliance: %s', (framework) => 
     })
 
     it('tags disconnect event with framework', async () => {
-      await adapter.disconnect('test-agent-001')
+      await adapter.disconnect('test-agent-001', TEST_WORKSPACE_ID)
 
       const payload = mockBroadcast.mock.calls[0][1]
       expect(payload.framework).toBe(framework)
@@ -318,7 +326,7 @@ describe.each(ALL_FRAMEWORKS)('FrameworkAdapter compliance: %s', (framework) => 
       await adapter.register(testAgent)
       await adapter.heartbeat(testHeartbeat)
       await adapter.reportTask(testReport)
-      await adapter.disconnect('test-agent-001')
+      await adapter.disconnect('test-agent-001', TEST_WORKSPACE_ID)
 
       // All 4 event-emitting calls should tag with framework
       for (const call of mockBroadcast.mock.calls) {
@@ -348,7 +356,7 @@ describe('Cross-adapter consistency', () => {
       await adapter.register(testAgent)
       await adapter.heartbeat(testHeartbeat)
       await adapter.reportTask(testReport)
-      await adapter.disconnect('test-agent-001')
+      await adapter.disconnect('test-agent-001', TEST_WORKSPACE_ID)
 
       eventsByFramework[fw] = mockBroadcast.mock.calls.map(c => c[0])
     }
@@ -366,7 +374,7 @@ describe('Cross-adapter consistency', () => {
 
     for (const fw of ALL_FRAMEWORKS) {
       const adapter = getAdapter(fw)
-      const result = await adapter.getAssignments('shared-agent')
+      const result = await adapter.getAssignments('shared-agent', TEST_WORKSPACE_ID)
       expect(result).toEqual(mockAssignments)
     }
   })
@@ -385,6 +393,7 @@ describe('GenericAdapter special behavior', () => {
       agentId: 'custom-agent',
       name: 'Custom Framework Agent',
       framework: 'my-custom-framework',
+      workspaceId: TEST_WORKSPACE_ID,
     })
 
     const payload = mockBroadcast.mock.calls[0][1]
@@ -397,6 +406,7 @@ describe('GenericAdapter special behavior', () => {
       agentId: 'unknown-agent',
       name: 'Unknown Agent',
       framework: '',
+      workspaceId: TEST_WORKSPACE_ID,
     })
 
     const payload = mockBroadcast.mock.calls[0][1]

--- a/src/lib/adapters/adapter.ts
+++ b/src/lib/adapters/adapter.ts
@@ -1,19 +1,20 @@
 import { getDatabase } from '@/lib/db'
 
-export function queryPendingAssignments(agentId: string): Assignment[] {
+export function queryPendingAssignments(agentId: string, workspaceId: number): Assignment[] {
   try {
     const db = getDatabase()
     const rows = db.prepare(`
       SELECT id, title, description, priority
       FROM tasks
       WHERE (assigned_to = ? OR assigned_to IS NULL)
+        AND workspace_id = ?
         AND status IN ('assigned', 'inbox')
       ORDER BY
         CASE priority WHEN 'critical' THEN 0 WHEN 'high' THEN 1 WHEN 'medium' THEN 2 WHEN 'low' THEN 3 ELSE 4 END ASC,
         due_date ASC,
         created_at ASC
       LIMIT 5
-    `).all(agentId) as Array<{ id: number; title: string; description: string | null; priority: string }>
+    `).all(agentId, workspaceId) as Array<{ id: number; title: string; description: string | null; priority: string }>
 
     return rows.map(row => ({
       taskId: String(row.id),
@@ -30,12 +31,14 @@ export interface AgentRegistration {
   name: string
   framework: string
   metadata?: Record<string, unknown>
+  workspaceId: number
 }
 
 export interface HeartbeatPayload {
   agentId: string
   status: string
   metrics?: Record<string, unknown>
+  workspaceId: number
 }
 
 export interface TaskReport {
@@ -44,6 +47,7 @@ export interface TaskReport {
   progress: number
   status: string
   output?: unknown
+  workspaceId: number
 }
 
 export interface Assignment {
@@ -58,6 +62,6 @@ export interface FrameworkAdapter {
   register(agent: AgentRegistration): Promise<void>
   heartbeat(payload: HeartbeatPayload): Promise<void>
   reportTask(report: TaskReport): Promise<void>
-  getAssignments(agentId: string): Promise<Assignment[]>
-  disconnect(agentId: string): Promise<void>
+  getAssignments(agentId: string, workspaceId: number): Promise<Assignment[]>
+  disconnect(agentId: string, workspaceId: number): Promise<void>
 }

--- a/src/lib/adapters/autogen.ts
+++ b/src/lib/adapters/autogen.ts
@@ -7,6 +7,7 @@ export class AutoGenAdapter implements FrameworkAdapter {
 
   async register(agent: AgentRegistration): Promise<void> {
     eventBus.broadcast('agent.created', {
+      workspace_id: agent.workspaceId,
       id: agent.agentId,
       name: agent.name,
       framework: this.framework,
@@ -17,6 +18,7 @@ export class AutoGenAdapter implements FrameworkAdapter {
 
   async heartbeat(payload: HeartbeatPayload): Promise<void> {
     eventBus.broadcast('agent.status_changed', {
+      workspace_id: payload.workspaceId,
       id: payload.agentId,
       status: payload.status,
       metrics: payload.metrics ?? {},
@@ -26,6 +28,7 @@ export class AutoGenAdapter implements FrameworkAdapter {
 
   async reportTask(report: TaskReport): Promise<void> {
     eventBus.broadcast('task.updated', {
+      workspace_id: report.workspaceId,
       id: report.taskId,
       agentId: report.agentId,
       progress: report.progress,
@@ -35,12 +38,13 @@ export class AutoGenAdapter implements FrameworkAdapter {
     })
   }
 
-  async getAssignments(agentId: string): Promise<Assignment[]> {
-    return queryPendingAssignments(agentId)
+  async getAssignments(agentId: string, workspaceId: number): Promise<Assignment[]> {
+    return queryPendingAssignments(agentId, workspaceId)
   }
 
-  async disconnect(agentId: string): Promise<void> {
+  async disconnect(agentId: string, workspaceId: number): Promise<void> {
     eventBus.broadcast('agent.status_changed', {
+      workspace_id: workspaceId,
       id: agentId,
       status: 'offline',
       framework: this.framework,

--- a/src/lib/adapters/claude-sdk.ts
+++ b/src/lib/adapters/claude-sdk.ts
@@ -7,6 +7,7 @@ export class ClaudeSdkAdapter implements FrameworkAdapter {
 
   async register(agent: AgentRegistration): Promise<void> {
     eventBus.broadcast('agent.created', {
+      workspace_id: agent.workspaceId,
       id: agent.agentId,
       name: agent.name,
       framework: this.framework,
@@ -17,6 +18,7 @@ export class ClaudeSdkAdapter implements FrameworkAdapter {
 
   async heartbeat(payload: HeartbeatPayload): Promise<void> {
     eventBus.broadcast('agent.status_changed', {
+      workspace_id: payload.workspaceId,
       id: payload.agentId,
       status: payload.status,
       metrics: payload.metrics ?? {},
@@ -26,6 +28,7 @@ export class ClaudeSdkAdapter implements FrameworkAdapter {
 
   async reportTask(report: TaskReport): Promise<void> {
     eventBus.broadcast('task.updated', {
+      workspace_id: report.workspaceId,
       id: report.taskId,
       agentId: report.agentId,
       progress: report.progress,
@@ -35,12 +38,13 @@ export class ClaudeSdkAdapter implements FrameworkAdapter {
     })
   }
 
-  async getAssignments(agentId: string): Promise<Assignment[]> {
-    return queryPendingAssignments(agentId)
+  async getAssignments(agentId: string, workspaceId: number): Promise<Assignment[]> {
+    return queryPendingAssignments(agentId, workspaceId)
   }
 
-  async disconnect(agentId: string): Promise<void> {
+  async disconnect(agentId: string, workspaceId: number): Promise<void> {
     eventBus.broadcast('agent.status_changed', {
+      workspace_id: workspaceId,
       id: agentId,
       status: 'offline',
       framework: this.framework,

--- a/src/lib/adapters/crewai.ts
+++ b/src/lib/adapters/crewai.ts
@@ -7,6 +7,7 @@ export class CrewAIAdapter implements FrameworkAdapter {
 
   async register(agent: AgentRegistration): Promise<void> {
     eventBus.broadcast('agent.created', {
+      workspace_id: agent.workspaceId,
       id: agent.agentId,
       name: agent.name,
       framework: this.framework,
@@ -17,6 +18,7 @@ export class CrewAIAdapter implements FrameworkAdapter {
 
   async heartbeat(payload: HeartbeatPayload): Promise<void> {
     eventBus.broadcast('agent.status_changed', {
+      workspace_id: payload.workspaceId,
       id: payload.agentId,
       status: payload.status,
       metrics: payload.metrics ?? {},
@@ -26,6 +28,7 @@ export class CrewAIAdapter implements FrameworkAdapter {
 
   async reportTask(report: TaskReport): Promise<void> {
     eventBus.broadcast('task.updated', {
+      workspace_id: report.workspaceId,
       id: report.taskId,
       agentId: report.agentId,
       progress: report.progress,
@@ -35,12 +38,13 @@ export class CrewAIAdapter implements FrameworkAdapter {
     })
   }
 
-  async getAssignments(agentId: string): Promise<Assignment[]> {
-    return queryPendingAssignments(agentId)
+  async getAssignments(agentId: string, workspaceId: number): Promise<Assignment[]> {
+    return queryPendingAssignments(agentId, workspaceId)
   }
 
-  async disconnect(agentId: string): Promise<void> {
+  async disconnect(agentId: string, workspaceId: number): Promise<void> {
     eventBus.broadcast('agent.status_changed', {
+      workspace_id: workspaceId,
       id: agentId,
       status: 'offline',
       framework: this.framework,

--- a/src/lib/adapters/generic.ts
+++ b/src/lib/adapters/generic.ts
@@ -7,6 +7,7 @@ export class GenericAdapter implements FrameworkAdapter {
 
   async register(agent: AgentRegistration): Promise<void> {
     eventBus.broadcast('agent.created', {
+      workspace_id: agent.workspaceId,
       id: agent.agentId,
       name: agent.name,
       framework: agent.framework || this.framework,
@@ -17,6 +18,7 @@ export class GenericAdapter implements FrameworkAdapter {
 
   async heartbeat(payload: HeartbeatPayload): Promise<void> {
     eventBus.broadcast('agent.status_changed', {
+      workspace_id: payload.workspaceId,
       id: payload.agentId,
       status: payload.status,
       metrics: payload.metrics ?? {},
@@ -26,6 +28,7 @@ export class GenericAdapter implements FrameworkAdapter {
 
   async reportTask(report: TaskReport): Promise<void> {
     eventBus.broadcast('task.updated', {
+      workspace_id: report.workspaceId,
       id: report.taskId,
       agentId: report.agentId,
       progress: report.progress,
@@ -35,12 +38,13 @@ export class GenericAdapter implements FrameworkAdapter {
     })
   }
 
-  async getAssignments(agentId: string): Promise<Assignment[]> {
-    return queryPendingAssignments(agentId)
+  async getAssignments(agentId: string, workspaceId: number): Promise<Assignment[]> {
+    return queryPendingAssignments(agentId, workspaceId)
   }
 
-  async disconnect(agentId: string): Promise<void> {
+  async disconnect(agentId: string, workspaceId: number): Promise<void> {
     eventBus.broadcast('agent.status_changed', {
+      workspace_id: workspaceId,
       id: agentId,
       status: 'offline',
       framework: this.framework,

--- a/src/lib/adapters/langgraph.ts
+++ b/src/lib/adapters/langgraph.ts
@@ -7,6 +7,7 @@ export class LangGraphAdapter implements FrameworkAdapter {
 
   async register(agent: AgentRegistration): Promise<void> {
     eventBus.broadcast('agent.created', {
+      workspace_id: agent.workspaceId,
       id: agent.agentId,
       name: agent.name,
       framework: this.framework,
@@ -17,6 +18,7 @@ export class LangGraphAdapter implements FrameworkAdapter {
 
   async heartbeat(payload: HeartbeatPayload): Promise<void> {
     eventBus.broadcast('agent.status_changed', {
+      workspace_id: payload.workspaceId,
       id: payload.agentId,
       status: payload.status,
       metrics: payload.metrics ?? {},
@@ -26,6 +28,7 @@ export class LangGraphAdapter implements FrameworkAdapter {
 
   async reportTask(report: TaskReport): Promise<void> {
     eventBus.broadcast('task.updated', {
+      workspace_id: report.workspaceId,
       id: report.taskId,
       agentId: report.agentId,
       progress: report.progress,
@@ -35,12 +38,13 @@ export class LangGraphAdapter implements FrameworkAdapter {
     })
   }
 
-  async getAssignments(agentId: string): Promise<Assignment[]> {
-    return queryPendingAssignments(agentId)
+  async getAssignments(agentId: string, workspaceId: number): Promise<Assignment[]> {
+    return queryPendingAssignments(agentId, workspaceId)
   }
 
-  async disconnect(agentId: string): Promise<void> {
+  async disconnect(agentId: string, workspaceId: number): Promise<void> {
     eventBus.broadcast('agent.status_changed', {
+      workspace_id: workspaceId,
       id: agentId,
       status: 'offline',
       framework: this.framework,

--- a/src/lib/adapters/openclaw.ts
+++ b/src/lib/adapters/openclaw.ts
@@ -7,6 +7,7 @@ export class OpenClawAdapter implements FrameworkAdapter {
 
   async register(agent: AgentRegistration): Promise<void> {
     eventBus.broadcast('agent.created', {
+      workspace_id: agent.workspaceId,
       id: agent.agentId,
       name: agent.name,
       framework: this.framework,
@@ -17,6 +18,7 @@ export class OpenClawAdapter implements FrameworkAdapter {
 
   async heartbeat(payload: HeartbeatPayload): Promise<void> {
     eventBus.broadcast('agent.status_changed', {
+      workspace_id: payload.workspaceId,
       id: payload.agentId,
       status: payload.status,
       metrics: payload.metrics,
@@ -26,6 +28,7 @@ export class OpenClawAdapter implements FrameworkAdapter {
 
   async reportTask(report: TaskReport): Promise<void> {
     eventBus.broadcast('task.updated', {
+      workspace_id: report.workspaceId,
       id: report.taskId,
       agentId: report.agentId,
       progress: report.progress,
@@ -35,12 +38,13 @@ export class OpenClawAdapter implements FrameworkAdapter {
     })
   }
 
-  async getAssignments(agentId: string): Promise<Assignment[]> {
-    return queryPendingAssignments(agentId)
+  async getAssignments(agentId: string, workspaceId: number): Promise<Assignment[]> {
+    return queryPendingAssignments(agentId, workspaceId)
   }
 
-  async disconnect(agentId: string): Promise<void> {
+  async disconnect(agentId: string, workspaceId: number): Promise<void> {
     eventBus.broadcast('agent.status_changed', {
+      workspace_id: workspaceId,
       id: agentId,
       status: 'offline',
       framework: this.framework,

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -212,6 +212,7 @@ export interface Task {
   completed_at?: number;
   tags?: string; // JSON string
   metadata?: string; // JSON string
+  workspace_id: number;
 }
 
 export interface Agent {
@@ -448,6 +449,7 @@ export const db_helpers = {
     // Broadcast agent status change to SSE clients
     if (agent) {
       eventBus.broadcast('agent.status_changed', {
+        workspace_id: workspaceId,
         id: agent.id,
         name: agentName,
         status,

--- a/src/lib/event-bus.ts
+++ b/src/lib/event-bus.ts
@@ -7,8 +7,12 @@ import { EventEmitter } from 'events'
 
 export interface ServerEvent {
   type: string
-  data: any
+  data: Record<string, unknown>
   timestamp: number
+}
+
+export interface WorkspaceEventData extends Record<string, unknown> {
+  workspace_id: number
 }
 
 export function eventBelongsToWorkspace(event: ServerEvent, workspaceId: number): boolean {
@@ -62,7 +66,7 @@ class ServerEventBus extends EventEmitter {
   /**
    * Broadcast an event to all SSE listeners
    */
-  broadcast(type: EventType, data: any): ServerEvent {
+  broadcast(type: EventType, data: WorkspaceEventData): ServerEvent {
     const event: ServerEvent = { type, data, timestamp: Date.now() }
     this.emit('server-event', event)
     return event

--- a/src/lib/runs.ts
+++ b/src/lib/runs.ts
@@ -186,7 +186,7 @@ export function createRun(run: AgentRun, workspaceId?: number): AgentRun {
   )
 
   const created = getRun(id, wsId)!
-  eventBus.broadcast('run.created', created)
+  eventBus.broadcast('run.created', { ...created, workspace_id: wsId })
   return created
 }
 
@@ -243,7 +243,7 @@ export function updateRun(id: string, updates: Partial<AgentRun>, workspaceId?: 
     const eventType = updated.status === 'completed' || updated.status === 'failed'
       ? 'run.completed' as const
       : 'run.updated' as const
-    eventBus.broadcast(eventType, updated)
+    eventBus.broadcast(eventType, { ...updated, workspace_id: wsId })
   }
   return updated
 }
@@ -267,7 +267,7 @@ export function attachEval(runId: string, evalResult: EvalResult, workspaceId?: 
   )
 
   const updated = getRun(runId, wsId)
-  if (updated) eventBus.broadcast('run.eval_attached', updated)
+  if (updated) eventBus.broadcast('run.eval_attached', { ...updated, workspace_id: wsId })
   return updated
 }
 

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -280,6 +280,7 @@ async function syncAgentLiveStatuses(requestedWorkspaceId?: number): Promise<num
       refreshed++
 
       eventBus.broadcast('agent.status_changed', {
+        workspace_id: workspaceId,
         id: agent.id,
         name: agent.name,
         status: matched.status,

--- a/src/lib/task-dispatch.ts
+++ b/src/lib/task-dispatch.ts
@@ -590,6 +590,7 @@ export async function reconcileDeferredTaskCompletions(options: {
       id: task.id,
       status: 'review',
       previous_status: 'in_progress',
+      workspace_id: task.workspace_id,
     })
     eventBus.broadcast('task.updated', {
       id: task.id,
@@ -598,6 +599,7 @@ export async function reconcileDeferredTaskCompletions(options: {
       assigned_to: task.assigned_to,
       dispatch_session_id: nextMetadata.dispatch_session_id,
       dispatch_run_id: nextMetadata.dispatch_run_id,
+      workspace_id: task.workspace_id,
     })
 
     db_helpers.logActivity(
@@ -1245,6 +1247,7 @@ export async function runAegisReviews(): Promise<{ ok: boolean; message: string 
       id: task.id,
       status: 'quality_review',
       previous_status: 'review',
+      workspace_id: task.workspace_id,
     })
 
     try {
@@ -1304,6 +1307,7 @@ export async function runAegisReviews(): Promise<{ ok: boolean; message: string 
           id: task.id,
           status: 'done',
           previous_status: 'quality_review',
+          workspace_id: task.workspace_id,
         })
         syncAndEscalateIfFailed(task, 'done')
       } else {
@@ -1324,6 +1328,7 @@ export async function runAegisReviews(): Promise<{ ok: boolean; message: string 
             previous_status: 'quality_review',
             error_message: `Aegis rejected ${newAttempts} times`,
             reason: 'max_aegis_retries_exceeded',
+            workspace_id: task.workspace_id,
           })
           syncAndEscalateIfFailed(task, 'failed', `Aegis rejected ${newAttempts} times`, newAttempts)
         } else {
@@ -1337,6 +1342,7 @@ export async function runAegisReviews(): Promise<{ ok: boolean; message: string 
             previous_status: 'quality_review',
             error_message: `Aegis rejected: ${verdict.notes}`,
             reason: 'aegis_rejection',
+            workspace_id: task.workspace_id,
           })
           syncAndEscalateIfFailed(task, 'assigned')
         }
@@ -1372,6 +1378,7 @@ export async function runAegisReviews(): Promise<{ ok: boolean; message: string 
         id: task.id,
         status: 'review',
         previous_status: 'quality_review',
+        workspace_id: task.workspace_id,
       })
 
       results.push({ id: task.id, verdict: 'error', error: errorMsg.substring(0, 100) })
@@ -1442,6 +1449,7 @@ export async function requeueStaleTasks(): Promise<{ ok: boolean; message: strin
         previous_status: 'in_progress',
         error_message: `Stale task — agent offline after ${newAttempts} attempts`,
         reason: 'stale_task_max_retries',
+        workspace_id: task.workspace_id,
       })
 
       syncAndEscalateIfFailed(task as any, 'failed', `Task stuck in_progress ${newAttempts} times`, newAttempts)
@@ -1462,6 +1470,7 @@ export async function requeueStaleTasks(): Promise<{ ok: boolean; message: strin
         previous_status: 'in_progress',
         error_message: `Agent "${task.assigned_to}" went offline`,
         reason: 'stale_task_requeue',
+        workspace_id: task.workspace_id,
       })
       syncAndEscalateIfFailed(task as any, 'assigned')
 
@@ -1530,6 +1539,7 @@ export async function dispatchAssignedTasks(): Promise<{ ok: boolean; message: s
       id: task.id,
       status: 'in_progress',
       previous_status: 'assigned',
+      workspace_id: task.workspace_id,
     })
 
     db_helpers.logActivity(
@@ -1616,6 +1626,7 @@ export async function dispatchAssignedTasks(): Promise<{ ok: boolean; message: s
           dispatch_session_id: targetSession,
           dispatch_run_id: pendingMeta.dispatch_run_id,
           async_state: asyncState,
+          workspace_id: task.workspace_id,
         })
 
         db_helpers.logActivity(
@@ -1685,6 +1696,7 @@ export async function dispatchAssignedTasks(): Promise<{ ok: boolean; message: s
           dispatch_session_id: dispatchSessionId,
           dispatch_run_id: pendingMeta.dispatch_run_id,
           async_state: asyncState,
+          workspace_id: task.workspace_id,
         })
 
         db_helpers.logActivity(
@@ -1743,6 +1755,7 @@ export async function dispatchAssignedTasks(): Promise<{ ok: boolean; message: s
         id: task.id,
         status: 'review',
         previous_status: 'in_progress',
+        workspace_id: task.workspace_id,
       })
 
       eventBus.broadcast('task.updated', {
@@ -1751,6 +1764,7 @@ export async function dispatchAssignedTasks(): Promise<{ ok: boolean; message: s
         outcome: 'success',
         assigned_to: task.assigned_to,
         dispatch_session_id: agentResponse.sessionId,
+        workspace_id: task.workspace_id,
       })
       syncAndEscalateIfFailed(task, 'review')
 
@@ -1787,6 +1801,7 @@ export async function dispatchAssignedTasks(): Promise<{ ok: boolean; message: s
           previous_status: 'in_progress',
           error_message: failureMessage,
           reason: 'max_dispatch_retries_exceeded',
+          workspace_id: task.workspace_id,
         })
         syncAndEscalateIfFailed(task, 'failed', `Dispatch failed ${newAttempts} times`, newAttempts)
       } else {
@@ -1800,6 +1815,7 @@ export async function dispatchAssignedTasks(): Promise<{ ok: boolean; message: s
           previous_status: 'in_progress',
           error_message: errorMsg.substring(0, 500),
           reason: 'dispatch_failed',
+          workspace_id: task.workspace_id,
         })
         syncAndEscalateIfFailed(task, 'assigned')
       }
@@ -1956,7 +1972,7 @@ export async function autoRouteInboxTasks(): Promise<{ ok: boolean; message: str
         { agent: alt.agent.name, role: alt.agent.role, score: alt.score },
         task.workspace_id)
 
-      eventBus.broadcast('task.status_changed', { id: task.id, status: 'assigned', previous_status: 'inbox', assigned_to: alt.agent.name })
+      eventBus.broadcast('task.status_changed', { id: task.id, status: 'assigned', previous_status: 'inbox', assigned_to: alt.agent.name, workspace_id: task.workspace_id })
       syncAndEscalateIfFailed(task as any, 'assigned')
       routed++
       continue
@@ -1970,7 +1986,7 @@ export async function autoRouteInboxTasks(): Promise<{ ok: boolean; message: str
       { agent: best.name, role: best.role, score: scored[0].score },
       task.workspace_id)
 
-    eventBus.broadcast('task.status_changed', { id: task.id, status: 'assigned', previous_status: 'inbox', assigned_to: best.name })
+    eventBus.broadcast('task.status_changed', { id: task.id, status: 'assigned', previous_status: 'inbox', assigned_to: best.name, workspace_id: task.workspace_id })
     syncAndEscalateIfFailed(task as any, 'assigned')
     routed++
   }


### PR DESCRIPTION
## Summary
- require numeric workspace ownership in the server event-bus broadcast contract
- attribute task, agent, chat, connection, pipeline, run, scheduler, and integration events at their authenticated or persisted workspace source
- propagate authenticated workspace context through framework adapters
- scope adapter assignment polling by workspace to prevent cross-workspace task disclosure
- add adapter assignment and event-boundary regression coverage

## Security impact
SSE and webhook delivery already fail closed for events without workspace ownership. This change repairs legitimate producers without weakening that boundary and closes an unscoped adapter assignment query discovered during the producer audit.

## Verification
- pnpm typecheck
- pnpm test (130 files, 1,330 tests)
- pnpm lint (0 errors; 100 existing warnings)
- pnpm api:parity
- pnpm build
- pnpm artifact:check
- dependency audit: no known vulnerabilities
- strict security scan: passed

Progresses #800.