### PR TITLE
fix: use shared API client for nodes

### DIFF
--- a/src/components/panels/nodes-panel.tsx
+++ b/src/components/panels/nodes-panel.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useTranslations } from 'next-intl'
 import { Button } from '@/components/ui/button'
+import { apiFetch, ApiError } from '@/lib/api-client'
 
 interface PresenceEntry {
   id: string
@@ -83,16 +84,28 @@ async function deviceAction(
   params: Record<string, unknown>,
 ): Promise<{ ok: boolean; error?: string; data?: Record<string, unknown> }> {
   try {
-    const res = await fetch('/api/nodes', {
+    const data = await apiFetch<Record<string, unknown>>('/api/nodes', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ action, ...params }),
     })
-    const data = await res.json()
-    if (!res.ok) return { ok: false, error: data.error || `Request failed (${res.status})` }
     return { ok: true, data }
-  } catch {
-    return { ok: false, error: 'Network error' }
+  } catch (err) {
+    const payload = err instanceof ApiError ? err.payload : null
+    const upstream =
+      payload && typeof payload === 'object' && 'error' in payload &&
+      typeof (payload as { error?: unknown }).error === 'string'
+        ? (payload as { error: string }).error
+        : null
+    return {
+      ok: false,
+      error:
+        upstream ||
+        (err instanceof ApiError &&
+        err.code !== 'NETWORK_ERROR' &&
+        err.code !== 'PARSE_ERROR'
+          ? `Request failed (${err.status})`
+          : 'Network error'),
+    }
   }
 }
 
@@ -108,9 +121,11 @@ export function NodesPanel() {
 
   const fetchNodes = useCallback(async () => {
     try {
-      const res = await fetch('/api/nodes')
-      if (!res.ok) { setError('Failed to fetch nodes'); return }
-      const data = await res.json()
+      const data = await apiFetch<{
+        nodes?: PresenceEntry[]
+        entries?: PresenceEntry[]
+        connected?: boolean
+      }>('/api/nodes')
       setNodes(data.nodes || data.entries || [])
       setConnected(data.connected !== false)
       setError(null)
@@ -123,9 +138,11 @@ export function NodesPanel() {
 
   const fetchDevices = useCallback(async () => {
     try {
-      const res = await fetch('/api/nodes?action=devices')
-      if (!res.ok) return
-      const data = await res.json()
+      const data = await apiFetch<{
+        paired?: PairedDevice[]
+        devices?: PairedDevice[]
+        pending?: PendingDevice[]
+      }>('/api/nodes?action=devices')
       setDevices(data.paired || data.devices || [])
       setPendingDevices(data.pending || [])
     } catch {

--- a/src/lib/__tests__/nodes-client-security.test.ts
+++ b/src/lib/__tests__/nodes-client-security.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('Nodes client security contract', () => {
+  it('routes node and device trust controls through the shared API client', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'src/components/panels/nodes-panel.tsx'),
+      'utf8',
+    )
+
+    expect(source.match(/apiFetch</g)).toHaveLength(3)
+    expect(source).not.toMatch(/fetch\(['"]\/api\/nodes/)
+    expect(source).toContain('const payload = err instanceof ApiError ? err.payload : null')
+    expect(source).toContain('`Request failed (${err.status})`')
+    expect(source).toContain("err.code !== 'NETWORK_ERROR'")
+    expect(source).toContain("err.code !== 'PARSE_ERROR'")
+    expect(source).toContain("apiFetch<{")
+    expect(source).toContain("}>('/api/nodes?action=devices')")
+    expect(source).toContain('// silent fallback')
+  })
+})


### PR DESCRIPTION
## Summary
- route node presence and device trust requests through the shared API client
- preserve structured upstream action errors while normalizing network and parse failures
- retain silent device polling fallback and add a regression contract for all node API paths

## Security
- removes direct fetch usage from node/device controls so shared request protections apply consistently
- no dependency, workflow, permission, or public/private boundary changes

## Verification
- focused Vitest: 17/17 passed
- focused ESLint: clean
- typecheck: passed
- full lint: 0 errors; warnings reduced from 16 to 13
- production build and artifact preparation: passed
- strict DevGod scan: passed
- private-boundary scan: clean
- git diff check: clean