### PR TITLE
ci: scope workflow write permissions by job

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,14 +15,16 @@ concurrency:
 
 permissions:
   contents: read
-  actions: read
-  security-events: write
 
 jobs:
   analyze:
     name: Analyze JavaScript and TypeScript
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,7 +14,6 @@ concurrency:
 
 permissions:
   contents: read
-  packages: write
 
 env:
   GHCR_IMAGE: ghcr.io/${{ github.repository }}
@@ -24,6 +23,9 @@ env:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -11,12 +11,14 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  actions: read
   contents: read
-  security-events: write
 
 jobs:
   scan:
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
     with:
       scan-args: |-

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -9,6 +9,9 @@ concurrency:
   group: quality-gate-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   quality-gate:
     runs-on: ubuntu-latest

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -11,18 +11,20 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  actions: read
-  checks: read
   contents: read
-  issues: read
-  pull-requests: read
-  security-events: write
 
 jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+      issues: read
+      pull-requests: read
+      security-events: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/star-chart.yml
+++ b/.github/workflows/star-chart.yml
@@ -9,11 +9,13 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   refresh:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 

--- a/src/lib/__tests__/workflow-token-permissions-security.test.ts
+++ b/src/lib/__tests__/workflow-token-permissions-security.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const workflows = [
+  'star-chart.yml',
+  'scorecard.yml',
+  'quality-gate.yml',
+  'osv-scanner.yml',
+  'docker-publish.yml',
+  'codeql.yml',
+]
+
+function readWorkflow(name: string): string {
+  return readFileSync(join(process.cwd(), '.github/workflows', name), 'utf8')
+}
+
+function topLevelPermissions(source: string): string {
+  const match = source.match(/^permissions:\n((?: {2}\S.*\n?)*)/m)
+  return match?.[1] ?? ''
+}
+
+describe('workflow token permission boundaries', () => {
+  it.each(workflows)('%s has no workflow-level write scope', (workflow) => {
+    const permissions = topLevelPermissions(readWorkflow(workflow))
+    expect(permissions).toContain('contents: read')
+    expect(permissions).not.toContain(': write')
+  })
+
+  it('grants chart commits only to the refresh job', () => {
+    expect(readWorkflow('star-chart.yml')).toMatch(
+      /refresh:\n {4}runs-on: ubuntu-latest\n {4}permissions:\n {6}contents: write/,
+    )
+  })
+
+  it.each(['scorecard.yml', 'osv-scanner.yml', 'codeql.yml'])(
+    'grants SARIF upload only inside the scanner job in %s',
+    (workflow) => {
+      expect(readWorkflow(workflow)).toMatch(
+        /jobs:\n(?:.|\n)*? {4}permissions:\n(?: {6}.+\n)*? {6}security-events: write/,
+      )
+    },
+  )
+
+  it('grants package publication only to the Docker publish job', () => {
+    expect(readWorkflow('docker-publish.yml')).toMatch(
+      /publish:\n {4}runs-on: ubuntu-latest\n {4}permissions:\n {6}contents: read\n {6}packages: write/,
+    )
+  })
+
+  it('keeps the quality gate read-only', () => {
+    expect(readWorkflow('quality-gate.yml')).not.toContain(': write')
+  })
+})


### PR DESCRIPTION
## Summary
- make all six affected workflows default to read-only contents access
- grant chart commits, SARIF uploads, and package publication only to the jobs that require them
- declare the quality gate explicitly read-only
- add regression tests for top-level and job-local token scopes

## Security impact
Reduces GitHub Actions token blast radius while preserving required chart publication, security result uploads, and container publishing. Addresses the six OpenSSF token-permission findings without removing required capabilities.

## Verification
- workflow permission and security contracts: 16 tests pass
- immutable action-pin check: 22 references pass
- typecheck: pass
- lint: pass
- strict DevGod scan: pass
- private-name exclusion scan: pass