### PR TITLE
fix: load deployment env files safely

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -46,7 +46,7 @@ jobs:
         run: pnpm api:parity
 
       - name: Security audit command tests
-        run: pnpm test:security-audit
+        run: pnpm test:security-shell
 
       - name: Lint
         run: pnpm lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,9 @@ COPY --from=deps /app/node_modules/.pnpm/node-pty@1.1.0/node_modules/node-pty ./
 RUN mkdir -p .data && chown nextjs:nodejs .data
 RUN echo 'const http=require("http");const r=http.get("http://localhost:"+(process.env.PORT||3000)+"/api/status?action=health",s=>{process.exit(s.statusCode===200?0:1)});r.on("error",()=>process.exit(1));r.setTimeout(4000,()=>{r.destroy();process.exit(1)})' > /app/healthcheck.js
 COPY docker-entrypoint.sh /app/docker-entrypoint.sh
+COPY scripts/load-env.sh /app/scripts/load-env.sh
 RUN chmod 755 /app/docker-entrypoint.sh && \
+    chmod 644 /app/scripts/load-env.sh && \
     chmod -R a+rX /app/public/ /app/src/
 USER nextjs
 ENV PORT=3000

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 set -e
 
-# --- Source .env if present ---
+. /app/scripts/load-env.sh
+
+# --- Load .env as literal configuration if present ---
 if [ -f /app/.env ]; then
   printf '[entrypoint] Loading .env\n'
-  set -a
-  . /app/.env
-  set +a
+  load_env_file /app/.env
 fi
 
 # --- Helper: generate a random hex secret ---
@@ -28,9 +28,7 @@ fi
 # Load previously generated secrets if they exist
 if [ -f "$SECRETS_FILE" ]; then
   printf '[entrypoint] Loading persisted secrets from .data\n'
-  set -a
-  . "$SECRETS_FILE"
-  set +a
+  load_env_file "$SECRETS_FILE"
 fi
 
 # --- AUTH_SECRET ---

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "typecheck": "pnpm run verify:node && tsc --noEmit",
     "test": "pnpm run verify:node && vitest run",
     "test:security-audit": "bash scripts/security-audit.test.sh",
+    "test:security-shell": "bash scripts/security-audit.test.sh && bash scripts/load-env.test.sh",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
     "test:e2e": "pnpm run verify:node && playwright test",

--- a/scripts/deploy-standalone.sh
+++ b/scripts/deploy-standalone.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+. "$PROJECT_ROOT/scripts/load-env.sh"
 
 BRANCH="${BRANCH:-$(git -C "$PROJECT_ROOT" branch --show-current)}"
 PORT="${PORT:-3000}"
@@ -128,16 +129,12 @@ stop_existing_server() {
 }
 
 load_env() {
-  set -a
   if [[ -f .env ]]; then
-    # shellcheck disable=SC1091
-    source .env
+    load_env_file .env
   fi
   if [[ -f .env.local ]]; then
-    # shellcheck disable=SC1091
-    source .env.local
+    load_env_file .env.local
   fi
-  set +a
 }
 
 migrate_runtime_data_dir() {

--- a/scripts/load-env.sh
+++ b/scripts/load-env.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+# Load dotenv-style KEY=VALUE assignments without evaluating shell syntax.
+# This file is sourced by both POSIX sh and Bash startup scripts.
+
+trim_env_field() {
+  printf '%s' "$1" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
+}
+
+load_env_file() {
+  mc_env_file="$1"
+  [ -f "$mc_env_file" ] || return 0
+
+  mc_env_line_number=0
+  while IFS= read -r mc_env_line || [ -n "$mc_env_line" ]; do
+    mc_env_line_number=$((mc_env_line_number + 1))
+    mc_env_line=$(printf '%s' "$mc_env_line" | sed 's/\r$//')
+    mc_env_line=$(trim_env_field "$mc_env_line")
+
+    case "$mc_env_line" in
+      ''|'#'*) continue ;;
+      export[[:space:]]*) mc_env_line=$(trim_env_field "${mc_env_line#export}") ;;
+    esac
+
+    case "$mc_env_line" in
+      *=*) ;;
+      *)
+        printf 'error: invalid env assignment in %s at line %s\n' "$mc_env_file" "$mc_env_line_number" >&2
+        return 1
+        ;;
+    esac
+
+    mc_env_key=$(trim_env_field "${mc_env_line%%=*}")
+    mc_env_value=$(trim_env_field "${mc_env_line#*=}")
+
+    case "$mc_env_key" in
+      ''|[0-9]*|*[!A-Za-z0-9_]*)
+        printf 'error: invalid env name in %s at line %s\n' "$mc_env_file" "$mc_env_line_number" >&2
+        return 1
+        ;;
+      mc_env_*|MC_ENV_LOADER_*|PATH|IFS|ENV|BASH_ENV|BASHOPTS|SHELLOPTS|CDPATH|GLOBIGNORE|NODE_OPTIONS|NODE_PATH|PYTHONPATH|PYTHONHOME|PYTHONSTARTUP|PERL5OPT|RUBYOPT|LD_*|DYLD_*)
+        printf 'error: unsafe process-control env name in %s at line %s\n' "$mc_env_file" "$mc_env_line_number" >&2
+        return 1
+        ;;
+    esac
+
+    case "$mc_env_value" in
+      \"*\") mc_env_value=${mc_env_value#\"}; mc_env_value=${mc_env_value%\"} ;;
+      \'*\') mc_env_value=${mc_env_value#\'}; mc_env_value=${mc_env_value%\'} ;;
+      \"*|*\"|\'*|*\')
+        printf 'error: unmatched quote in %s at line %s\n' "$mc_env_file" "$mc_env_line_number" >&2
+        return 1
+        ;;
+      *)
+        mc_env_value=$(printf '%s' "$mc_env_value" | sed 's/[[:space:]]#.*$//')
+        mc_env_value=$(trim_env_field "$mc_env_value")
+        ;;
+    esac
+
+    export "$mc_env_key=$mc_env_value"
+  done < "$mc_env_file"
+}

