### PR TITLE
fix(gateway): keep tunnel reconnects on stable websocket URL

### DIFF
--- a/src/lib/websocket.ts
+++ b/src/lib/websocket.ts
@@ -731,6 +731,7 @@ export function useWebSocket() {
 
       ws.onclose = (event) => {
         log.info(`Disconnected from Gateway: ${event.code} ${event.reason}`)
+        const wasHandshakeComplete = handshakeCompleteRef.current
         setConnection({ isConnected: false })
         handshakeCompleteRef.current = false
         stopHeartbeat()
@@ -740,7 +741,11 @@ export function useWebSocket() {
 
         // If the initial handshake never completed and the URL is root-only,
         // try common reverse-proxy websocket paths before exponential backoff.
-        if (!handshakeCompleteRef.current) {
+        // Capture handshake state before clearing it; otherwise established
+        // tunnel connections that drop later are misclassified as initial
+        // handshake failures and reconnect to /gateway-ws or /gw instead of
+        // the last known-good URL.
+        if (!wasHandshakeComplete) {
           const fallback = buildGatewayPathFallbackUrls(normalizedUrl).find(
             (candidate) => !wsPathFallbackTriedRef.current.has(candidate),
           )


### PR DESCRIPTION
## Summary\n- Fix reconnect handling after a successful gateway WebSocket handshake drops later\n- Preserve the last known-good tunnel URL instead of misclassifying established disconnects as initial handshake failures\n- Prevent unintended fallback from a working root URL to /gateway-ws or /gw during normal tunnel reconnects\n\n## Why\nFollow-up for #194: users reported tunnel connections establishing and then disconnecting later. The close handler cleared handshake state before checking it, so every close looked like a failed initial handshake.\n\n## Testing\n- pnpm typecheck\n- pnpm exec vitest run src/lib/__tests__/gateway-url.test.ts\n\nRefs #194