### PR TITLE
docs: define community support routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ agent, task, and system events for operator review.
 | [CLI integration](docs/cli-integration.md) | Claude Code, Codex, and gateway-free connections |
 | [Deployment](docs/deployment.md) | Local, Docker, standalone, reverse proxy, and VPS setup |
 | [Security hardening](docs/SECURITY-HARDENING.md) | Network, container, CSP, and secret controls |
+| [Support](SUPPORT.md) | Questions, bugs, feature proposals, and security-report routing |
 | [OpenClaw compatibility](docs/openclaw-config-compatibility.md) | Config and state-directory behavior |
 | [Release process](RELEASE.md) | Versioning, tags, images, and release checks |
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,37 @@
+# Support
+
+Mission Control is maintained as an open-source project. Community support is available,
+but response times vary with maintainer and community availability.
+
+## Questions and setup help
+
+For installation questions, configuration help, and advice about supported workflows, open a
+[GitHub Discussions Q&A](https://github.com/builderz-labs/mission-control/discussions/categories/q-a).
+Search existing discussions before opening a new one, and include the Mission Control version, install
+method, operating system, and relevant runtime when they affect the question.
+
+## Bugs
+
+Report reproducible product failures with the
+[bug report form](https://github.com/builderz-labs/mission-control/issues/new?template=bug_report.yml).
+Include a focused reproduction. Remove API
+keys, credentials, private prompts, personal data, hostnames, and internal paths from logs and
+screenshots.
+
+## Feature proposals
+
+Submit a scoped product change through the
+[feature request form](https://github.com/builderz-labs/mission-control/issues/new?template=feature_request.yml).
+For early ideas or design discussion, start in
+[GitHub Discussions](https://github.com/builderz-labs/mission-control/discussions/categories/ideas).
+
+## Security reports
+
+Do not disclose a suspected vulnerability in an issue or discussion. Follow the private reporting
+instructions in [SECURITY.md](SECURITY.md).
+
+## Maintainer scope
+
+Maintainers prioritize security, data-loss risk, release regressions, and reproducible defects.
+Questions may be answered by maintainers or other community members. The project does not include
+private deployment support, custom integration work, or a response-time commitment.


### PR DESCRIPTION
## Summary
- add a public support boundary for questions, bugs, features, and security reports
- route users to existing Q&A, issue forms, and the security policy
- document maintainer capacity without inventing a response SLA
- link the policy from the README

## Verification
- supported-profile OSS audit: no local community-file gaps
- unmachined copy scan: 0/100
- strict security scan: passing
- support URLs verified against enabled repository channels
- private-boundary scan: clean