### PR TITLE
fix: unify gateway control requests

### DIFF
--- a/src/components/panels/gateway-control-panel.tsx
+++ b/src/components/panels/gateway-control-panel.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { useTranslations } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import { Loader } from '@/components/ui/loader'
+import { apiFetch, ApiError } from '@/lib/api-client'
 
 interface GatewayStatus {
   type: string
@@ -16,6 +17,21 @@ interface GatewayStatus {
   error?: string
 }
 
+interface GatewayActionResponse {
+  success?: boolean
+  output?: string
+  error?: string
+}
+
+function getApiErrorMessage(error: unknown): string | null {
+  if (!(error instanceof ApiError)) return null
+  const payload = error.payload
+  if (!payload || typeof payload !== 'object' || !('error' in payload)) return null
+  return typeof (payload as { error?: unknown }).error === 'string'
+    ? (payload as { error: string }).error
+    : null
+}
+
 export function GatewayControlPanel() {
   const t = useTranslations('gatewayControl')
   const [gateways, setGateways] = useState<GatewayStatus[]>([])
@@ -25,11 +41,8 @@ export function GatewayControlPanel() {
 
   const fetchStatus = useCallback(async () => {
     try {
-      const res = await fetch('/api/gateways/control')
-      if (res.ok) {
-        const data = await res.json()
-        setGateways(data.gateways || [])
-      }
+      const data = await apiFetch<{ gateways?: GatewayStatus[] }>('/api/gateways/control')
+      setGateways(data.gateways || [])
     } catch { /* ignore */ }
     finally { setLoading(false) }
   }, [])
@@ -41,17 +54,15 @@ export function GatewayControlPanel() {
     setActionInProgress(key)
     setOutput(null)
     try {
-      const res = await fetch('/api/gateways/control', {
+      const data = await apiFetch<GatewayActionResponse>('/api/gateways/control', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ gateway, action }),
       })
-      const data = await res.json()
       setOutput({ gateway, text: data.output || data.error || 'Done', ok: data.success !== false })
       // Refresh status after action
       await fetchStatus()
-    } catch (err) {
-      setOutput({ gateway, text: 'Action failed', ok: false })
+    } catch (error) {
+      setOutput({ gateway, text: getApiErrorMessage(error) || 'Action failed', ok: false })
     } finally {
       setActionInProgress(null)
     }


### PR DESCRIPTION
## Summary
- move gateway status and process actions onto the shared authenticated API client
- preserve server-provided action errors from typed API failures
- remove duplicate JSON headers and response parsing
- retain the panel's best-effort status loading and action refresh behavior

## Evidence
- full unit suite: 1,349 tests
- TypeScript typecheck
- ESLint: 0 errors; bare-fetch warnings reduced from 90 to 88
- strict security scan
- private-context diff scan
- hosted quality gate will run the full build, artifact, and 513-test Playwright suite on the exact commit

## Dependency
Built from main after the gateway process-control security hardening in #828.