### PR TITLE
test: add property-based security fuzzing

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@types/ws": "^8.18.1",
     "@vitejs/plugin-react": "^4.7.0",
     "@vitest/coverage-v8": "^3.2.7",
+    "fast-check": "4.9.0",
     "jsdom": "^29.1.1",
     "pino-pretty": "^13.1.3",
     "vite": "^6.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^3.2.7
         version: 3.2.7(vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.1.0)(jiti@2.7.0)(jsdom@29.1.1)(lightningcss@1.32.0)(yaml@2.9.0))
+      fast-check:
+        specifier: 4.9.0
+        version: 4.9.0
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
@@ -2840,6 +2843,10 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  fast-check@4.9.0:
+    resolution: {integrity: sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==}
+    engines: {node: '>=12.17.0'}
+
   fast-copy@4.0.3:
     resolution: {integrity: sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==}
 
@@ -4100,6 +4107,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@8.4.1:
+    resolution: {integrity: sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -7966,6 +7976,10 @@ snapshots:
 
   extend@3.0.2: {}
 
+  fast-check@4.9.0:
+    dependencies:
+      pure-rand: 8.4.1
+
   fast-copy@4.0.3: {}
 
   fast-deep-equal@3.1.3: {}
@@ -9524,6 +9538,8 @@ snapshots:
       once: 1.4.0
 
   punycode@2.3.1: {}
+
+  pure-rand@8.4.1: {}
 
   queue-microtask@1.2.3: {}
 

--- a/src/lib/__tests__/security-properties.test.ts
+++ b/src/lib/__tests__/security-properties.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import fc from 'fast-check'
+import { canonicalizeMemoryRelativePath } from '@/lib/memory-path'
+import { resolveWithin } from '@/lib/paths'
+import { setNestedConfigValue } from '@/lib/config-path'
+
+const SAFE_BASE = '/srv/mission-control/memory'
+const safeSegment = fc
+  .stringMatching(/^[A-Za-z0-9_-]{1,20}$/)
+  .filter((value) => !['__proto__', 'prototype', 'constructor'].includes(value))
+
+describe('property-based security boundaries', () => {
+  it('never resolves an accepted memory path outside its configured root', () => {
+    fc.assert(
+      fc.property(fc.string({ maxLength: 1100 }), (candidate) => {
+        let canonical: string
+        try {
+          canonical = canonicalizeMemoryRelativePath(candidate)
+        } catch {
+          return
+        }
+
+        expect(canonical).not.toMatch(/^\/|^[A-Za-z]:/)
+        expect(canonical.split('/')).not.toContain('')
+        expect(canonical.split('/')).not.toContain('.')
+        expect(canonical.split('/')).not.toContain('..')
+
+        const resolved = resolveWithin(SAFE_BASE, canonical)
+        expect(resolved.startsWith(`${SAFE_BASE}/`)).toBe(true)
+      }),
+      { numRuns: 1000 },
+    )
+  })
+
+  it('round-trips generated canonical nested paths without widening scope', () => {
+    fc.assert(
+      fc.property(
+        fc.array(safeSegment, { minLength: 1, maxLength: 8 }),
+        (segments) => {
+          const input = segments.join('/')
+          expect(canonicalizeMemoryRelativePath(input)).toBe(input)
+          expect(resolveWithin(SAFE_BASE, input).startsWith(`${SAFE_BASE}/`)).toBe(true)
+        },
+      ),
+      { numRuns: 500 },
+    )
+  })
+
+  it('rejects generated prototype-pollution paths without global mutation', () => {
+    fc.assert(
+      fc.property(
+        fc.array(safeSegment, { maxLength: 3 }),
+        fc.constantFrom('__proto__', 'prototype', 'constructor'),
+        fc.array(safeSegment, { maxLength: 3 }),
+        (prefix, unsafe, suffix) => {
+          const target: Record<string, unknown> = {}
+          const before = Object.getOwnPropertyNames(Object.prototype)
+          const path = [...prefix, unsafe, ...suffix].join('.')
+
+          expect(() => setNestedConfigValue(target, path, true)).toThrow(
+            'Config path contains an unsafe segment',
+          )
+          expect(Object.getOwnPropertyNames(Object.prototype)).toEqual(before)
+        },
+      ),
+      { numRuns: 1000 },
+    )
+  })
+
+  it('creates only own null-prototype intermediates for safe generated paths', () => {
+    fc.assert(
+      fc.property(
+        fc.array(safeSegment, { minLength: 1, maxLength: 6 }),
+        fc.jsonValue(),
+        (segments, value) => {
+          const target: Record<string, unknown> = {}
+          setNestedConfigValue(target, segments.join('.'), value)
+
+          let current = target
+          for (const segment of segments.slice(0, -1)) {
+            expect(Object.hasOwn(current, segment)).toBe(true)
+            const next = current[segment] as Record<string, unknown>
+            expect(Object.getPrototypeOf(next)).toBeNull()
+            current = next
+          }
+          expect(current[segments.at(-1)!]).toEqual(value)
+        },
+      ),
+      { numRuns: 500 },
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- add Scorecard-recognized `fast-check` property-based fuzzing to the existing Vitest quality gate
- generate 3,000 adversarial cases per run across four security properties
- prove accepted memory paths stay confined and canonical paths round-trip
- prove unsafe nested-config segments cannot mutate global prototypes
- prove safe nested assignments create only own null-prototype intermediates

## Why this approach
OpenSSF Scorecard explicitly recognizes `fast-check` for JavaScript/TypeScript. ClusterFuzzLite does not list JavaScript/TypeScript among its supported languages. This provides real, replayable security coverage in every PR rather than a score-only workflow marker.

## Verification
- focused fuzz suite passed (4 properties, 3,000 generated cases)
- pinned `tsc --noEmit`
- pinned `eslint .`
- production dependency audit: no known vulnerabilities
- strict DevGod scan
- `git diff --check`
- prohibited-content exclusion scan