### PR TITLE
ci: add pinned CodeQL analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: '23 4 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze JavaScript and TypeScript
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@9e7c070092090e89e8b3d62f977d4456e0732cd7 # v4
+        with:
+          languages: javascript-typescript
+          queries: security-extended
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@9e7c070092090e89e8b3d62f977d4456e0732cd7 # v4
+        with:
+          category: /language:javascript-typescript

--- a/src/lib/__tests__/codeql-workflow-security.test.ts
+++ b/src/lib/__tests__/codeql-workflow-security.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('CodeQL workflow security contract', () => {
+  it('uses least privilege, immutable actions, and the JavaScript/TypeScript analyzer', () => {
+    const source = readFileSync(
+      join(process.cwd(), '.github/workflows/codeql.yml'),
+      'utf8',
+    )
+
+    expect(source).toContain('pull_request:')
+    expect(source).toContain('push:')
+    expect(source).toContain('schedule:')
+    expect(source).toContain('workflow_dispatch:')
+    expect(source).toContain('contents: read')
+    expect(source).toContain('actions: read')
+    expect(source).toContain('security-events: write')
+    expect(source).not.toContain('contents: write')
+    expect(source).not.toContain('pull-requests: write')
+    expect(source).toContain('languages: javascript-typescript')
+    expect(source).toContain('queries: security-extended')
+    expect(source).not.toContain('autobuild')
+
+    const actionRefs = [...source.matchAll(/uses:\s+\S+@(\S+)/g)].map((match) => match[1])
+    expect(actionRefs).toHaveLength(3)
+    for (const ref of actionRefs) {
+      expect(ref).toMatch(/^[0-9a-f]{40}$/)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- add CodeQL analysis for JavaScript and TypeScript on pull requests, main pushes, weekly schedule, and manual dispatch
- run the extended security query suite without duplicating the production build
- pin checkout and CodeQL actions to immutable commit SHAs
- add a regression contract for triggers, permissions, analyzer configuration, and pins

## Security
- permissions are limited to contents/actions read and security-events write
- no pull-request, package, workflow, or repository-content write permission
- establishes the repository's first GitHub code-scanning analysis
- no repository security settings are changed by this PR

## Verification
- workflow action pin checker: passed (17 references)
- workflow YAML parse: passed
- focused Vitest: passed
- focused and full ESLint: clean
- typecheck: passed
- strict DevGod scan: passed
- prohibited-name scan: clean
- git diff check: clean

## Source basis
Configured against GitHub's current CodeQL advanced-setup documentation for the javascript-typescript language and v4 action.