### PR TITLE
security: harden backup administration

### DIFF
--- a/src/app/api/backup/route.ts
+++ b/src/app/api/backup/route.ts
@@ -149,6 +149,12 @@ export async function DELETE(request: NextRequest) {
   const rateCheck = backupMutationLimiter(limitKey)
   if (rateCheck) return rateCheck
 
+  try {
+    await request.clone().json()
+  } catch {
+    return NextResponse.json({ error: 'Request body required' }, { status: 400 })
+  }
+
   const result = await validateBody(request, backupDeleteSchema)
   if ('error' in result) return result.error
   const { name } = result.data

--- a/src/app/api/backup/route.ts
+++ b/src/app/api/backup/route.ts
@@ -4,10 +4,11 @@ import { getDatabase, logAuditEvent } from '@/lib/db'
 import { config, ensureDirExists } from '@/lib/config'
 import { join, dirname } from 'path'
 import { readdirSync, statSync, unlinkSync } from 'fs'
-import { heavyLimiter } from '@/lib/rate-limit'
+import { backupMutationLimiter, extractClientIp } from '@/lib/rate-limit'
 import { logger } from '@/lib/logger'
 import { runOpenClaw } from '@/lib/command'
 import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
+import { backupDeleteSchema, validateBody } from '@/lib/validation'
 
 const BACKUP_DIR = join(dirname(config.dbPath), 'backups')
 const MAX_BACKUPS = 10
@@ -36,9 +37,9 @@ export async function GET(request: NextRequest) {
       })
       .sort((a, b) => b.created_at - a.created_at)
 
-    return NextResponse.json({ backups: files, dir: BACKUP_DIR })
+    return NextResponse.json({ backups: files })
   } catch {
-    return NextResponse.json({ backups: [], dir: BACKUP_DIR })
+    return NextResponse.json({ backups: [] })
   }
 }
 
@@ -51,15 +52,19 @@ export async function POST(request: NextRequest) {
   const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'host_administration', new URL(request.url).pathname)
   if (isolationDeny) return isolationDeny
 
-  const rateCheck = heavyLimiter(request)
+  const limitKey = `${auth.user.tenant_id ?? 1}:${auth.user.workspace_id ?? 1}:${auth.user.id}:backup`
+  const rateCheck = backupMutationLimiter(limitKey)
   if (rateCheck) return rateCheck
 
   const target = request.nextUrl.searchParams.get('target')
+  if (target !== null && target !== 'gateway') {
+    return NextResponse.json({ error: 'Invalid backup target' }, { status: 400 })
+  }
 
   // Gateway state backup via `openclaw backup create`
   if (target === 'gateway') {
     ensureDirExists(BACKUP_DIR)
-    const ipAddress = request.headers.get('x-forwarded-for') || request.headers.get('x-real-ip') || 'unknown'
+    const ipAddress = extractClientIp(request)
     try {
       let stdout: string
       let stderr: string
@@ -73,26 +78,23 @@ export async function POST(request: NextRequest) {
         stderr = error.stderr || ''
         const combined = `${stdout}\n${stderr}`
         if (!combined.includes('Created')) {
-          const message = stderr || error.message || 'Unknown error'
           logger.error({ err: error }, 'Gateway backup failed')
-          return NextResponse.json({ error: `Gateway backup failed: ${message}` }, { status: 500 })
+          return NextResponse.json({ error: 'Gateway backup failed' }, { status: 500 })
         }
       }
-
-      const output = (stdout || stderr).trim()
 
       logAuditEvent({
         action: 'openclaw.backup',
         actor: auth.user.username,
         actor_id: auth.user.id,
-        detail: { output },
+        detail: { target: 'gateway' },
         ip_address: ipAddress,
       })
 
-      return NextResponse.json({ success: true, output })
+      return NextResponse.json({ success: true, output: 'Gateway backup created' })
     } catch (error: any) {
       logger.error({ err: error }, 'Gateway backup failed')
-      return NextResponse.json({ error: `Gateway backup failed: ${error.message}` }, { status: 500 })
+      return NextResponse.json({ error: 'Gateway backup failed' }, { status: 500 })
     }
   }
 
