### PR TITLE
fix: stabilize React hook dependencies

### DIFF
--- a/src/components/panels/agent-detail-tabs.tsx
+++ b/src/components/panels/agent-detail-tabs.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { useTranslations } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import { Loader } from '@/components/ui/loader'
@@ -2213,7 +2213,7 @@ export function FilesTab({ agent }: { agent: Agent }) {
   const [saving, setSaving] = useState(false)
   const [workspace, setWorkspace] = useState<string | null>(null)
 
-  const loadFiles = async () => {
+  const loadFiles = useCallback(async () => {
     setLoading(true)
     setError(null)
     try {
@@ -2232,9 +2232,9 @@ export function FilesTab({ agent }: { agent: Agent }) {
     } finally {
       setLoading(false)
     }
-  }
+  }, [agent.id])
 
-  useEffect(() => { loadFiles() }, [agent.id])
+  useEffect(() => { loadFiles() }, [loadFiles])
 
   const activeEntry = activeFile ? files.find(f => f.name === activeFile) : null
   const baseContent = activeEntry?.content || ''

--- a/src/components/panels/agent-squad-panel.tsx
+++ b/src/components/panels/agent-squad-panel.tsx
@@ -68,7 +68,7 @@ export function AgentSquadPanel() {
     } finally {
       setLoading(false)
     }
-  }, [agents.length])
+  }, [agents.length, t])
 
   // Initial load
   useEffect(() => {

--- a/src/components/panels/audit-trail-panel.tsx
+++ b/src/components/panels/audit-trail-panel.tsx
@@ -146,7 +146,7 @@ export function AuditTrailPanel() {
     } finally {
       setLoading(false)
     }
-  }, [filter, page])
+  }, [filter, page, t])
 
   useEffect(() => { fetchEvents() }, [fetchEvents])
   useSmartPoll(fetchEvents, 30000, { pauseWhenDisconnected: true })

--- a/src/components/panels/memory-graph.tsx
+++ b/src/components/panels/memory-graph.tsx
@@ -109,7 +109,7 @@ const obsidianTheme: Theme = {
 export function MemoryGraph() {
   const t = useTranslations('memoryGraph')
   const { memoryGraphAgents, setMemoryGraphAgents } = useMissionControl()
-  const agents = memoryGraphAgents || []
+  const agents = useMemo(() => memoryGraphAgents || [], [memoryGraphAgents])
   const [selectedAgent, setSelectedAgent] = useState<string>('all')
   const [isLoading, setIsLoading] = useState(memoryGraphAgents === null)
   const [error, setError] = useState<string | null>(null)

--- a/src/components/panels/user-management-panel.tsx
+++ b/src/components/panels/user-management-panel.tsx
@@ -91,7 +91,7 @@ export function UserManagementPanel() {
     } finally {
       setLoading(false)
     }
-  }, [])
+  }, [t])
 
   useEffect(() => { fetchAll() }, [fetchAll])
 

--- a/src/lib/injection-guard.ts
+++ b/src/lib/injection-guard.ts
@@ -204,7 +204,6 @@ export function generateDecodingVariants(
     seen.add(candidate)
     try {
       const decoded = atob(candidate)
-      // eslint-disable-next-line no-control-regex
       if (decoded.length >= 4 && !/[\x00-\x08\x0B-\x1F\x7F]/.test(decoded)) {
         variants.push({ label: `base64-decoded:${candidate.slice(0, 12)}…`, text: cap(decoded) })
       }


### PR DESCRIPTION
## What changed\n- stabilizes the agent file loader and keys its effect to the callback\n- includes translation functions in callbacks that use translated error messages\n- memoizes the memory graph's empty agent fallback\n- removes an obsolete lint suppression from the injection guard\n\n## Why\nThe repository had seven React exhaustive-dependency warnings. They represented stale-closure or unstable-reference risks in polling, data loading, graph memoization, and error handling.\n\n## Verification\n- 1,336 unit tests passed\n- typecheck passed\n- lint passed with 0 errors\n- React hook warnings reduced from 7 to 0\n- total lint warnings reduced from 100 to 92\n- strict security scan passed\n- diff and private-identifier scans passed