### PR TITLE
fix: include pnpm workspace in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /app
 FROM base AS deps
 # Copy only dependency manifests first for better layer caching
 COPY package.json ./
+COPY pnpm-workspace.yaml ./
 COPY pnpm-lock.yaml* ./
 # better-sqlite3 requires native compilation tools
 RUN apt-get update && apt-get install -y python3 make g++ --no-install-recommends && rm -rf /var/lib/apt/lists/*

--- a/src/lib/__tests__/docker-compose-schema.test.ts
+++ b/src/lib/__tests__/docker-compose-schema.test.ts
@@ -30,6 +30,14 @@ describe('docker-compose.yml schema', () => {
 describe('Dockerfile runtime stage', () => {
   const content = readFileSync(resolve(ROOT, 'Dockerfile'), 'utf-8')
 
+  it('copies the pnpm workspace manifest before the frozen dependency install', () => {
+    const workspaceCopy = content.indexOf('COPY pnpm-workspace.yaml ./')
+    const frozenInstall = content.indexOf('pnpm install --frozen-lockfile')
+
+    expect(workspaceCopy).toBeGreaterThan(-1)
+    expect(frozenInstall).toBeGreaterThan(workspaceCopy)
+  })
+
   it('copies public directory to runtime stage', () => {
     expect(content).toContain('COPY --from=build /app/public ./public')
   })


### PR DESCRIPTION
## Summary
- copy `pnpm-workspace.yaml` into the Docker dependency stage
- preserve frozen-lockfile reproducibility with the overrides that generated the lockfile
- add a contract test enforcing manifest ordering before install

## Why
Docker Publish currently fails with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` because the lockfile contains workspace overrides while the dependency stage omits their source manifest.

## Verification
- focused Docker contract: 7/7 passing
- ESLint: 0 errors
- TypeScript: passing
- strict security scan: passing
- hosted quality and Docker Publish required before completion