### PR TITLE
security: harden gateway process controls

### DIFF
--- a/src/app/api/gateways/control/route.ts
+++ b/src/app/api/gateways/control/route.ts
@@ -7,6 +7,22 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync, openSync } from 'no
 import { join } from 'node:path'
 import { spawn } from 'node:child_process'
 import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
+import { logAuditEvent } from '@/lib/db'
+import { gatewayControlLimiter } from '@/lib/rate-limit'
+import { redactSecrets } from '@/lib/secret-scanner'
+import { gatewayControlSchema, validateBody } from '@/lib/validation'
+import { runCommand } from '@/lib/command'
+
+const MAX_COMMAND_OUTPUT_LENGTH = 16_000
+
+function formatCommandOutput(stdout: string, stderr: string): string {
+  const redacted = redactSecrets(`${stdout || ''}\n${stderr || ''}`.trim()).replace(
+    /((?:api[_-]?key|access[_-]?token|refresh[_-]?token|token|password|secret|authorization)\s*[=:]\s*)[^\r\n]+/gi,
+    '$1***REDACTED***',
+  )
+  if (redacted.length <= MAX_COMMAND_OUTPUT_LENGTH) return redacted
+  return `${redacted.slice(0, MAX_COMMAND_OUTPUT_LENGTH)}\n…[truncated]`
+}
 
 /** True when MC is running inside a Docker container without systemd. */
 function isDockerEnvironment(): boolean {
@@ -90,7 +106,6 @@ function stopHermesGatewayDetached(homeDir: string): { stopped: boolean; error?:
 }
 
 type GatewayType = 'hermes' | 'openclaw'
-type GatewayAction = 'status' | 'start' | 'stop' | 'restart' | 'diagnose'
 
 interface GatewayStatus {
   type: GatewayType
@@ -170,23 +185,22 @@ export async function POST(request: NextRequest) {
   const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'runtime_configuration', new URL(request.url).pathname)
   if (isolationDeny) return isolationDeny
 
+  const limitKey = `${auth.user.tenant_id ?? 1}:${auth.user.workspace_id ?? 1}:${auth.user.id}`
+  const limited = gatewayControlLimiter(limitKey)
+  if (limited) return limited
+
+  const validated = await validateBody(request, gatewayControlSchema)
+  if ('error' in validated) return validated.error
+  const { gateway, action } = validated.data
+
   try {
-    const body = await request.json()
-    const { gateway, action } = body as { gateway: GatewayType; action: GatewayAction }
-
-    if (!gateway || !action) {
-      return NextResponse.json({ error: 'gateway and action are required' }, { status: 400 })
-    }
-
-    if (!['hermes', 'openclaw'].includes(gateway)) {
-      return NextResponse.json({ error: 'Invalid gateway type' }, { status: 400 })
-    }
-
-    if (!['start', 'stop', 'restart', 'diagnose'].includes(action)) {
-      return NextResponse.json({ error: 'Invalid action' }, { status: 400 })
-    }
-
-    const { runCommand } = require('@/lib/command')
+    logAuditEvent({
+      action: 'gateway.control',
+      actor: auth.user.username,
+      actor_id: auth.user.id,
+      target_type: 'runtime',
+      detail: { gateway, action },
+    })
 
     if (gateway === 'hermes') {
       const bin = join(config.homeDir, '.local', 'bin', 'hermes')
@@ -197,7 +211,7 @@ export async function POST(request: NextRequest) {
         const result = await runCommand(hermesBin, ['doctor'], { timeoutMs: 30_000 })
         return NextResponse.json({
           success: result.code === 0,
-          output: ((result.stdout || '') + '\n' + (result.stderr || '')).trim(),
+          output: formatCommandOutput(result.stdout, result.stderr),
         })
       }
 
@@ -264,7 +278,7 @@ export async function POST(request: NextRequest) {
 
       return NextResponse.json({
         success: result.code === 0,
-        output: ((result.stdout || '') + '\n' + (result.stderr || '')).trim(),
+        output: formatCommandOutput(result.stdout, result.stderr),
         status: getHermesGatewayStatus(),
       })
     }
@@ -276,7 +290,7 @@ export async function POST(request: NextRequest) {
         const result = await runCommand(openclawBin, ['doctor'], { timeoutMs: 30_000 })
         return NextResponse.json({
           success: result.code === 0,
-          output: ((result.stdout || '') + '\n' + (result.stderr || '')).trim(),
+          output: formatCommandOutput(result.stdout, result.stderr),
         })
       }
 
@@ -289,7 +303,7 @@ export async function POST(request: NextRequest) {
 
       return NextResponse.json({
         success: result.code === 0,
-        output: ((result.stdout || '') + '\n' + (result.stderr || '')).trim(),
+        output: formatCommandOutput(result.stdout, result.stderr),
         status: getOpenClawGatewayStatus(),
       })
     }

--- a/src/lib/__tests__/gateway-control-route-security.test.ts
+++ b/src/lib/__tests__/gateway-control-route-security.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest, NextResponse } from 'next/server'
+
+const {
+  gatewayControlLimiterMock,
+  isolationMock,
+  logAuditEventMock,
+  requireRoleMock,
+  runCommandMock,
+} = vi.hoisted(() => ({
+  gatewayControlLimiterMock: vi.fn(),
+  isolationMock: vi.fn(),
+  logAuditEventMock: vi.fn(),
+  requireRoleMock: vi.fn(),
+  runCommandMock: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({ requireRole: requireRoleMock }))
+vi.mock('@/lib/command', () => ({ runCommand: runCommandMock }))
+vi.mock('@/lib/db', () => ({ logAuditEvent: logAuditEventMock }))
+vi.mock('@/lib/rate-limit', () => ({ gatewayControlLimiter: gatewayControlLimiterMock }))
+vi.mock('@/lib/workspace-isolation', () => ({
+  denyUnscopedResourceForStrictWorkspace: isolationMock,
+}))
+vi.mock('@/lib/config', () => ({
+  config: {
+    homeDir: '/tmp/mission-control-gateway-test',
+    openclawBin: 'openclaw',
+    openclawConfigPath: '/tmp/missing-openclaw.json',
+  },
+}))
+vi.mock('@/lib/hermes-sessions', () => ({ isHermesGatewayRunning: vi.fn(() => false) }))
+vi.mock('@/lib/logger', () => ({ logger: { info: vi.fn(), error: vi.fn() } }))
+
+const admin = {
+  user: { id: 7, username: 'admin', role: 'admin', workspace_id: 3, tenant_id: 9 },
+}
+
+function request(body: string) {
+  return new NextRequest('http://localhost/api/gateways/control', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body,
+  })
+}
+
+describe('gateway control route security', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    requireRoleMock.mockReturnValue(admin)
+    isolationMock.mockReturnValue(null)
+    gatewayControlLimiterMock.mockReturnValue(null)
+    runCommandMock.mockResolvedValue({ stdout: 'ok', stderr: '', code: 0 })
+  })
+
+  it('authenticates and isolates before limiting or parsing', async () => {
+    requireRoleMock.mockReturnValue({ error: 'Authentication required', status: 401 })
+    const { POST } = await import('@/app/api/gateways/control/route')
+
+    const response = await POST(request('{not-json'))
+
+    expect(response.status).toBe(401)
+    expect(isolationMock).not.toHaveBeenCalled()
+    expect(gatewayControlLimiterMock).not.toHaveBeenCalled()
+    expect(runCommandMock).not.toHaveBeenCalled()
+  })
+
+  it('applies a critical identity limiter before parsing or execution', async () => {
+    gatewayControlLimiterMock.mockReturnValue(
+      NextResponse.json({ error: 'Too many gateway control attempts' }, { status: 429 }),
+    )
+    const { POST } = await import('@/app/api/gateways/control/route')
+
+    const response = await POST(request('{not-json'))
+
+    expect(response.status).toBe(429)
+    expect(gatewayControlLimiterMock).toHaveBeenCalledWith('9:3:7')
+    expect(runCommandMock).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    {},
+    { gateway: 'unknown', action: 'start' },
+    { gateway: 'openclaw', action: 'destroy' },
+  ])('rejects invalid control input without executing commands', async (body) => {
+    const { POST } = await import('@/app/api/gateways/control/route')
+
+    const response = await POST(request(JSON.stringify(body)))
+
+    expect(response.status).toBe(400)
+    expect(runCommandMock).not.toHaveBeenCalled()
+    expect(logAuditEventMock).not.toHaveBeenCalled()
+  })
+
+  it('redacts and bounds command output while attributing the action', async () => {
+    const token = `ghp_${'a'.repeat(40)}`
+    runCommandMock.mockResolvedValue({
+      stdout: `${token}\ngateway_token=plain-secret-value\n${'x'.repeat(20_000)}`,
+      stderr: '',
+      code: 0,
+    })
+    const { POST } = await import('@/app/api/gateways/control/route')
+
+    const response = await POST(request(JSON.stringify({ gateway: 'openclaw', action: 'diagnose' })))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.output).not.toContain(token)
+    expect(body.output).not.toContain('plain-secret-value')
+    expect(body.output).toContain('***REDACTED***')
+    expect(body.output).toContain('…[truncated]')
+    expect(body.output.length).toBeLessThanOrEqual(16_020)
+    expect(logAuditEventMock).toHaveBeenCalledWith({
+      action: 'gateway.control',
+      actor: 'admin',
+      actor_id: 7,
+      target_type: 'runtime',
+      detail: { gateway: 'openclaw', action: 'diagnose' },
+    })
+  })
+})

