### PR TITLE
ci: add private Scorecard analysis

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,50 @@
+name: OpenSSF Scorecard
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '17 2 * * 6'
+
+concurrency:
+  group: scorecard-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  checks: read
+  contents: read
+  issues: read
+  pull-requests: read
+  security-events: write
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: false
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: results.sarif

--- a/src/lib/__tests__/scorecard-workflow-security.test.ts
+++ b/src/lib/__tests__/scorecard-workflow-security.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('OpenSSF Scorecard workflow security contract', () => {
+  it('keeps results repository-local with constrained permissions and immutable actions', () => {
+    const source = readFileSync(
+      join(process.cwd(), '.github/workflows/scorecard.yml'),
+      'utf8',
+    )
+
+    expect(source).toContain('push:')
+    expect(source).toContain('schedule:')
+    expect(source).not.toContain('pull_request:')
+    expect(source).toContain('actions: read')
+    expect(source).toContain('checks: read')
+    expect(source).toContain('contents: read')
+    expect(source).toContain('issues: read')
+    expect(source).toContain('pull-requests: read')
+    expect(source).toContain('security-events: write')
+    expect(source).not.toContain('id-token: write')
+    expect(source).toContain('persist-credentials: false')
+    expect(source).toContain('publish_results: false')
+    expect(source).toContain('results_format: sarif')
+    expect(source).toContain('retention-days: 5')
+    expect(source).toContain('sarif_file: results.sarif')
+
+    const actionRefs = [...source.matchAll(/uses:\s+\S+@(\S+)/g)].map((match) => match[1])
+    expect(actionRefs).toHaveLength(4)
+    for (const ref of actionRefs) {
+      expect(ref).toMatch(/^[0-9a-f]{40}$/)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- add OpenSSF Scorecard analysis on main pushes and a weekly schedule
- store SARIF as a five-day workflow artifact and upload findings to GitHub code scanning
- explicitly disable public Scorecard result publication
- pin checkout, Scorecard, artifact, and SARIF actions to the current official immutable SHAs
- add a workflow security regression contract

## Security
- no pull-request or experimental trigger
- no OIDC id-token permission and no public score publication
- checkout credentials are not persisted
- permissions are constrained to the read surfaces Scorecard evaluates plus security-events write for SARIF
- no repository setting changes

## Verification
- official current Scorecard example and release pins inspected
- workflow action pin checker: passed (22 references)
- workflow YAML parse: passed
- focused Vitest: passed
- focused and full ESLint: clean
- typecheck: passed
- strict DevGod scan: passed
- prohibited-name scan: clean
- git diff check: clean

The Scorecard job intentionally starts only after merge because OpenSSF supports default-branch push and schedule as its stable triggers.