### PR TITLE
fix: harden nested config assignment

### DIFF
--- a/src/app/api/gateway-config/route.ts
+++ b/src/app/api/gateway-config/route.ts
@@ -8,6 +8,7 @@ import { gatewayConfigMutationLimiter } from '@/lib/rate-limit'
 import { getDetectedGatewayToken } from '@/lib/gateway-runtime'
 import { parseJsonRelaxed } from '@/lib/json-relaxed'
 import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
+import { setNestedConfigValue } from '@/lib/config-path'
 
 function getConfigPath(): string | null {
   return config.openclawConfigPath || null
@@ -173,7 +174,7 @@ export async function PUT(request: NextRequest) {
     // Apply updates via dot-notation
     const appliedKeys: string[] = []
     for (const [dotPath, value] of Object.entries(body.updates)) {
-      setNestedValue(parsed, dotPath, value)
+      setNestedConfigValue(parsed, dotPath, value)
       appliedKeys.push(dotPath)
     }
 
@@ -272,17 +273,6 @@ async function updateSystem(request: NextRequest, auth: any): Promise<NextRespon
       { status: 502 },
     )
   }
-}
-
-/** Set a value in a nested object using dot-notation path */
-function setNestedValue(obj: any, path: string, value: any) {
-  const keys = path.split('.')
-  let current = obj
-  for (let i = 0; i < keys.length - 1; i++) {
-    if (current[keys[i]] === undefined) current[keys[i]] = {}
-    current = current[keys[i]]
-  }
-  current[keys[keys.length - 1]] = value
 }
 
 /** Redact sensitive values for display */

--- a/src/lib/__tests__/config-path-security.test.ts
+++ b/src/lib/__tests__/config-path-security.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { setNestedConfigValue } from '@/lib/config-path'
+
+describe('nested gateway config assignment security', () => {
+  it.each([
+    '__proto__.polluted',
+    'constructor.prototype.polluted',
+    'gateway.__proto__.polluted',
+    'gateway..polluted',
+  ])('rejects unsafe path %s', (path) => {
+    const target: Record<string, unknown> = { gateway: {} }
+
+    expect(() => setNestedConfigValue(target, path, true)).toThrow(
+      'Config path contains an unsafe segment',
+    )
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+  })
+
+  it('does not traverse inherited properties', () => {
+    const inherited = { nested: {} }
+    const target = Object.create({ inherited }) as Record<string, unknown>
+
+    setNestedConfigValue(target, 'inherited.value', true)
+
+    expect(Object.hasOwn(target, 'inherited')).toBe(true)
+    expect(inherited).toEqual({ nested: {} })
+  })
+
+  it('creates null-prototype intermediate records', () => {
+    const target: Record<string, unknown> = {}
+
+    setNestedConfigValue(target, 'gateway.channels.enabled', true)
+
+    const gateway = target.gateway as Record<string, unknown>
+    const channels = gateway.channels as Record<string, unknown>
+    expect(Object.getPrototypeOf(gateway)).toBeNull()
+    expect(Object.getPrototypeOf(channels)).toBeNull()
+    expect(channels.enabled).toBe(true)
+  })
+
+  it('rejects traversal through arrays and scalar values', () => {
+    expect(() => setNestedConfigValue({ gateway: [] }, 'gateway.value', true)).toThrow(
+      'Cannot traverse non-object config value at: gateway',
+    )
+    expect(() => setNestedConfigValue({ gateway: 'local' }, 'gateway.value', true)).toThrow(
+      'Cannot traverse non-object config value at: gateway',
+    )
+  })
+})

--- a/src/lib/config-path.ts
+++ b/src/lib/config-path.ts
@@ -1,0 +1,34 @@
+const UNSAFE_CONFIG_SEGMENTS = new Set(['__proto__', 'prototype', 'constructor'])
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function setNestedConfigValue(
+  target: Record<string, unknown>,
+  path: string,
+  value: unknown,
+): void {
+  const segments = path.split('.')
+  if (
+    segments.length === 0
+    || segments.some((segment) => segment.length === 0 || UNSAFE_CONFIG_SEGMENTS.has(segment))
+  ) {
+    throw new Error('Config path contains an unsafe segment')
+  }
+
+  let current = target
+  for (const segment of segments.slice(0, -1)) {
+    if (!Object.hasOwn(current, segment)) {
+      current[segment] = Object.create(null) as Record<string, unknown>
+    }
+
+    const next = current[segment]
+    if (!isRecord(next)) {
+      throw new Error(`Cannot traverse non-object config value at: ${segment}`)
+    }
+    current = next
+  }
+
+  current[segments.at(-1)!] = value
+}


### PR DESCRIPTION
## Summary
- extract gateway config dot-path mutation into a focused pure helper
- reject prototype-related and empty path segments inside the assignment primitive
- traverse only own record properties and create null-prototype intermediates
- reject arrays and scalar values as intermediate traversal nodes

## Security impact
Closes the prototype-pollution utility finding with defense in depth. The HTTP schema already rejects unsafe paths; the mutation primitive now independently preserves the same invariant for future callers.

## Verification
- focused helper and route security tests: 15 pass
- typecheck: pass
- lint: pass
- strict DevGod scan: pass
- private-name exclusion scan: pass