### PR TITLE
docs: complete v2.2.0 security notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to Mission Control are documented in this file.
 
 ---
 
-## [2.2.0] - 2026-07-16
+## [2.2.0] - 2026-07-17
 
 This release strengthens Mission Control's self-hosted security boundary, adds native workspace isolation foundations, and modernizes the frontend and release toolchain.
 
@@ -22,16 +22,24 @@ This release strengthens Mission Control's self-hosted security boundary, adds n
 - Migrated to Tailwind CSS v4 (#768): config converted to CSS `@theme`, `@tailwindcss/postcss`, `@custom-variant dark`. Visual QA verified across login, dashboard, task board, onboarding, and all 11 themes including the light Paper theme.
 - Hardened privileged runtime setup, identity, gateway, release-update, OS-user, PTY, skill, backup, and maintenance mutations with strict schemas, critical throttling, bounded output, trusted attribution, and safer audit records (#784, #790 through #799, #828 through #835).
 - Hardened OSS contribution intake with structured issue forms, clearer contributor provenance expectations, and focused PR risk/evidence requirements (#803, #814, #816, #824).
+- Hardened CLI, TUI, MCP, installer, gateway, and operator boundaries against unsafe destinations, path escapes, unbounded remote input, malformed configuration, and executable environment-file semantics (#866 through #884, #886 through #889).
 
 ### Fixed
 - Model catalog: `costPer1k` renamed to `costPerMTok` (the field held per-million values), `classifyDirectModel` now derives from the catalog instead of a parallel hard-coded list, and all prices re-verified against provider docs (#769, supersedes #751). Fixed two real billing-estimate undercounts: Kimi K2.5 and MiniMax M2.1 output rates.
 - Preserved gateway configuration integrity and unified privileged setup/control client error handling (#825 through #831).
 - Removed plaintext device-key fallback and tightened execution approval, webhook delivery, CI publishing, backup automation, and standalone release behavior (#782, #789, #791 through #793).
+- Restored websocket reconnection after transient disconnects (#832).
+- Aligned authentication diagnostics and security reports with encoded-password deployments (#887).
+- Restored the Docker release build context for the non-executable environment loader (#889).
 
 ### Security
 - Workspace isolation now fails closed for ambiguous or unowned resources instead of silently falling back to deployment-wide access.
 - Sensitive host mutations use scoped critical rate limits, strict allowlists, bounded/redacted responses, and audit-safe identifiers.
 - Workflow actions are pinned to reviewed commit SHAs; standalone builds are checked for runtime-data and secret-boundary violations.
+- Added descriptor-based filesystem operations, atomic configuration/workspace writes, randomized build scratch paths, stronger path confinement, and resource bounds across trust boundaries (#868 through #871, #874, #881).
+- Added HTML sanitization, cryptographic event identifiers, adapter-key isolation, workspace-scoped MCP receipts, and nested configuration assignment guards (#872, #875, #876, #879, #883).
+- Added property-based fuzzing with thousands of adversarial path and configuration cases per run (#873, #885).
+- Replaced deployment shell sourcing with a strict environment-file data parser and regression-tested the security audit command itself (#886, #888).
 - Dependency audit reports no known high-severity vulnerabilities at release preparation time.
 
 ### Upgrade notes


### PR DESCRIPTION
## Summary
- align the prepared v2.2.0 date with the release-readiness pass
- document the landed CLI, TUI, MCP, installer, gateway, filesystem, environment-loader, and fuzzing hardening
- record the websocket, encoded-auth diagnostics, and Docker build-context fixes

## Verification
- strict DevGod security scan
- diff hygiene check
- repository privacy scan

## Risk
Documentation-only. No runtime or dependency changes.