### PR TITLE
fix: validate CLI API destinations

### DIFF
--- a/scripts/mc-base-url.cjs
+++ b/scripts/mc-base-url.cjs
@@ -1,0 +1,37 @@
+'use strict';
+
+const MAX_BASE_URL_LENGTH = 2048;
+
+function normalizeMissionControlBaseUrl(value) {
+  const input = String(value || '').trim();
+  if (!input || input.length > MAX_BASE_URL_LENGTH || /[\u0000-\u001F\u007F]/.test(input)) {
+    throw new Error('Mission Control URL is invalid');
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(input);
+  } catch {
+    throw new Error('Mission Control URL must be an absolute HTTP(S) URL');
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error('Mission Control URL must use HTTP or HTTPS');
+  }
+  if (!parsed.hostname) {
+    throw new Error('Mission Control URL must include a host');
+  }
+  if (parsed.username || parsed.password) {
+    throw new Error('Mission Control URL must not contain embedded credentials');
+  }
+  if (parsed.search || parsed.hash) {
+    throw new Error('Mission Control URL must not contain a query string or fragment');
+  }
+
+  return parsed.toString().replace(/\/+$/, '');
+}
+
+module.exports = {
+  MAX_BASE_URL_LENGTH,
+  normalizeMissionControlBaseUrl,
+};