@@ -108,12 +110,12 @@ export async function POST(request: NextRequest) {
 
     const stat = statSync(backupPath)
 
-    const ipAddress = request.headers.get('x-forwarded-for') || request.headers.get('x-real-ip') || 'unknown'
+    const ipAddress = extractClientIp(request)
     logAuditEvent({
       action: 'backup_create',
       actor: auth.user.username,
       actor_id: auth.user.id,
-      detail: { path: backupPath, size: stat.size },
+      detail: { name: `mc-backup-${timestamp}.db`, size: stat.size },
       ip_address: ipAddress,
     })
 
@@ -130,7 +132,7 @@ export async function POST(request: NextRequest) {
     })
   } catch (error: any) {
     logger.error({ err: error }, 'Backup failed')
-    return NextResponse.json({ error: `Backup failed: ${error.message}` }, { status: 500 })
+    return NextResponse.json({ error: 'Backup failed' }, { status: 500 })
   }
 }
 
@@ -143,19 +145,19 @@ export async function DELETE(request: NextRequest) {
   const isolationDeny = denyUnscopedResourceForStrictWorkspace(auth.user, 'host_administration', new URL(request.url).pathname)
   if (isolationDeny) return isolationDeny
 
-  let body: any
-  try { body = await request.json() } catch { return NextResponse.json({ error: 'Request body required' }, { status: 400 }) }
-  const name = body.name
+  const limitKey = `${auth.user.tenant_id ?? 1}:${auth.user.workspace_id ?? 1}:${auth.user.id}:backup`
+  const rateCheck = backupMutationLimiter(limitKey)
+  if (rateCheck) return rateCheck
 
-  if (!name || !name.endsWith('.db') || name.includes('/') || name.includes('..')) {
-    return NextResponse.json({ error: 'Invalid backup name' }, { status: 400 })
-  }
+  const result = await validateBody(request, backupDeleteSchema)
+  if ('error' in result) return result.error
+  const { name } = result.data
 
   try {
     const fullPath = join(BACKUP_DIR, name)
     unlinkSync(fullPath)
 
-    const ipAddress = request.headers.get('x-forwarded-for') || request.headers.get('x-real-ip') || 'unknown'
+    const ipAddress = extractClientIp(request)
     logAuditEvent({
       action: 'backup_delete',
       actor: auth.user.username,

--- a/src/lib/__tests__/backup-route-security.test.ts
+++ b/src/lib/__tests__/backup-route-security.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { backupDeleteSchema } from '@/lib/validation'
+
+describe('backup administration security boundary', () => {
+  it.each(['backup.db', 'mc-backup-2026-07-16.db'])('accepts a local database backup name: %s', (name) => {
+    expect(backupDeleteSchema.safeParse({ name }).success).toBe(true)
+  })
+
+  it.each([
+    '../backup.db',
+    'folder/backup.db',
+    'folder\\backup.db',
+    'backup.sqlite',
+    'backup.db.extra',
+  ])('rejects an unsafe backup name: %s', (name) => {
+    expect(backupDeleteSchema.safeParse({ name }).success).toBe(false)
+  })
+
+  it('rejects extra deletion fields', () => {
+    expect(backupDeleteSchema.safeParse({ name: 'backup.db', path: '/tmp/backup.db' }).success).toBe(false)
+  })
+
+  it('uses critical identity throttling and non-sensitive responses', () => {
+    const source = readFileSync(resolve(process.cwd(), 'src/app/api/backup/route.ts'), 'utf8')
+
+    expect(source.match(/backupMutationLimiter\(limitKey\)/g)).toHaveLength(2)
+    expect(source).not.toContain('heavyLimiter(request)')
+    expect(source).not.toContain('dir: BACKUP_DIR')
+    expect(source).not.toContain('detail: { path: backupPath')
+    expect(source).not.toContain('Gateway backup failed: ${')
+    expect(source).not.toContain('Backup failed: ${')
+    expect(source).toContain("target !== null && target !== 'gateway'")
+    expect(source).toContain('extractClientIp(request)')
+  })
+
+  it('defines the backup limiter as critical', () => {
+    const source = readFileSync(resolve(process.cwd(), 'src/lib/rate-limit.ts'), 'utf8')
+    const definition = source.slice(
+      source.indexOf('export const backupMutationLimiter'),
+      source.indexOf('/** User lifecycle'),
+    )
+
+    expect(definition).toContain('createKeyedRateLimiter')
+    expect(definition).toContain('critical: true')
+    expect(definition).toContain('maxRequests: 10')
+  })
+})

--- a/src/lib/__tests__/backup-route-security.test.ts
+++ b/src/lib/__tests__/backup-route-security.test.ts
@@ -33,6 +33,7 @@ describe('backup administration security boundary', () => {
     expect(source).not.toContain('Backup failed: ${')
     expect(source).toContain("target !== null && target !== 'gateway'")
     expect(source).toContain('extractClientIp(request)')
+    expect(source).toContain("{ error: 'Request body required' }")
   })
 
   it('defines the backup limiter as critical', () => {

--- a/src/lib/__tests__/host-administration-isolation.test.ts
+++ b/src/lib/__tests__/host-administration-isolation.test.ts
@@ -26,8 +26,8 @@ describe('deployment host administration isolation', () => {
   it('guards whole-deployment backup operations before side effects or parsing', () => {
     const file = 'src/app/api/backup/route.ts'
     expectGuardBefore(file, 'GET', 'ensureDirExists(BACKUP_DIR)')
-    expectGuardBefore(file, 'POST', 'heavyLimiter(request)')
-    expectGuardBefore(file, 'DELETE', 'request.json()')
+    expectGuardBefore(file, 'POST', 'backupMutationLimiter(limitKey)')
+    expectGuardBefore(file, 'DELETE', 'backupMutationLimiter(limitKey)')
   })
 
   it('guards global retention operations before database, limiting, or parsing', () => {

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -305,6 +305,14 @@ export const hermesMutationLimiter = createKeyedRateLimiter({
   critical: true,
 })
 
+/** Deployment backup creation and deletion: 10 attempts per minute per admin. */
+export const backupMutationLimiter = createKeyedRateLimiter({
+  windowMs: 60_000,
+  maxRequests: 10,
+  message: 'Too many backup changes. Try again in a minute.',
+  critical: true,
+})
+
 /** User lifecycle, access approval, and API-key rotation: 20 attempts per minute per admin and domain. */
 export const identitySecurityMutationLimiter = createKeyedRateLimiter({
   windowMs: 60_000,

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -347,6 +347,13 @@ export const skillDeleteSchema = z.object({
   confirmation: z.literal('delete_skill'),
 }).strict()
 
+export const backupDeleteSchema = z.object({
+  name: z.string().trim().min(1).max(255).endsWith('.db').refine(
+    (name) => !name.includes('..') && !name.includes('/') && !name.includes('\\'),
+    'Invalid backup name',
+  ),
+}).strict()
+
 export const accessRequestActionSchema = z.object({
   request_id: z.number(),
   action: z.enum(['approve', 'reject']),


### PR DESCRIPTION
## Summary
- apply a dedicated critical per-admin limiter to backup creation and deletion
- strictly validate backup targets and delete payloads
- remove host paths and raw command failures from API and audit responses
- attribute backup audit events through the trusted client-IP helper
- add focused security regression coverage

## Risk
Low-to-moderate. This intentionally tightens administrative API contracts and redacts diagnostic output; the existing UI success contract is preserved.

## Verification
- 1,384 unit tests
- 513 E2E tests
- typecheck
- lint (0 errors; existing warnings only)
- strict security scan
- dependency audit (no known vulnerabilities)
- diff and public-boundary scans