### PR TITLE
fix: include artifact script in Docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@ node_modules
 ops
 scripts/*
 !scripts/check-node-version.mjs
+!scripts/prepare-standalone-artifact.mjs

--- a/src/lib/__tests__/docker-compose-schema.test.ts
+++ b/src/lib/__tests__/docker-compose-schema.test.ts
@@ -54,3 +54,12 @@ describe('Dockerfile runtime stage', () => {
     expect(content).toContain('schema.sql')
   })
 })
+
+describe('Docker build context', () => {
+  const content = readFileSync(resolve(ROOT, '.dockerignore'), 'utf-8')
+
+  it('includes scripts required by the package build command', () => {
+    expect(content).toContain('!scripts/check-node-version.mjs')
+    expect(content).toContain('!scripts/prepare-standalone-artifact.mjs')
+  })
+})


### PR DESCRIPTION
## Summary
- allowlist the standalone artifact preparation script in `.dockerignore`
- keep the Docker context narrow instead of including the full scripts directory
- add a contract test for both scripts required by `pnpm build`

## Why
Post-merge Docker Publish now clears dependency installation but fails after the Next.js build because `scripts/prepare-standalone-artifact.mjs` is excluded from the build context.

## Verification
- Docker contract: 8/8 passing
- focused ESLint: passing
- TypeScript: passing
- strict security and private-boundary scans: passing
- hosted quality and post-merge Docker Publish required before completion