### PR TITLE
fix: harden channel property handling

### DIFF
--- a/src/app/api/channels/route.ts
+++ b/src/app/api/channels/route.ts
@@ -4,6 +4,7 @@ import { config } from '@/lib/config'
 import { logger } from '@/lib/logger'
 import { getDetectedGatewayToken } from '@/lib/gateway-runtime'
 import { callOpenClawGateway } from '@/lib/openclaw-gateway'
+import { transformGatewayChannels, type ChannelsSnapshot } from '@/lib/channel-snapshot'
 
 const gatewayInternalUrl = `http://${config.gatewayHost}:${config.gatewayPort}`
 
@@ -15,136 +16,6 @@ function gatewayHeaders(): Record<string, string> {
 }
 
 type GatewayData = unknown
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === 'object' ? (value as Record<string, unknown>) : null
-}
-
-function readBoolean(value: unknown): boolean | undefined {
-  return typeof value === 'boolean' ? value : undefined
-}
-
-function readString(value: unknown): string | undefined {
-  return typeof value === 'string' ? value : undefined
-}
-
-function readNumber(value: unknown): number | undefined {
-  return typeof value === 'number' ? value : undefined
-}
-
-interface ChannelStatus {
-  configured: boolean
-  linked?: boolean
-  running: boolean
-  connected?: boolean
-  lastConnectedAt?: number | null
-  lastMessageAt?: number | null
-  lastStartAt?: number | null
-  lastError?: string | null
-  authAgeMs?: number | null
-  mode?: string | null
-  baseUrl?: string | null
-  publicKey?: string | null
-  probe?: GatewayData
-  profile?: GatewayData
-}
-
-interface ChannelAccount {
-  accountId: string
-  name?: string | null
-  configured?: boolean | null
-  linked?: boolean | null
-  running?: boolean | null
-  connected?: boolean | null
-  lastConnectedAt?: number | null
-  lastInboundAt?: number | null
-  lastOutboundAt?: number | null
-  lastError?: string | null
-  lastStartAt?: number | null
-  mode?: string | null
-  probe?: GatewayData
-  publicKey?: string | null
-  profile?: GatewayData
-}
-
-interface ChannelsSnapshot {
-  channels: Record<string, ChannelStatus>
-  channelAccounts: Record<string, ChannelAccount[]>
-  channelOrder: string[]
-  channelLabels: Record<string, string>
-  connected: boolean
-  updatedAt?: number
-}
-
-function transformGatewayChannels(data: GatewayData): ChannelsSnapshot {
-  const parsed = asRecord(data)
-  const rawChannels = asRecord(parsed?.channels) ?? {}
-  const rawAccounts = asRecord(parsed?.channelAccounts) ?? {}
-  const channelLabels = asRecord(parsed?.channelLabels)
-  const order = Array.isArray(parsed?.channelOrder)
-    ? parsed.channelOrder.filter((value): value is string => typeof value === 'string')
-    : Object.keys(rawChannels)
-
-  const channels: Record<string, ChannelStatus> = {}
-  const channelAccounts: Record<string, ChannelAccount[]> = {}
-  const labels: Record<string, string> = Object.fromEntries(
-    Object.entries(channelLabels ?? {}).flatMap(([key, value]) => typeof value === 'string' ? [[key, value]] : [])
-  )
-
-  for (const key of order) {
-    const ch = asRecord(rawChannels[key])
-    if (!ch) continue
-
-    channels[key] = {
-      configured: !!readBoolean(ch.configured),
-      linked: readBoolean(ch.linked),
-      running: !!readBoolean(ch.running),
-      connected: readBoolean(ch.connected),
-      lastConnectedAt: readNumber(ch.lastConnectedAt) ?? null,
-      lastMessageAt: readNumber(ch.lastMessageAt) ?? null,
-      lastStartAt: readNumber(ch.lastStartAt) ?? null,
-      lastError: readString(ch.lastError) ?? null,
-      authAgeMs: readNumber(ch.authAgeMs) ?? null,
-      mode: readString(ch.mode) ?? null,
-      baseUrl: readString(ch.baseUrl) ?? null,
-      publicKey: readString(ch.publicKey) ?? null,
-      probe: ch.probe ?? null,
-      profile: ch.profile ?? null,
-    }
-
-    const accounts = rawAccounts[key] || []
-    const accountEntries = (Array.isArray(accounts) ? accounts : Object.values(accounts)) as GatewayData[]
-    channelAccounts[key] = accountEntries.map((acct) => {
-      const parsedAccount = asRecord(acct) ?? {}
-      return {
-        accountId: readString(parsedAccount.accountId) ?? 'default',
-        name: readString(parsedAccount.name) ?? null,
-        configured: readBoolean(parsedAccount.configured) ?? null,
-        linked: readBoolean(parsedAccount.linked) ?? null,
-        running: readBoolean(parsedAccount.running) ?? null,
-        connected: readBoolean(parsedAccount.connected) ?? null,
-        lastConnectedAt: readNumber(parsedAccount.lastConnectedAt) ?? null,
-        lastInboundAt: readNumber(parsedAccount.lastInboundAt) ?? null,
-        lastOutboundAt: readNumber(parsedAccount.lastOutboundAt) ?? null,
-        lastError: readString(parsedAccount.lastError) ?? null,
-        lastStartAt: readNumber(parsedAccount.lastStartAt) ?? null,
-        mode: readString(parsedAccount.mode) ?? null,
-        probe: parsedAccount.probe ?? null,
-        publicKey: readString(parsedAccount.publicKey) ?? null,
-        profile: parsedAccount.profile ?? null,
-      }
-    })
-  }
-
-  return {
-    channels,
-    channelAccounts,
-    channelOrder: order,
-    channelLabels: labels,
-    connected: true,
-    updatedAt: readNumber(parsed?.ts),
-  }
-}
 
 async function loadChannelsViaRpc(probe = false): Promise<ChannelsSnapshot> {
   const payload = await callOpenClawGateway<GatewayData>(

--- a/src/lib/__tests__/channels-route-security.test.ts
+++ b/src/lib/__tests__/channels-route-security.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { transformGatewayChannels } from '@/lib/channel-snapshot'
+
+describe('channel snapshot property safety', () => {
+  it('stores special channel names without mutating dictionary prototypes', () => {
+    const snapshot = transformGatewayChannels(JSON.parse(`{
+      "channels": {
+        "__proto__": { "configured": true, "running": true },
+        "constructor": { "configured": true, "running": false }
+      },
+      "channelAccounts": {
+        "__proto__": [{ "accountId": "safe" }],
+        "constructor": [{ "accountId": "also-safe" }]
+      },
+      "channelOrder": ["__proto__", "constructor"]
+    }`))
+
+    expect(Object.getPrototypeOf(snapshot.channels)).toBeNull()
+    expect(Object.getPrototypeOf(snapshot.channelAccounts)).toBeNull()
+    expect(Object.hasOwn(snapshot.channels, '__proto__')).toBe(true)
+    expect(Object.hasOwn(snapshot.channels, 'constructor')).toBe(true)
+    expect(snapshot.channels.__proto__.configured).toBe(true)
+    expect(snapshot.channelAccounts['constructor'][0].accountId).toBe('also-safe')
+  })
+
+  it('ignores inherited channel and account properties', () => {
+    const channels = Object.create({
+      inherited: { configured: true, running: true },
+    }) as Record<string, unknown>
+    const channelAccounts = Object.create({
+      inherited: [{ accountId: 'inherited' }],
+    }) as Record<string, unknown>
+
+    const snapshot = transformGatewayChannels({
+      channels,
+      channelAccounts,
+      channelOrder: ['inherited'],
+    })
+
+    expect(snapshot.channelOrder).toEqual(['inherited'])
+    expect(Object.hasOwn(snapshot.channels, 'inherited')).toBe(false)
+    expect(Object.hasOwn(snapshot.channelAccounts, 'inherited')).toBe(false)
+  })
+})

--- a/src/lib/channel-snapshot.ts
+++ b/src/lib/channel-snapshot.ts
@@ -1,0 +1,135 @@
+type GatewayData = unknown
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : null
+}
+
+function readBoolean(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined
+}
+
+function readNumber(value: unknown): number | undefined {
+  return typeof value === 'number' ? value : undefined
+}
+
+interface ChannelStatus {
+  configured: boolean
+  linked?: boolean
+  running: boolean
+  connected?: boolean
+  lastConnectedAt?: number | null
+  lastMessageAt?: number | null
+  lastStartAt?: number | null
+  lastError?: string | null
+  authAgeMs?: number | null
+  mode?: string | null
+  baseUrl?: string | null
+  publicKey?: string | null
+  probe?: GatewayData
+  profile?: GatewayData
+}
+
+interface ChannelAccount {
+  accountId: string
+  name?: string | null
+  configured?: boolean | null
+  linked?: boolean | null
+  running?: boolean | null
+  connected?: boolean | null
+  lastConnectedAt?: number | null
+  lastInboundAt?: number | null
+  lastOutboundAt?: number | null
+  lastError?: string | null
+  lastStartAt?: number | null
+  mode?: string | null
+  probe?: GatewayData
+  publicKey?: string | null
+  profile?: GatewayData
+}
+
+export interface ChannelsSnapshot {
+  channels: Record<string, ChannelStatus>
+  channelAccounts: Record<string, ChannelAccount[]>
+  channelOrder: string[]
+  channelLabels: Record<string, string>
+  connected: boolean
+  updatedAt?: number
+}
+
+export function transformGatewayChannels(data: GatewayData): ChannelsSnapshot {
+  const parsed = asRecord(data)
+  const rawChannels = asRecord(parsed?.channels) ?? {}
+  const rawAccounts = asRecord(parsed?.channelAccounts) ?? {}
+  const channelLabels = asRecord(parsed?.channelLabels)
+  const order = Array.isArray(parsed?.channelOrder)
+    ? parsed.channelOrder.filter((value): value is string => typeof value === 'string')
+    : Object.keys(rawChannels)
+
+  const channels: Record<string, ChannelStatus> = Object.create(null)
+  const channelAccounts: Record<string, ChannelAccount[]> = Object.create(null)
+  const labels: Record<string, string> = Object.fromEntries(
+    Object.entries(channelLabels ?? {}).flatMap(([key, value]) => typeof value === 'string' ? [[key, value]] : [])
+  )
+
+  for (const key of order) {
+    if (!Object.hasOwn(rawChannels, key)) continue
+    const channel = asRecord(rawChannels[key])
+    if (!channel) continue
+
+    channels[key] = {
+      configured: !!readBoolean(channel.configured),
+      linked: readBoolean(channel.linked),
+      running: !!readBoolean(channel.running),
+      connected: readBoolean(channel.connected),
+      lastConnectedAt: readNumber(channel.lastConnectedAt) ?? null,
+      lastMessageAt: readNumber(channel.lastMessageAt) ?? null,
+      lastStartAt: readNumber(channel.lastStartAt) ?? null,
+      lastError: readString(channel.lastError) ?? null,
+      authAgeMs: readNumber(channel.authAgeMs) ?? null,
+      mode: readString(channel.mode) ?? null,
+      baseUrl: readString(channel.baseUrl) ?? null,
+      publicKey: readString(channel.publicKey) ?? null,
+      probe: channel.probe ?? null,
+      profile: channel.profile ?? null,
+    }
+
+    const accounts = Object.hasOwn(rawAccounts, key) ? rawAccounts[key] : []
+    const accountRecord = asRecord(accounts)
+    const accountEntries = Array.isArray(accounts)
+      ? accounts
+      : accountRecord ? Object.values(accountRecord) : []
+    channelAccounts[key] = accountEntries.map((account) => {
+      const parsedAccount = asRecord(account) ?? {}
+      return {
+        accountId: readString(parsedAccount.accountId) ?? 'default',
+        name: readString(parsedAccount.name) ?? null,
+        configured: readBoolean(parsedAccount.configured) ?? null,
+        linked: readBoolean(parsedAccount.linked) ?? null,
+        running: readBoolean(parsedAccount.running) ?? null,
+        connected: readBoolean(parsedAccount.connected) ?? null,
+        lastConnectedAt: readNumber(parsedAccount.lastConnectedAt) ?? null,
+        lastInboundAt: readNumber(parsedAccount.lastInboundAt) ?? null,
+        lastOutboundAt: readNumber(parsedAccount.lastOutboundAt) ?? null,
+        lastError: readString(parsedAccount.lastError) ?? null,
+        lastStartAt: readNumber(parsedAccount.lastStartAt) ?? null,
+        mode: readString(parsedAccount.mode) ?? null,
+        probe: parsedAccount.probe ?? null,
+        publicKey: readString(parsedAccount.publicKey) ?? null,
+        profile: parsedAccount.profile ?? null,
+      }
+    })
+  }
+
+  return {
+    channels,
+    channelAccounts,
+    channelOrder: order,
+    channelLabels: labels,
+    connected: true,
+    updatedAt: readNumber(parsed?.ts),
+  }
+}


### PR DESCRIPTION
## Summary
- move gateway channel transformation into a focused, testable module
- store gateway-controlled channel names in null-prototype dictionaries
- ignore inherited channel and account properties before dynamic reads and writes

## Security impact
Closes the two CodeQL remote-property-injection paths in the channels status transformation without restricting valid extensible channel identifiers.

## Verification
- focused Vitest regression tests: pass
- typecheck: pass
- lint: pass
- strict DevGod scan: pass
- private-name exclusion scan: pass

## Test note
A local full-suite invocation also ran the focused tests successfully but exposed three pre-existing device-identity test failures caused by unavailable localStorage in that invocation environment. Protected CI remains the release-quality authority for the complete suite.