### PR TITLE
security: harden gateway config mutations

### DIFF
--- a/src/app/api/gateway-config/route.ts
+++ b/src/app/api/gateway-config/route.ts
@@ -4,7 +4,7 @@ import { requireRole } from '@/lib/auth'
 import { logAuditEvent } from '@/lib/db'
 import { config } from '@/lib/config'
 import { validateBody, gatewayConfigUpdateSchema } from '@/lib/validation'
-import { mutationLimiter } from '@/lib/rate-limit'
+import { gatewayConfigMutationLimiter } from '@/lib/rate-limit'
 import { getDetectedGatewayToken } from '@/lib/gateway-runtime'
 import { parseJsonRelaxed } from '@/lib/json-relaxed'
 import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
@@ -64,11 +64,11 @@ export async function GET(request: NextRequest) {
       raw_size: raw.length,
       hash,
     })
-  } catch (err: any) {
-    if (err.code === 'ENOENT') {
+  } catch (error: unknown) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
       return NextResponse.json({ error: 'Config file not found', path: configPath }, { status: 404 })
     }
-    return NextResponse.json({ error: `Failed to read config: ${err.message}` }, { status: 500 })
+    return NextResponse.json({ error: 'Failed to read gateway configuration' }, { status: 500 })
   }
 }
 
@@ -111,7 +111,8 @@ export async function PUT(request: NextRequest) {
   const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'runtime_configuration', new URL(request.url).pathname)
   if (isolationDeny) return isolationDeny
 
-  const rateCheck = mutationLimiter(request)
+  const limitKey = `${auth.user.tenant_id ?? 1}:${auth.user.workspace_id ?? 1}:${auth.user.id}`
+  const rateCheck = gatewayConfigMutationLimiter(limitKey)
   if (rateCheck) return rateCheck
 
   const action = request.nextUrl.searchParams.get('action')
@@ -161,7 +162,7 @@ export async function PUT(request: NextRequest) {
 
     for (const dotPath of Object.keys(body.updates)) {
       const [rootKey] = dotPath.split('.')
-      if (!rootKey || !(rootKey in parsed)) {
+      if (!rootKey || !Object.hasOwn(parsed, rootKey)) {
         return NextResponse.json(
           { error: `Unknown config root: ${rootKey || dotPath}` },
           { status: 400 },
@@ -194,8 +195,8 @@ export async function PUT(request: NextRequest) {
       count: appliedKeys.length,
       hash: computeHash(newRaw),
     })
-  } catch (err: any) {
-    return NextResponse.json({ error: `Failed to update config: ${err.message}` }, { status: 500 })
+  } catch {
+    return NextResponse.json({ error: 'Failed to update gateway configuration' }, { status: 500 })
   }
 }
 
@@ -220,9 +221,8 @@ async function applyConfig(request: NextRequest, auth: any): Promise<NextRespons
     })
 
     if (!res.ok) {
-      const text = await res.text().catch(() => '')
       return NextResponse.json(
-        { error: `Apply failed (${res.status}): ${text}` },
+        { error: `Gateway rejected config apply with status ${res.status}` },
         { status: 502 },
       )
     }
@@ -258,9 +258,8 @@ async function updateSystem(request: NextRequest, auth: any): Promise<NextRespon
     })
 
     if (!res.ok) {
-      const text = await res.text().catch(() => '')
       return NextResponse.json(
-        { error: `Update failed (${res.status}): ${text}` },
+        { error: `Gateway rejected system update with status ${res.status}` },
         { status: 502 },
       )
     }