--- a/src/lib/__tests__/gateway-local-runtime-isolation.test.ts
+++ b/src/lib/__tests__/gateway-local-runtime-isolation.test.ts
@@ -31,7 +31,7 @@ describe('gateway and local host runtime isolation', () => {
 
   it('guards gateway status, control, and discovery before host access', () => {
     expectGuardBefore('src/app/api/gateways/control/route.ts', 'GET', 'const gateways:')
-    expectGuardBefore('src/app/api/gateways/control/route.ts', 'POST', 'request.json()')
+    expectGuardBefore('src/app/api/gateways/control/route.ts', 'POST', 'gatewayControlLimiter(limitKey)')
     expectGuardBefore('src/app/api/gateways/discover/route.ts', 'GET', 'execFileSync(')
   })
 

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -281,6 +281,14 @@ export const openClawMaintenanceLimiter = createKeyedRateLimiter({
   critical: true,
 })
 
+/** Gateway process start, stop, restart, and diagnostics: 10 attempts per minute per admin. */
+export const gatewayControlLimiter = createKeyedRateLimiter({
+  windowMs: 60_000,
+  maxRequests: 10,
+  message: 'Too many gateway control attempts. Try again in a minute.',
+  critical: true,
+})
+
 /** Local skill writes and recursive deletion: 20 attempts per minute per operator. */
 export const skillMutationLimiter = createKeyedRateLimiter({
   windowMs: 60_000,

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -253,6 +253,11 @@ export const gatewayConfigUpdateSchema = z.object({
   hash: z.string().optional(),
 })
 
+export const gatewayControlSchema = z.object({
+  gateway: z.enum(['hermes', 'openclaw']),
+  action: z.enum(['start', 'stop', 'restart', 'diagnose']),
+})
+
 export const qualityReviewSchema = z.object({
   taskId: z.number(),
   reviewer: z.string().default('aegis'),


### PR DESCRIPTION
## Summary
- add a critical tenant/workspace/admin-keyed throttle to gateway start, stop, restart, and diagnose actions
- validate the control request with a strict schema before any command execution
- record attributed audit events for accepted gateway actions
- redact known credentials and named secret assignments from command output
- cap diagnostic output at 16 KB to prevent unbounded responses
- replace the route's hidden command-runner require with an explicit dependency

## Security ordering
authenticate → workspace isolation → critical identity limit → validate → audit → execute

## Evidence
- 9 focused gateway security/isolation tests
- full unit suite: 1,349 tests
- full Playwright suite: 513 tests
- TypeScript typecheck
- ESLint: 0 errors; no new warnings
- strict security scan
- dependency audit: no known high-severity vulnerabilities
- private-context diff scan

## Risk
This changes a privileged host-process boundary. Existing admin and workspace requirements remain in place; successful control behavior is unchanged except that command output is now redacted and bounded.