### PR TITLE
fix: bind filesystem checks to descriptors

### DIFF
--- a/src/app/api/sessions/continue/route.ts
+++ b/src/app/api/sessions/continue/route.ts
@@ -65,11 +65,6 @@ async function resolveClaudeSessionCwd(sessionId: string): Promise<string | null
   }
   for (const encoded of entries) {
     const candidate = path.join(projectsRoot, encoded, `${sessionId}.jsonl`)
-    try {
-      await fs.access(candidate)
-    } catch {
-      continue
-    }
     // Read up to ~64KB and walk lines until we find a `cwd` field.
     let head: string
     try {
@@ -82,7 +77,7 @@ async function resolveClaudeSessionCwd(sessionId: string): Promise<string | null
         await handle.close()
       }
     } catch {
-      return null
+      continue
     }
     for (const line of head.split('\n')) {
       const trimmed = line.trim()

--- a/src/app/api/tokens/route.ts
+++ b/src/app/api/tokens/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { readFile, writeFile, access } from 'fs/promises'
+import { readFile, writeFile } from 'fs/promises'
 import { dirname } from 'path'
 import { config, ensureDirExists } from '@/lib/config'
 import { requireRole } from '@/lib/auth'
@@ -162,7 +162,6 @@ function dedupeTokenRecords(records: TokenUsageRecord[]): TokenUsageRecord[] {
 async function loadTokenDataFromFile(workspaceId: number, providerSubscriptions: Record<string, boolean>): Promise<TokenUsageRecord[]> {
   try {
     ensureDirExists(dirname(DATA_PATH))
-    await access(DATA_PATH)
     const data = await readFile(DATA_PATH, 'utf-8')
     const parsed = JSON.parse(data)
     if (!Array.isArray(parsed)) return []

--- a/src/lib/__tests__/filesystem-race-security.test.ts
+++ b/src/lib/__tests__/filesystem-race-security.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function source(path: string): string {
+  return readFileSync(resolve(process.cwd(), path), 'utf8')
+}
+
+describe('filesystem race hardening contracts', () => {
+  it('opens session and token files directly without access probes', () => {
+    const sessions = source('src/app/api/sessions/continue/route.ts')
+    const tokens = source('src/app/api/tokens/route.ts')
+
+    expect(sessions).not.toContain('await fs.access(candidate)')
+    expect(tokens).not.toContain('await access(DATA_PATH)')
+  })
+
+  it('binds workspace size validation and reads to one descriptor', () => {
+    const agentSync = source('src/lib/agent-sync.ts')
+
+    expect(agentSync).toContain("const descriptor = openSync(safePath, 'r')")
+    expect(agentSync).toContain('const size = fstatSync(descriptor).size')
+    expect(agentSync).toContain("readFileSync(descriptor, 'utf-8')")
+  })
+
+  it('uses exclusive initialization for GNAP metadata', () => {
+    const gnap = source('src/lib/gnap-sync.ts')
+
+    expect(gnap).toContain("{ flag: 'wx', mode: 0o600 }")
+    expect(gnap).not.toContain('if (!fs.existsSync(versionFile))')
+    expect(gnap).not.toContain('if (!fs.existsSync(agentsFile))')
+  })
+
+  it('writes local agent soul files through no-follow descriptors', () => {
+    const localSync = source('src/lib/local-agent-sync.ts')
+
+    expect(localSync).toContain('constants.O_NOFOLLOW')
+    expect(localSync).toContain('constants.O_EXCL')
+    expect(localSync).not.toContain('const targetPath = existsSync(soulPath)')
+  })
+})

--- a/src/lib/agent-sync.ts
+++ b/src/lib/agent-sync.ts
@@ -9,7 +9,7 @@ import { config } from './config'
 import { getDatabase, db_helpers, logAuditEvent } from './db'
 import { eventBus } from './event-bus'
 import { join, isAbsolute, resolve } from 'path'
-import { existsSync, readFileSync, statSync } from 'fs'
+import { closeSync, fstatSync, openSync, readFileSync } from 'fs'
 import { resolveWithin } from './paths'
 import { logger } from './logger'
 import { parseJsonRelaxed } from './json-relaxed'
@@ -148,13 +148,16 @@ function readWorkspaceFile(workspace: string | undefined, filename: string): str
   try {
     const safeWorkspace = resolveAgentWorkspacePath(workspace)
     const safePath = resolveWithin(safeWorkspace, filename)
-    if (existsSync(safePath)) {
-      const size = statSync(safePath).size
+    const descriptor = openSync(safePath, 'r')
+    try {
+      const size = fstatSync(descriptor).size
       if (size > MAX_WORKSPACE_FILE_BYTES) {
         logger.warn({ workspace, filename, size }, `Workspace file exceeds ${MAX_WORKSPACE_FILE_BYTES} byte limit, skipping`)
         return null
       }
-      return readFileSync(safePath, 'utf-8')
+      return readFileSync(descriptor, 'utf-8')
+    } finally {
+      closeSync(descriptor)
     }
   } catch (err) {
     logger.warn({ err, workspace, filename }, 'Failed to read workspace file')

--- a/src/lib/docs-knowledge.ts
+++ b/src/lib/docs-knowledge.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile, stat, lstat, realpath } from 'fs/promises'
+import { open, readdir, readFile, stat, lstat, realpath } from 'fs/promises'
 import { existsSync } from 'fs'
 import { dirname, join, sep } from 'path'
 import { resolveWithin } from '@/lib/paths'
@@ -193,10 +193,12 @@ export async function searchDocs(query: string, limit = 100): Promise<Array<{ pa
   const results: Array<{ path: string; name: string; matches: number }> = []
 
   const searchFile = async (fullPath: string, relativePath: string) => {
+    let handle
     try {
-      const info = await stat(fullPath)
+      handle = await open(fullPath, 'r')
+      const info = await handle.stat()
       if (info.size > 1_000_000) return
-      const content = (await readFile(fullPath, 'utf-8')).toLowerCase()
+      const content = (await handle.readFile('utf-8')).toLowerCase()
       let count = 0
       let idx = content.indexOf(q)
       while (idx !== -1) {
@@ -212,6 +214,8 @@ export async function searchDocs(query: string, limit = 100): Promise<Array<{ pa
       }
     } catch {
       // Ignore unreadable files
+    } finally {
+      await handle?.close()
     }
   }
 

--- a/src/lib/gnap-sync.ts
+++ b/src/lib/gnap-sync.ts
@@ -117,13 +117,17 @@ export function initGnapRepo(repoPath: string): void {
   fs.mkdirSync(path.join(repoPath, 'tasks'), { recursive: true })
 
   const versionFile = path.join(repoPath, 'version')
-  if (!fs.existsSync(versionFile)) {
-    fs.writeFileSync(versionFile, '1\n')
+  try {
+    fs.writeFileSync(versionFile, '1\n', { flag: 'wx', mode: 0o600 })
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error
   }
 
   const agentsFile = path.join(repoPath, 'agents.json')
-  if (!fs.existsSync(agentsFile)) {
-    fs.writeFileSync(agentsFile, JSON.stringify({ agents: [] }, null, 2) + '\n')
+  try {
+    fs.writeFileSync(agentsFile, JSON.stringify({ agents: [] }, null, 2) + '\n', { flag: 'wx', mode: 0o600 })
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error
   }
 
   // Init git if not already a repo

--- a/src/lib/local-agent-sync.ts
+++ b/src/lib/local-agent-sync.ts
@@ -12,7 +12,7 @@
  */
 
 import { createHash } from 'node:crypto'
-import { readdirSync, readFileSync, statSync, existsSync, writeFileSync, mkdirSync } from 'node:fs'
+import { closeSync, constants, fstatSync, mkdirSync, openSync, readFileSync, readdirSync, statSync, existsSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { getDatabase, logAuditEvent } from './db'
@@ -88,6 +88,21 @@ function sha256(content: string): string {
   return createHash('sha256').update(content, 'utf8').digest('hex')
 }
 
+function readRegularFile(path: string): string | null {
+  let descriptor: number
+  try {
+    descriptor = openSync(path, 'r')
+  } catch {
+    return null
+  }
+  try {
+    if (!fstatSync(descriptor).isFile()) return null
+    return readFileSync(descriptor, 'utf8')
+  } finally {
+    closeSync(descriptor)
+  }
+}
+
 function extractRole(content: string): string {
   const lines = content.split('\n').map(l => l.trim()).filter(Boolean)
   // Look for "role:" or "theme:" in first 10 lines
@@ -140,7 +155,8 @@ function scanLocalAgents(): DiskAgent[] {
       // --- Flat .md agent files (Claude Code format) ---
       if (stat.isFile() && entry.endsWith('.md') && entry !== 'CLAUDE.md' && entry !== 'AGENTS.md') {
         try {
-          const content = readFileSync(fullPath, 'utf8')
+          const content = readRegularFile(fullPath)
+          if (content === null) continue
           const { frontmatter, body } = parseYamlFrontmatter(content)
           const agentName = frontmatter.name || entry.replace(/\.md$/, '')
           if (seen.has(agentName)) continue
@@ -314,10 +330,27 @@ export function writeLocalAgentSoul(agentDir: string, soulContent: string): void
   // Prefer soul.md, fall back to AGENT.md
   const soulPath = join(agentDir, 'soul.md')
   const agentMdPath = join(agentDir, 'AGENT.md')
-  const targetPath = existsSync(soulPath) ? soulPath : existsSync(agentMdPath) ? agentMdPath : soulPath
 
   mkdirSync(agentDir, { recursive: true })
-  writeFileSync(targetPath, soulContent, 'utf8')
+  const writeFlags = constants.O_WRONLY | constants.O_TRUNC | (constants.O_NOFOLLOW || 0)
+  const createFlags = writeFlags | constants.O_CREAT | constants.O_EXCL
+  let descriptor: number
+  try {
+    descriptor = openSync(soulPath, writeFlags)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+    try {
+      descriptor = openSync(agentMdPath, writeFlags)
+    } catch (fallbackError) {
+      if ((fallbackError as NodeJS.ErrnoException).code !== 'ENOENT') throw fallbackError
+      descriptor = openSync(soulPath, createFlags, 0o600)
+    }
+  }
+  try {
+    writeFileSync(descriptor, soulContent, 'utf8')
+  } finally {
+    closeSync(descriptor)
+  }
 
   // Update the DB hash so the next sync doesn't re-overwrite
   try {


### PR DESCRIPTION
## Summary
- remove redundant access probes before session and token reads
- bind workspace size checks and content reads to the same file descriptor
- bind documentation size checks and reads to one async file handle
- initialize GNAP metadata through exclusive owner-only creation
- read and write local agent files through validated/no-follow descriptors
- add filesystem race security contracts

## Security impact
Repairs eight of ten high-severity check-then-act findings. The two remaining configuration read-modify-write findings are intentionally reserved for a separate atomic-update design.

## Verification
- focused security, agent sync, gateway, and GNAP tests: 24 passed
- lint: passed
- typecheck: passed
- strict security scan: passed
- repository privacy scan: passed

GNAP tests required disabling the unavailable local commit-signing socket for fixture commits; hosted CI uses its isolated Git identity.