--- a/scripts/mc-cli.cjs
+++ b/scripts/mc-cli.cjs
@@ -11,6 +11,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
+const { normalizeMissionControlBaseUrl } = require('./mc-base-url.cjs');
 
 const EXIT = {
   OK: 0,
@@ -129,10 +130,6 @@ function saveProfile(profile) {
   fs.writeFileSync(p, `${JSON.stringify(profile, null, 2)}\n`, 'utf8');
 }
 
-function normalizeBaseUrl(url) {
-  return String(url || '').replace(/\/+$/, '');
-}
-
 function mapStatusToExit(status) {
   if (status === 401) return EXIT.AUTH;
   if (status === 403) return EXIT.FORBIDDEN;
@@ -170,7 +167,7 @@ async function httpRequest({ baseUrl, apiKey, cookie, method, route, body, timeo
     headers['Content-Type'] = 'application/json';
     payload = JSON.stringify(body);
   }
-  const url = `${normalizeBaseUrl(baseUrl)}${route.startsWith('/') ? route : `/${route}`}`;
+  const url = `${baseUrl}${route.startsWith('/') ? route : `/${route}`}`;
 
   try {
     const res = await fetch(url, {
@@ -208,7 +205,7 @@ async function sseStream({ baseUrl, apiKey, cookie, route, timeoutMs, onEvent, o
   const headers = { Accept: 'text/event-stream' };
   if (apiKey) headers['x-api-key'] = apiKey;
   if (cookie) headers['Cookie'] = cookie;
-  const url = `${normalizeBaseUrl(baseUrl)}${route}`;
+  const url = `${baseUrl}${route}`;
 
   const controller = new AbortController();
   let timer;
@@ -646,7 +643,7 @@ async function run() {
   const asJson = Boolean(parsed.flags.json);
   const profileName = String(parsed.flags.profile || 'default');
   const profile = loadProfile(profileName);
-  const baseUrl = parsed.flags.url ? String(parsed.flags.url) : profile.url;
+  const baseUrlInput = parsed.flags.url ? String(parsed.flags.url) : profile.url;
   const apiKey = parsed.flags['api-key'] ? String(parsed.flags['api-key']) : profile.apiKey;
   const timeoutMs = Number(parsed.flags['timeout-ms'] || 20000);
 
@@ -655,9 +652,9 @@ async function run() {
   // For compound subcommands like: agents memory get / tasks comments add
   const sub = parsed._[2];
 
-  const ctx = { baseUrl, apiKey, profile, timeoutMs, asJson };
-
   try {
+    const baseUrl = normalizeMissionControlBaseUrl(baseUrlInput);
+    const ctx = { baseUrl, apiKey, profile, timeoutMs, asJson };
     // Raw passthrough
     if (group === 'raw') {
       const method = String(required(parsed.flags, 'method')).toUpperCase();

--- a/scripts/mc-mcp-server.cjs
+++ b/scripts/mc-mcp-server.cjs
@@ -15,6 +15,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
+const { normalizeMissionControlBaseUrl } = require('./mc-base-url.cjs');
 
 // ---------------------------------------------------------------------------
 // Config
@@ -29,7 +30,9 @@ function loadConfig() {
   } catch { /* no profile */ }
 
   return {
-    baseUrl: (process.env.MC_URL || profile.url || 'http://127.0.0.1:3000').replace(/\/+$/, ''),
+    baseUrl: normalizeMissionControlBaseUrl(
+      process.env.MC_URL || profile.url || 'http://127.0.0.1:3000'
+    ),
     apiKey: process.env.MC_API_KEY || profile.apiKey || '',
     cookie: process.env.MC_COOKIE || profile.cookie || '',
   };

--- a/scripts/mc-tui.cjs
+++ b/scripts/mc-tui.cjs
@@ -15,6 +15,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
 const readline = require('node:readline');
+const { normalizeMissionControlBaseUrl } = require('./mc-base-url.cjs');
 
 // ---------------------------------------------------------------------------
 // Config
@@ -756,7 +757,7 @@ Keys (Agent Detail):
   }
 
   const profile = loadProfile(String(flags.profile || 'default'));
-  baseUrl = flags.url ? String(flags.url) : profile.url;
+  baseUrl = normalizeMissionControlBaseUrl(flags.url ? String(flags.url) : profile.url);
   apiKey = flags['api-key'] ? String(flags['api-key']) : profile.apiKey;
   cookie = profile.cookie;
   refreshMs = Number(flags.refresh || 5000);

--- a/src/lib/__tests__/mc-base-url-security.test.ts
+++ b/src/lib/__tests__/mc-base-url-security.test.ts
@@ -1,0 +1,41 @@
+import { createRequire } from 'node:module'
+import { describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const {
+  MAX_BASE_URL_LENGTH,
+  normalizeMissionControlBaseUrl,
+} = require('../../../scripts/mc-base-url.cjs') as {
+  MAX_BASE_URL_LENGTH: number
+  normalizeMissionControlBaseUrl: (value: unknown) => string
+}
+
+describe('Mission Control CLI base URL validation', () => {
+  it.each([
+    ['http://127.0.0.1:3000', 'http://127.0.0.1:3000'],
+    ['https://control.example.com/', 'https://control.example.com'],
+    ['https://control.example.com/base/', 'https://control.example.com/base'],
+  ])('normalizes an HTTP(S) destination: %s', (input, expected) => {
+    expect(normalizeMissionControlBaseUrl(input)).toBe(expected)
+  })
+
+  it.each([
+    'file:///tmp/socket',
+    'data:text/plain,hello',
+    'ftp://control.example.com',
+    'https://user:secret@control.example.com',
+    'https://control.example.com?next=https://evil.example',
+    'https://control.example.com/#fragment',
+    'https://control.example.com/\nmalformed',
+    'not-a-url',
+    '',
+  ])('rejects an unsafe destination: %s', (input) => {
+    expect(() => normalizeMissionControlBaseUrl(input)).toThrow()
+  })
+
+  it('rejects excessively long profile values', () => {
+    expect(() => normalizeMissionControlBaseUrl(
+      `https://control.example.com/${'a'.repeat(MAX_BASE_URL_LENGTH)}`,
+    )).toThrow('Mission Control URL is invalid')
+  })
+})


### PR DESCRIPTION
## Summary
- share one zero-dependency base-URL validator across the CLI, TUI, and MCP server
- require absolute HTTP(S) destinations before attaching stored authentication
- reject embedded credentials, query strings, fragments, controls, malformed URLs, and oversized profile values
- preserve localhost, remote HTTPS, custom ports, and base-path deployments

## Security impact
Hardens the remaining local-profile-to-network credential flows against poisoned or confusing destination values while preserving explicitly configured remote deployments.

## Verification
- focused URL security tests (13 passed)
- `node --check` for all three clients
- CLI and TUI help smoke tests
- `pnpm typecheck`
- `pnpm lint`
- strict DevGod scan
- `git diff --check`
- prohibited-content exclusion scan