### PR TITLE
fix: secure local read API requests

### DIFF
--- a/src/components/panels/local-agents-doc-panel.tsx
+++ b/src/components/panels/local-agents-doc-panel.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { Button } from '@/components/ui/button'
+import { apiFetch } from '@/lib/api-client'
 
 interface AgentsDocResponse {
   found: boolean
@@ -25,12 +26,14 @@ export function LocalAgentsDocPanel() {
       setLoading(true)
       setError(null)
       try {
-        const res = await fetch('/api/local/agents-doc', { cache: 'no-store' })
-        const body = await res.json()
-        if (!res.ok) throw new Error(body?.error || 'Failed to load AGENTS.md')
-        if (!cancelled) setData(body as AgentsDocResponse)
-      } catch (err: any) {
-        if (!cancelled) setError(err?.message || 'Failed to load AGENTS.md')
+        const body = await apiFetch<AgentsDocResponse>('/api/local/agents-doc', {
+          cache: 'no-store',
+        })
+        if (!cancelled) setData(body)
+      } catch (err: unknown) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load AGENTS.md')
+        }
       } finally {
         if (!cancelled) setLoading(false)
       }

--- a/src/components/panels/system-monitor-panel.tsx
+++ b/src/components/panels/system-monitor-panel.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useRef } from 'react'
 import { useSmartPoll } from '@/lib/use-smart-poll'
+import { apiFetch } from '@/lib/api-client'
 import { AreaChart, Area, BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip, CartesianGrid } from 'recharts'
 
 interface CpuData {
@@ -106,9 +107,9 @@ export function SystemMonitorPanel() {
     abortRef.current = controller
 
     try {
-      const res = await fetch('/api/system-monitor', { signal: controller.signal })
-      if (!res.ok) throw new Error(`HTTP ${res.status}`)
-      const data: Snapshot = await res.json()
+      const data = await apiFetch<Snapshot>('/api/system-monitor', {
+        signal: controller.signal,
+      })
       setLatest(data)
       setError(null)
 
@@ -153,8 +154,10 @@ export function SystemMonitorPanel() {
         const next = [...prevHistory, point]
         return next.length > MAX_POINTS ? next.slice(-MAX_POINTS) : next
       })
-    } catch (err: any) {
-      if (err.name !== 'AbortError') setError(err.message)
+    } catch (err: unknown) {
+      if (!controller.signal.aborted) {
+        setError(err instanceof Error ? err.message : 'Failed to load system metrics')
+      }
     }
   }, [])
 

--- a/src/lib/__tests__/local-read-client-security.test.ts
+++ b/src/lib/__tests__/local-read-client-security.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('Local read client security contract', () => {
+  it('routes host-scoped reads through the shared API client with lifecycle guards', () => {
+    const systemMonitor = readFileSync(
+      join(process.cwd(), 'src/components/panels/system-monitor-panel.tsx'),
+      'utf8',
+    )
+    const agentsDoc = readFileSync(
+      join(process.cwd(), 'src/components/panels/local-agents-doc-panel.tsx'),
+      'utf8',
+    )
+
+    expect(systemMonitor.match(/apiFetch</g)).toHaveLength(1)
+    expect(systemMonitor).not.toMatch(/fetch\([`'"]\/api\/system-monitor/)
+    expect(systemMonitor).toContain("apiFetch<Snapshot>('/api/system-monitor'")
+    expect(systemMonitor).toContain('signal: controller.signal')
+    expect(systemMonitor).toContain('if (!controller.signal.aborted)')
+
+    expect(agentsDoc.match(/apiFetch</g)).toHaveLength(1)
+    expect(agentsDoc).not.toMatch(/fetch\([`'"]\/api\/local\/agents-doc/)
+    expect(agentsDoc).toContain(
+      "apiFetch<AgentsDocResponse>('/api/local/agents-doc'",
+    )
+    expect(agentsDoc).toContain("cache: 'no-store'")
+    expect(agentsDoc).toContain('if (!cancelled) setData(body)')
+    expect(agentsDoc).toContain('if (!cancelled) {')
+  })
+})


### PR DESCRIPTION
## Summary
- route system metrics polling and local agent-document reads through the shared API client
- preserve metric request cancellation without surfacing superseded polls as errors
- preserve document-load unmount guards and no-store behavior
- add a regression contract for both host-scoped read surfaces

## Security
- applies centralized authentication expiry, workspace isolation denial, server, parse, and network handling
- keeps interactive terminal and office control paths outside this read-only PR
- no dependency, workflow, permission, or public/private boundary changes

## Verification
- focused Vitest: passed
- focused ESLint: clean
- typecheck: passed
- full lint: 0 errors; warnings reduced from 6 to 4
- release-style webpack production build: passed
- standalone artifact preparation and boundary check: passed
- strict DevGod scan: passed
- prohibited-name scan: clean
- git diff check: clean