### PR TITLE
fix: align auth security reports

### DIFF
--- a/src/app/api/diagnostics/route.ts
+++ b/src/app/api/diagnostics/route.ts
@@ -3,7 +3,7 @@ import net from 'node:net'
 import { existsSync, statSync } from 'node:fs'
 import { requireRole } from '@/lib/auth'
 import { config } from '@/lib/config'
-import { getDatabase } from '@/lib/db'
+import { getDatabase, resolveSeedAuthPassword } from '@/lib/db'
 import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 import { runOpenClaw } from '@/lib/command'
 import { logger } from '@/lib/logger'
@@ -77,11 +77,11 @@ function getSecurityInfo() {
     detail: !apiKey ? 'API_KEY is not set' : apiKey === 'generate-a-random-key' ? 'API_KEY is default value' : 'API_KEY is set',
   })
 
-  const authPass = process.env.AUTH_PASS || ''
+  const authPass = resolveSeedAuthPassword() || ''
   checks.push({
     name: 'Auth password secure',
     pass: Boolean(authPass) && !INSECURE_PASSWORDS.has(authPass),
-    detail: !authPass ? 'AUTH_PASS is not set' : INSECURE_PASSWORDS.has(authPass) ? 'AUTH_PASS is a known insecure password' : 'AUTH_PASS is not a common default',
+    detail: !authPass ? 'Admin password is not set' : INSECURE_PASSWORDS.has(authPass) ? 'Admin password is a known insecure password' : 'Admin password is not a common default',
   })
 
   const allowedHosts = process.env.MC_ALLOWED_HOSTS || ''

--- a/src/lib/__tests__/security-scan-auth-password.test.ts
+++ b/src/lib/__tests__/security-scan-auth-password.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { runSecurityScan } from '@/lib/security-scan'
+
+const originalAuthPass = process.env.AUTH_PASS
+const originalAuthPassB64 = process.env.AUTH_PASS_B64
+
+function restore(name: 'AUTH_PASS' | 'AUTH_PASS_B64', value: string | undefined) {
+  if (value === undefined) delete process.env[name]
+  else process.env[name] = value
+}
+
+function authPasswordCheck() {
+  return runSecurityScan().categories.credentials.checks.find((check) => check.id === 'auth_pass')
+}
+
+describe('security scan admin password resolution', () => {
+  afterEach(() => {
+    restore('AUTH_PASS', originalAuthPass)
+    restore('AUTH_PASS_B64', originalAuthPassB64)
+  })
+
+  it('accepts a strong base64-only password', () => {
+    delete process.env.AUTH_PASS
+    process.env.AUTH_PASS_B64 = Buffer.from('strong-password-123').toString('base64')
+
+    expect(authPasswordCheck()).toMatchObject({ status: 'pass' })
+  })
+
+  it('uses the plain password when base64 configuration is invalid', () => {
+    process.env.AUTH_PASS = 'strong-fallback-123'
+    process.env.AUTH_PASS_B64 = '%%%invalid%%%'
+
+    expect(authPasswordCheck()).toMatchObject({ status: 'pass' })
+  })
+
+  it('rejects an insecure default supplied through base64 configuration', () => {
+    delete process.env.AUTH_PASS
+    process.env.AUTH_PASS_B64 = Buffer.from('password').toString('base64')
+
+    expect(authPasswordCheck()).toMatchObject({ status: 'fail' })
+  })
+})

--- a/src/lib/security-scan.ts
+++ b/src/lib/security-scan.ts
@@ -3,7 +3,7 @@ import { execSync } from 'node:child_process'
 import path from 'node:path'
 import os from 'node:os'
 import { config } from '@/lib/config'
-import { getDatabase } from '@/lib/db'
+import { getDatabase, resolveSeedAuthPassword } from '@/lib/db'
 import { getSchedulerStatus } from '@/lib/scheduler'
 
 // ---------------------------------------------------------------------------
@@ -245,15 +245,15 @@ function tryExecBatch(script: string): Record<string, string> {
 function scanCredentials(): Category {
   const checks: Check[] = []
 
-  const authPass = process.env.AUTH_PASS || ''
+  const authPass = resolveSeedAuthPassword() || ''
   if (!authPass) {
-    checks.push({ id: 'auth_pass', name: 'Admin password configured', status: 'fail', detail: 'AUTH_PASS is not configured', fix: 'Set AUTH_PASS in .env to a strong password (12+ characters)', severity: 'critical' })
+    checks.push({ id: 'auth_pass', name: 'Admin password configured', status: 'fail', detail: 'Admin password is not configured', fix: 'Set AUTH_PASS or AUTH_PASS_B64 in .env to a strong password (12+ characters)', severity: 'critical' })
   } else if (INSECURE_PASSWORDS.has(authPass)) {
-    checks.push({ id: 'auth_pass', name: 'Admin password strength', status: 'fail', detail: 'AUTH_PASS is set to a known insecure default', fix: 'Change AUTH_PASS to a unique password with 12+ characters', severity: 'critical' })
+    checks.push({ id: 'auth_pass', name: 'Admin password strength', status: 'fail', detail: 'Admin password is set to a known insecure default', fix: 'Change AUTH_PASS or AUTH_PASS_B64 to a unique password with 12+ characters', severity: 'critical' })
   } else if (authPass.length < 12) {
-    checks.push({ id: 'auth_pass', name: 'Admin password strength', status: 'warn', detail: `AUTH_PASS is only ${authPass.length} characters`, fix: 'Use a password with at least 12 characters', severity: 'critical' })
+    checks.push({ id: 'auth_pass', name: 'Admin password strength', status: 'warn', detail: `Admin password is only ${authPass.length} characters`, fix: 'Use a password with at least 12 characters', severity: 'critical' })
   } else {
-    checks.push({ id: 'auth_pass', name: 'Admin password strength', status: 'pass', detail: 'AUTH_PASS is a strong, non-default password', fix: '', severity: 'critical' })
+    checks.push({ id: 'auth_pass', name: 'Admin password strength', status: 'pass', detail: 'Admin password is strong and non-default', fix: '', severity: 'critical' })
   }
 
   const apiKey = process.env.API_KEY || ''


### PR DESCRIPTION
## Summary
- resolve the configured admin password through the same helper used by runtime database seeding
- recognize supported `AUTH_PASS_B64` configuration in the security scan and diagnostics
- keep invalid base64 fallback behavior identical to the authentication boundary
- avoid identifying the credential source in report text

## Security impact
Security reporting no longer produces a false critical finding for supported base64-only deployments, and insecure defaults remain rejected regardless of which supported configuration form supplies them.

## Verification
- focused password-report regression suite: 3 tests passed
- `pnpm lint`
- `pnpm typecheck`
- `pnpm audit --prod` (no known vulnerabilities)
- strict repository security scan
- `git diff --check`