### PR TITLE
ci: scan dependency changes with OSV

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,0 +1,25 @@
+name: OSV-Scanner
+
+on:
+  pull_request:
+    branches: [main]
+  merge_group:
+    branches: [main]
+
+concurrency:
+  group: osv-scanner-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      scan-args: |-
+        --lockfile=./pnpm-lock.yaml
+      upload-sarif: true
+      fail-on-vuln: true

--- a/src/lib/__tests__/osv-scanner-workflow-security.test.ts
+++ b/src/lib/__tests__/osv-scanner-workflow-security.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('OSV-Scanner workflow security contract', () => {
+  it('compares the pnpm lockfile on pull requests with a pinned reusable workflow', () => {
+    const source = readFileSync(
+      join(process.cwd(), '.github/workflows/osv-scanner.yml'),
+      'utf8',
+    )
+
+    expect(source).toContain('pull_request:')
+    expect(source).toContain('merge_group:')
+    expect(source).not.toContain('push:')
+    expect(source).toContain('actions: read')
+    expect(source).toContain('contents: read')
+    expect(source).toContain('security-events: write')
+    expect(source).not.toContain('contents: write')
+    expect(source).not.toContain('pull-requests: write')
+    expect(source).toContain('--lockfile=./pnpm-lock.yaml')
+    expect(source).toContain('upload-sarif: true')
+    expect(source).toContain('fail-on-vuln: true')
+
+    const actionRefs = [...source.matchAll(/uses:\s+\S+@(\S+)/g)].map((match) => match[1])
+    expect(actionRefs).toEqual(['9a498708959aeaef5ef730655706c5a1df1edbc2'])
+  })
+})


### PR DESCRIPTION
## Summary
- add OSV-Scanner pull-request comparison for the pnpm lockfile
- fail when a branch introduces new known vulnerabilities relative to main
- upload SARIF results for security review and annotations
- pin the official reusable workflow to an immutable commit
- add a workflow security regression contract

## Security
- scans pnpm-lock.yaml, which OSV-Scanner supports natively
- permissions are limited to actions/contents read and security-events write for SARIF
- does not require the currently disabled GitHub dependency graph setting
- replaces the initial dependency-review attempt, which hosted CI proved unsupported on this repository
- avoids pnpm audit because npm has retired the endpoint used by the current pnpm version

## Verification
- hosted evidence: GitHub dependency review rejected the disabled dependency graph prerequisite
- local evidence: pnpm audit returned HTTP 410 from the retired npm audit endpoint
- workflow action pin checker: passed (18 references)
- workflow YAML parse: passed
- focused Vitest: passed
- focused and full ESLint: clean
- typecheck: passed
- strict DevGod scan: passed
- prohibited-name scan: clean
- git diff check: clean

Configured against OSV-Scanner v2.3.8 documentation for PR comparison and native pnpm-lock.yaml support.