### PR TITLE
fix: canonicalize filesystem request paths

### DIFF
--- a/src/app/api/agents/[id]/soul/route.ts
+++ b/src/app/api/agents/[id]/soul/route.ts
@@ -140,6 +140,9 @@ export async function PUT(
     
     // If template_name is provided, load from template
     if (template_name) {
+      if (typeof template_name !== 'string' || !/^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/.test(template_name)) {
+        return NextResponse.json({ error: 'Invalid template name' }, { status: 400 })
+      }
       if (isStrictWorkspace) {
         return NextResponse.json({ error: 'Global SOUL templates are unavailable in strict workspaces' }, { status: 403 })
       }

--- a/src/app/api/memory/route.ts
+++ b/src/app/api/memory/route.ts
@@ -7,7 +7,7 @@ import { requireRole } from '@/lib/auth'
 import { readLimiter, mutationLimiter } from '@/lib/rate-limit'
 import { logger } from '@/lib/logger'
 import { validateSchema, extractWikiLinks } from '@/lib/memory-utils'
-import { MEMORY_PATH, MEMORY_ALLOWED_PREFIXES, isPathAllowed, resolveSafeMemoryPath } from '@/lib/memory-path'
+import { MEMORY_PATH, MEMORY_ALLOWED_PREFIXES, canonicalizeMemoryRelativePath, isPathAllowed, resolveSafeMemoryPath } from '@/lib/memory-path'
 import { searchMemory, indexFile, removeFromIndex } from '@/lib/memory-search'
 import { resolveWorkspaceMemoryAccess } from '@/lib/workspace-isolation'
 
@@ -109,12 +109,13 @@ export async function GET(request: NextRequest) {
         if (!isPathAllowed(path)) {
           return NextResponse.json({ error: 'Path not allowed' }, { status: 403 })
         }
-        const fullPath = await resolveSafeMemoryPath(memoryPath, path)
+        const canonicalPath = canonicalizeMemoryRelativePath(path)
+        const fullPath = await resolveSafeMemoryPath(memoryPath, canonicalPath)
         const stats = await stat(fullPath).catch(() => null)
         if (!stats?.isDirectory()) {
           return NextResponse.json({ error: 'Directory not found' }, { status: 404 })
         }
-        const tree = await buildFileTree(fullPath, path, maxDepth)
+        const tree = await buildFileTree(fullPath, canonicalPath, maxDepth)
         return NextResponse.json({ tree })
       }
       if (MEMORY_ALLOWED_PREFIXES.length) {
@@ -151,14 +152,15 @@ export async function GET(request: NextRequest) {
       if (!memoryPath || !existsSync(memoryPath)) {
         return NextResponse.json({ error: 'Memory directory not configured' }, { status: 500 })
       }
-      const fullPath = await resolveSafeMemoryPath(memoryPath, path)
+      const canonicalPath = canonicalizeMemoryRelativePath(path)
+      const fullPath = await resolveSafeMemoryPath(memoryPath, canonicalPath)
       
       try {
         const content = await readFile(fullPath, 'utf-8')
         const stats = await stat(fullPath)
 
         // Extract wiki-links and schema validation for .md files
-        const isMarkdown = path.endsWith('.md')
+        const isMarkdown = canonicalPath.endsWith('.md')
         const wikiLinks = isMarkdown ? extractWikiLinks(content) : []
         const schemaResult = isMarkdown ? validateSchema(content) : null
 
@@ -166,7 +168,7 @@ export async function GET(request: NextRequest) {
           content,
           size: stats.size,
           modified: stats.mtime.getTime(),
-          path,
+          path: canonicalPath,
           wikiLinks,
           schema: schemaResult,
         })
@@ -220,8 +222,9 @@ export async function POST(request: NextRequest) {
     if (!memoryPath) {
       return NextResponse.json({ error: 'Memory directory not configured' }, { status: 500 })
     }
+    const canonicalPath = canonicalizeMemoryRelativePath(path)
     await mkdir(memoryPath, { recursive: true })
-    const fullPath = await resolveSafeMemoryPath(memoryPath, path)
+    const fullPath = await resolveSafeMemoryPath(memoryPath, canonicalPath)
 
     if (action === 'save') {
       // Save file content
@@ -230,14 +233,14 @@ export async function POST(request: NextRequest) {
       }
 
       // Validate schema if present (warn but don't block save)
-      const schemaResult = path.endsWith('.md') ? validateSchema(content) : null
+      const schemaResult = canonicalPath.endsWith('.md') ? validateSchema(content) : null
       const schemaWarnings = schemaResult?.errors ?? []
 
       await writeFile(fullPath, content, 'utf-8')
       // Incrementally update FTS index
-      try { indexFile(getDatabase(), memoryPath, path, memoryAccess!.scope) } catch { /* best-effort */ }
+      try { indexFile(getDatabase(), memoryPath, canonicalPath, memoryAccess!.scope) } catch { /* best-effort */ }
       try {
-        db_helpers.logActivity('memory_file_saved', 'memory', 0, auth.user.username || 'unknown', `Updated ${path}`, { path, size: content.length })
+        db_helpers.logActivity('memory_file_saved', 'memory', 0, auth.user.username || 'unknown', `Updated ${canonicalPath}`, { path: canonicalPath, size: content.length })
       } catch { /* best-effort */ }
       return NextResponse.json({
         success: true,
@@ -257,18 +260,18 @@ export async function POST(request: NextRequest) {
         // Directory might already exist
       }
 
-      // Check if file already exists
       try {
-        await stat(fullPath)
-        return NextResponse.json({ error: 'File already exists' }, { status: 409 })
+        await writeFile(fullPath, content || '', { encoding: 'utf-8', flag: 'wx', mode: 0o600 })
       } catch (error) {
-        // File doesn't exist, which is what we want
+        if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+          return NextResponse.json({ error: 'File already exists' }, { status: 409 })
+        }
+        throw error
       }
 
-      await writeFile(fullPath, content || '', 'utf-8')
-      try { indexFile(getDatabase(), memoryPath, path, memoryAccess!.scope) } catch { /* best-effort */ }
+      try { indexFile(getDatabase(), memoryPath, canonicalPath, memoryAccess!.scope) } catch { /* best-effort */ }
       try {
-        db_helpers.logActivity('memory_file_created', 'memory', 0, auth.user.username || 'unknown', `Created ${path}`, { path })
+        db_helpers.logActivity('memory_file_created', 'memory', 0, auth.user.username || 'unknown', `Created ${canonicalPath}`, { path: canonicalPath })
       } catch { /* best-effort */ }
       return NextResponse.json({ success: true, message: 'File created successfully' })
     }
@@ -304,7 +307,8 @@ export async function DELETE(request: NextRequest) {
     if (!memoryPath || !existsSync(memoryPath)) {
       return NextResponse.json({ error: 'Memory directory not configured' }, { status: 500 })
     }
-    const fullPath = await resolveSafeMemoryPath(memoryPath, path)
+    const canonicalPath = canonicalizeMemoryRelativePath(path)
+    const fullPath = await resolveSafeMemoryPath(memoryPath, canonicalPath)
 
     if (action === 'delete') {
       // Check if file exists
@@ -315,9 +319,9 @@ export async function DELETE(request: NextRequest) {
       }
 
       await unlink(fullPath)
-      try { removeFromIndex(getDatabase(), path, memoryAccess!.scope) } catch { /* best-effort */ }
+      try { removeFromIndex(getDatabase(), canonicalPath, memoryAccess!.scope) } catch { /* best-effort */ }
       try {
-        db_helpers.logActivity('memory_file_deleted', 'memory', 0, auth.user.username || 'unknown', `Deleted ${path}`, { path })
+        db_helpers.logActivity('memory_file_deleted', 'memory', 0, auth.user.username || 'unknown', `Deleted ${canonicalPath}`, { path: canonicalPath })
       } catch { /* best-effort */ }
       return NextResponse.json({ success: true, message: 'File deleted successfully' })
     }

--- a/src/lib/__tests__/agent-filesystem-isolation.test.ts
+++ b/src/lib/__tests__/agent-filesystem-isolation.test.ts
@@ -108,4 +108,32 @@ describe('strict agent filesystem isolation', () => {
     expect(getAgentWorkspaceCandidatesMock).not.toHaveBeenCalled()
     expect(readAgentWorkspaceFileMock).not.toHaveBeenCalled()
   })
+
+  it('rejects unsafe SOUL template identifiers before filesystem access', async () => {
+    requireRoleMock.mockReturnValue(authUser())
+    getWorkspaceIsolationMock.mockReturnValue('shared')
+    const get = vi.fn(() => ({
+      id: 42,
+      name: 'agent-a',
+      role: 'operator',
+      soul_content: '',
+      updated_at: 123,
+      config: '{}',
+    }))
+    getDatabaseMock.mockReturnValue({ prepare: vi.fn(() => ({ get })) })
+    const { PUT } = await import('@/app/api/agents/[id]/soul/route')
+
+    const response = await PUT(
+      new NextRequest('http://localhost/api/agents/42/soul', {
+        method: 'PUT',
+        body: JSON.stringify({ template_name: '../outside' }),
+        headers: { 'content-type': 'application/json' },
+      }),
+      { params: Promise.resolve({ id: '42' }) },
+    )
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({ error: 'Invalid template name' })
+    expect(getAgentWorkspaceCandidatesMock).not.toHaveBeenCalled()
+  })
 })

--- a/src/lib/__tests__/memory-path-security.test.ts
+++ b/src/lib/__tests__/memory-path-security.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { canonicalizeMemoryRelativePath, isPathAllowed } from '@/lib/memory-path'
+
+describe('memory path security boundary', () => {
+  it.each([
+    '',
+    '/absolute.md',
+    'C:\\absolute.md',
+    '../escape.md',
+    'folder/../escape.md',
+    './note.md',
+    'folder//note.md',
+    'folder/./note.md',
+    'folder/\0note.md',
+  ])('rejects non-canonical path %j', (path) => {
+    expect(() => canonicalizeMemoryRelativePath(path)).toThrow()
+    expect(isPathAllowed(path)).toBe(false)
+  })
+
+  it('canonicalizes platform separators without changing the path scope', () => {
+    expect(canonicalizeMemoryRelativePath('folder\\nested\\note.md')).toBe('folder/nested/note.md')
+  })
+
+  it('accepts a bounded nested relative path', () => {
+    expect(canonicalizeMemoryRelativePath('projects/mission-control/note.md')).toBe(
+      'projects/mission-control/note.md',
+    )
+  })
+})

--- a/src/lib/memory-path.ts
+++ b/src/lib/memory-path.ts
@@ -12,14 +12,36 @@ import { resolveWithin } from '@/lib/paths'
 export const MEMORY_PATH = config.memoryDir
 export const MEMORY_ALLOWED_PREFIXES = (config.memoryAllowedPrefixes || []).map((p) => p.replace(/\\/g, '/'))
 
-export function normalizeRelativePath(value: string): string {
-  return String(value || '').replace(/\\/g, '/').replace(/^\/+/, '')
+export function canonicalizeMemoryRelativePath(value: unknown): string {
+  const input = typeof value === 'string' ? value : ''
+  if (!input || input.length > 1024 || input.includes('\0')) {
+    throw new Error('Invalid memory path')
+  }
+
+  const normalized = input.replace(/\\/g, '/')
+  if (normalized.startsWith('/') || /^[A-Za-z]:/.test(normalized)) {
+    throw new Error('Memory path must be relative')
+  }
+
+  const segments = normalized.split('/')
+  if (segments.some((segment) => !segment || segment === '.' || segment === '..')) {
+    throw new Error('Memory path must be canonical')
+  }
+  return segments.join('/')
 }
 
 export function isPathAllowed(relativePath: string): boolean {
+  let normalized: string
+  try {
+    normalized = canonicalizeMemoryRelativePath(relativePath)
+  } catch {
+    return false
+  }
   if (!MEMORY_ALLOWED_PREFIXES.length) return true
-  const normalized = normalizeRelativePath(relativePath)
-  return MEMORY_ALLOWED_PREFIXES.some((prefix) => normalized === prefix.slice(0, -1) || normalized.startsWith(prefix))
+  return MEMORY_ALLOWED_PREFIXES.some((prefix) => {
+    const root = prefix.endsWith('/') ? prefix.slice(0, -1) : prefix
+    return normalized === root || normalized.startsWith(`${root}/`)
+  })
 }
 
 function isWithinBase(base: string, candidate: string): boolean {
@@ -28,8 +50,9 @@ function isWithinBase(base: string, candidate: string): boolean {
 }
 
 export async function resolveSafeMemoryPath(baseDir: string, relativePath: string): Promise<string> {
+  const canonicalPath = canonicalizeMemoryRelativePath(relativePath)
   const baseReal = await realpath(baseDir)
-  const fullPath = resolveWithin(baseDir, relativePath)
+  const fullPath = resolveWithin(baseDir, canonicalPath)
 
   // For non-existent targets, validate containment using the nearest existing ancestor.
   // This allows nested creates (mkdir -p) while still blocking symlink escapes.

--- a/src/lib/memory-search.ts
+++ b/src/lib/memory-search.ts
@@ -16,6 +16,8 @@ import { join } from 'path'
 import { getDatabase } from '@/lib/db'
 import { scanMemoryFiles, type MemoryFileInfo } from '@/lib/memory-utils'
 import { logger } from '@/lib/logger'
+import { canonicalizeMemoryRelativePath } from '@/lib/memory-path'
+import { resolveWithin } from '@/lib/paths'
 
 // ─── Schema ──────────────────────────────────────────────────────
 
@@ -113,14 +115,15 @@ export async function rebuildIndex(baseDir: string, allowedPrefixes: string[], s
 export function indexFile(db: Database.Database, baseDir: string, relativePath: string, scope = 'shared'): void {
   ensureFtsTable(db)
   try {
-    const content = readFileSync(join(baseDir, relativePath), 'utf-8')
-    const name = relativePath.split('/').pop() || relativePath
+    const canonicalPath = canonicalizeMemoryRelativePath(relativePath)
+    const content = readFileSync(resolveWithin(baseDir, canonicalPath), 'utf-8')
+    const name = canonicalPath.split('/').pop() || canonicalPath
     const title = extractTitle(content, name)
     const body = stripFrontmatter(content)
 
     db.transaction(() => {
-      db.prepare('DELETE FROM memory_fts_v2 WHERE scope = ? AND path = ?').run(scope, relativePath)
-      db.prepare('INSERT INTO memory_fts_v2 (scope, path, title, content) VALUES (?, ?, ?, ?)').run(scope, relativePath, title, body)
+      db.prepare('DELETE FROM memory_fts_v2 WHERE scope = ? AND path = ?').run(scope, canonicalPath)
+      db.prepare('INSERT INTO memory_fts_v2 (scope, path, title, content) VALUES (?, ?, ?, ?)').run(scope, canonicalPath, title, body)
     })()
   } catch (err) {
     logger.warn({ err, path: relativePath }, 'Failed to index file for FTS')


### PR DESCRIPTION
## Summary
- reject ambiguous, absolute, traversal, drive-prefixed, NUL, and oversized memory paths
- propagate only canonical paths into filesystem, search-index, response, and audit operations
- make memory file creation atomic with exclusive creation and owner-only mode
- constrain SOUL template identifiers before filesystem access
- add path and template regression coverage

## Security impact
Hardens the shared boundary behind the high-severity memory and SOUL path-injection cluster and removes the create check-then-write race. Existing lexical containment and symlink checks remain in force.

## Verification
- focused security tests: 31 passed
- lint: passed
- typecheck: passed
- strict security scan: passed
- repository privacy scan: passed