### PR TITLE
fix: harden terminal attachment handshake

### DIFF
--- a/src/components/terminal/terminal-view.tsx
+++ b/src/components/terminal/terminal-view.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState, useCallback } from 'react'
+import { apiFetch } from '@/lib/api-client'
 
 interface TerminalViewProps {
   sessionId: string
@@ -12,6 +13,20 @@ interface TerminalViewProps {
 }
 
 type ConnectionState = 'connecting' | 'ready' | 'disconnected' | 'error' | 'unsupported'
+
+type PtyAttachResponse =
+  | {
+      supported: false
+      reason?: string
+      message?: string
+    }
+  | {
+      supported: true
+      wsPath: string
+      sessionId: string
+      kind: string
+      mode: 'readonly' | 'interactive'
+    }
 
 export function TerminalView({ sessionId, sessionKind, mode, onExit, onError, onReady }: TerminalViewProps) {
   const containerRef = useRef<HTMLDivElement>(null)
@@ -29,18 +44,19 @@ export function TerminalView({ sessionId, sessionKind, mode, onExit, onError, on
 
     // Step 1: Check PTY support via REST API
     try {
-      const res = await fetch('/api/pty/attach', {
+      const data = await apiFetch<PtyAttachResponse>('/api/pty/attach', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ sessionId, kind: sessionKind, mode }),
       })
-      const data = await res.json()
 
       if (!data.supported) {
         setConnState('unsupported')
         setErrorMessage(data.message || 'Terminal not supported for this session')
         onError?.(data.message || 'Terminal not supported')
         return
+      }
+      if (!/^\/ws\/pty(?:\?|$)/.test(data.wsPath)) {
+        throw new Error('Terminal endpoint was invalid')
       }
 
       // Step 2: Load xterm.js dynamically (heavy dependency, client-only)
@@ -177,9 +193,7 @@ export function TerminalView({ sessionId, sessionKind, mode, onExit, onError, on
       }
 
       ws.onclose = () => {
-        if (connState !== 'error') {
-          setConnState('disconnected')
-        }
+        setConnState(current => current === 'error' ? current : 'disconnected')
       }
 
       ws.onerror = () => {
@@ -225,7 +239,7 @@ export function TerminalView({ sessionId, sessionKind, mode, onExit, onError, on
       setErrorMessage(msg)
       onError?.(msg)
     }
-  }, [sessionId, sessionKind, mode, onExit, onError, onReady, connState])
+  }, [sessionId, sessionKind, mode, onExit, onError, onReady])
 
   useEffect(() => {
     const cleanup = connect()

--- a/src/lib/__tests__/terminal-attach-client-security.test.ts
+++ b/src/lib/__tests__/terminal-attach-client-security.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('Terminal attachment client security contract', () => {
+  it('secures the privileged handshake and keeps connection state out of callback dependencies', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'src/components/terminal/terminal-view.tsx'),
+      'utf8',
+    )
+
+    expect(source.match(/apiFetch</g)).toHaveLength(1)
+    expect(source).not.toMatch(/fetch\([`'"]\/api\/pty\/attach/)
+    expect(source).toContain(
+      "apiFetch<PtyAttachResponse>('/api/pty/attach'",
+    )
+    expect(source).toContain("/^\\/ws\\/pty(?:\\?|$)/.test(data.wsPath)")
+    expect(source).toContain("throw new Error('Terminal endpoint was invalid')")
+    expect(source).toContain(
+      "setConnState(current => current === 'error' ? current : 'disconnected')",
+    )
+    expect(source).toContain(
+      '}, [sessionId, sessionKind, mode, onExit, onError, onReady])',
+    )
+    expect(source).not.toContain(
+      '}, [sessionId, sessionKind, mode, onExit, onError, onReady, connState])',
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- route the operator-only PTY attachment handshake through the shared API client
- accept only same-origin /ws/pty paths returned by the server
- remove connection state from callback dependencies to prevent state-driven reconnect loops
- preserve error state on WebSocket close through a functional state update
- add a focused regression contract

## Security
- applies centralized authentication expiry, operator permission, workspace isolation denial, server, parse, and network handling
- rejects unexpected WebSocket paths before creating a connection
- does not broaden terminal kinds, modes, roles, or WebSocket authority

## Verification
- focused Vitest: passed
- focused ESLint: clean
- typecheck: passed
- full lint: 0 errors; warnings reduced from 4 to 3
- release-style webpack production build: passed
- standalone artifact preparation and boundary check: passed
- strict DevGod scan: passed
- prohibited-name scan: clean
- git diff check: clean