### PR TITLE
release: v2.3.0 — dependency security patch, toolchain refresh, locale integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,46 @@ All notable changes to Mission Control are documented in this file.
 
 ## [Unreleased]
 
+---
+
+## [2.3.0] - 2026-07-25
+
+This release patches 13 known dependency vulnerabilities (8 high severity), refreshes the test toolchain to current majors, and closes a locale-integrity gap. Self-hosted operators should upgrade promptly for the dependency fixes.
+
 ### Security
+- Patched 13 OSV advisories across the dependency tree (#904):
+  - `next` 16.2.10 → 16.2.11 — 9 advisories including SSRF in Server Actions
+    (GHSA-89xv-2m56-2m9x, GHSA-p9j2-gv94-2wf4), middleware/proxy bypass
+    (GHSA-6gpp-xcg3-4w24), response cache confusion, and denial of service.
+  - `sharp` 0.34.5 → 0.35.3 via bounded workspace override (GHSA-f88m-g3jw-g9cj,
+    inherited libvips CVEs) — next still pins the vulnerable range.
+  - `brace-expansion` DoS on all three resolved major lines
+    (GHSA-3jxr-9vmj-r5cp, GHSA-mh99-v99m-4gvg), each dependent kept on its
+    expected API line via per-major bounded overrides.
+  - Transitive `postcss` forced to ≥8.5.18 (GHSA-r28c-9q8g-f849).
+  Release-age exclusions for the fresh fixes are documented in
+  `pnpm-workspace.yaml` and age out naturally.
 - Removed operational screenshots from the public tree, retained only privacy-reviewed
-  documentation artwork, and documented a synthetic-data-only screenshot process.
+  documentation artwork, and documented a synthetic-data-only screenshot process (#892).
+
+### Added
+- `MC_DISABLE_RUNTIME_SCAN` environment flag to skip local CLI probing during
+  runtime detection — for hosts where probing is slow, noisy, or undesirable (#895).
+
+### Fixed
+- Locale integrity: restored 4 `taskBoard` keys missing from all 9 non-English
+  locales and added a parity guard test, so locale drift now fails the quality
+  gate instead of shipping (#907); added the missing `calMode_day` translation (#894).
+- README imagery restored with sanitized demo screenshots; removed the
+  single-tenant blueprint embed (#893, #896).
+
+### Changed
+- Test toolchain migrated to vite 8 / vitest 4 / @vitejs/plugin-react 6 (#908).
+  Test infrastructure only — production builds remain webpack. Includes the
+  vitest 4 mock-constructor migration for the affected test files.
+- Routine grouped dependency updates (#897, #899, #905, #906).
+- Documented project attribution (Builderz Labs / nyk) and runtime independence;
+  added maintainer sponsorship links.
 
 ---
 

--- a/docs/releases/2.3.0.md
+++ b/docs/releases/2.3.0.md
@@ -1,0 +1,36 @@
+# Mission Control 2.3.0
+
+Mission Control 2.3.0 is a dependency-security and maintenance release. It patches 13 known vulnerabilities in the dependency tree (8 high severity), refreshes the test toolchain to current majors, and closes a locale-integrity gap — all behind the same protected quality gate as feature work.
+
+## Highlights
+
+- 13 OSV advisories patched: next 16.2.11 (SSRF in Server Actions, middleware/proxy bypass, cache confusion, DoS), sharp 0.35.3, brace-expansion across three major lines, transitive postcss ≥8.5.18
+- Supply-chain posture retained: fixes younger than the 7-day release-age gate are excluded explicitly and age out naturally; every workspace override carries an explicit major-line upper bound
+- `MC_DISABLE_RUNTIME_SCAN` opt-out for local CLI probing during runtime detection
+- Locale parity restored across all 10 locales, now enforced by a guard test in the quality gate
+- Test toolchain on current majors: vite 8, vitest 4, @vitejs/plugin-react 6 (production builds remain webpack)
+
+## Security posture
+
+This release concentrates on the dependency boundary. The patched advisories include server-side request forgery in Server Actions and a middleware/proxy bypass in the framework the dashboard runs on — self-hosted operators exposing Mission Control beyond localhost should treat this as a priority upgrade. No Mission Control application code required security changes; the protected quality gate (API parity, lint, typecheck, unit tests, production build, standalone artifact boundaries, Playwright suite) passed on the patch series unchanged.
+
+A note for downstream forks: pnpm overrides replace a dependent's declared version range entirely, so an unbounded override range can jump major API lines in transitive dependencies. Every override this release ships carries an explicit upper bound; keep that pattern if you extend them.
+
+## Upgrade notes
+
+1. Back up the Mission Control database and runtime configuration.
+2. Upgrade from the protected `v2.3.0` tag or corresponding immutable container digest.
+3. No migrations in this release; no configuration changes are required.
+4. Optionally set `MC_DISABLE_RUNTIME_SCAN=1` on hosts where local CLI probing is unwanted.
+5. Forks that patched dependencies independently should reconcile against the `pnpm-workspace.yaml` overrides and release-age exclusions.
+
+## Compatibility
+
+- Node.js 22 or newer remains required.
+- No public API routes were added or removed.
+- No database schema changes.
+- The vite/vitest major migration affects the test toolchain only; downstream forks with custom tests should review the vitest 4 mock-constructor semantics (constructible implementations for mocks invoked with `new`).
+
+## Verification
+
+The release commit must pass the repository's protected `quality-gate` before tagging. Tags are created only from the merged `main` commit.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mission-control",
-  "version": "2.2.0",
-  "description": "OpenClaw Mission Control — open-source agent orchestration dashboard",
+  "version": "2.3.0",
+  "description": "OpenClaw Mission Control \u2014 open-source agent orchestration dashboard",
   "scripts": {
     "verify:node": "node scripts/check-node-version.mjs",
     "api:parity": "node scripts/check-api-contract-parity.mjs --root . --openapi openapi.json --ignore-file scripts/api-contract-parity.ignore",
@@ -29,7 +29,7 @@
     "test:e2e:openclaw": "pnpm test:e2e:openclaw:local && pnpm test:e2e:openclaw:gateway",
     "test:all": "pnpm lint && pnpm typecheck && pnpm test && pnpm build && pnpm test:e2e",
     "quality:gate": "pnpm test:all",
-    "postinstall": "node -e \"try{require('better-sqlite3')}catch(e){if(e.code==='ERR_DLOPEN_FAILED'||/NODE_MODULE_VERSION/.test(e.message)){console.error('\\n⚠  better-sqlite3 compiled for wrong Node version. Run: pnpm rebuild better-sqlite3\\n');process.exit(1)}}\""
+    "postinstall": "node -e \"try{require('better-sqlite3')}catch(e){if(e.code==='ERR_DLOPEN_FAILED'||/NODE_MODULE_VERSION/.test(e.message)){console.error('\\n\u26a0  better-sqlite3 compiled for wrong Node version. Run: pnpm rebuild better-sqlite3\\n');process.exit(1)}}\""
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.3.0",

--- a/scripts/mc-mcp-server.cjs
+++ b/scripts/mc-mcp-server.cjs
@@ -735,7 +735,7 @@ for (const tool of TOOLS) {
 
 const SERVER_INFO = {
   name: 'mission-control',
-  version: '2.2.0',
+  version: '2.3.0',
 };
 
 const CAPABILITIES = {


### PR DESCRIPTION
Release rollup for the post-2.2.0 series. Headline: **13 OSV advisories patched (#904)** — 8 high severity, including SSRF in Server Actions and a middleware/proxy bypass in next. Also: vite 8 / vitest 4 toolchain migration (#908), locale parity restoration with a permanent guard test (#907), `MC_DISABLE_RUNTIME_SCAN` (#895), grouped dependency updates (#897/#899/#905/#906).

- CHANGELOG: `[Unreleased]` promoted to `[2.3.0] - 2026-07-25`
- New `docs/releases/2.3.0.md` following the 2.2.0 format (includes the pnpm bounded-override guidance for forks)
- Version aligned: `package.json` + `scripts/mc-mcp-server.cjs` → 2.3.0

Tag `v2.3.0` will be created from the merged main commit per the release verification contract. Verified locally: 1524/1524 unit tests, typecheck.