### PR TITLE
fix: use shared API client for navigation requests

### DIFF
--- a/src/components/layout/nav-rail.tsx
+++ b/src/components/layout/nav-rail.tsx
@@ -947,7 +947,7 @@ function ContextSwitcher({ currentUser, isAdmin, isLocal, isConnected, tenants, 
                     setInterfaceMode('essential')
                     const essentialIds = new Set(['overview', 'agents', 'tasks', 'chat', 'activity', 'logs', 'settings'])
                     if (!essentialIds.has(activeTab)) navigateToPanel('overview')
-                    try { await fetch('/api/settings', { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ settings: { 'general.interface_mode': 'essential' } }) }) } catch {}
+                    try { await apiFetch('/api/settings', { method: 'PUT', body: JSON.stringify({ settings: { 'general.interface_mode': 'essential' } }) }) } catch {}
                   }}
                   className={`flex items-center gap-1 px-2 py-1 text-[11px] font-medium transition-colors ${
                     interfaceMode === 'essential'
@@ -962,7 +962,7 @@ function ContextSwitcher({ currentUser, isAdmin, isLocal, isConnected, tenants, 
                   onClick={async () => {
                     if (interfaceMode === 'full') return
                     setInterfaceMode('full')
-                    try { await fetch('/api/settings', { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ settings: { 'general.interface_mode': 'full' } }) }) } catch {}
+                    try { await apiFetch('/api/settings', { method: 'PUT', body: JSON.stringify({ settings: { 'general.interface_mode': 'full' } }) }) } catch {}
                   }}
                   className={`flex items-center gap-1 px-2 py-1 text-[11px] font-medium transition-colors border-l border-border ${
                     interfaceMode === 'full'
@@ -1006,7 +1006,9 @@ function ContextSwitcher({ currentUser, isAdmin, isLocal, isConnected, tenants, 
               <Button
                 variant="ghost"
                 onClick={async () => {
-                  await fetch('/api/auth/logout', { method: 'POST', credentials: 'include' })
+                  try {
+                    await apiFetch('/api/auth/logout', { method: 'POST' })
+                  } catch {}
                   router.push('/login')
                 }}
                 className="w-full flex items-center gap-2 px-2 py-1.5 h-auto rounded-md text-xs justify-start text-red-400 hover:text-red-300 hover:bg-red-500/10"

--- a/src/components/panels/activity-feed-panel.tsx
+++ b/src/components/panels/activity-feed-panel.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import { Loader } from '@/components/ui/loader'
 import { useMissionControl } from '@/store'
+import { apiFetch } from '@/lib/api-client'
 import { useSmartPoll } from '@/lib/use-smart-poll'
 
 interface Activity {
@@ -289,9 +290,7 @@ export function ActivityFeedPanel() {
   // ── Fetch sessions (for agent sidebar) ────────
   const fetchSessions = useCallback(async () => {
     try {
-      const res = await fetch('/api/sessions')
-      if (!res.ok) return
-      const data = await res.json()
+      const data = await apiFetch<{ sessions?: SessionInfo[] }>('/api/sessions')
       setSessions(data.sessions || [])
     } catch {
       /* silent */

--- a/src/lib/__tests__/navigation-activity-client-security.test.ts
+++ b/src/lib/__tests__/navigation-activity-client-security.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('Navigation and activity client security contract', () => {
+  it('routes targeted internal requests through the shared API client', () => {
+    const navSource = readFileSync(
+      join(process.cwd(), 'src/components/layout/nav-rail.tsx'),
+      'utf8',
+    )
+    const activitySource = readFileSync(
+      join(process.cwd(), 'src/components/panels/activity-feed-panel.tsx'),
+      'utf8',
+    )
+
+    expect(navSource.match(/apiFetch\('\/api\/settings'/g)).toHaveLength(2)
+    expect(navSource).toContain("apiFetch('/api/auth/logout', { method: 'POST' })")
+    expect(navSource).not.toMatch(/fetch\(['"]\/api\/(?:settings|auth\/logout)/)
+    expect(navSource).toContain("} catch {}\n                  router.push('/login')")
+
+    expect(activitySource).toContain(
+      "apiFetch<{ sessions?: SessionInfo[] }>('/api/sessions')",
+    )
+    expect(activitySource).not.toMatch(/fetch\(['"]\/api\/sessions/)
+    expect(activitySource).toContain('/* silent */')
+  })
+})


### PR DESCRIPTION
## Summary
- route activity session loading through the shared authenticated API client
- route interface-mode persistence and logout through the same client
- preserve silent supplementary loading, optimistic mode switching, and login navigation on logout failure
- add focused source-level regression coverage

## Security impact
This removes four bare internal fetch paths so expired sessions, authorization failures, server errors, and network failures consistently pass through the central API boundary.

## Verification
- `./node_modules/.bin/vitest run src/lib/__tests__/navigation-activity-client-security.test.ts src/lib/__tests__/api-client.test.ts` (17 passed)
- `pnpm typecheck`
- `pnpm lint` (0 errors; warnings reduced from 70 to 66)
- `pnpm build`
- strict DevGod security scan
- private-boundary scan

## Local test note
The package-level `pnpm test -- ...` script expanded to the complete suite locally. The new test passed, while three existing device-identity tests failed because the local Node process exposed no `localStorage`; hosted Quality Gate remains the authoritative full-suite check.