### PR TITLE
fix: use shared API client for alert rules

### DIFF
--- a/src/components/panels/alert-rules-panel.tsx
+++ b/src/components/panels/alert-rules-panel.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useTranslations } from 'next-intl'
 import { Button } from '@/components/ui/button'
+import { apiFetch, ApiError } from '@/lib/api-client'
 
 interface AlertRule {
   id: number
@@ -28,6 +29,14 @@ interface EvalResult {
   rule_name: string
   triggered: boolean
   reason?: string
+}
+
+interface AlertRulesData {
+  rules: AlertRule[]
+}
+
+interface AlertEvaluationData {
+  results: EvalResult[]
 }
 
 const ENTITY_FIELDS: Record<string, string[]> = {
@@ -65,8 +74,7 @@ export function AlertRulesPanel() {
 
   const fetchRules = useCallback(async () => {
     try {
-      const res = await fetch('/api/alerts')
-      const data = await res.json()
+      const data = await apiFetch<AlertRulesData>('/api/alerts')
       setRules(data.rules || [])
     } catch { /* ignore */ }
     setLoading(false)
@@ -75,36 +83,38 @@ export function AlertRulesPanel() {
   useEffect(() => { fetchRules() }, [fetchRules])
 
   const toggleRule = async (rule: AlertRule) => {
-    await fetch('/api/alerts', {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ id: rule.id, enabled: rule.enabled ? 0 : 1 }),
-    })
-    fetchRules()
+    try {
+      await apiFetch('/api/alerts', {
+        method: 'PUT',
+        body: JSON.stringify({ id: rule.id, enabled: rule.enabled ? 0 : 1 }),
+      })
+    } catch { /* refresh the authoritative state below */ }
+    finally { fetchRules() }
   }
 
   const deleteRule = async (id: number) => {
-    await fetch('/api/alerts', {
-      method: 'DELETE',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ id }),
-    })
-    fetchRules()
+    try {
+      await apiFetch('/api/alerts', {
+        method: 'DELETE',
+        body: JSON.stringify({ id }),
+      })
+    } catch { /* refresh the authoritative state below */ }
+    finally { fetchRules() }
   }
 
   const evaluateAll = async () => {
     setEvaluating(true)
     try {
-      const res = await fetch('/api/alerts', {
+      const data = await apiFetch<AlertEvaluationData>('/api/alerts', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action: 'evaluate' }),
       })
-      const data = await res.json()
       setEvalResults(data.results || [])
     } catch { /* ignore */ }
-    setEvaluating(false)
-    fetchRules() // refresh trigger counts
+    finally {
+      setEvaluating(false)
+      fetchRules() // refresh trigger counts
+    }
   }
 
   const enabledCount = rules.filter(r => r.enabled).length
@@ -299,9 +309,8 @@ function CreateRuleForm({ onCreated, onCancel }: { onCreated: () => void; onCanc
     setSaving(true)
 
     try {
-      const res = await fetch('/api/alerts', {
+      await apiFetch('/api/alerts', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           name: form.name,
           description: form.description || null,
@@ -314,14 +323,15 @@ function CreateRuleForm({ onCreated, onCancel }: { onCreated: () => void; onCanc
           action_config: { recipient: form.recipient },
         }),
       })
-      const data = await res.json()
-      if (!res.ok) {
-        setError(data.error || t('failedToCreate'))
-        return
-      }
       onCreated()
-    } catch {
-      setError(t('networkError'))
+    } catch (err) {
+      setError(
+        err instanceof ApiError && err.code === 'NETWORK_ERROR'
+          ? t('networkError')
+          : err instanceof Error
+            ? err.message
+            : t('failedToCreate'),
+      )
     } finally {
       setSaving(false)
     }

--- a/src/lib/__tests__/alert-rules-client-security.test.ts
+++ b/src/lib/__tests__/alert-rules-client-security.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('Alert Rules client security contract', () => {
+  it('uses the shared client while preserving refresh and network feedback', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'src/components/panels/alert-rules-panel.tsx'),
+      'utf8',
+    )
+
+    expect(source.match(/apiFetch(?:<[^>]+>)?\('\/api\/alerts'/g)).toHaveLength(5)
+    expect(source).not.toMatch(/fetch\(['"]\/api\/alerts/)
+    expect(source).toContain("err.code === 'NETWORK_ERROR'")
+    expect(source).toContain("t('networkError')")
+    expect(source.match(/finally \{ fetchRules\(\) \}/g)).toHaveLength(2)
+    expect(source).toContain('fetchRules() // refresh trigger counts')
+  })
+})


### PR DESCRIPTION
## Summary
- route all five Alert Rules requests through `apiFetch`
- refresh authoritative rule state after toggle and delete attempts
- preserve trigger-count refresh after evaluation
- keep localized network errors distinct from API validation errors during creation
- add a source-level security regression contract

## Verification
- focused and API-client tests: 17/17 passing
- focused ESLint: passing
- TypeScript: passing
- full lint warnings reduced from 75 to 70
- strict security and private-boundary scans: passing