### PR TITLE
fix: reject failed API responses

### DIFF
--- a/src/lib/__tests__/api-client.test.ts
+++ b/src/lib/__tests__/api-client.test.ts
@@ -11,7 +11,7 @@ function mockResponse(status: number, body: unknown = {}, opts: { json?: boolean
   })
 }
 
-describe('apiFetch — global 401 / 403 / 5xx / network handling', () => {
+describe('apiFetch — global HTTP and network error handling', () => {
   let dispatched: CustomEvent[] = []
   let originalHref = ''
   let authExpiredListener: ((e: Event) => void) | null = null
@@ -91,6 +91,31 @@ describe('apiFetch — global 401 / 403 / 5xx / network handling', () => {
     })
   })
 
+  it.each([400, 409, 422, 429])(
+    'throws CLIENT_ERROR with the upstream payload on %i',
+    async (status) => {
+      const payload = { error: `request rejected with ${status}`, field: 'name' }
+      global.fetch = vi.fn().mockResolvedValue(mockResponse(status, payload))
+
+      await expect(apiFetch('/api/tasks', { method: 'POST' })).rejects.toMatchObject({
+        code: 'CLIENT_ERROR',
+        status,
+        message: payload.error,
+        payload,
+      })
+    }
+  )
+
+  it('uses a status fallback when a client error has no upstream message', async () => {
+    global.fetch = vi.fn().mockResolvedValue(mockResponse(400, { field: 'title' }))
+
+    await expect(apiFetch('/api/tasks', { method: 'POST' })).rejects.toMatchObject({
+      code: 'CLIENT_ERROR',
+      status: 400,
+      message: 'Request failed with status 400',
+    })
+  })
+
   it('throws SERVER_ERROR on 500 with upstream message', async () => {
     global.fetch = vi.fn().mockResolvedValue(mockResponse(500, { error: 'database is locked' }))
     await expect(apiFetch('/api/tokens')).rejects.toMatchObject({
@@ -122,5 +147,27 @@ describe('apiFetch — global 401 / 403 / 5xx / network handling', () => {
     global.fetch = vi.fn().mockResolvedValue(new Response(null, { status: 204 }))
     const data = await apiFetch('/api/sessions/123', { method: 'DELETE' })
     expect(data).toBeUndefined()
+  })
+
+  it('returns a successful raw response when requested', async () => {
+    global.fetch = vi.fn().mockResolvedValue(mockResponse(200, { ok: true }))
+    const response = await apiFetch<Response>('/api/tasks', { raw: true })
+
+    expect(response).toBeInstanceOf(Response)
+    expect(response.status).toBe(200)
+  })
+
+  it('preserves non-specialized client errors for raw response inspection', async () => {
+    const payload = { error: 'Task needs a title', field: 'title' }
+    global.fetch = vi.fn().mockResolvedValue(mockResponse(422, payload))
+
+    const response = await apiFetch<Response>('/api/tasks', {
+      method: 'POST',
+      raw: true,
+    })
+
+    expect(response.ok).toBe(false)
+    expect(response.status).toBe(422)
+    await expect(response.json()).resolves.toEqual(payload)
   })
 })

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -16,6 +16,7 @@
  *   - Always sends cookies (credentials: 'include')
  *   - On 401: emits an `mc:auth-expired` CustomEvent, redirects to /login?from=…
  *   - On 403: throws ApiError with code='FORBIDDEN'
+ *   - On other 4xx: throws ApiError with code='CLIENT_ERROR' unless raw mode is requested
  *   - On 5xx: throws ApiError with code='SERVER_ERROR' and the upstream message
  *   - On network failure: throws ApiError with code='NETWORK_ERROR'
  *
@@ -27,6 +28,7 @@ export type ApiErrorCode =
   | 'UNAUTHENTICATED'
   | 'FORBIDDEN'
   | 'NOT_FOUND'
+  | 'CLIENT_ERROR'
   | 'SERVER_ERROR'
   | 'NETWORK_ERROR'
   | 'PARSE_ERROR'
@@ -61,7 +63,7 @@ function emitAuthExpired(detail: { path: string; status: number }): void {
 export interface ApiFetchOptions extends RequestInit {
   /** When true (default) and the response is 401, redirect to /login. */
   redirectOnUnauthenticated?: boolean
-  /** When true, return raw Response instead of parsed JSON. */
+  /** When true, return raw Response for statuses without specialized handling. */
   raw?: boolean
 }
 
@@ -131,6 +133,16 @@ export async function apiFetch<T = unknown>(
   }
 
   if (raw) return response as unknown as T
+
+  if (response.status >= 400 && response.status < 500) {
+    const payload = await safeParseJson(response)
+    const msg =
+      (typeof payload === 'object' && payload !== null && 'error' in payload &&
+        typeof (payload as { error: unknown }).error === 'string'
+        ? (payload as { error: string }).error
+        : null) || `Request failed with status ${response.status}`
+    throw new ApiError('CLIENT_ERROR', response.status, msg, payload)
+  }
 
   if (response.status === 204) return undefined as T
 


### PR DESCRIPTION
## Summary
- reject previously unhandled 400, 409, 422, and 429 responses in parsed mode
- preserve upstream error messages and payloads in a typed CLIENT_ERROR
- preserve raw-response inspection for non-specialized 4xx callers

## Compatibility
Existing specialized behavior for 401, 403, 404, and 5xx responses is unchanged. Raw-mode callers can still inspect validation and conflict responses directly.

## Evidence
- 16 focused API-client tests
- 1,343 unit tests
- TypeScript typecheck
- ESLint: 0 errors; 92 pre-existing bare-fetch migration warnings
- strict security scan
- production build, API parity, artifact check, and 513 Playwright tests completed on this slice before the final raw-mode compatibility correction; hosted CI will re-run the integrated gate on the exact commit

## Risk
Shared client boundary change. Regression coverage includes parsed and raw non-2xx behavior.