### PR TITLE
security: deny ambiguous agent self access

### DIFF
--- a/src/lib/__tests__/heartbeat-route-security.test.ts
+++ b/src/lib/__tests__/heartbeat-route-security.test.ts
@@ -91,4 +91,24 @@ describe('heartbeat route security', () => {
     })
     expect(prepareMock).not.toHaveBeenCalled()
   })
+
+  it('GET denies numeric access when custom agent identity lacks authoritative agent_id', async () => {
+    const prepareMock = vi.fn()
+    getDatabaseMock.mockReturnValue({ prepare: prepareMock })
+    requireRoleMock.mockReturnValue({
+      user: { username: 'custom-agent', role: 'viewer', agent_name: 'agent-a', workspace_id: 7 },
+    })
+
+    const { GET } = await import('@/app/api/agents/[id]/heartbeat/route')
+    const response = await GET(
+      new NextRequest('http://localhost/api/agents/42/heartbeat'),
+      { params: Promise.resolve({ id: '42' }) },
+    )
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Access denied: agent key may only access its own agent.',
+    })
+    expect(prepareMock).not.toHaveBeenCalled()
+  })
 })

--- a/src/lib/__tests__/workspace-scope.test.ts
+++ b/src/lib/__tests__/workspace-scope.test.ts
@@ -165,9 +165,11 @@ describe('requireAgentSelfAccess — agent key (numeric ID path)', () => {
     expect(result!.status).toBe(403)
   })
 
-  it('allows numeric path when agent_id is not set (falls through to workspace filter)', () => {
+  it('denies numeric paths when authenticated agent ownership is ambiguous', () => {
     const user = makeUser({ agent_name: 'repo-steward', agent_id: null, role: 'operator' })
-    expect(requireAgentSelfAccess(user, '42')).toBeNull()
+    const result = requireAgentSelfAccess(user, '42')
+    expect(result).not.toBeNull()
+    expect(result!.status).toBe(403)
   })
 })
 

--- a/src/lib/enforcement/workspace-scope.ts
+++ b/src/lib/enforcement/workspace-scope.ts
@@ -65,7 +65,7 @@ export function enforceWorkspaceBoundary(user: User, resourceWorkspaceId: number
  *
  * Accepts the URL path segment which may be a name ("repo-steward") or a
  * numeric DB id ("42"). Compares by agent_id when numeric, by agent_name
- * when a name string. Falls through (allows) when type cannot be determined.
+ * when a name string. Ambiguous numeric ownership fails closed.
  *
  * Human users (no agent_name) and admin-scoped keys are not restricted.
  *
@@ -77,8 +77,9 @@ export function requireAgentSelfAccess(user: User, targetAgentIdOrName: string):
 
   const targetNumeric = Number(targetAgentIdOrName)
   if (Number.isFinite(targetNumeric) && targetNumeric > 0) {
-    // Numeric ID path: compare by agent_id when available
-    if (user.agent_id != null && user.agent_id !== targetNumeric) {
+    // Numeric ID path requires authoritative numeric ownership. Custom auth
+    // resolvers that provide only agent_name can use the name-based route.
+    if (user.agent_id == null || user.agent_id !== targetNumeric) {
       return NextResponse.json(
         { error: 'Access denied: agent key may only access its own agent.' },
         { status: 403 },


### PR DESCRIPTION
## Summary
- fail closed when an agent-scoped identity targets a numeric agent route without authoritative numeric agent ownership
- preserve name-based access for compatible custom authentication resolvers
- retain valid numeric self-access when authenticated agent_id matches
- add central and route-level regressions proving denial occurs before agent records are read

## Security impact
The central self-access helper previously allowed numeric agent paths when agent_name existed but agent_id was absent, relying on later workspace filtering. That could allow a custom agent-scoped resolver to target another agent in the same workspace. Numeric access now requires an exact authenticated agent_id match.

## Verification
- pnpm typecheck
- pnpm test (130 files, 1,331 tests)
- pnpm lint (0 errors; 100 existing warnings)
- pnpm build
- strict security scan: passed

Progresses #800.