### PR TITLE
fix: use shared API client in agent squad

### DIFF
--- a/src/components/panels/agent-squad-panel.tsx
+++ b/src/components/panels/agent-squad-panel.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { useTranslations } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import { Loader } from '@/components/ui/loader'
+import { apiFetch } from '@/lib/api-client'
 import { createClientLogger } from '@/lib/client-logger'
 
 const log = createClientLogger('AgentSquadPanel')
@@ -58,10 +59,7 @@ export function AgentSquadPanel() {
       setError(null)
       if (agents.length === 0) setLoading(true)
 
-      const response = await fetch('/api/agents')
-      if (!response.ok) throw new Error(t('failedToFetch'))
-
-      const data = await response.json()
+      const data = await apiFetch<{ agents: Agent[] }>('/api/agents')
       setAgents(data.agents || [])
     } catch (err) {
       setError(err instanceof Error ? err.message : t('errorOccurred'))
@@ -86,17 +84,14 @@ export function AgentSquadPanel() {
   // Update agent status
   const updateAgentStatus = async (agentName: string, status: Agent['status'], activity?: string) => {
     try {
-      const response = await fetch('/api/agents', {
+      await apiFetch('/api/agents', {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           name: agentName,
           status,
           last_activity: activity || `Status changed to ${status}`
         })
       })
-
-      if (!response.ok) throw new Error(t('failedToUpdateStatus'))
 
       // Update local state
       setAgents(prev => prev.map(agent =>
@@ -355,16 +350,13 @@ function AgentDetailModal({
 
   const handleSave = async () => {
     try {
-      const response = await fetch('/api/agents', {
+      await apiFetch('/api/agents', {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           name: agent.name,
           ...formData
         })
       })
-
-      if (!response.ok) throw new Error(t('failedToUpdate'))
       
       setEditing(false)
       onUpdate()
@@ -543,16 +535,13 @@ function CreateAgentModal({
     e.preventDefault()
     
     try {
-      const response = await fetch('/api/agents', {
+      await apiFetch('/api/agents', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           ...formData,
           runtime_type: formData.runtime_type || undefined,
         })
       })
-
-      if (!response.ok) throw new Error(t('failedToCreate'))
       
       onCreated()
       onClose()

--- a/src/lib/__tests__/agent-squad-client-security.test.ts
+++ b/src/lib/__tests__/agent-squad-client-security.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('Agent Squad client security contract', () => {
+  it('routes every agents API request through the shared authenticated client', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'src/components/panels/agent-squad-panel.tsx'),
+      'utf8',
+    )
+
+    expect(source).toContain("apiFetch<{ agents: Agent[] }>('/api/agents')")
+    expect(source.match(/apiFetch\('\/api\/agents'/g)).toHaveLength(3)
+    expect(source).not.toMatch(/fetch\(['"]\/api\/agents/)
+  })
+})


### PR DESCRIPTION
## Summary
- route Agent Squad list, status, edit, and create requests through `apiFetch`
- inherit uniform cookie, auth-expiry, authorization, server-error, and network-error handling
- add a source contract preventing direct `/api/agents` fetch calls from returning

## Verification
- focused and API-client tests: 17/17 passing
- focused ESLint: passing
- TypeScript: passing
- full lint warnings reduced from 83 to 79
- strict security and private-boundary scans: passing