### PR TITLE
security: scope residual workspace queries

### DIFF
--- a/src/app/api/agents/[id]/hide/route.ts
+++ b/src/app/api/agents/[id]/hide/route.ts
@@ -27,7 +27,8 @@ export async function POST(
       return NextResponse.json({ error: 'Agent not found' }, { status: 404 })
     }
 
-    db.prepare('UPDATE agents SET hidden = 1, updated_at = unixepoch() WHERE id = ?').run(agent.id)
+    db.prepare('UPDATE agents SET hidden = 1, updated_at = unixepoch() WHERE id = ? AND workspace_id = ?')
+      .run(agent.id, workspaceId)
 
     return NextResponse.json({ success: true, agent_id: agent.id, hidden: true })
   } catch (error) {
@@ -60,7 +61,8 @@ export async function DELETE(
       return NextResponse.json({ error: 'Agent not found' }, { status: 404 })
     }
 
-    db.prepare('UPDATE agents SET hidden = 0, updated_at = unixepoch() WHERE id = ?').run(agent.id)
+    db.prepare('UPDATE agents SET hidden = 0, updated_at = unixepoch() WHERE id = ? AND workspace_id = ?')
+      .run(agent.id, workspaceId)
 
     return NextResponse.json({ success: true, agent_id: agent.id, hidden: false })
   } catch (error) {

--- a/src/app/api/alerts/route.ts
+++ b/src/app/api/alerts/route.ts
@@ -21,6 +21,7 @@ interface AlertRule {
   created_by: string
   created_at: number
   updated_at: number
+  workspace_id: number
 }
 
 /**
@@ -215,7 +216,8 @@ function evaluateRules(db: ReturnType<typeof getDatabase>, workspaceId: number) 
 
     if (triggered) {
       // Update trigger tracking
-      db.prepare('UPDATE alert_rules SET last_triggered_at = ?, trigger_count = trigger_count + 1 WHERE id = ?').run(now, rule.id)
+      db.prepare('UPDATE alert_rules SET last_triggered_at = ?, trigger_count = trigger_count + 1 WHERE id = ? AND workspace_id = ?')
+        .run(now, rule.id, workspaceId)
 
       // Create notification
       try {

--- a/src/app/api/connect/route.ts
+++ b/src/app/api/connect/route.ts
@@ -43,8 +43,8 @@ export async function POST(request: NextRequest) {
 
   // Deactivate previous connections for this agent
   db.prepare(
-    `UPDATE direct_connections SET status = 'disconnected', updated_at = ? WHERE agent_id = ? AND status = 'connected'`
-  ).run(now, agent.id)
+    `UPDATE direct_connections SET status = 'disconnected', updated_at = ? WHERE agent_id = ? AND status = 'connected' AND workspace_id = ?`
+  ).run(now, agent.id, workspaceId)
 
   // Create new connection
   const connectionId = randomUUID()
@@ -128,13 +128,13 @@ export async function DELETE(request: NextRequest) {
     return NextResponse.json({ error: 'Connection not found' }, { status: 404 })
   }
 
-  db.prepare('UPDATE direct_connections SET status = ?, updated_at = ? WHERE connection_id = ?')
-    .run('disconnected', now, connection_id)
+  db.prepare('UPDATE direct_connections SET status = ?, updated_at = ? WHERE connection_id = ? AND workspace_id = ?')
+    .run('disconnected', now, connection_id, workspaceId)
 
   // Check if agent has other active connections; if not, set offline
   const otherActive = db.prepare(
-    'SELECT COUNT(*) as count FROM direct_connections WHERE agent_id = ? AND status = ? AND connection_id != ?'
-  ).get(conn.agent_id, 'connected', connection_id) as any
+    'SELECT COUNT(*) as count FROM direct_connections WHERE agent_id = ? AND status = ? AND connection_id != ? AND workspace_id = ?'
+  ).get(conn.agent_id, 'connected', connection_id, workspaceId) as any
   if (!otherActive?.count) {
     db.prepare('UPDATE agents SET status = ?, updated_at = ? WHERE id = ? AND workspace_id = ?')
       .run('offline', now, conn.agent_id, workspaceId)

--- a/src/app/api/diagnostics/route.ts
+++ b/src/app/api/diagnostics/route.ts
@@ -28,7 +28,7 @@ export async function GET(request: NextRequest) {
       getVersionInfo(),
       getSecurityInfo(),
       getDatabaseInfo(),
-      getAgentInfo(),
+      getAgentInfo(auth.user.workspace_id ?? 1),
       getSessionInfo(),
       getGatewayInfo(),
     ])
@@ -161,12 +161,12 @@ function getDatabaseInfo() {
   }
 }
 
-function getAgentInfo() {
+function getAgentInfo(workspaceId: number) {
   try {
     const db = getDatabase()
     const rows = db.prepare(
-      'SELECT status, COUNT(*) as count FROM agents GROUP BY status'
-    ).all() as Array<{ status: string; count: number }>
+      'SELECT status, COUNT(*) as count FROM agents WHERE workspace_id = ? GROUP BY status'
+    ).all(workspaceId) as Array<{ status: string; count: number }>
 
     const byStatus: Record<string, number> = {}
     let total = 0

--- a/src/app/api/pipelines/route.ts
+++ b/src/app/api/pipelines/route.ts
@@ -38,7 +38,8 @@ export async function GET(request: NextRequest) {
     ).all(workspaceId) as Pipeline[]
 
     // Enrich steps with template names
-    const templates = db.prepare('SELECT id, name FROM workflow_templates').all() as Array<{ id: number; name: string }>
+    const templates = db.prepare('SELECT id, name FROM workflow_templates WHERE workspace_id = ?')
+      .all(workspaceId) as Array<{ id: number; name: string }>
     const nameMap = new Map(templates.map(t => [t.id, t.name]))
 
     // Get run counts per pipeline
@@ -88,8 +89,8 @@ export async function POST(request: NextRequest) {
     // Validate template IDs exist
     const templateIds = steps.map((s: PipelineStep) => s.template_id)
     const existing = db.prepare(
-      `SELECT id FROM workflow_templates WHERE id IN (${templateIds.map(() => '?').join(',')})`
-    ).all(...templateIds) as Array<{ id: number }>
+      `SELECT id FROM workflow_templates WHERE id IN (${templateIds.map(() => '?').join(',')}) AND workspace_id = ?`
+    ).all(...templateIds, workspaceId) as Array<{ id: number }>
     if (existing.length !== new Set(templateIds).size) {
       return NextResponse.json({ error: 'One or more template IDs not found' }, { status: 400 })
     }

--- a/src/app/api/pipelines/run/route.ts
+++ b/src/app/api/pipelines/run/route.ts
@@ -166,8 +166,8 @@ async function startPipeline(db: ReturnType<typeof getDatabase>, pipelineId: num
   // Get template names for snapshot
   const templateIds = steps.map(s => s.template_id)
   const templates = db.prepare(
-    `SELECT id, name, model, task_prompt, timeout_seconds FROM workflow_templates WHERE id IN (${templateIds.map(() => '?').join(',')})`
-  ).all(...templateIds) as Array<{ id: number; name: string; model: string; task_prompt: string; timeout_seconds: number }>
+    `SELECT id, name, model, task_prompt, timeout_seconds FROM workflow_templates WHERE id IN (${templateIds.map(() => '?').join(',')}) AND workspace_id = ?`
+  ).all(...templateIds, workspaceId) as Array<{ id: number; name: string; model: string; task_prompt: string; timeout_seconds: number }>
   const templateMap = new Map(templates.map(t => [t.id, t]))
 
   // Build step snapshot
@@ -275,8 +275,8 @@ async function advanceRun(db: ReturnType<typeof getDatabase>, runId: number, suc
   steps[nextIdx].status = 'running'
   steps[nextIdx].started_at = now
 
-  const template = db.prepare('SELECT id, name, model, task_prompt, timeout_seconds FROM workflow_templates WHERE id = ?')
-    .get(steps[nextIdx].template_id) as any
+  const template = db.prepare('SELECT id, name, model, task_prompt, timeout_seconds FROM workflow_templates WHERE id = ? AND workspace_id = ?')
+    .get(steps[nextIdx].template_id, workspaceId) as any
 
   let spawnResult: any = null
   if (template) {

--- a/src/app/api/status/route.ts
+++ b/src/app/api/status/route.ts
@@ -190,8 +190,8 @@ function getDbStats(workspaceId: number) {
     let pipelineActive = 0
     let pipelineRecent = 0
     try {
-      pipelineActive = (db.prepare("SELECT COUNT(*) as c FROM pipeline_runs WHERE status = 'running'").get() as any).c
-      pipelineRecent = (db.prepare('SELECT COUNT(*) as c FROM pipeline_runs WHERE created_at > ?').get(day) as any).c
+      pipelineActive = (db.prepare("SELECT COUNT(*) as c FROM pipeline_runs WHERE status = 'running' AND workspace_id = ?").get(workspaceId) as any).c
+      pipelineRecent = (db.prepare('SELECT COUNT(*) as c FROM pipeline_runs WHERE created_at > ? AND workspace_id = ?').get(day, workspaceId) as any).c
     } catch {
       // Pipeline tables may not exist yet
     }
@@ -231,7 +231,7 @@ function getDbStats(workspaceId: number) {
     // Webhook configs count
     let webhookCount = 0
     try {
-      webhookCount = (db.prepare('SELECT COUNT(*) as c FROM webhooks').get() as any).c
+      webhookCount = (db.prepare('SELECT COUNT(*) as c FROM webhooks WHERE workspace_id = ?').get(workspaceId) as any).c
     } catch {
       // table may not exist
     }

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -340,7 +340,7 @@ export async function POST(request: NextRequest) {
         WHERE id = ? AND workspace_id = ?
       `).get(parsedTask.project_id, workspaceId) as any
       if (project?.github_sync_enabled && project?.github_repo) {
-        pushTaskToGitHub(parsedTask as any, project).catch(err =>
+        pushTaskToGitHub(parsedTask, project).catch(err =>
           logger.error({ err, taskId }, 'Outbound GitHub sync failed for new task')
         )
       }

--- a/src/lib/__tests__/agent-evals.test.ts
+++ b/src/lib/__tests__/agent-evals.test.ts
@@ -1,15 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-const mockGet = vi.fn()
+const mockGet = vi.fn((..._args: unknown[]) => undefined as any)
 const mockAll = vi.fn(() => [])
 const mockRun = vi.fn(() => ({ lastInsertRowid: 1, changes: 1 }))
-const mockPrepare = vi.fn(() => ({ get: mockGet, all: mockAll, run: mockRun }))
+const mockPrepare = vi.fn((_sql: string) => ({ get: mockGet, all: mockAll, run: mockRun }))
 
 vi.mock('@/lib/db', () => ({
   getDatabase: () => ({ prepare: mockPrepare }),
 }))
 
-import { convergenceScore, checkDrift, evalTaskCompletion, evalCorrectnessScore } from '@/lib/agent-evals'
+import { convergenceScore, checkDrift, evalTaskCompletion, evalCorrectnessScore, runDriftCheck } from '@/lib/agent-evals'
 
 describe('convergenceScore', () => {
   it('returns score 1.0 when no unique tools', () => {
@@ -84,6 +84,30 @@ describe('checkDrift', () => {
     // delta = |0.95 - 0.8| / 0.8 = 0.1875
     expect(result.drifted).toBe(true)
     expect(result.threshold).toBe(0.10)
+  })
+})
+
+describe('workspace-scoped drift metrics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGet.mockReturnValue(undefined)
+  })
+
+  it('binds workspace ownership to every token-usage window', () => {
+    runDriftCheck('shared-name', 42)
+
+    const tokenQueries = mockPrepare.mock.calls
+      .filter(([sql]) => String(sql).includes('FROM token_usage'))
+    expect(tokenQueries).toHaveLength(2)
+    for (const [sql] of tokenQueries) {
+      expect(sql).toContain('workspace_id = ?')
+    }
+
+    const tokenGets = mockGet.mock.calls.slice(0, 2) as unknown[][]
+    expect(tokenGets[0][0]).toBe('shared-name')
+    expect(tokenGets[0][1]).toBe(42)
+    expect(tokenGets[1][0]).toBe('shared-name')
+    expect(tokenGets[1][1]).toBe(42)
   })
 })
 

--- a/src/lib/__tests__/task-dispatch-reconciliation.test.ts
+++ b/src/lib/__tests__/task-dispatch-reconciliation.test.ts
@@ -57,7 +57,7 @@ vi.mock('../db', () => ({
             : mockDbState.tasks,
         }
       }
-      if (sql.includes('SELECT metadata FROM tasks WHERE id = ?')) {
+      if (sql.includes('SELECT metadata FROM tasks WHERE id = ? AND workspace_id = ?')) {
         return {
           get: (taskId: number) => {
             const task = mockDbState.tasks.find((item) => item.id === taskId)
@@ -75,8 +75,8 @@ vi.mock('../db', () => ({
       // Matches both the plain status update and the atomic claim variant
       // (UPDATE ... WHERE id = ? AND status = 'assigned') introduced in #698.
       if (
-        sql === 'UPDATE tasks SET status = ?, updated_at = ? WHERE id = ?' ||
-        sql === "UPDATE tasks SET status = ?, updated_at = ? WHERE id = ? AND status = 'assigned'"
+        sql === 'UPDATE tasks SET status = ?, updated_at = ? WHERE id = ? AND workspace_id = ?' ||
+        sql === "UPDATE tasks SET status = ?, updated_at = ? WHERE id = ? AND status = 'assigned' AND workspace_id = ?"
       ) {
         return {
           run: (status: string, _updatedAt: number, taskId: number) => {
@@ -85,7 +85,7 @@ vi.mock('../db', () => ({
           },
         }
       }
-      if (sql === 'UPDATE tasks SET metadata = ?, updated_at = ? WHERE id = ?') {
+      if (sql === 'UPDATE tasks SET metadata = ?, updated_at = ? WHERE id = ? AND workspace_id = ?') {
         return {
           run: (metadata: string, _updatedAt: number, taskId: number) => {
             mockDbState.metadataUpdates.push({ metadata, taskId })

--- a/src/lib/__tests__/workspace-sql-regressions.test.ts
+++ b/src/lib/__tests__/workspace-sql-regressions.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function source(path: string): string {
+  return readFileSync(join(process.cwd(), path), 'utf8')
+}
+
+function preparedTemplateSql(path: string): string[] {
+  return [...source(path).matchAll(/\.prepare\(`([\s\S]*?)`\)/g)].map((match) => match[1])
+}
+
+describe('workspace-owned SQL regressions', () => {
+  it('scopes pipeline template reads and validation', () => {
+    const pipelines = source('src/app/api/pipelines/route.ts')
+    const runs = source('src/app/api/pipelines/run/route.ts')
+
+    expect(pipelines).toContain('FROM workflow_templates WHERE workspace_id = ?')
+    expect(pipelines).toContain('AND workspace_id = ?`')
+    expect(runs.match(/FROM workflow_templates[^\n]+workspace_id = \?/g)).toHaveLength(2)
+  })
+
+  it('scopes reusable activity and status aggregates', () => {
+    const db = source('src/lib/db.ts')
+    const status = source('src/app/api/status/route.ts')
+    const diagnostics = source('src/app/api/diagnostics/route.ts')
+
+    expect(db).toContain('SELECT * FROM activities\n      WHERE workspace_id = ?')
+    expect(status).toContain("pipeline_runs WHERE status = 'running' AND workspace_id = ?")
+    expect(status).toContain('webhooks WHERE workspace_id = ?')
+    expect(diagnostics).toContain('agents WHERE workspace_id = ? GROUP BY status')
+  })
+
+  it('scopes every token-usage analytics query', () => {
+    for (const file of ['src/lib/agent-evals.ts', 'src/lib/agent-optimizer.ts']) {
+      const tokenQueries = preparedTemplateSql(file).filter((sql) => sql.includes('token_usage'))
+      expect(tokenQueries.length, file).toBeGreaterThan(0)
+      for (const sql of tokenQueries) {
+        expect(sql, file).toContain('workspace_id = ?')
+      }
+    }
+  })
+
+  it('scopes background task and integration mutations', () => {
+    const dispatch = source('src/lib/task-dispatch.ts')
+    const github = source('src/lib/github-sync-engine.ts')
+    const recurring = source('src/lib/recurring-tasks.ts')
+    const webhooks = source('src/lib/webhooks.ts')
+
+    expect(dispatch).not.toMatch(/(?:FROM|UPDATE) tasks WHERE id = \?(?! AND workspace_id)/)
+    expect(dispatch).not.toMatch(/FROM comments\s+WHERE task_id = \?(?![\s\S]{0,120}workspace_id)/)
+    expect(github).toContain('UPDATE tasks SET github_synced_at = ? WHERE id = ? AND workspace_id = ?')
+    expect(github).toContain('WHERE id = ? AND workspace_id = ?\n    `).run(created.number')
+    expect(recurring).toContain('WHERE id = ? AND workspace_id = ?')
+    expect(webhooks).toContain('webhook_deliveries SET next_retry_at = ? WHERE id = ? AND workspace_id = ?')
+  })
+})

--- a/src/lib/agent-evals.ts
+++ b/src/lib/agent-evals.ts
@@ -226,14 +226,14 @@ export function runDriftCheck(
   const currentTokens = db.prepare(`
     SELECT AVG(input_tokens + output_tokens) as avg_tokens
     FROM token_usage
-    WHERE agent_name = ? AND created_at > ?
-  `).get(agentName, currentStart) as any
+    WHERE agent_name = ? AND workspace_id = ? AND created_at > ?
+  `).get(agentName, workspaceId, currentStart) as any
 
   const baselineTokens = db.prepare(`
     SELECT AVG(input_tokens + output_tokens) as avg_tokens
     FROM token_usage
-    WHERE agent_name = ? AND created_at > ? AND created_at <= ?
-  `).get(agentName, baselineStart, baselineEnd) as any
+    WHERE agent_name = ? AND workspace_id = ? AND created_at > ? AND created_at <= ?
+  `).get(agentName, workspaceId, baselineStart, baselineEnd) as any
 
   const tokenDrift = checkDrift(
     currentTokens?.avg_tokens ?? 0,
@@ -314,8 +314,8 @@ export function getDriftTimeline(
     const tokens = db.prepare(`
       SELECT AVG(input_tokens + output_tokens) as avg_tokens
       FROM token_usage
-      WHERE agent_name = ? AND created_at > ? AND created_at <= ?
-    `).get(agentName, weekStart, weekEnd) as any
+      WHERE agent_name = ? AND workspace_id = ? AND created_at > ? AND created_at <= ?
+    `).get(agentName, workspaceId, weekStart, weekEnd) as any
 
     const tools = db.prepare(`
       SELECT

--- a/src/lib/agent-optimizer.ts
+++ b/src/lib/agent-optimizer.ts
@@ -58,8 +58,8 @@ export function analyzeTokenEfficiency(
       COALESCE(SUM(output_tokens), 0) as output_tokens,
       COALESCE(SUM(cost_usd), 0) as total_cost
     FROM token_usage
-    WHERE agent_name = ? AND created_at > ?
-  `).get(agentName, since) as any
+    WHERE agent_name = ? AND workspace_id = ? AND created_at > ?
+  `).get(agentName, workspaceId, since) as any
 
   const sessions = row?.sessions ?? 0
   const inputTokens = row?.input_tokens ?? 0
@@ -240,17 +240,17 @@ export function generateRecommendations(
   const agentCost = db.prepare(`
     SELECT COALESCE(SUM(cost_usd), 0) as cost, COUNT(DISTINCT task_id) as tasks
     FROM token_usage
-    WHERE agent_name = ? AND task_id IS NOT NULL
-  `).get(agentName) as any
+    WHERE agent_name = ? AND task_id IS NOT NULL AND workspace_id = ?
+  `).get(agentName, workspaceId) as any
 
   const fleetAvg = db.prepare(`
     SELECT AVG(cost_per_task) as avg_cost FROM (
       SELECT SUM(COALESCE(cost_usd, 0)) * 1.0 / NULLIF(COUNT(DISTINCT task_id), 0) as cost_per_task
       FROM token_usage
-      WHERE agent_name IS NOT NULL AND task_id IS NOT NULL
+      WHERE agent_name IS NOT NULL AND task_id IS NOT NULL AND workspace_id = ?
       GROUP BY agent_name
     )
-  `).get() as any
+  `).get(workspaceId) as any
 
   if (agentCost?.tasks > 0 && fleetAvg?.avg_cost > 0) {
     const agentCostPerTask = agentCost.cost / agentCost.tasks

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -465,15 +465,16 @@ export const db_helpers = {
   /**
    * Get recent activities for feed
    */
-  getRecentActivities: (limit: number = 50): Activity[] => {
+  getRecentActivities: (limit: number = 50, workspaceId: number = 1): Activity[] => {
     const db = getDatabase();
     const stmt = db.prepare(`
-      SELECT * FROM activities 
+      SELECT * FROM activities
+      WHERE workspace_id = ?
       ORDER BY created_at DESC 
       LIMIT ?
     `);
     
-    return stmt.all(limit) as Activity[];
+    return stmt.all(workspaceId, limit) as Activity[];
   },
 
   /**

--- a/src/lib/github-sync-engine.ts
+++ b/src/lib/github-sync-engine.ts
@@ -46,7 +46,7 @@ export async function pushTaskToGitHub(
     priority: string
     github_issue_number?: number | null
     github_repo?: string | null
-    workspace_id?: number
+    workspace_id: number
   },
   project: {
     id: number
@@ -90,8 +90,8 @@ export async function pushTaskToGitHub(
 
     // Mark synced to prevent ping-pong
     db.prepare(`
-      UPDATE tasks SET github_synced_at = ? WHERE id = ?
-    `).run(now, task.id)
+      UPDATE tasks SET github_synced_at = ? WHERE id = ? AND workspace_id = ?
+    `).run(now, task.id, task.workspace_id)
 
     logger.info({ repo, issue: task.github_issue_number }, 'Pushed task update to GitHub')
   } else if (project.github_sync_enabled) {
@@ -108,8 +108,8 @@ export async function pushTaskToGitHub(
     db.prepare(`
       UPDATE tasks
       SET github_issue_number = ?, github_repo = ?, github_synced_at = ?
-      WHERE id = ?
-    `).run(created.number, repo, now, task.id)
+      WHERE id = ? AND workspace_id = ?
+    `).run(created.number, repo, now, task.id, task.workspace_id)
 
     logger.info({ repo, issue: created.number, taskId: task.id }, 'Created GitHub issue for task')
   }
@@ -280,7 +280,7 @@ export function syncTaskOutbound(
         'SELECT id, github_repo, github_sync_enabled FROM projects WHERE id = ? AND workspace_id = ?'
       ).get(task.project_id, workspaceId) as { id: number; github_repo?: string | null; github_sync_enabled?: number | null } | undefined
       if (project?.github_sync_enabled) {
-        pushTaskToGitHub(task as any, project).catch(err =>
+        pushTaskToGitHub({ ...task, workspace_id: workspaceId }, project).catch(err =>
           logger.warn({ err, taskId: task.id }, 'Outbound GitHub sync failed')
         )
       }

--- a/src/lib/recurring-tasks.ts
+++ b/src/lib/recurring-tasks.ts
@@ -165,8 +165,8 @@ export async function spawnRecurringTasks(): Promise<{ ok: boolean; message: str
         }
         const updatedMetadata = { ...metadata, recurrence: updatedRecurrence }
         db.prepare(`
-          UPDATE tasks SET metadata = ?, updated_at = ? WHERE id = ?
-        `).run(JSON.stringify(updatedMetadata), nowSec, template.id)
+          UPDATE tasks SET metadata = ?, updated_at = ? WHERE id = ? AND workspace_id = ?
+        `).run(JSON.stringify(updatedMetadata), nowSec, template.id, template.workspace_id)
 
         db_helpers.logActivity(
           'task_created',

--- a/src/lib/task-dispatch.ts
+++ b/src/lib/task-dispatch.ts
@@ -701,7 +701,8 @@ function classifyDirectModel(task: DispatchableTask): string {
   if (descLength > 2000) return anthropicDispatchId('opus', 'claude-opus-4-6')
   try {
     const db = getDatabase()
-    const row = db.prepare('SELECT estimated_hours FROM tasks WHERE id = ?').get(task.id) as { estimated_hours: number | null } | undefined
+    const row = db.prepare('SELECT estimated_hours FROM tasks WHERE id = ? AND workspace_id = ?')
+      .get(task.id, task.workspace_id) as { estimated_hours: number | null } | undefined
     if (row?.estimated_hours && row.estimated_hours >= 4) return anthropicDispatchId('opus', 'claude-opus-4-6')
   } catch { /* ignore */ }
 
@@ -1440,8 +1441,8 @@ export async function requeueStaleTasks(): Promise<{ ok: boolean; message: strin
     const newAttempts = (task.dispatch_attempts ?? 0) + 1
 
     if (newAttempts >= maxDispatchRetries) {
-      db.prepare('UPDATE tasks SET status = ?, error_message = ?, dispatch_attempts = ?, updated_at = ? WHERE id = ?')
-        .run('failed', `Task stuck in_progress ${newAttempts} times — agent "${task.assigned_to}" offline. Moved to failed.`, newAttempts, now, task.id)
+      db.prepare('UPDATE tasks SET status = ?, error_message = ?, dispatch_attempts = ?, updated_at = ? WHERE id = ? AND workspace_id = ?')
+        .run('failed', `Task stuck in_progress ${newAttempts} times — agent "${task.assigned_to}" offline. Moved to failed.`, newAttempts, now, task.id, task.workspace_id)
 
       eventBus.broadcast('task.status_changed', {
         id: task.id,
@@ -1455,8 +1456,8 @@ export async function requeueStaleTasks(): Promise<{ ok: boolean; message: strin
       syncAndEscalateIfFailed(task as any, 'failed', `Task stuck in_progress ${newAttempts} times`, newAttempts)
       failed++
     } else {
-      db.prepare('UPDATE tasks SET status = ?, error_message = ?, dispatch_attempts = ?, updated_at = ? WHERE id = ?')
-        .run('assigned', `Requeued: agent "${task.assigned_to}" went offline while task was in_progress`, newAttempts, now, task.id)
+      db.prepare('UPDATE tasks SET status = ?, error_message = ?, dispatch_attempts = ?, updated_at = ? WHERE id = ? AND workspace_id = ?')
+        .run('assigned', `Requeued: agent "${task.assigned_to}" went offline while task was in_progress`, newAttempts, now, task.id, task.workspace_id)
 
       // Add a comment explaining the requeue
       db.prepare(`
@@ -1526,8 +1527,8 @@ export async function dispatchAssignedTasks(): Promise<{ ok: boolean; message: s
     // multiple workers polling), exactly one UPDATE reports changes=1 and the
     // loser skips this task — preventing double-dispatch (issue/PR #698).
     const claim = db
-      .prepare("UPDATE tasks SET status = ?, updated_at = ? WHERE id = ? AND status = 'assigned'")
-      .run('in_progress', now, task.id)
+      .prepare("UPDATE tasks SET status = ?, updated_at = ? WHERE id = ? AND status = 'assigned' AND workspace_id = ?")
+      .run('in_progress', now, task.id, task.workspace_id)
 
     if (claim.changes === 0) {
       // Another dispatcher won the race (or the task was cancelled between
@@ -1556,9 +1557,9 @@ export async function dispatchAssignedTasks(): Promise<{ ok: boolean; message: s
       // Check for previous Aegis rejection feedback
       const rejectionRow = db.prepare(`
         SELECT content FROM comments
-        WHERE task_id = ? AND author = 'aegis' AND content LIKE 'Quality Review Rejected:%'
+        WHERE task_id = ? AND author = 'aegis' AND content LIKE 'Quality Review Rejected:%' AND workspace_id = ?
         ORDER BY created_at DESC LIMIT 1
-      `).get(task.id) as { content: string } | undefined
+      `).get(task.id, task.workspace_id) as { content: string } | undefined
       const rejectionFeedback = rejectionRow?.content?.replace(/^Quality Review Rejected:\n?/, '') || null
 
       const prompt = buildTaskPrompt(task, rejectionFeedback)
@@ -1566,7 +1567,8 @@ export async function dispatchAssignedTasks(): Promise<{ ok: boolean; message: s
       // Check if task has a target session specified in metadata
       const taskMeta = (() => {
         try {
-          const row = db.prepare('SELECT metadata FROM tasks WHERE id = ?').get(task.id) as { metadata: string } | undefined
+          const row = db.prepare('SELECT metadata FROM tasks WHERE id = ? AND workspace_id = ?')
+            .get(task.id, task.workspace_id) as { metadata: string } | undefined
           return row?.metadata ? JSON.parse(row.metadata) : {}
         } catch { return {} }
       })()
@@ -1616,8 +1618,8 @@ export async function dispatchAssignedTasks(): Promise<{ ok: boolean; message: s
           async_state: asyncState,
           async_dispatched_at: Math.floor(Date.now() / 1000),
         }
-        db.prepare('UPDATE tasks SET metadata = ?, updated_at = ? WHERE id = ?')
-          .run(JSON.stringify(pendingMeta), Math.floor(Date.now() / 1000), task.id)
+        db.prepare('UPDATE tasks SET metadata = ?, updated_at = ? WHERE id = ? AND workspace_id = ?')
+          .run(JSON.stringify(pendingMeta), Math.floor(Date.now() / 1000), task.id, task.workspace_id)
 
         eventBus.broadcast('task.updated', {
           id: task.id,
@@ -1686,8 +1688,8 @@ export async function dispatchAssignedTasks(): Promise<{ ok: boolean; message: s
           async_state: asyncState,
           async_dispatched_at: Math.floor(Date.now() / 1000),
         }
-        db.prepare('UPDATE tasks SET metadata = ?, updated_at = ? WHERE id = ?')
-          .run(JSON.stringify(pendingMeta), Math.floor(Date.now() / 1000), task.id)
+        db.prepare('UPDATE tasks SET metadata = ?, updated_at = ? WHERE id = ? AND workspace_id = ?')
+          .run(JSON.stringify(pendingMeta), Math.floor(Date.now() / 1000), task.id, task.workspace_id)
 
         eventBus.broadcast('task.updated', {
           id: task.id,
@@ -1726,7 +1728,8 @@ export async function dispatchAssignedTasks(): Promise<{ ok: boolean; message: s
       // Merge dispatch_session_id into existing metadata
       const existingMeta = (() => {
         try {
-          const row = db.prepare('SELECT metadata FROM tasks WHERE id = ?').get(task.id) as { metadata: string } | undefined
+          const row = db.prepare('SELECT metadata FROM tasks WHERE id = ? AND workspace_id = ?')
+            .get(task.id, task.workspace_id) as { metadata: string } | undefined
           return row?.metadata ? JSON.parse(row.metadata) : {}
         } catch { return {} }
       })()
@@ -1736,8 +1739,8 @@ export async function dispatchAssignedTasks(): Promise<{ ok: boolean; message: s
 
       // Update task: status → review, set outcome
       db.prepare(`
-        UPDATE tasks SET status = ?, outcome = ?, resolution = ?, metadata = ?, updated_at = ? WHERE id = ?
-      `).run('review', 'success', truncated, JSON.stringify(existingMeta), Math.floor(Date.now() / 1000), task.id)
+        UPDATE tasks SET status = ?, outcome = ?, resolution = ?, metadata = ?, updated_at = ? WHERE id = ? AND workspace_id = ?
+      `).run('review', 'success', truncated, JSON.stringify(existingMeta), Math.floor(Date.now() / 1000), task.id, task.workspace_id)
 
       // Add a comment from the agent with the full response
       db.prepare(`
@@ -1785,15 +1788,16 @@ export async function dispatchAssignedTasks(): Promise<{ ok: boolean; message: s
       logger.error({ taskId: task.id, agent: task.agent_name, err }, 'Task dispatch failed')
 
       // Increment dispatch_attempts and decide next status
-      const currentAttempts = (db.prepare('SELECT dispatch_attempts FROM tasks WHERE id = ?').get(task.id) as { dispatch_attempts: number } | undefined)?.dispatch_attempts ?? 0
+      const currentAttempts = (db.prepare('SELECT dispatch_attempts FROM tasks WHERE id = ? AND workspace_id = ?')
+        .get(task.id, task.workspace_id) as { dispatch_attempts: number } | undefined)?.dispatch_attempts ?? 0
       const newAttempts = currentAttempts + 1
       const maxDispatchRetries = 5
 
       if (newAttempts >= maxDispatchRetries) {
         const failureMessage = `Dispatch failed ${newAttempts} times. Last: ${errorMsg.substring(0, 5000)}`
         // Too many failures — move to failed
-        db.prepare('UPDATE tasks SET status = ?, error_message = ?, dispatch_attempts = ?, updated_at = ? WHERE id = ?')
-          .run('failed', failureMessage, newAttempts, Math.floor(Date.now() / 1000), task.id)
+        db.prepare('UPDATE tasks SET status = ?, error_message = ?, dispatch_attempts = ?, updated_at = ? WHERE id = ? AND workspace_id = ?')
+          .run('failed', failureMessage, newAttempts, Math.floor(Date.now() / 1000), task.id, task.workspace_id)
 
         eventBus.broadcast('task.status_changed', {
           id: task.id,
@@ -1806,8 +1810,8 @@ export async function dispatchAssignedTasks(): Promise<{ ok: boolean; message: s
         syncAndEscalateIfFailed(task, 'failed', `Dispatch failed ${newAttempts} times`, newAttempts)
       } else {
         // Revert to assigned so it can be retried on the next tick
-        db.prepare('UPDATE tasks SET status = ?, error_message = ?, dispatch_attempts = ?, updated_at = ? WHERE id = ?')
-          .run('assigned', errorMsg.substring(0, 5000), newAttempts, Math.floor(Date.now() / 1000), task.id)
+        db.prepare('UPDATE tasks SET status = ?, error_message = ?, dispatch_attempts = ?, updated_at = ? WHERE id = ? AND workspace_id = ?')
+          .run('assigned', errorMsg.substring(0, 5000), newAttempts, Math.floor(Date.now() / 1000), task.id, task.workspace_id)
 
         eventBus.broadcast('task.status_changed', {
           id: task.id,

--- a/src/lib/webhooks.ts
+++ b/src/lib/webhooks.ts
@@ -332,7 +332,8 @@ async function deliverWebhook(
           // Schedule retry
           const delaySec = nextRetryDelay(attempt)
           const nextRetryAt = Math.floor(Date.now() / 1000) + delaySec
-          db.prepare(`UPDATE webhook_deliveries SET next_retry_at = ? WHERE id = ?`).run(nextRetryAt, deliveryId)
+          db.prepare(`UPDATE webhook_deliveries SET next_retry_at = ? WHERE id = ? AND workspace_id = ?`)
+            .run(nextRetryAt, deliveryId, workspaceId)
         } else {
           // Exhausted retries — trip circuit breaker
           const wh = db.prepare(`SELECT consecutive_failures FROM webhooks WHERE id = ? AND workspace_id = ?`).get(webhook.id, workspaceId) as { consecutive_failures: number } | undefined


### PR DESCRIPTION
## Summary
- bind background task claims, reads, retries, metadata updates, completion, and recurring-template mutations to task workspace ownership
- scope agent hide, connection lifecycle, alert tracking, webhook retry, and outbound GitHub-sync mutations
- restrict pipeline template enrichment, validation, and execution to the authenticated workspace
- scope status, diagnostics, activity helpers, agent drift, and optimizer token analytics
- require outbound task sync to carry authoritative workspace ownership
- add durable SQL-invariant and token-window regression coverage

## Security impact
The residual SQL audit found workspace-owned operations that relied on globally unique row IDs after an earlier scoped lookup, plus direct read-side leaks in pipeline-template and token-analytics queries. Every affected operation now binds the already-authoritative workspace identifier at the SQL boundary. Deployment-global diagnostics, external Hermes storage, migrations, and explicitly compatibility-gated GitHub queries remain unchanged.

## Verification
- pnpm typecheck
- pnpm test (131 files, 1,336 tests)
- pnpm lint (0 errors; 100 existing warnings)
- pnpm api:parity
- pnpm build
- strict security scan: passed

Progresses #800.