### PR TITLE
fix: use shared API client for context inventory

### DIFF
--- a/src/lib/__tests__/context-inventory-client-security.test.ts
+++ b/src/lib/__tests__/context-inventory-client-security.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('Context inventory client security contract', () => {
+  it('routes tenant, OS-user, and project inventory through the shared client', () => {
+    const source = readFileSync(join(process.cwd(), 'src/store/index.ts'), 'utf8')
+
+    expect(source).toContain("apiFetch<{ tenants?: Tenant[] }>('/api/super/tenants'")
+    expect(source).toContain("apiFetch<{ users?: OsUser[] }>('/api/super/os-users'")
+    expect(source).toContain("apiFetch<{ projects?: Project[] }>('/api/projects'")
+    expect(source).not.toMatch(
+      /fetch\(['"]\/api\/(?:super\/tenants|super\/os-users|projects)/,
+    )
+    expect(source.match(/Array\.isArray\(data\?\./g)).toHaveLength(3)
+    expect((source.match(/\} catch \{\}/g) || []).length).toBeGreaterThanOrEqual(3)
+  })
+})

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,6 +2,7 @@
 
 import { create } from 'zustand'
 import { subscribeWithSelector } from 'zustand/middleware'
+import { apiFetch } from '@/lib/api-client'
 import { MODEL_CATALOG } from '@/lib/models'
 
 export type JsonPrimitive = string | number | boolean | null
@@ -839,18 +840,18 @@ export const useMissionControl = create<MissionControlStore>()(
     setTenants: (tenants) => set({ tenants }),
     fetchTenants: async () => {
       try {
-        const res = await fetch('/api/super/tenants', { cache: 'no-store' })
-        if (!res.ok) return
-        const data = await res.json()
+        const data = await apiFetch<{ tenants?: Tenant[] }>('/api/super/tenants', {
+          cache: 'no-store',
+        })
         const tenantList = Array.isArray(data?.tenants) ? data.tenants : []
         set({ tenants: tenantList })
       } catch {}
     },
     fetchOsUsers: async () => {
       try {
-        const res = await fetch('/api/super/os-users', { cache: 'no-store' })
-        if (!res.ok) return
-        const data = await res.json()
+        const data = await apiFetch<{ users?: OsUser[] }>('/api/super/os-users', {
+          cache: 'no-store',
+        })
         set({ osUsers: Array.isArray(data?.users) ? data.users : [] })
       } catch {}
     },
@@ -877,9 +878,9 @@ export const useMissionControl = create<MissionControlStore>()(
     setProjects: (projects) => set({ projects }),
     fetchProjects: async () => {
       try {
-        const res = await fetch('/api/projects', { cache: 'no-store' })
-        if (!res.ok) return
-        const data = await res.json()
+        const data = await apiFetch<{ projects?: Project[] }>('/api/projects', {
+          cache: 'no-store',
+        })
         const projectList = Array.isArray(data?.projects) ? data.projects : []
         set({ projects: projectList })
       } catch {}


### PR DESCRIPTION
## Summary
- route tenant, host OS-user, and project inventory through the shared API client
- preserve silent background failures and valid cached context lists
- retain defensive array normalization for every response
- add focused source-level regression coverage

## Security impact
Privileged organization, host-user, and project context selectors now consistently enforce centralized session-expiry, authorization, server-error, parse-error, and network handling.

## Verification
- `./node_modules/.bin/vitest run src/lib/__tests__/context-inventory-client-security.test.ts src/lib/__tests__/api-client.test.ts` (17 passed)
- focused ESLint (clean)
- `pnpm typecheck`
- `pnpm lint` (0 errors; warnings reduced from 19 to 16)
- `pnpm build`
- strict security scan
- private-boundary scan