### PR TITLE
ci: cancel superseded Docker publishes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,8 +11,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: docker-publish-${{ github.ref }}
-  cancel-in-progress: false
+  group: docker-publish-${{ github.event_name == 'workflow_run' && format('branch-{0}', github.event.workflow_run.head_branch) || format('{0}-{1}', github.ref_type, github.ref_name) }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/src/lib/__tests__/docker-publish-workflow-security.test.ts
+++ b/src/lib/__tests__/docker-publish-workflow-security.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('Docker publication workflow contracts', () => {
+  const source = readFileSync(
+    join(process.cwd(), '.github/workflows/docker-publish.yml'),
+    'utf8',
+  )
+
+  it('cancels superseded publications without sharing branch and tag groups', () => {
+    expect(source).toContain(
+      "group: docker-publish-${{ github.event_name == 'workflow_run' && format('branch-{0}', github.event.workflow_run.head_branch) || format('{0}-{1}', github.ref_type, github.ref_name) }}",
+    )
+    expect(source).toContain('cancel-in-progress: true')
+    expect(source).not.toContain('cancel-in-progress: false')
+  })
+})


### PR DESCRIPTION
## Summary
- group Docker publications by normalized source branch or tag
- cancel older builds only when a newer run targets the same source ref
- keep main, manual branch, and release-tag publication boundaries distinct
- add a workflow concurrency regression contract

## Why
The first successful multi-architecture publish took 39m53s. With cancellation disabled, every later main commit queues another full build even when a newer commit supersedes the pending `main` image.

## Safety
- release tags use `tag-<name>` groups and cannot be canceled by main
- direct/manual main and workflow-run main normalize to `branch-main`
- all remote actions remain SHA-pinned

## Verification
- workflow contract test: passing
- workflow action pin check: 14/14 references immutable
- YAML syntax: passing
- ESLint and TypeScript: passing
- strict security and private-boundary scans: passing