### PR TITLE
fix: use shared API client for channels

### DIFF
--- a/src/components/panels/channels-panel.tsx
+++ b/src/components/panels/channels-panel.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useTranslations } from 'next-intl'
 import { Button } from '@/components/ui/button'
+import { apiFetch, ApiError } from '@/lib/api-client'
 import { useMissionControl } from '@/store'
 
 // ---------------------------------------------------------------------------
@@ -651,20 +652,15 @@ export function ChannelsPanel() {
 
   const fetchChannels = useCallback(async () => {
     try {
-      const res = await fetch('/api/channels')
-      if (res.status === 401 || res.status === 403) {
-        setError('Authentication required')
-        return
-      }
-      if (!res.ok) {
-        setError('Failed to load channels')
-        return
-      }
-      const data: ChannelsSnapshot = await res.json()
+      const data = await apiFetch<ChannelsSnapshot>('/api/channels')
       setSnapshot(data)
       setError(null)
-    } catch {
-      setError('Failed to load channels')
+    } catch (err) {
+      setError(
+        err instanceof ApiError && (err.status === 401 || err.status === 403)
+          ? 'Authentication required'
+          : 'Failed to load channels',
+      )
     } finally {
       setLoading(false)
     }
@@ -679,7 +675,7 @@ export function ChannelsPanel() {
   const handleProbe = async (channelId: string) => {
     setProbing(channelId)
     try {
-      await fetch(`/api/channels?action=probe&channel=${encodeURIComponent(channelId)}`)
+      await apiFetch(`/api/channels?action=probe&channel=${encodeURIComponent(channelId)}`)
       await fetchChannels()
     } catch {
       // next poll will refresh
@@ -691,16 +687,18 @@ export function ChannelsPanel() {
   const handleAction = async (action: string, params: Record<string, unknown>): Promise<unknown> => {
     setActionBusy(true)
     try {
-      const res = await fetch('/api/channels', {
+      const data = await apiFetch<ActionResult>('/api/channels', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action, ...params }),
       })
-      const data = await res.json()
       // Refresh channel data after action
       await fetchChannels()
       return data
-    } catch {
+    } catch (err) {
+      if (err instanceof ApiError && err.payload !== undefined) {
+        await fetchChannels()
+        return err.payload
+      }
       return null
     } finally {
       setActionBusy(false)

--- a/src/lib/__tests__/channels-client-security.test.ts
+++ b/src/lib/__tests__/channels-client-security.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('Channels client security contract', () => {
+  it('uses the shared client without weakening channel error handling', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'src/components/panels/channels-panel.tsx'),
+      'utf8',
+    )
+
+    expect(source).toContain("apiFetch<ChannelsSnapshot>('/api/channels')")
+    expect(source).toContain(
+      'apiFetch(`/api/channels?action=probe&channel=${encodeURIComponent(channelId)}`)',
+    )
+    expect(source).toContain("apiFetch<ActionResult>('/api/channels'")
+    expect(source).not.toMatch(/fetch\((?:['"`])\/api\/channels/)
+
+    expect(source).toContain("err.status === 401 || err.status === 403")
+    expect(source).toContain("'Authentication required'")
+    expect(source).toContain('err.payload !== undefined')
+    expect(source).toContain('return err.payload')
+    expect(source.match(/await fetchChannels\(\)/g)).toHaveLength(3)
+  })
+})


### PR DESCRIPTION
## Summary
- route channel inventory, probes, and actions through the shared authenticated API client
- preserve explicit authentication feedback for inventory loading
- preserve structured action error payloads and post-action refresh behavior
- add focused source-level regression coverage

## Security impact
All privileged Channels panel requests now share centralized cookie, session-expiry, authorization, server-error, and network-failure handling.

## Verification
- `./node_modules/.bin/vitest run src/lib/__tests__/channels-client-security.test.ts src/lib/__tests__/api-client.test.ts` (17 passed)
- focused ESLint (clean)
- `pnpm typecheck`
- `pnpm lint` (0 errors; warnings reduced from 66 to 64)
- `pnpm build`
- strict security scan
- private-boundary scan