### PR TITLE
fix: harden security audit command

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -45,6 +45,9 @@ jobs:
       - name: API contract parity
         run: pnpm api:parity
 
+      - name: Security audit command tests
+        run: pnpm test:security-audit
+
       - name: Lint
         run: pnpm lint
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint": "pnpm run verify:node && eslint .",
     "typecheck": "pnpm run verify:node && tsc --noEmit",
     "test": "pnpm run verify:node && vitest run",
+    "test:security-audit": "bash scripts/security-audit.test.sh",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
     "test:e2e": "pnpm run verify:node && playwright test",

--- a/scripts/security-audit.sh
+++ b/scripts/security-audit.sh
@@ -80,7 +80,13 @@ echo ""
 # 1. .env file permissions
 echo "--- File Permissions ---"
 if [[ -f "$ENV_FILE" ]]; then
-  perms=$(stat -f '%A' "$ENV_FILE" 2>/dev/null || stat -c '%a' "$ENV_FILE" 2>/dev/null)
+  if perms=$(stat -c '%a' -- "$ENV_FILE" 2>/dev/null); then
+    : # GNU stat
+  elif perms=$(stat -f '%Lp' "$ENV_FILE" 2>/dev/null); then
+    : # BSD stat
+  else
+    perms="unknown"
+  fi
   if [[ "$perms" == "600" ]]; then
     pass ".env permissions are 600 (owner read/write only)"
   else

--- a/scripts/security-audit.sh
+++ b/scripts/security-audit.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Mission Control Security Audit
-# Run: bash scripts/security-audit.sh [--env-file .env]
+# Run: bash scripts/security-audit.sh [--env-file .env] [--strict]
 
 set -euo pipefail
 
@@ -8,18 +8,69 @@ SCORE=0
 MAX_SCORE=0
 ISSUES=()
 
-pass() { echo "  [PASS] $1"; ((SCORE++)); ((MAX_SCORE++)); }
-fail() { echo "  [FAIL] $1"; ISSUES+=("$1"); ((MAX_SCORE++)); }
-warn() { echo "  [WARN] $1"; ((MAX_SCORE++)); }
+pass() { echo "  [PASS] $1"; ((++SCORE)); ((++MAX_SCORE)); }
+fail() { echo "  [FAIL] $1"; ISSUES+=("$1"); ((++MAX_SCORE)); }
+warn() { echo "  [WARN] $1"; ((++MAX_SCORE)); }
 info() { echo "  [INFO] $1"; }
 
-# Load .env if exists
-ENV_FILE="${1:-.env}"
+# Parse only the settings this audit reads. Never source an env file or import
+# arbitrary names: values such as PATH, BASH_ENV, or command hooks must not be
+# able to change how the audit itself executes.
+ENV_FILE=".env"
+STRICT=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env-file)
+      [[ $# -ge 2 ]] || { echo "Missing value for --env-file" >&2; exit 2; }
+      ENV_FILE="$2"
+      shift 2
+      ;;
+    --strict)
+      STRICT=1
+      shift
+      ;;
+    --help|-h)
+      echo "Usage: bash scripts/security-audit.sh [--env-file FILE] [--strict]"
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+trim_env_value() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  if [[ ${#value} -ge 2 ]]; then
+    if [[ "${value:0:1}" == '"' && "${value: -1}" == '"' ]] ||
+       [[ "${value:0:1}" == "'" && "${value: -1}" == "'" ]]; then
+      value="${value:1:${#value}-2}"
+    fi
+  fi
+  printf '%s' "$value"
+}
+
 if [[ -f "$ENV_FILE" ]]; then
-  while IFS='=' read -r key value; do
-    [[ "$key" =~ ^#.*$ ]] && continue
-    [[ -z "$key" ]] && continue
-    declare "$key=$value" 2>/dev/null || true
+  while IFS='=' read -r raw_key raw_value || [[ -n "$raw_key$raw_value" ]]; do
+    raw_key="${raw_key%$'\r'}"
+    raw_value="${raw_value%$'\r'}"
+    key="${raw_key#"${raw_key%%[![:space:]]*}"}"
+    key="${key%"${key##*[![:space:]]}"}"
+    [[ -z "$key" || "$key" == \#* ]] && continue
+    value="$(trim_env_value "$raw_value")"
+    case "$key" in
+      AUTH_PASS) AUTH_PASS="$value" ;;
+      API_KEY) API_KEY="$value" ;;
+      MC_ALLOWED_HOSTS) MC_ALLOWED_HOSTS="$value" ;;
+      MC_ALLOW_ANY_HOST) MC_ALLOW_ANY_HOST="$value" ;;
+      MC_COOKIE_SECURE) MC_COOKIE_SECURE="$value" ;;
+      MC_COOKIE_SAMESITE) MC_COOKIE_SAMESITE="$value" ;;
+      MC_ENABLE_HSTS) MC_ENABLE_HSTS="$value" ;;
+      MC_DISABLE_RATE_LIMIT) MC_DISABLE_RATE_LIMIT="$value" ;;
+    esac
   done < "$ENV_FILE"
 fi
 
