### PR TITLE
fix: make adapter registry prototype-safe

### DIFF
--- a/src/lib/adapters/__tests__/adapter-compliance.test.ts
+++ b/src/lib/adapters/__tests__/adapter-compliance.test.ts
@@ -82,6 +82,13 @@ describe('Adapter Registry', () => {
   it('throws for unknown framework', () => {
     expect(() => getAdapter('nonexistent')).toThrow('Unknown framework adapter')
   })
+
+  it.each(['toString', 'constructor', '__proto__', 'hasOwnProperty'])(
+    'rejects inherited Object property name %s',
+    (framework) => {
+      expect(() => getAdapter(framework)).toThrow(`Unknown framework adapter: ${framework}`)
+    },
+  )
 })
 
 // Run the full compliance suite for EVERY adapter

--- a/src/lib/adapters/index.ts
+++ b/src/lib/adapters/index.ts
@@ -6,23 +6,23 @@ import { AutoGenAdapter } from './autogen'
 import { ClaudeSdkAdapter } from './claude-sdk'
 import type { FrameworkAdapter } from './adapter'
 
-const adapters: Record<string, () => FrameworkAdapter> = {
-  openclaw: () => new OpenClawAdapter(),
-  generic: () => new GenericAdapter(),
-  crewai: () => new CrewAIAdapter(),
-  langgraph: () => new LangGraphAdapter(),
-  autogen: () => new AutoGenAdapter(),
-  'claude-sdk': () => new ClaudeSdkAdapter(),
-}
+const adapters = new Map<string, () => FrameworkAdapter>([
+  ['openclaw', () => new OpenClawAdapter()],
+  ['generic', () => new GenericAdapter()],
+  ['crewai', () => new CrewAIAdapter()],
+  ['langgraph', () => new LangGraphAdapter()],
+  ['autogen', () => new AutoGenAdapter()],
+  ['claude-sdk', () => new ClaudeSdkAdapter()],
+])
 
 export function getAdapter(framework: string): FrameworkAdapter {
-  const factory = adapters[framework]
+  const factory = adapters.get(framework)
   if (!factory) throw new Error(`Unknown framework adapter: ${framework}`)
   return factory()
 }
 
 export function listAdapters(): string[] {
-  return Object.keys(adapters)
+  return Array.from(adapters.keys())
 }
 
 export type { FrameworkAdapter, AgentRegistration, HeartbeatPayload, TaskReport, Assignment } from './adapter'


### PR DESCRIPTION
## Summary
- replace the plain-object adapter factory registry with an explicit Map
- preserve supported adapter order and factory behavior
- reject inherited Object property names before invocation

## Security impact
Closes the CodeQL unvalidated-dynamic-method-call path where a user-controlled framework name could resolve an inherited callable property instead of a registered adapter factory.

## Verification
- adapter compliance suite: 125 tests pass
- typecheck: pass
- lint: pass
- strict DevGod scan: pass
- private-name exclusion scan: pass