### PR TITLE
fix: serialize atomic config updates

### DIFF
--- a/src/app/api/security-scan/fix/route.ts
+++ b/src/app/api/security-scan/fix/route.ts
@@ -9,6 +9,7 @@ import { getDatabase } from '@/lib/db'
 import { logger } from '@/lib/logger'
 import { FIX_SAFETY, runSecurityScan, type FixSafety } from '@/lib/security-scan'
 import { securityFixLimiter } from '@/lib/rate-limit'
+import { acquireFileLockSync, atomicReplaceFileSync } from '@/lib/atomic-file'
 import { z } from 'zod'
 
 export interface FixResult {
@@ -213,12 +214,20 @@ export async function POST(request: NextRequest) {
   const ocFixIds = ['config_permissions', 'gateway_auth', 'gateway_bind', 'elevated_disabled', 'dm_isolation', 'exec_restricted', 'control_ui_device_auth', 'control_ui_insecure_auth', 'fs_workspace_only', 'log_redaction']
   const configPath = config.openclawConfigPath
   if (ocFixIds.some(id => shouldFix(id)) && configPath && existsSync(configPath)) {
+    let releaseConfigLock: (() => void) | undefined
     let ocConfig: any
     try {
+      releaseConfigLock = acquireFileLockSync(configPath)
       ocConfig = JSON.parse(readFileSync(configPath, 'utf-8'))
-    } catch { ocConfig = null }
+    } catch (error: any) {
+      ocConfig = null
+      if (error?.code === 'EBUSY') {
+        results.push({ id: 'config_write', name: 'Write OpenClaw config', fixed: false, detail: error.message })
+      }
+    }
 
-    if (ocConfig) {
+    try {
+      if (ocConfig) {
       let configChanged = false
 
       // Fix config file permissions
@@ -329,11 +338,14 @@ export async function POST(request: NextRequest) {
 
       if (configChanged) {
         try {
-          writeFileSync(configPath, JSON.stringify(ocConfig, null, 2) + '\n', 'utf-8')
+          atomicReplaceFileSync(configPath, JSON.stringify(ocConfig, null, 2) + '\n')
         } catch (e: any) {
           results.push({ id: 'config_write', name: 'Write OpenClaw config', fixed: false, detail: e.message })
         }
       }
+    }
+    } finally {
+      releaseConfigLock?.()
     }
   }
 

--- a/src/lib/__tests__/atomic-file.test.ts
+++ b/src/lib/__tests__/atomic-file.test.ts
@@ -1,0 +1,66 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { acquireFileLockSync, atomicReplaceFileSync } from '@/lib/atomic-file'
+
+describe('atomic file updates', () => {
+  let root = ''
+  let target = ''
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'mc-atomic-file-'))
+    target = join(root, 'config.json')
+    writeFileSync(target, '{"value":1}\n', 'utf8')
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  it('atomically replaces a file and removes temporary artifacts', () => {
+    const release = acquireFileLockSync(target)
+    try {
+      atomicReplaceFileSync(target, '{"value":2}\n')
+    } finally {
+      release()
+    }
+
+    expect(readFileSync(target, 'utf8')).toBe('{"value":2}\n')
+    expect(readdirSync(root)).toEqual(['config.json'])
+  })
+
+  it('rejects a concurrent live lock without changing the target', () => {
+    const release = acquireFileLockSync(target)
+    try {
+      expect(() => acquireFileLockSync(target)).toThrow(/busy/i)
+      expect(readFileSync(target, 'utf8')).toBe('{"value":1}\n')
+    } finally {
+      release()
+    }
+  })
+
+  it('treats a lock still writing its owner record as busy', () => {
+    mkdirSync(`${target}.mc-lock`, { mode: 0o700 })
+
+    expect(() => acquireFileLockSync(target)).toThrow(/busy/i)
+    expect(readFileSync(target, 'utf8')).toBe('{"value":1}\n')
+  })
+
+  it('recovers a lock owned by a dead process', () => {
+    mkdirSync(`${target}.mc-lock`, { mode: 0o700 })
+    writeFileSync(`${target}.mc-lock/owner`, '99999999\n', { flag: 'wx', mode: 0o600 })
+    const release = acquireFileLockSync(target)
+    release()
+
+    expect(existsSync(`${target}.mc-lock`)).toBe(false)
+  })
+})

--- a/src/lib/__tests__/gateway-runtime.test.ts
+++ b/src/lib/__tests__/gateway-runtime.test.ts
@@ -72,4 +72,16 @@ describe('registerMcAsDashboard', () => {
     expect(result).toEqual({ registered: false, alreadySet: true })
     expect(after).toBe(before)
   })
+
+  it('leaves no lock or temporary artifacts after registration', async () => {
+    writeFileSync(configPath, JSON.stringify({ gateway: {} }), 'utf8')
+    const { registerMcAsDashboard } = await import('@/lib/gateway-runtime')
+
+    expect(registerMcAsDashboard('https://mc.example.com')).toEqual({
+      registered: true,
+      alreadySet: false,
+    })
+    expect(readFileSync(configPath, 'utf8')).toContain('https://mc.example.com')
+    expect(() => readFileSync(`${configPath}.mc-lock`, 'utf8')).toThrow()
+  })
 })

