### PR TITLE
fix: include env loader in Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,4 @@ ops/templates/*
 scripts/*
 !scripts/check-node-version.mjs
 !scripts/prepare-standalone-artifact.mjs
+!scripts/load-env.sh

--- a/src/lib/__tests__/docker-compose-schema.test.ts
+++ b/src/lib/__tests__/docker-compose-schema.test.ts
@@ -61,6 +61,7 @@ describe('Docker build context', () => {
   it('includes scripts required by the package build command', () => {
     expect(content).toContain('!scripts/check-node-version.mjs')
     expect(content).toContain('!scripts/prepare-standalone-artifact.mjs')
+    expect(content).toContain('!scripts/load-env.sh')
   })
 
   it('includes only the operations template required by the runtime artifact', () => {


### PR DESCRIPTION
## Summary
- explicitly include the runtime env loader in the otherwise restricted Docker build context
- add a Docker build-context regression assertion

## Root cause
Post-main Docker Publish failed because `.dockerignore` excludes `scripts/*`, while the runtime stage now copies `scripts/load-env.sh`. The quality gate built the Next.js artifact but did not exercise that Docker context boundary.

## Verification
- focused Docker contract suite: 9 tests passed
- lint
- typecheck
- `git diff --check`

After merge, Docker Publish on the repaired main commit is the authoritative release-path verification.