### PR TITLE
fix: include runtime template in Docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,10 @@ node_modules
 .env
 *.md
 .github
-ops
+ops/*
+!ops/templates/
+ops/templates/*
+!ops/templates/openclaw-gateway@.service
 scripts/*
 !scripts/check-node-version.mjs
 !scripts/prepare-standalone-artifact.mjs

--- a/src/lib/__tests__/docker-compose-schema.test.ts
+++ b/src/lib/__tests__/docker-compose-schema.test.ts
@@ -62,4 +62,12 @@ describe('Docker build context', () => {
     expect(content).toContain('!scripts/check-node-version.mjs')
     expect(content).toContain('!scripts/prepare-standalone-artifact.mjs')
   })
+
+  it('includes only the operations template required by the runtime artifact', () => {
+    expect(content).not.toMatch(/^ops$/m)
+    expect(content).toContain('ops/*')
+    expect(content).toContain('!ops/templates/')
+    expect(content).toContain('ops/templates/*')
+    expect(content).toContain('!ops/templates/openclaw-gateway@.service')
+  })
 })


### PR DESCRIPTION
## Summary
- replace the broad `ops` Docker exclusion with ordered narrow rules
- include only `ops/templates/openclaw-gateway@.service`, which standalone tracing requires
- keep the provisioner daemon and unrelated operations tooling outside the build context
- add a build-context regression contract

## Why
Docker Publish now completes dependency installation and the application build, then fails because standalone artifact preparation cannot find `.next/standalone/ops`. The required service template is traced by Next.js but excluded from the Docker context.

## Verification
- Docker contracts: 9/9 passing
- focused ESLint: passing
- TypeScript: passing
- strict security and private-boundary scans: passing
- local Docker unavailable; hosted BuildKit is the required integration gate