--- a/src/lib/__tests__/security-scan-fix-route.test.ts
+++ b/src/lib/__tests__/security-scan-fix-route.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdtempSync, readFileSync, statSync, writeFileSync, rmSync } from 'node:fs'
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync, rmSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -31,6 +31,7 @@ vi.mock('@/lib/logger', () => ({
 
 vi.mock('@/lib/security-scan', () => ({
   FIX_SAFETY: {
+    gateway_bind: 'safe',
     rate_limiting: 'safe',
     world_writable: 'safe',
   },
@@ -161,5 +162,26 @@ describe('security-scan fix route env mutation', () => {
 
     expect(response.status).toBe(200)
     expect(statSync(filePath).mode & 0o777).toBe(0o664)
+  })
+
+  it('reports a busy OpenClaw config without overwriting it', async () => {
+    const configPath = path.join(tempDir, 'openclaw.json')
+    const original = '{"gateway":{"bind":"lan"}}\n'
+    writeFileSync(configPath, original, 'utf8')
+    mkdirSync(`${configPath}.mc-lock`, { mode: 0o700 })
+    writeFileSync(`${configPath}.mc-lock/owner`, `${process.pid}\n`, { flag: 'wx', mode: 0o600 })
+    const { config } = await import('@/lib/config')
+    config.openclawConfigPath = configPath
+
+    const { POST } = await import('@/app/api/security-scan/fix/route')
+    const response = await POST(request(JSON.stringify({ ids: ['gateway_bind'] })))
+
+    expect(response.status).toBe(200)
+    expect(readFileSync(configPath, 'utf8')).toBe(original)
+    await expect(response.json()).resolves.toMatchObject({
+      results: expect.arrayContaining([
+        expect.objectContaining({ id: 'config_write', fixed: false }),
+      ]),
+    })
   })
 })

--- a/src/lib/atomic-file.ts
+++ b/src/lib/atomic-file.ts
@@ -1,0 +1,110 @@
+import {
+  closeSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { basename, dirname, join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+
+function processIsAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH'
+  }
+}
+
+function removeDeadLock(lockDir: string): boolean {
+  try {
+    const pid = Number.parseInt(readFileSync(join(lockDir, 'owner'), 'utf8').trim(), 10)
+    if (processIsAlive(pid)) return false
+    rmSync(lockDir, { recursive: true, force: true })
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function acquireFileLockSync(targetPath: string): () => void {
+  const lockDir = `${targetPath}.mc-lock`
+
+  try {
+    mkdirSync(lockDir, { mode: 0o700 })
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST' || !removeDeadLock(lockDir)) {
+      const busy = new Error(`Configuration file is busy: ${targetPath}`) as NodeJS.ErrnoException
+      busy.code = 'EBUSY'
+      throw busy
+    }
+    mkdirSync(lockDir, { mode: 0o700 })
+  }
+
+  const ownerPath = join(lockDir, 'owner')
+  let descriptor: number | undefined
+  try {
+    descriptor = openSync(ownerPath, 'wx', 0o600)
+    writeFileSync(descriptor, `${process.pid}\n`, 'utf8')
+    fsyncSync(descriptor)
+    closeSync(descriptor)
+    descriptor = undefined
+  } catch (error) {
+    if (descriptor !== undefined) {
+      try {
+        closeSync(descriptor)
+      } catch {
+        // Preserve the acquisition error.
+      }
+    }
+    rmSync(lockDir, { recursive: true, force: true })
+    throw error
+  }
+
+  let released = false
+  return () => {
+    if (released) return
+    released = true
+    rmSync(lockDir, { recursive: true, force: true })
+  }
+}
+
+export function atomicReplaceFileSync(
+  targetPath: string,
+  content: string,
+  mode = 0o600,
+): void {
+  const tempPath = join(
+    dirname(targetPath),
+    `.${basename(targetPath)}.${process.pid}.${randomUUID()}.tmp`,
+  )
+  let descriptor: number | undefined
+
+  try {
+    descriptor = openSync(tempPath, 'wx', mode)
+    writeFileSync(descriptor, content, 'utf8')
+    fsyncSync(descriptor)
+    closeSync(descriptor)
+    descriptor = undefined
+    renameSync(tempPath, targetPath)
+  } finally {
+    if (descriptor !== undefined) {
+      try {
+        closeSync(descriptor)
+      } catch {
+        // Best effort; the original error is more useful.
+      }
+    }
+    try {
+      unlinkSync(tempPath)
+    } catch {
+      // Successful rename removes the temporary path.
+    }
+  }
+}

--- a/src/lib/gateway-runtime.ts
+++ b/src/lib/gateway-runtime.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import { config } from '@/lib/config'
 import { logger } from '@/lib/logger'
+import { acquireFileLockSync, atomicReplaceFileSync } from '@/lib/atomic-file'
 
 interface OpenClawGatewayConfig {
   gateway?: {
@@ -29,11 +30,13 @@ function readOpenClawConfig(): OpenClawGatewayConfig | null {
 
 export function registerMcAsDashboard(mcUrl: string): { registered: boolean; alreadySet: boolean } {
   const configPath = config.openclawConfigPath
-  if (!configPath || !fs.existsSync(configPath)) {
+  if (!configPath) {
     return { registered: false, alreadySet: false }
   }
 
+  let releaseLock: (() => void) | undefined
   try {
+    releaseLock = acquireFileLockSync(configPath)
     const raw = fs.readFileSync(configPath, 'utf8')
     const parsed = JSON.parse(raw) as Record<string, any>
 
@@ -55,7 +58,7 @@ export function registerMcAsDashboard(mcUrl: string): { registered: boolean; alr
     origins.push(origin)
     parsed.gateway.controlUi.allowedOrigins = origins
 
-    fs.writeFileSync(configPath, JSON.stringify(parsed, null, 2) + '\n')
+    atomicReplaceFileSync(configPath, JSON.stringify(parsed, null, 2) + '\n')
     logger.info({ origin }, 'Registered MC origin in gateway config')
     return { registered: true, alreadySet: false }
   } catch (err: any) {
@@ -72,6 +75,8 @@ export function registerMcAsDashboard(mcUrl: string): { registered: boolean; alr
     }
     logger.error({ err }, 'Failed to register MC in gateway config')
     return { registered: false, alreadySet: false }
+  } finally {
+    releaseLock?.()
   }
 }
 


### PR DESCRIPTION
## Summary
- serialize cross-process configuration mutations with exclusive lock directories
- distinguish live, initializing, and dead lock owners safely
- write complete owner-only replacements to same-directory temporary files
- fsync and atomically rename completed configuration content
- migrate gateway origin registration and security repair configuration writes
- add busy, stale-lock, cleanup, preservation, and failure regression coverage

## Security impact
Repairs the final two high-severity filesystem read-modify-write races. Concurrent Mission Control writers can no longer silently overwrite each other, and failed writes leave the original configuration intact.

## Verification
- focused atomic/configuration tests: 18 passed
- lint: passed
- typecheck: passed
- strict security scan: passed
- repository privacy scan: passed