--- a/scripts/load-env.test.sh
+++ b/scripts/load-env.test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOADER="$ROOT_DIR/scripts/load-env.sh"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/mc-load-env.XXXXXX")"
+SAFE_ENV="$TMP_DIR/safe.env"
+OVERRIDE_ENV="$TMP_DIR/override.env"
+UNSAFE_ENV="$TMP_DIR/unsafe.env"
+INVALID_ENV="$TMP_DIR/invalid.env"
+MARKER="$TMP_DIR/executed"
+
+cleanup() {
+  rm -f "$SAFE_ENV" "$OVERRIDE_ENV" "$UNSAFE_ENV" "$INVALID_ENV" "$MARKER"
+  rmdir "$TMP_DIR"
+}
+trap cleanup EXIT
+
+cat > "$SAFE_ENV" <<EOF
+# Values are data, not shell syntax.
+AUTH_PASS='\$(touch "$MARKER")'
+API_KEY="literal # value"
+MC_ALLOWED_HOSTS=127.0.0.1,localhost
+MC_COOKIE_SECURE=1 # inline documentation is not part of the value
+EMPTY_VALUE=
+EOF
+
+result="$(sh -c '. "$1"; load_env_file "$2"; printf "%s\n%s\n%s\n%s" "$AUTH_PASS" "$API_KEY" "$MC_COOKIE_SECURE" "$EMPTY_VALUE"' _ "$LOADER" "$SAFE_ENV")"
+expected="$(printf '%s\n%s\n%s\n%s' "\$(touch \"$MARKER\")" 'literal # value' '1' '')"
+[[ "$result" == "$expected" ]]
+[[ ! -e "$MARKER" ]]
+
+cat > "$OVERRIDE_ENV" <<'EOF'
+AUTH_PASS=overridden-literal
+EOF
+result="$(sh -c '. "$1"; load_env_file "$2"; load_env_file "$3"; printf "%s" "$AUTH_PASS"' _ "$LOADER" "$SAFE_ENV" "$OVERRIDE_ENV")"
+[[ "$result" == 'overridden-literal' ]]
+
+cat > "$UNSAFE_ENV" <<'EOF'
+PATH=/tmp/untrusted-bin
+EOF
+if sh -c '. "$1"; load_env_file "$2"' _ "$LOADER" "$UNSAFE_ENV" >/dev/null 2>&1; then
+  echo 'Expected process-control variables to be rejected' >&2
+  exit 1
+fi
+
+cat > "$INVALID_ENV" <<'EOF'
+mc_env_line_number=1+1
+EOF
+if sh -c '. "$1"; load_env_file "$2"' _ "$LOADER" "$INVALID_ENV" >/dev/null 2>&1; then
+  echo 'Expected loader-internal variable names to be rejected' >&2
+  exit 1
+fi
+
+cat > "$INVALID_ENV" <<'EOF'
+INVALID-NAME=value
+EOF
+if sh -c '. "$1"; load_env_file "$2"' _ "$LOADER" "$INVALID_ENV" >/dev/null 2>&1; then
+  echo 'Expected malformed variable names to be rejected' >&2
+  exit 1
+fi
+
+echo 'load-env tests passed'

--- a/scripts/start-standalone.sh
+++ b/scripts/start-standalone.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+. "$PROJECT_ROOT/scripts/load-env.sh"
 STANDALONE_DIR="$PROJECT_ROOT/.next/standalone"
 STANDALONE_NEXT_DIR="$STANDALONE_DIR/.next"
 STANDALONE_STATIC_DIR="$STANDALONE_NEXT_DIR/static"
@@ -31,13 +32,11 @@ fi
 
 cd "$STANDALONE_DIR"
 
-# Source .env if it exists (consistent with Docker entrypoint behavior)
+# Load .env as literal configuration if it exists (consistent with Docker).
 # NEXT_PUBLIC_* vars are already baked into the bundle at build time,
 # but server-side vars (AUTH_*, OPENCLAW_*, etc.) need this to take effect.
 if [[ -f "$PROJECT_ROOT/.env" ]]; then
-  set -a
-  . "$PROJECT_ROOT/.env"
-  set +a
+  load_env_file "$PROJECT_ROOT/.env"
 fi
 
 export MISSION_CONTROL_DATA_DIR="${MISSION_CONTROL_DATA_DIR:-$PROJECT_ROOT/.data}"


### PR DESCRIPTION
## Summary
- replace direct shell sourcing of deployment env files with a shared POSIX-compatible literal parser
- validate variable names and reject process-control variables that can alter command execution
- preserve quoted values, hashes, blank values, inline comments, and ordered overrides without evaluating expansions
- apply the loader to Docker, standalone start, standalone deploy, and persisted generated secrets
- run the loader regression suite in the required quality gate

## Security impact
Environment files are now configuration data, not executable shell programs. Command substitutions and other shell syntax remain literal, while malformed assignments, parser-internal names, and process-control variables fail closed.

## Compatibility
Documented dotenv forms remain supported. Undocumented shell execution/interpolation inside env files is intentionally no longer supported.

## Verification
- `bash scripts/load-env.test.sh`
- `bash scripts/security-audit.test.sh`
- POSIX and Bash syntax checks
- workflow action pin verifier
- `pnpm lint`
- `pnpm typecheck`
- `pnpm audit --prod` (no known vulnerabilities)
- strict repository security scan
- `git diff --check`