### PR TITLE
fix: use shared API client for skills

### DIFF
--- a/src/components/panels/skills-panel.tsx
+++ b/src/components/panels/skills-panel.tsx
@@ -5,6 +5,7 @@ import { createPortal } from 'react-dom'
 import { useTranslations } from 'next-intl'
 import { useMissionControl } from '@/store'
 import { Button } from '@/components/ui/button'
+import { apiFetch, ApiError } from '@/lib/api-client'
 
 interface SkillSummary {
   id: string
@@ -46,6 +47,32 @@ interface RegistrySkill {
   source: string
   installCount?: number
   tags?: string[]
+}
+
+interface RegistryResponse {
+  skills?: RegistrySkill[]
+}
+
+interface RegistryInstallResponse {
+  message?: string
+  error?: string
+  securityReport?: { status?: string }
+}
+
+function skillApiPayload<T>(error: unknown): T | null {
+  if (
+    error instanceof ApiError &&
+    error.payload !== null &&
+    typeof error.payload === 'object'
+  ) {
+    return error.payload as T
+  }
+  return null
+}
+
+function skillApiMessage(error: unknown, fallback: string): string {
+  const payload = skillApiPayload<{ error?: string; message?: string }>(error)
+  return payload?.message || payload?.error || (error instanceof Error ? error.message : fallback)
 }
 
 type PanelTab = 'installed' | 'registry'
@@ -118,10 +145,7 @@ export function SkillsPanel() {
   const loadSkills = useCallback(async (opts?: { initial?: boolean }) => {
     if (opts?.initial) setLoading(true)
     setError(null)
-    const res = await fetch('/api/skills', { cache: 'no-store' })
-    const body = await res.json()
-    if (!res.ok) throw new Error(body?.error || 'Failed to load skills')
-    const resp = body as SkillsResponse
+    const resp = await apiFetch<SkillsResponse>('/api/skills', { cache: 'no-store' })
     setSkillsData(resp.skills, resp.groups, resp.total)
     if (opts?.initial) setLoading(false)
   }, [setSkillsData])
@@ -133,9 +157,9 @@ export function SkillsPanel() {
     async function run() {
       try {
         await loadSkills({ initial: true })
-      } catch (err: any) {
+      } catch (err) {
         if (!cancelled) {
-          setError(err?.message || 'Failed to load skills')
+          setError(skillApiMessage(err, 'Failed to load skills'))
           setLoading(false)
         }
       }
@@ -177,12 +201,13 @@ export function SkillsPanel() {
           source: skill.source,
           name: skill.name,
         })
-        const res = await fetch(`/api/skills?${params.toString()}`, { cache: 'no-store' })
-        const body = await res.json()
-        if (!res.ok) throw new Error(body?.error || 'Failed to load SKILL.md')
-        if (!cancelled) setSelectedContent(body as SkillContentResponse)
-      } catch (err: any) {
-        if (!cancelled) setDrawerError(err?.message || 'Failed to load SKILL.md')
+        const body = await apiFetch<SkillContentResponse>(
+          `/api/skills?${params.toString()}`,
+          { cache: 'no-store' },
+        )
+        if (!cancelled) setSelectedContent(body)
+      } catch (err) {
+        if (!cancelled) setDrawerError(skillApiMessage(err, 'Failed to load SKILL.md'))
       } finally {
         if (!cancelled) setDrawerLoading(false)
       }
@@ -208,8 +233,8 @@ export function SkillsPanel() {
     setLoading(true)
     try {
       await loadSkills()
-    } catch (err: any) {
-      setError(err?.message || 'Failed to refresh skills')
+    } catch (err) {
+      setError(skillApiMessage(err, 'Failed to refresh skills'))
     } finally {
       setLoading(false)
     }
@@ -219,21 +244,18 @@ export function SkillsPanel() {
     setCreateError(null)
     setSaving(true)
     try {
-      const res = await fetch('/api/skills', {
+      await apiFetch<Record<string, unknown>>('/api/skills', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           source: createSource,
           name: createName.trim(),
           content: createContent,
         }),
       })
-      const body = await res.json()
-      if (!res.ok) throw new Error(body?.error || 'Failed to create skill')
       setCreateName('')
       await loadSkills()
-    } catch (err: any) {
-      setCreateError(err?.message || 'Failed to create skill')
+    } catch (err) {
+      setCreateError(skillApiMessage(err, 'Failed to create skill'))
     } finally {
       setSaving(false)
     }
@@ -244,21 +266,18 @@ export function SkillsPanel() {
     setSaving(true)
     setDrawerError(null)
     try {
-      const res = await fetch('/api/skills', {
+      await apiFetch<Record<string, unknown>>('/api/skills', {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           source: selectedSkill.source,
           name: selectedSkill.name,
           content: draftContent,
         }),
       })
-      const body = await res.json()
-      if (!res.ok) throw new Error(body?.error || 'Failed to save skill')
       await loadSkills()
       setSelectedContent((prev) => prev ? { ...prev, content: draftContent } : prev)
-    } catch (err: any) {
-      setDrawerError(err?.message || 'Failed to save skill')
+    } catch (err) {
+      setDrawerError(skillApiMessage(err, 'Failed to save skill'))
     } finally {
       setSaving(false)
     }
@@ -271,22 +290,19 @@ export function SkillsPanel() {
     setSaving(true)
     setDrawerError(null)
     try {
-      const res = await fetch('/api/skills', {
+      await apiFetch<Record<string, unknown>>('/api/skills', {
         method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           source: selectedSkill.source,
           name: selectedSkill.name,
           confirmation: 'delete_skill',
         }),
       })
-      const body = await res.json()
-      if (!res.ok) throw new Error(body?.error || 'Failed to delete skill')
       setSelectedSkill(null)
       setSelectedContent(null)
       await loadSkills()
-    } catch (err: any) {
-      setDrawerError(err?.message || 'Failed to delete skill')
+    } catch (err) {
+      setDrawerError(skillApiMessage(err, 'Failed to delete skill'))
     } finally {
       setSaving(false)
     }
@@ -298,13 +314,14 @@ export function SkillsPanel() {
     setRegistryError(null)
     try {
       const params = new URLSearchParams({ source: registrySource, q: registryQuery.trim() })
-      const res = await fetch(`/api/skills/registry?${params.toString()}`, { cache: 'no-store' })
-      const body = await res.json()
-      if (!res.ok) throw new Error(body?.error || 'Search failed')
+      const body = await apiFetch<RegistryResponse>(
+        `/api/skills/registry?${params.toString()}`,
+        { cache: 'no-store' },
+      )
       setRegistryResults(body?.skills || [])
       setRegistrySearched(true)
-    } catch (err: any) {
-      setRegistryError(err?.message || 'Search failed')
+    } catch (err) {
+      setRegistryError(skillApiMessage(err, 'Search failed'))
     } finally {
       setRegistryLoading(false)
     }
@@ -315,35 +332,39 @@ export function SkillsPanel() {
     setInstalling(slug)
     setInstallMessage(null)
     setInstallModal({ slug, name: displayName, step: 'fetching' })
+    let stepTimer: ReturnType<typeof setTimeout> | undefined
+    let writeTimer: ReturnType<typeof setTimeout> | undefined
     try {
       // Simulate step progression — the API does fetch+scan+write in one call,
       // so we show intermediate steps on a timer for UX feedback
-      const stepTimer = setTimeout(() => {
+      stepTimer = setTimeout(() => {
         setInstallModal(prev => prev?.slug === slug ? { ...prev, step: 'scanning' } : prev)
       }, 800)
-      const writeTimer = setTimeout(() => {
+      writeTimer = setTimeout(() => {
         setInstallModal(prev => prev?.slug === slug ? { ...prev, step: 'writing' } : prev)
       }, 1600)
 
-      const res = await fetch('/api/skills/registry', {
+      const body = await apiFetch<RegistryInstallResponse>('/api/skills/registry', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ source: registrySource, slug, targetRoot: installTarget }),
       })
-      const body = await res.json()
       clearTimeout(stepTimer)
       clearTimeout(writeTimer)
 
-      if (!res.ok) {
-        const msg = body?.message || body?.error || 'Install failed'
-        setInstallModal({ slug, name: displayName, step: 'error', message: msg, securityStatus: body?.securityReport?.status })
-      } else {
-        setInstallModal({ slug, name: displayName, step: 'done', message: body?.message || 'Installed successfully', securityStatus: body?.securityReport?.status })
-        await loadSkills()
-      }
-    } catch (err: any) {
-      setInstallModal({ slug, name: displayName, step: 'error', message: err?.message || 'Network error' })
+      setInstallModal({ slug, name: displayName, step: 'done', message: body?.message || 'Installed successfully', securityStatus: body?.securityReport?.status })
+      await loadSkills()
+    } catch (err) {
+      const body = skillApiPayload<RegistryInstallResponse>(err)
+      setInstallModal({
+        slug,
+        name: displayName,
+        step: 'error',
+        message: body?.message || body?.error || skillApiMessage(err, 'Network error'),
+        securityStatus: body?.securityReport?.status,
+      })
     } finally {
+      if (stepTimer) clearTimeout(stepTimer)
+      if (writeTimer) clearTimeout(writeTimer)
       setInstalling(null)
     }
   }
@@ -351,9 +372,11 @@ export function SkillsPanel() {
   const checkSecurity = async (skill: SkillSummary) => {
     try {
       const params = new URLSearchParams({ mode: 'check', source: skill.source, name: skill.name })
-      const res = await fetch(`/api/skills?${params.toString()}`, { cache: 'no-store' })
-      const body = await res.json()
-      if (res.ok && body?.security) {
+      const body = await apiFetch<SkillContentResponse>(
+        `/api/skills?${params.toString()}`,
+        { cache: 'no-store' },
+      )
+      if (body?.security) {
         await loadSkills() // refresh to pick up updated security_status
       }
     } catch { /* best-effort */ }
@@ -376,9 +399,11 @@ export function SkillsPanel() {
       setScanAll({ ...state })
       try {
         const params = new URLSearchParams({ mode: 'check', source: skill.source, name: skill.name })
-        const res = await fetch(`/api/skills?${params.toString()}`, { cache: 'no-store' })
-        const body = await res.json()
-        if (res.ok && body?.security) {
+        const body = await apiFetch<SkillContentResponse>(
+          `/api/skills?${params.toString()}`,
+          { cache: 'no-store' },
+        )
+        if (body?.security) {
           const s = body.security.status as string
           if (s === 'clean') state.results.clean++
           else if (s === 'warning') state.results.warning++

--- a/src/lib/__tests__/skills-client-security.test.ts
+++ b/src/lib/__tests__/skills-client-security.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('Skills client security contract', () => {
+  it('routes all extension-management requests through the shared API client', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'src/components/panels/skills-panel.tsx'),
+      'utf8',
+    )
+
+    expect(source.match(/apiFetch</g)).toHaveLength(9)
+    expect(source).not.toMatch(/fetch\((?:['"`])\/api\/skills/)
+    expect(source).toContain('function skillApiPayload<T>')
+    expect(source).toContain('function skillApiMessage')
+    expect(source).toContain("apiFetch<RegistryInstallResponse>('/api/skills/registry'")
+    expect(source).toContain('securityStatus: body?.securityReport?.status')
+    expect(source.match(/apiFetch<SkillContentResponse>/g)).toHaveLength(3)
+    expect(source).toContain('state.results.error++')
+  })
+})


### PR DESCRIPTION
## Summary
- route all nine Skills inventory, content, disk mutation, registry search, installation, and security-scan requests through the shared API client
- cover four URLSearchParams-based paths missed by the current lint rule
- preserve registry rejection security reports and scan-all result accounting
- retain periodic disk synchronization and cancellation behavior
- clear installation progress timers on every terminal path so stale timers cannot overwrite errors
- add focused source-level regression coverage

## Security impact
Extension disk writes, remote registry installation, and security scanning now consistently enforce centralized session-expiry, authorization, server-error, parse-error, and network handling while retaining securityReport diagnostics.

## Verification
- `./node_modules/.bin/vitest run src/lib/__tests__/skills-client-security.test.ts src/lib/__tests__/api-client.test.ts` (17 passed)
- focused ESLint (clean)
- `pnpm typecheck`
- `pnpm lint` (0 errors; warnings reduced from 24 to 19)
- `pnpm build`
- strict security scan
- private-boundary scan