### PR TITLE
fix: unify setup API handling

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image'
 import { useTranslations } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import { LanguageSwitcherSelect } from '@/components/ui/language-switcher'
+import { apiFetch } from '@/lib/api-client'
 import { STORAGE_GATEWAY_URL } from '@/lib/device-identity'
 
 interface GoogleCredentialResponse {
@@ -176,8 +177,9 @@ export default function LoginPage() {
 
   // Check if first-time setup is needed on page load — auto-redirect to /setup
   useEffect(() => {
-    fetch('/api/setup')
-      .then((res) => res.json())
+    apiFetch<{ needsSetup?: boolean }>('/api/setup', {
+      redirectOnUnauthenticated: false,
+    })
       .then((data) => {
         if (data.needsSetup) {
           window.location.href = '/setup'

--- a/src/app/setup/page.tsx
+++ b/src/app/setup/page.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image'
 import { useTranslations } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import { LanguageSwitcherSelect } from '@/components/ui/language-switcher'
+import { apiFetch, ApiError } from '@/lib/api-client'
 import { fetchSetupStatusWithRetry } from '@/lib/setup-status'
 
 type SetupStep = 'form' | 'creating'
@@ -134,14 +135,15 @@ export default function SetupPage() {
     // Step 2: Creating account
     updateProgress(1, 'active')
     try {
-      const res = await fetch('/api/setup', {
+      const res = await apiFetch<Response>('/api/setup', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           username,
           password,
           displayName: displayName || undefined,
         }),
+        redirectOnUnauthenticated: false,
+        raw: true,
       })
 
       if (!res.ok) {
@@ -169,9 +171,19 @@ export default function SetupPage() {
 
       await new Promise((r) => setTimeout(r, 500))
       window.location.href = '/'
-    } catch {
+    } catch (error) {
       updateProgress(1, 'error')
-      setError(t('networkError'))
+      const payload = error instanceof ApiError ? error.payload : null
+      const message =
+        payload && typeof payload === 'object' && 'error' in payload &&
+        typeof (payload as { error?: unknown }).error === 'string'
+          ? (payload as { error: string }).error
+          : null
+      const fallback =
+        error instanceof ApiError && error.status > 0
+          ? t('setupFailed')
+          : t('networkError')
+      setError(message || fallback)
       await new Promise((r) => setTimeout(r, 1500))
       setStep('form')
       setProgress(getInitialProgress(t))


### PR DESCRIPTION
## Summary
- route the login page's best-effort setup probe through the shared API client
- route first-admin creation through the same credential and network contract
- preserve raw 400 validation handling and recover server-provided messages from typed errors
- disable unauthenticated redirects on both intentionally public requests

## Evidence
- full unit suite: 1,343 tests
- full Playwright suite: 513 tests
- TypeScript typecheck
- ESLint: 0 errors; warnings reduced from 92 to 90
- strict security scan
- private-context diff scan

## Risk
Public authentication surface. The patch is limited to the two literal setup API calls and keeps the dynamic login status-code flow unchanged.