### PR TITLE
fix: atomically replace operator workspace files

### DIFF
--- a/src/app/api/agents/[id]/files/route.ts
+++ b/src/app/api/agents/[id]/files/route.ts
@@ -2,12 +2,13 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getDatabase, db_helpers } from '@/lib/db'
 import { requireRole } from '@/lib/auth'
 import { config } from '@/lib/config'
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync } from 'node:fs'
 import { dirname, isAbsolute, resolve } from 'node:path'
 import { resolveWithin } from '@/lib/paths'
 import { getAgentWorkspaceCandidates, readAgentWorkspaceFile } from '@/lib/agent-workspace'
 import { logger } from '@/lib/logger'
 import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
+import { atomicReplaceFileSync } from '@/lib/atomic-file'
 
 const ALLOWED_FILES = new Set([
   'agent.md',
@@ -137,7 +138,7 @@ export async function PUT(
 
     const safePath = resolveWithin(safeWorkspace, file)
     mkdirSync(dirname(safePath), { recursive: true })
-    writeFileSync(safePath, content, 'utf-8')
+    atomicReplaceFileSync(safePath, content)
 
     if (file === 'soul.md') {
       db.prepare('UPDATE agents SET soul_content = ?, updated_at = unixepoch() WHERE id = ? AND workspace_id = ?')

--- a/src/app/api/agents/[id]/memory/route.ts
+++ b/src/app/api/agents/[id]/memory/route.ts
@@ -3,9 +3,10 @@ import { getDatabase, db_helpers } from '@/lib/db';
 import { requireRole } from '@/lib/auth';
 import { logger } from '@/lib/logger';
 import { requireAgentSelfAccess, requireWorkspaceId } from '@/lib/enforcement/workspace-scope';
-import { statSync, mkdirSync, writeFileSync } from 'node:fs';
+import { statSync, mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { resolveWithin } from '@/lib/paths';
+import { atomicReplaceFileSync } from '@/lib/atomic-file';
 import { getAgentWorkspaceCandidates, readAgentWorkspaceFile } from '@/lib/agent-workspace';
 import type Database from 'better-sqlite3';
 import { getWorkspaceIsolation } from '@/lib/workspace-isolation';
@@ -183,7 +184,7 @@ export async function PUT(
         if (safeWorkspace) {
           const safeWorkingPath = resolveWithin(safeWorkspace, 'WORKING.md');
           mkdirSync(dirname(safeWorkingPath), { recursive: true });
-          writeFileSync(safeWorkingPath, newContent, 'utf-8');
+          atomicReplaceFileSync(safeWorkingPath, newContent);
           savedToWorkspace = true;
         }
       }
@@ -271,7 +272,7 @@ export async function DELETE(
         if (safeWorkspace) {
           const safeWorkingPath = resolveWithin(safeWorkspace, 'WORKING.md');
           mkdirSync(dirname(safeWorkingPath), { recursive: true });
-          writeFileSync(safeWorkingPath, '', 'utf-8');
+          atomicReplaceFileSync(safeWorkingPath, '');
         }
       }
     } catch (err) {

--- a/src/app/api/agents/[id]/soul/route.ts
+++ b/src/app/api/agents/[id]/soul/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDatabase, db_helpers } from '@/lib/db';
-import { readFileSync, existsSync, readdirSync, writeFileSync, mkdirSync } from 'fs';
+import { readFileSync, existsSync, readdirSync, mkdirSync } from 'fs';
 import { join, dirname, isAbsolute, resolve } from 'path';
 import { config } from '@/lib/config';
 import { resolveWithin } from '@/lib/paths';
+import { atomicReplaceFileSync } from '@/lib/atomic-file';
 import { getAgentWorkspaceCandidates, readAgentWorkspaceFile } from '@/lib/agent-workspace';
 import { requireRole } from '@/lib/auth';
 import { logger } from '@/lib/logger';
@@ -185,7 +186,7 @@ export async function PUT(
         if (safeWorkspace) {
           const safeSoulPath = resolveWithin(safeWorkspace, 'soul.md')
           mkdirSync(dirname(safeSoulPath), { recursive: true })
-          writeFileSync(safeSoulPath, newSoulContent || '', 'utf-8')
+          atomicReplaceFileSync(safeSoulPath, newSoulContent || '')
           savedToWorkspace = true
         }
       } catch (err) {

--- a/src/app/api/memory/route.ts
+++ b/src/app/api/memory/route.ts
@@ -10,6 +10,7 @@ import { validateSchema, extractWikiLinks } from '@/lib/memory-utils'
 import { MEMORY_PATH, MEMORY_ALLOWED_PREFIXES, canonicalizeMemoryRelativePath, isPathAllowed, resolveSafeMemoryPath } from '@/lib/memory-path'
 import { searchMemory, indexFile, removeFromIndex } from '@/lib/memory-search'
 import { resolveWorkspaceMemoryAccess } from '@/lib/workspace-isolation'
+import { atomicReplaceFileSync } from '@/lib/atomic-file'
 
 // Ensure memory directory exists on startup
 if (MEMORY_PATH && !existsSync(MEMORY_PATH)) {
@@ -236,7 +237,7 @@ export async function POST(request: NextRequest) {
       const schemaResult = canonicalPath.endsWith('.md') ? validateSchema(content) : null
       const schemaWarnings = schemaResult?.errors ?? []
 
-      await writeFile(fullPath, content, 'utf-8')
+      atomicReplaceFileSync(fullPath, content)
       // Incrementally update FTS index
       try { indexFile(getDatabase(), memoryPath, canonicalPath, memoryAccess!.scope) } catch { /* best-effort */ }
       try {

--- a/src/lib/__tests__/workspace-isolation-enforcement.test.ts
+++ b/src/lib/__tests__/workspace-isolation-enforcement.test.ts
@@ -175,14 +175,21 @@ describe('direct session API coverage', () => {
 
   it('guards remaining runtime filesystem consumers', () => {
     const filesRoute = readFileSync(join(process.cwd(), 'src/app/api/agents/[id]/files/route.ts'), 'utf8')
+    const memoryRoute = readFileSync(join(process.cwd(), 'src/app/api/memory/route.ts'), 'utf8')
+    const agentMemoryRoute = readFileSync(join(process.cwd(), 'src/app/api/agents/[id]/memory/route.ts'), 'utf8')
     const soulRoute = readFileSync(join(process.cwd(), 'src/app/api/agents/[id]/soul/route.ts'), 'utf8')
     const tokensRoute = readFileSync(join(process.cwd(), 'src/app/api/tokens/route.ts'), 'utf8')
     const hermesRoute = readFileSync(join(process.cwd(), 'src/app/api/hermes/route.ts'), 'utf8')
     const claudeTasksRoute = readFileSync(join(process.cwd(), 'src/app/api/claude-tasks/route.ts'), 'utf8')
 
     expect(filesRoute).toContain("'agent_filesystem'")
+    expect(filesRoute).toContain('atomicReplaceFileSync(safePath, content)')
+    expect(memoryRoute).toContain('atomicReplaceFileSync(fullPath, content)')
+    expect(agentMemoryRoute).toContain('atomicReplaceFileSync(safeWorkingPath, newContent)')
+    expect(agentMemoryRoute).toContain("atomicReplaceFileSync(safeWorkingPath, '')")
     expect(soulRoute).toContain("const auth = requireRole(request, 'viewer')")
     expect(soulRoute).toContain('if (!isStrictWorkspace)')
+    expect(soulRoute).toContain("atomicReplaceFileSync(safeSoulPath, newSoulContent || '')")
     expect(tokensRoute).toContain("const tokenData = await loadTokenData(workspaceId, isolation === 'shared')")
     expect(tokensRoute).toContain('if (!isStrictWorkspace)')
     expect(hermesRoute.match(/'runtime_configuration'/g)).toHaveLength(2)


### PR DESCRIPTION
## Summary
- replace direct overwrites at four authenticated workspace-document boundaries with the existing descriptor-backed atomic replacement helper
- cover both WORKING.md update and clear paths
- add a regression invariant for the affected routes

## Security impact
Prevents partial or truncated operator documents if a process or filesystem operation fails during an overwrite. The helper creates an exclusive randomized temporary file, fsyncs it, and renames it over the destination. Existing authentication, workspace isolation, path allowlists, size limits, and create-only semantics remain unchanged.

## Verification
- `./node_modules/.bin/vitest run src/lib/__tests__/workspace-isolation-enforcement.test.ts src/lib/__tests__/atomic-file.test.ts` (20 passed)
- `pnpm typecheck`
- `pnpm lint`
- strict DevGod scan
- `git diff --check`
- prohibited-content exclusion scan

## Local suite note
An initial command unintentionally ran the full suite: 1,473 tests passed and three unrelated device-identity tests failed because local storage was unavailable in that invocation. The focused tests above pass; hosted CI is authoritative for the full suite.