@@ -165,4 +216,8 @@ elif [[ $SCORE -ge $((MAX_SCORE * 7 / 10)) ]]; then
   echo "Good security posture with minor improvements needed."
 else
   echo "Security improvements recommended before production use."
+fi
+
+if [[ "$STRICT" == "1" && ${#ISSUES[@]} -gt 0 ]]; then
+  exit 1
 fi

--- a/scripts/security-audit.test.sh
+++ b/scripts/security-audit.test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+AUDIT="$ROOT_DIR/scripts/security-audit.sh"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/mc-security-audit.XXXXXX")"
+HARDENED_ENV="$TMP_DIR/hardened.env"
+INSECURE_ENV="$TMP_DIR/insecure.env"
+
+cleanup() {
+  rm -f "$HARDENED_ENV" "$INSECURE_ENV"
+  rmdir "$TMP_DIR"
+}
+trap cleanup EXIT
+
+cat > "$HARDENED_ENV" <<'EOF'
+PATH=/definitely/not/a/real/path
+BASH_ENV=/tmp/should-not-be-loaded
+AUTH_PASS="a secure # password"
+API_KEY=test-api-key
+MC_ALLOWED_HOSTS=127.0.0.1,localhost
+MC_ALLOW_ANY_HOST=0
+MC_COOKIE_SECURE=1
+MC_COOKIE_SAMESITE=strict
+MC_ENABLE_HSTS=1
+MC_DISABLE_RATE_LIMIT=0
+EOF
+chmod 600 "$HARDENED_ENV"
+
+output="$(bash "$AUDIT" --env-file "$HARDENED_ENV" --strict)"
+grep -Fq '[PASS] AUTH_PASS is set to a non-default value (19 chars)' <<< "$output"
+grep -Fq '=== Security Score: 8 / 8 ===' <<< "$output"
+grep -Fq 'All checks passed!' <<< "$output"
+
+cat > "$INSECURE_ENV" <<'EOF'
+AUTH_PASS=password
+API_KEY=generate-a-random-key
+MC_ALLOW_ANY_HOST=1
+MC_DISABLE_RATE_LIMIT=1
+EOF
+chmod 600 "$INSECURE_ENV"
+
+if bash "$AUDIT" --env-file "$INSECURE_ENV" --strict >/dev/null 2>&1; then
+  echo 'Expected --strict to fail when the audit reports security findings' >&2
+  exit 1
+fi
+
+if bash "$AUDIT" --unknown >/dev/null 2>&1; then
+  echo 'Expected an unknown option to fail' >&2
+  exit 1
+fi
+
+echo 'security-audit tests passed'


### PR DESCRIPTION
## Summary
- parse only the configuration keys consumed by the audit instead of importing arbitrary env-file names
- keep the audit running through every scored check under `set -e`
- add explicit `--env-file`, `--strict`, and help handling
- add shell regression coverage for env poisoning, quoted values, strict failures, and an all-pass configuration

## Security impact
Entries such as `PATH` and `BASH_ENV` in a selected env file are now inert. The audit no longer exits on its first score increment, so operators receive the complete findings report.

## Verification
- `bash scripts/security-audit.test.sh`
- `bash -n scripts/security-audit.sh scripts/security-audit.test.sh`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm audit --prod` (no known vulnerabilities)
- strict repository security scan
- `git diff --check`