--- a/src/lib/__tests__/gateway-config-route-security.test.ts
+++ b/src/lib/__tests__/gateway-config-route-security.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest, NextResponse } from 'next/server'
+
+const {
+  fetchMock,
+  gatewayConfigMutationLimiterMock,
+  isolationMock,
+  requireRoleMock,
+} = vi.hoisted(() => ({
+  fetchMock: vi.fn(),
+  gatewayConfigMutationLimiterMock: vi.fn(),
+  isolationMock: vi.fn(),
+  requireRoleMock: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({ requireRole: requireRoleMock }))
+vi.mock('@/lib/config', () => ({
+  config: {
+    gatewayHost: '127.0.0.1',
+    gatewayPort: 18789,
+    openclawConfigPath: '/tmp/mission-control-gateway-config-test.json',
+  },
+}))
+vi.mock('@/lib/db', () => ({ logAuditEvent: vi.fn() }))
+vi.mock('@/lib/gateway-runtime', () => ({ getDetectedGatewayToken: vi.fn(() => null) }))
+vi.mock('@/lib/rate-limit', () => ({
+  gatewayConfigMutationLimiter: gatewayConfigMutationLimiterMock,
+}))
+vi.mock('@/lib/workspace-isolation', () => ({
+  denyUnscopedResourceForStrictWorkspace: isolationMock,
+}))
+
+const admin = {
+  user: { id: 7, username: 'admin', role: 'admin', workspace_id: 3, tenant_id: 9 },
+}
+
+function request(body: unknown, action?: string) {
+  const suffix = action ? `?action=${action}` : ''
+  return new NextRequest(`http://localhost/api/gateway-config${suffix}`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('gateway configuration route security', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    vi.stubGlobal('fetch', fetchMock)
+    requireRoleMock.mockReturnValue(admin)
+    isolationMock.mockReturnValue(null)
+    gatewayConfigMutationLimiterMock.mockReturnValue(null)
+  })
+
+  it('authenticates and isolates before applying the critical limiter', async () => {
+    requireRoleMock.mockReturnValue({ error: 'Authentication required', status: 401 })
+    const { PUT } = await import('@/app/api/gateway-config/route')
+
+    const response = await PUT(request({}, 'apply'))
+
+    expect(response.status).toBe(401)
+    expect(isolationMock).not.toHaveBeenCalled()
+    expect(gatewayConfigMutationLimiterMock).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('limits by authenticated tenant, workspace, and admin before action handling', async () => {
+    gatewayConfigMutationLimiterMock.mockReturnValue(
+      NextResponse.json({ error: 'Too many gateway configuration changes' }, { status: 429 }),
+    )
+    const { PUT } = await import('@/app/api/gateway-config/route')
+
+    const response = await PUT(request({}, 'apply'))
+
+    expect(response.status).toBe(429)
+    expect(gatewayConfigMutationLimiterMock).toHaveBeenCalledWith('9:3:7')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it.each(['__proto__.polluted', 'constructor.prototype.polluted', 'gateway.__proto__.polluted'])(
+    'rejects unsafe config path %s before filesystem access',
+    async (path) => {
+      const { PUT } = await import('@/app/api/gateway-config/route')
+
+      const response = await PUT(request({ updates: { [path]: true } }))
+
+      expect(response.status).toBe(400)
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+    },
+  )
+
+  it('rejects oversized update maps', async () => {
+    const updates = Object.fromEntries(
+      Array.from({ length: 101 }, (_, index) => [`gateway.field_${index}`, index]),
+    )
+    const { PUT } = await import('@/app/api/gateway-config/route')
+
+    const response = await PUT(request({ updates }))
+
+    expect(response.status).toBe(400)
+  })
+
+  it.each(['apply', 'update'])('does not reflect upstream text when %s fails', async (action) => {
+    fetchMock.mockResolvedValue(new Response('SENSITIVE_GATEWAY_RESPONSE', { status: 503 }))
+    const { PUT } = await import('@/app/api/gateway-config/route')
+
+    const response = await PUT(request({}, action))
+    const body = await response.json()
+
+    expect(response.status).toBe(502)
+    expect(body.error).toContain('503')
+    expect(JSON.stringify(body)).not.toContain('SENSITIVE_GATEWAY_RESPONSE')
+  })
+})

--- a/src/lib/__tests__/gateway-local-runtime-isolation.test.ts
+++ b/src/lib/__tests__/gateway-local-runtime-isolation.test.ts
@@ -26,7 +26,7 @@ describe('gateway and local host runtime isolation', () => {
   it('guards deployment gateway configuration before reads, RPC, or mutation work', () => {
     const file = 'src/app/api/gateway-config/route.ts'
     expectGuardBefore(file, 'GET', 'request.nextUrl.searchParams')
-    expectGuardBefore(file, 'PUT', 'mutationLimiter(request)')
+    expectGuardBefore(file, 'PUT', 'gatewayConfigMutationLimiter(limitKey)')
   })
 
   it('guards gateway status, control, and discovery before host access', () => {

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -289,6 +289,14 @@ export const gatewayControlLimiter = createKeyedRateLimiter({
   critical: true,
 })
 
+/** Gateway configuration writes, applies, and system updates: 20 attempts per minute per admin. */
+export const gatewayConfigMutationLimiter = createKeyedRateLimiter({
+  windowMs: 60_000,
+  maxRequests: 20,
+  message: 'Too many gateway configuration changes. Try again in a minute.',
+  critical: true,
+})
+
 /** Local skill writes and recursive deletion: 20 attempts per minute per operator. */
 export const skillMutationLimiter = createKeyedRateLimiter({
   windowMs: 60_000,

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -248,8 +248,18 @@ export const updateSettingsSchema = z.object({
   settings: z.record(z.string(), z.unknown()),
 })
 
+const gatewayConfigPathSchema = z.string().min(1).max(500).refine(
+  (path) => path.split('.').every(
+    (segment) => segment.length > 0 && !['__proto__', 'prototype', 'constructor'].includes(segment),
+  ),
+  'Config path contains an unsafe segment',
+)
+
 export const gatewayConfigUpdateSchema = z.object({
-  updates: z.record(z.string(), z.unknown()),
+  updates: z.record(gatewayConfigPathSchema, z.unknown()).refine(
+    (updates) => Object.keys(updates).length > 0 && Object.keys(updates).length <= 100,
+    'Updates must contain between 1 and 100 fields',
+  ),
   hash: z.string().optional(),
 })
 


### PR DESCRIPTION
## Summary
- reject __proto__, prototype, and constructor segments in dot-path configuration updates
- require own config roots instead of accepting inherited object properties
- bound updates to 1–100 fields
- replace the bypassable IP mutation limiter with a critical tenant/workspace/admin-keyed limiter
- stop reflecting upstream gateway response bodies and filesystem exception messages
- add direct regression coverage for ordering, prototype paths, update bounds, and disclosure failures

## Security ordering
authenticate → workspace isolation → critical identity limit → validate → mutate

## Evidence
- 11 focused gateway configuration/isolation tests
- full unit suite: 1,357 tests
- full Playwright suite: 513 tests
- TypeScript typecheck
- ESLint: 0 errors; 88 existing migration warnings
- strict security scan
- dependency audit: no known high-severity vulnerabilities
- private-context diff scan

## Risk
This changes a privileged configuration-write boundary. Valid existing dot-path updates remain supported; unsafe inherited paths and oversized maps are now rejected.