### PR TITLE
fix: secure observability API reads

### DIFF
--- a/src/components/panels/log-viewer-panel.tsx
+++ b/src/components/panels/log-viewer-panel.tsx
@@ -4,9 +4,10 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { useTranslations } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import { Loader } from '@/components/ui/loader'
-import { useMissionControl } from '@/store'
+import { useMissionControl, type LogEntry } from '@/store'
 import { useSmartPoll } from '@/lib/use-smart-poll'
 import { createClientLogger } from '@/lib/client-logger'
+import { apiFetch } from '@/lib/api-client'
 
 const log = createClientLogger('LogViewer')
 
@@ -76,8 +77,7 @@ export function LogViewerPanel() {
       })
 
       log.debug(`Fetching /api/logs?${params}`)
-      const response = await fetch(`/api/logs?${params}`)
-      const data = await response.json()
+      const data = await apiFetch<{ logs?: LogEntry[] }>(`/api/logs?${params}`)
 
       log.debug(`Received ${data.logs?.length || 0} logs from API`)
 
@@ -113,8 +113,7 @@ export function LogViewerPanel() {
 
   const loadSources = useCallback(async () => {
     try {
-      const response = await fetch('/api/logs?action=sources')
-      const data = await response.json()
+      const data = await apiFetch<{ sources?: string[] }>('/api/logs?action=sources')
       setAvailableSources(data.sources || [])
     } catch (error) {
       log.error('Failed to load log sources:', error)
@@ -124,8 +123,10 @@ export function LogViewerPanel() {
   // Try to fetch log file path from gateway status
   const loadLogFilePath = useCallback(async () => {
     try {
-      const response = await fetch('/api/status')
-      const data = await response.json()
+      const data = await apiFetch<{
+        config?: { logFile?: string }
+        logFile?: string
+      }>('/api/status')
       const path = data?.config?.logFile || data?.logFile || null
       setLogFilePath(path)
     } catch {

--- a/src/components/panels/memory-graph.tsx
+++ b/src/components/panels/memory-graph.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { GraphCanvas, GraphCanvasRef, type Theme, type GraphNode as ReagraphNode, type GraphEdge as ReagraphEdge, type InternalGraphNode } from 'reagraph'
 import { useMissionControl } from '@/store'
+import { apiFetch } from '@/lib/api-client'
 
 // --- Data interfaces (match API response) ---
 
@@ -125,12 +126,9 @@ export function MemoryGraph() {
     setIsLoading(true)
     setError(null)
     try {
-      const res = await fetch('/api/memory/graph?agent=all')
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}))
-        throw new Error(data.error || `HTTP ${res.status}`)
-      }
-      const data = await res.json()
+      const data = await apiFetch<{ agents?: AgentGraphData[] }>(
+        '/api/memory/graph?agent=all',
+      )
       setMemoryGraphAgents(data.agents || [])
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Failed to load')

--- a/src/lib/__tests__/observability-client-security.test.ts
+++ b/src/lib/__tests__/observability-client-security.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('Observability client security contract', () => {
+  it('routes log and memory graph reads through the shared API client', () => {
+    const logViewer = readFileSync(
+      join(process.cwd(), 'src/components/panels/log-viewer-panel.tsx'),
+      'utf8',
+    )
+    const memoryGraph = readFileSync(
+      join(process.cwd(), 'src/components/panels/memory-graph.tsx'),
+      'utf8',
+    )
+
+    expect(logViewer.match(/apiFetch</g)).toHaveLength(3)
+    expect(logViewer).not.toMatch(/fetch\([`'"]\/api\//)
+    expect(logViewer).toContain("apiFetch<{ sources?: string[] }>('/api/logs?action=sources')")
+    expect(logViewer).toContain("}>('/api/status')")
+
+    expect(memoryGraph.match(/apiFetch</g)).toHaveLength(1)
+    expect(memoryGraph).not.toMatch(/fetch\([`'"]\/api\//)
+    expect(memoryGraph).toContain("'/api/memory/graph?agent=all'")
+    expect(memoryGraph).toContain(
+      "setError(err instanceof Error ? err.message : 'Failed to load')",
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- route log, log-source, gateway status, and memory graph reads through the shared API client
- preserve log polling, optional status fallback, and visible memory graph error behavior
- add a regression contract covering both observability panels

## Security
- applies centralized authentication expiry, permission, server, parse, and network handling to internal observability reads
- no dependency, workflow, permission, or public/private boundary changes

## Verification
- focused Vitest: passed
- focused ESLint: clean
- typecheck: passed
- full lint: 0 errors; warnings reduced from 13 to 10
- production Next build: passed
- standalone artifact preparation and boundary check: passed
- strict DevGod scan: passed
- prohibited-name scan: clean
- git diff check: clean

Note: the pnpm command wrapper encountered a local metadata database access error, so equivalent project-local binaries and artifact scripts were run directly. Hosted CI remains the merge authority.