### PR TITLE
build: pin Docker base image digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.18.0-slim AS base
+FROM node:24.18.0-slim@sha256:6f7b03f7c2c8e2e784dcf9295400527b9b1270fd37b7e9a7285cf83b6951452d AS base
 # Pin pnpm to v10 to match CI and package.json#packageManager. pnpm 11 turns
 # ERR_PNPM_IGNORED_BUILDS into a hard error, breaking fresh Docker builds.
 RUN corepack enable && corepack prepare pnpm@10.29.3 --activate
@@ -50,7 +50,7 @@ ENV NEXT_PUBLIC_GOOGLE_CLIENT_ID=${NEXT_PUBLIC_GOOGLE_CLIENT_ID}
 
 RUN pnpm build
 
-FROM node:24.18.0-slim AS runtime
+FROM node:24.18.0-slim@sha256:6f7b03f7c2c8e2e784dcf9295400527b9b1270fd37b7e9a7285cf83b6951452d AS runtime
 
 ARG MC_VERSION=dev
 LABEL org.opencontainers.image.source="https://github.com/builderz-labs/mission-control"


### PR DESCRIPTION
## Summary
- pin both external Node.js base-image references to the current multi-architecture SHA-256 digest
- retain the human-readable node:24.18.0-slim tag for update visibility
- leave internal stage references unchanged

## Security impact
Makes Docker builds reproducible against an immutable base image and addresses the actionable OpenSSF pinned-dependency findings.

## Verification
- Dockerfile external FROM references include SHA-256 digests
- diff check: pass
- strict DevGod scan: pass
- private-name exclusion scan: pass

## Environment note
Docker is not installed in the local workspace, so the protected hosted Buildx workflow is the authoritative container validation.