### PR TITLE
fix: scope MCP receipt verification

### DIFF
--- a/src/app/api/mcp-audit/verify/route.ts
+++ b/src/app/api/mcp-audit/verify/route.ts
@@ -11,6 +11,15 @@ import { requireRole } from '@/lib/auth'
 import { verifyMcpCallReceipt, verifyMcpCallReceipts } from '@/lib/mcp-audit'
 import { getPublicKey } from '@/lib/receipt-signing'
 
+const DEFAULT_VERIFY_HOURS = 24
+const MAX_VERIFY_HOURS = 24 * 7
+
+function parsePositiveInteger(value: string): number | null {
+  if (!/^[1-9]\d*$/.test(value)) return null
+  const parsed = Number(value)
+  return Number.isSafeInteger(parsed) ? parsed : null
+}
+
 export async function GET(request: Request) {
   const auth = requireRole(request, 'admin')
   if ('error' in auth) {
@@ -18,11 +27,17 @@ export async function GET(request: Request) {
   }
 
   const { searchParams } = new URL(request.url)
-  const recordId = searchParams.get('id')
+  const recordIdParam = searchParams.get('id')
+  const workspaceId = auth.user.workspace_id ?? 1
 
   // Single record verification
-  if (recordId) {
-    const result = verifyMcpCallReceipt(parseInt(recordId, 10))
+  if (recordIdParam !== null) {
+    const recordId = parsePositiveInteger(recordIdParam)
+    if (recordId === null) {
+      return NextResponse.json({ error: 'id must be a positive integer' }, { status: 400 })
+    }
+
+    const result = verifyMcpCallReceipt(recordId, workspaceId)
     return NextResponse.json({
       ...result,
       publicKey: getPublicKey(),
@@ -31,8 +46,13 @@ export async function GET(request: Request) {
   }
 
   // Batch verification (default: last 24 hours)
-  const hours = parseInt(searchParams.get('hours') ?? '24', 10)
-  const workspaceId = parseInt(searchParams.get('workspace_id') ?? '1', 10)
+  const hoursParam = searchParams.get('hours')
+  const hours = hoursParam === null ? DEFAULT_VERIFY_HOURS : parsePositiveInteger(hoursParam)
+  if (hours === null || hours > MAX_VERIFY_HOURS) {
+    return NextResponse.json({
+      error: `hours must be a positive integer no greater than ${MAX_VERIFY_HOURS}`,
+    }, { status: 400 })
+  }
 
   const result = verifyMcpCallReceipts(hours, workspaceId)
   return NextResponse.json({

--- a/src/lib/__tests__/mcp-audit-verification-scope.test.ts
+++ b/src/lib/__tests__/mcp-audit-verification-scope.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getDatabase: vi.fn(),
+}))
+
+vi.mock('@/lib/db', () => ({ getDatabase: mocks.getDatabase }))
+vi.mock('@/lib/receipt-signing', () => ({
+  signAuditRecord: vi.fn(),
+  verifyAuditRecord: vi.fn(),
+}))
+
+import { verifyMcpCallReceipt } from '@/lib/mcp-audit'
+
+describe('MCP audit receipt workspace isolation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('queries a single record by both ID and workspace ID', () => {
+    const get = vi.fn().mockReturnValue(undefined)
+    const prepare = vi.fn().mockReturnValue({ get })
+    mocks.getDatabase.mockReturnValue({ prepare })
+
+    const result = verifyMcpCallReceipt(42, 7)
+
+    expect(prepare).toHaveBeenCalledWith(
+      'SELECT * FROM mcp_call_log WHERE id = ? AND workspace_id = ?',
+    )
+    expect(get).toHaveBeenCalledWith(42, 7)
+    expect(result).toEqual({ valid: false, record: null, error: 'Record not found' })
+  })
+})

--- a/src/lib/__tests__/mcp-audit-verify-route-security.test.ts
+++ b/src/lib/__tests__/mcp-audit-verify-route-security.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  requireRole: vi.fn(),
+  verifyOne: vi.fn(),
+  verifyMany: vi.fn(),
+  getPublicKey: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({ requireRole: mocks.requireRole }))
+vi.mock('@/lib/mcp-audit', () => ({
+  verifyMcpCallReceipt: mocks.verifyOne,
+  verifyMcpCallReceipts: mocks.verifyMany,
+}))
+vi.mock('@/lib/receipt-signing', () => ({ getPublicKey: mocks.getPublicKey }))
+
+import { GET } from '@/app/api/mcp-audit/verify/route'
+
+describe('MCP audit verification route security', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.requireRole.mockReturnValue({
+      user: { workspace_id: 7 },
+    })
+    mocks.verifyOne.mockReturnValue({ valid: true, record: {} })
+    mocks.verifyMany.mockReturnValue({
+      total: 0,
+      signed: 0,
+      verified: 0,
+      failed: 0,
+      unsigned: 0,
+    })
+    mocks.getPublicKey.mockReturnValue('public-key')
+  })
+
+  it('uses authenticated workspace scope for batch verification', async () => {
+    const response = await GET(new Request(
+      'http://localhost/api/mcp-audit/verify?hours=48&workspace_id=999',
+    ))
+
+    expect(response.status).toBe(200)
+    expect(mocks.verifyMany).toHaveBeenCalledWith(48, 7)
+  })
+
+  it('uses authenticated workspace scope for single-record verification', async () => {
+    const response = await GET(new Request(
+      'http://localhost/api/mcp-audit/verify?id=42&workspace_id=999',
+    ))
+
+    expect(response.status).toBe(200)
+    expect(mocks.verifyOne).toHaveBeenCalledWith(42, 7)
+  })
+
+  it.each([
+    ['id=0', 'id'],
+    ['id=12junk', 'id'],
+    ['hours=0', 'hours'],
+    ['hours=169', 'hours'],
+    ['hours=Infinity', 'hours'],
+  ])('rejects invalid verification selector %s', async (query, field) => {
+    const response = await GET(new Request(`http://localhost/api/mcp-audit/verify?${query}`))
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toMatchObject({ error: expect.stringContaining(field) })
+    expect(mocks.verifyOne).not.toHaveBeenCalled()
+    expect(mocks.verifyMany).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/mcp-audit.ts
+++ b/src/lib/mcp-audit.ts
@@ -152,15 +152,15 @@ export function getMcpCallStats(
  * recomputes the SHA-256 hash, and checks the Ed25519 signature.
  * Returns false if the record has been tampered with.
  */
-export function verifyMcpCallReceipt(recordId: number): {
+export function verifyMcpCallReceipt(recordId: number, workspaceId: number): {
   valid: boolean
   record: Record<string, unknown> | null
   error?: string
 } {
   const db = getDatabase()
   const row = db.prepare(
-    'SELECT * FROM mcp_call_log WHERE id = ?'
-  ).get(recordId) as any
+    'SELECT * FROM mcp_call_log WHERE id = ? AND workspace_id = ?'
+  ).get(recordId, workspaceId) as any
 
   if (!row) return { valid: false, record: null, error: 'Record not found' }
 


### PR DESCRIPTION
## Summary
- derive MCP receipt verification scope only from the authenticated administrator
- require workspace_id in single-record receipt queries
- reject malformed record IDs and verification windows over seven days
- ignore caller-supplied workspace selectors

## Security impact
Prevents cross-workspace MCP audit receipt access through both global record IDs and caller-selected batch workspace parameters. It also bounds verification workload from query input.

## Verification
- focused route and SQL isolation tests: 8 pass
- typecheck: pass
- lint: pass
- strict DevGod scan: pass
- private-name exclusion scan: pass