### PR TITLE
fix: secure office API requests

### DIFF
--- a/src/components/panels/office-panel.tsx
+++ b/src/components/panels/office-panel.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button'
 import { Loader } from '@/components/ui/loader'
 import { useMissionControl, Agent } from '@/store'
 import { buildOfficeLayout } from '@/lib/office-layout'
+import { apiFetch, ApiError } from '@/lib/api-client'
 
 type ViewMode = 'office' | 'org-chart'
 type OrgSegmentMode = 'category' | 'role' | 'status'
@@ -21,6 +22,24 @@ interface SessionAgentRow {
   active: boolean
   lastActivity?: number
   workingDir?: string | null
+}
+
+interface FlightDeckResponse {
+  installed: boolean
+  launched?: boolean
+  downloadUrl?: string
+  fallbackUrl?: string
+  error?: string
+}
+
+function getSafeHttpUrl(value: unknown): string | null {
+  if (typeof value !== 'string' || !value) return null
+  try {
+    const url = new URL(value)
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url.toString() : null
+  } catch {
+    return null
+  }
 }
 
 interface SeatPosition {
@@ -517,20 +536,20 @@ export function OfficePanel() {
     let nextSessionAgents: Agent[] = []
 
     try {
-      const [agentRes, sessionRes] = await Promise.all([
-        fetch('/api/agents'),
-        isLocalMode ? fetch('/api/sessions') : Promise.resolve(null),
+      const [agentData, sessionData] = await Promise.all([
+        apiFetch<{ agents?: Agent[] }>('/api/agents').catch(() => null),
+        isLocalMode
+          ? apiFetch<{ sessions?: SessionAgentRow[] }>('/api/sessions').catch(() => null)
+          : Promise.resolve(null),
       ])
 
-      if (agentRes.ok) {
-        const data = await agentRes.json()
-        nextLocalAgents = Array.isArray(data.agents) ? data.agents : []
+      if (agentData) {
+        nextLocalAgents = Array.isArray(agentData.agents) ? agentData.agents : []
         setLocalAgents(nextLocalAgents)
       }
 
-      if (isLocalMode && sessionRes?.ok) {
-        const sessionJson = await sessionRes.json().catch(() => ({}))
-        const rows = Array.isArray(sessionJson?.sessions) ? sessionJson.sessions as SessionAgentRow[] : []
+      if (isLocalMode && sessionData) {
+        const rows = Array.isArray(sessionData.sessions) ? sessionData.sessions : []
         const byAgent = new Map<string, Agent>()
         let idx = 0
 
@@ -1285,19 +1304,16 @@ export function OfficePanel() {
   const openFlightDeck = async (agent: Agent) => {
     setFlightDeckLaunching(true)
     try {
-      const res = await fetch('/api/local/flight-deck', {
+      const json = await apiFetch<FlightDeckResponse>('/api/local/flight-deck', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           agent: agent.name,
           session: agent.session_key || '',
         }),
       })
-      const json = await res.json().catch(() => ({}))
-      if (!res.ok || json?.installed === false) {
-        if (typeof json?.downloadUrl === 'string' && json.downloadUrl) {
-          setFlightDeckDownloadUrl(json.downloadUrl)
-        }
+      if (json.installed === false) {
+        const downloadUrl = getSafeHttpUrl(json.downloadUrl)
+        if (downloadUrl) setFlightDeckDownloadUrl(downloadUrl)
         setShowFlightDeckModal(true)
         showLaunchToast({
           kind: 'info',
@@ -1308,8 +1324,9 @@ export function OfficePanel() {
       }
       if (!json?.launched) {
         // Fallback for environments where native launch fails.
-        if (typeof json?.fallbackUrl === 'string' && json.fallbackUrl) {
-          window.open(json.fallbackUrl, '_blank', 'noopener,noreferrer')
+        const fallbackUrl = getSafeHttpUrl(json?.fallbackUrl)
+        if (fallbackUrl) {
+          window.open(fallbackUrl, '_blank', 'noopener,noreferrer')
           showLaunchToast({
             kind: 'info',
             title: 'Opened browser fallback',
@@ -1329,12 +1346,39 @@ export function OfficePanel() {
         title: 'Opened in Flight Deck',
         detail: 'Launched native Flight Deck app for this session.',
       })
-    } catch {
-      setShowFlightDeckModal(true)
+    } catch (err) {
+      const payload =
+        err instanceof ApiError && err.payload && typeof err.payload === 'object'
+          ? err.payload as Partial<FlightDeckResponse>
+          : null
+
+      if (payload?.installed === false) {
+        const downloadUrl = getSafeHttpUrl(payload.downloadUrl)
+        if (downloadUrl) setFlightDeckDownloadUrl(downloadUrl)
+        setShowFlightDeckModal(true)
+        showLaunchToast({
+          kind: 'info',
+          title: 'Flight Deck not installed',
+          detail: 'Install Flight Deck to open this session.',
+        })
+        return
+      }
+
+      const fallbackUrl = getSafeHttpUrl(payload?.fallbackUrl)
+      if (fallbackUrl) {
+        window.open(fallbackUrl, '_blank', 'noopener,noreferrer')
+        showLaunchToast({
+          kind: 'info',
+          title: 'Opened browser fallback',
+          detail: 'Native launch failed, opened Flight Deck web fallback.',
+        })
+        return
+      }
+
       showLaunchToast({
         kind: 'error',
         title: 'Flight Deck request failed',
-        detail: 'Could not reach local launch endpoint.',
+        detail: payload?.error || 'Could not reach local launch endpoint.',
       })
     } finally {
       setFlightDeckLaunching(false)

--- a/src/lib/__tests__/office-client-security.test.ts
+++ b/src/lib/__tests__/office-client-security.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('Office client security contract', () => {
+  it('secures all office API paths and preserves partial polling and safe fallbacks', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'src/components/panels/office-panel.tsx'),
+      'utf8',
+    )
+
+    expect(source.match(/apiFetch</g)).toHaveLength(3)
+    expect(source).not.toMatch(/fetch\([`'"]\/api\//)
+    expect(source).toContain("apiFetch<{ agents?: Agent[] }>('/api/agents').catch(() => null)")
+    expect(source).toContain(
+      "apiFetch<{ sessions?: SessionAgentRow[] }>('/api/sessions').catch(() => null)",
+    )
+    expect(source).toContain(
+      "apiFetch<FlightDeckResponse>('/api/local/flight-deck'",
+    )
+    expect(source).toContain('err instanceof ApiError')
+    expect(source).toContain('payload?.installed === false')
+    expect(source).toContain('getSafeHttpUrl(payload?.fallbackUrl)')
+    expect(source).toContain("url.protocol === 'http:' || url.protocol === 'https:'")
+    expect(source).toContain("window.open(fallbackUrl, '_blank', 'noopener,noreferrer')")
+    expect(source).not.toContain('if (!res.ok || json?.installed === false)')
+  })
+})


### PR DESCRIPTION
## Summary
- route office agent/session polling and Flight Deck launch through the shared API client
- preserve successful agent or session results when the other polling source fails
- distinguish Flight Deck installation failures from native-launch failures
- restore the server-provided browser fallback for native launch failures
- permit only validated HTTP(S) download and fallback URLs
- add a focused regression contract

## Security and correctness
- applies centralized authentication expiry, operator permission, workspace isolation denial, server, parse, and network handling
- removes all remaining direct internal API fetch warnings repository-wide
- prevents non-HTTP protocols from reaching browser fallback navigation
- no dependency, workflow, permission, or public/private boundary changes

## Verification
- focused Vitest: passed
- focused ESLint: clean
- typecheck: passed
- full lint: 0 errors and 0 warnings
- release-style webpack production build: passed
- standalone artifact preparation and boundary check: passed
- strict DevGod scan: passed
- prohibited-name scan: clean
- git diff check: clean