### PR TITLE
feat: per-agent Claude Code session dispatch (runtime_type: claude)

### DIFF
--- a/src/app/api/agents/route.ts
+++ b/src/app/api/agents/route.ts
@@ -3,6 +3,7 @@ import { getDatabase, Agent, db_helpers } from '@/lib/db';
 import { eventBus } from '@/lib/event-bus';
 import { getTemplate, buildAgentConfig } from '@/lib/agent-templates';
 import { writeAgentToConfig, enrichAgentConfigFromWorkspace } from '@/lib/agent-sync';
+import { rotateClaudeBaseSession } from '@/lib/claude-code-sessions';
 import { logAuditEvent } from '@/lib/db';
 import { requireRole } from '@/lib/auth';
 import { mutationLimiter } from '@/lib/rate-limit';
@@ -387,7 +388,7 @@ export async function PUT(request: NextRequest) {
     // Handle single agent update or bulk updates
     if (body.name) {
       // Single agent update
-      const { name, status, last_activity, config, session_key, soul_content, role } = body;
+      const { name, status, last_activity, config, session_key, soul_content, role, runtime_type } = body;
       
       const agent = db
         .prepare('SELECT * FROM agents WHERE name = ? AND workspace_id = ?')
@@ -429,10 +430,25 @@ export async function PUT(request: NextRequest) {
         fieldsToUpdate.push('soul_content = ?');
         params.push(soul_content);
       }
-      
+
       if (role !== undefined) {
         fieldsToUpdate.push('role = ?');
         params.push(role);
+      }
+
+      if (runtime_type !== undefined) {
+        // Same vocabulary as createAgentSchema; empty string clears the field.
+        const allowedRuntimes = ['hermes', 'openclaw', 'claude', 'codex', 'custom'];
+        if (runtime_type !== null && runtime_type !== '' && !allowedRuntimes.includes(runtime_type)) {
+          return NextResponse.json({ error: 'Invalid runtime_type' }, { status: 400 });
+        }
+        fieldsToUpdate.push('runtime_type = ?');
+        params.push(runtime_type || null);
+        // Opting out of the claude runtime retires the base session (#602):
+        // authority is the opt-in, so the session must not outlive it.
+        if ((agent as { runtime_type?: string | null }).runtime_type === 'claude' && runtime_type !== 'claude') {
+          rotateClaudeBaseSession(agent.id, auth.user.username || 'operator', 'runtime_type changed away from claude');
+        }
       }
       
       fieldsToUpdate.push('updated_at = ?');

--- a/src/components/panels/agent-squad-panel.tsx
+++ b/src/components/panels/agent-squad-panel.tsx
@@ -346,6 +346,7 @@ function AgentDetailModal({
     role: agent.role,
     session_key: agent.session_key || '',
     soul_content: agent.soul_content || '',
+    runtime_type: agent.runtime_type || '',
   })
 
   const handleSave = async () => {
@@ -425,6 +426,26 @@ function AgentDetailModal({
                 />
               ) : (
                 <p className="text-white font-mono">{agent.session_key || t('notSet')}</p>
+              )}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-400 mb-1">{t('runtimeType')}</label>
+              {editing ? (
+                <select
+                  value={formData.runtime_type}
+                  onChange={(e) => setFormData(prev => ({ ...prev, runtime_type: e.target.value }))}
+                  className="w-full bg-gray-700 text-white rounded px-3 py-2 focus:outline-hidden focus:ring-2 focus:ring-blue-500"
+                >
+                  <option value="">{t('runtimeTypeAuto')}</option>
+                  <option value="hermes">Hermes Agent</option>
+                  <option value="openclaw">OpenClaw</option>
+                  <option value="claude">Claude Code</option>
+                  <option value="codex">Codex CLI</option>
+                  <option value="custom">{t('runtimeTypeCustom')}</option>
+                </select>
+              ) : (
+                <p className="text-white font-mono">{agent.runtime_type || t('notSet')}</p>
               )}
             </div>
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,6 +119,8 @@ export interface Agent {
   name: string
   role: string
   session_key?: string
+  /** 'claude' opts into per-agent Claude Code session dispatch (#602). */
+  runtime_type?: string | null
   soul_content?: string
   status: 'offline' | 'idle' | 'busy' | 'error'
   last_seen?: number

--- a/src/lib/__tests__/claude-code-sessions.test.ts
+++ b/src/lib/__tests__/claude-code-sessions.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import Database from 'better-sqlite3'
+import { runMigrations } from '@/lib/migrations'
+
+// The session manager reads through getDatabase() and audits through
+// logAuditEvent; route both at a per-test in-memory database so behavior is
+// tested end to end without touching the config-resolved database file.
+const state = vi.hoisted(() => ({
+  db: null as unknown,
+  auditEvents: [] as Array<Record<string, unknown>>,
+}))
+
+vi.mock('@/lib/db', () => ({
+  getDatabase: () => state.db,
+  logAuditEvent: (event: Record<string, unknown>) => { state.auditEvents.push(event) },
+}))
+
+import {
+  assertSessionOwnedByAgent,
+  ensureClaudeBaseSession,
+  isValidClaudeSessionId,
+  markClaudeBaseSessionMaterialized,
+  rotateClaudeBaseSession,
+} from '@/lib/claude-code-sessions'
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+let db: InstanceType<typeof Database>
+
+function insertAgent(name: string): number {
+  return Number(db.prepare("INSERT INTO agents (name, role, workspace_id) VALUES (?, 'agent', 1)").run(name).lastInsertRowid)
+}
+
+function agentRow(id: number) {
+  return db.prepare('SELECT claude_base_session_id, claude_base_session_created_at FROM agents WHERE id = ?').get(id) as {
+    claude_base_session_id: string | null
+    claude_base_session_created_at: string | null
+  }
+}
+
+beforeEach(() => {
+  db = new Database(':memory:')
+  db.pragma('foreign_keys = ON')
+  runMigrations(db)
+  state.db = db
+  state.auditEvents = []
+})
+
+afterEach(() => db.close())
+
+describe('migration 055_agent_claude_base_session', () => {
+  it('adds nullable base-session columns and replays idempotently', () => {
+    const cols = (db.pragma('table_info(agents)') as Array<{ name: string }>).map(c => c.name)
+    expect(cols).toContain('claude_base_session_id')
+    expect(cols).toContain('claude_base_session_created_at')
+
+    db.prepare("DELETE FROM schema_migrations WHERE id = '055_agent_claude_base_session'").run()
+    expect(() => runMigrations(db)).not.toThrow()
+  })
+})
+
+describe('ensureClaudeBaseSession', () => {
+  it('lazily claims a server-generated UUID and audits base creation once', () => {
+    const agentId = insertAgent('claude-worker')
+    const first = ensureClaudeBaseSession(agentId)
+
+    expect(first.sessionId).toMatch(UUID_RE)
+    expect(first.materialized).toBe(false)
+    expect(agentRow(agentId).claude_base_session_id).toBe(first.sessionId)
+
+    const second = ensureClaudeBaseSession(agentId)
+    expect(second.sessionId).toBe(first.sessionId)
+
+    const created = state.auditEvents.filter(e => e.action === 'claude_session.base_created')
+    expect(created).toHaveLength(1)
+    expect(created[0].target_id).toBe(agentId)
+  })
+
+  it('refuses a hand-edited non-UUID base id instead of regenerating it', () => {
+    const agentId = insertAgent('tampered')
+    db.prepare("UPDATE agents SET claude_base_session_id = 'not-a-uuid' WHERE id = ?").run(agentId)
+    expect(() => ensureClaudeBaseSession(agentId)).toThrow(/non-UUID/)
+  })
+
+  it('throws for an unknown agent', () => {
+    expect(() => ensureClaudeBaseSession(99999)).toThrow(/not found/)
+  })
+})
+
+describe('markClaudeBaseSessionMaterialized', () => {
+  it('stamps once and only for the matching session id', () => {
+    const agentId = insertAgent('stamper')
+    const { sessionId } = ensureClaudeBaseSession(agentId)
+
+    markClaudeBaseSessionMaterialized(agentId, '11111111-2222-4333-8444-555555555555')
+    expect(agentRow(agentId).claude_base_session_created_at).toBeNull()
+
+    markClaudeBaseSessionMaterialized(agentId, sessionId)
+    const stamped = agentRow(agentId).claude_base_session_created_at
+    expect(stamped).not.toBeNull()
+
+    markClaudeBaseSessionMaterialized(agentId, sessionId)
+    expect(agentRow(agentId).claude_base_session_created_at).toBe(stamped)
+
+    expect(ensureClaudeBaseSession(agentId).materialized).toBe(true)
+  })
+})
+
+describe('assertSessionOwnedByAgent', () => {
+  it('rejects invalid ids, foreign sessions, and cross-agent reuse', () => {
+    const a = insertAgent('owner-a')
+    const b = insertAgent('owner-b')
+    const sessionA = ensureClaudeBaseSession(a).sessionId
+
+    expect(() => assertSessionOwnedByAgent(a, 'not-a-uuid')).toThrow(/invalid/)
+    expect(() => assertSessionOwnedByAgent(a, '99999999-9999-4999-8999-999999999999')).toThrow(/not owned/)
+    expect(() => assertSessionOwnedByAgent(b, sessionA)).toThrow(/not owned/)
+    expect(() => assertSessionOwnedByAgent(a, sessionA)).not.toThrow()
+  })
+})
+
+describe('rotateClaudeBaseSession', () => {
+  it('clears the base session, audits with the previous id, and allows a fresh claim', () => {
+    const agentId = insertAgent('rotator')
+    const { sessionId } = ensureClaudeBaseSession(agentId)
+    markClaudeBaseSessionMaterialized(agentId, sessionId)
+
+    rotateClaudeBaseSession(agentId, 'operator', 'runtime_type changed away from claude')
+    expect(agentRow(agentId)).toEqual({ claude_base_session_id: null, claude_base_session_created_at: null })
+
+    const rotated = state.auditEvents.filter(e => e.action === 'claude_session.rotated')
+    expect(rotated).toHaveLength(1)
+    expect((rotated[0].detail as Record<string, unknown>).previous_base_session_id).toBe(sessionId)
+
+    const fresh = ensureClaudeBaseSession(agentId)
+    expect(fresh.sessionId).not.toBe(sessionId)
+    expect(fresh.materialized).toBe(false)
+  })
+
+  it('is a no-op without a base session', () => {
+    const agentId = insertAgent('nothing-to-rotate')
+    rotateClaudeBaseSession(agentId, 'operator', 'noop')
+    expect(state.auditEvents.filter(e => e.action === 'claude_session.rotated')).toHaveLength(0)
+  })
+})
+
+describe('audit hygiene', () => {
+  it('never records prompt or soul contents', () => {
+    const agentId = insertAgent('hygiene')
+    const { sessionId } = ensureClaudeBaseSession(agentId)
+    rotateClaudeBaseSession(agentId, 'operator', 'hygiene check')
+    const serialized = JSON.stringify(state.auditEvents)
+    expect(serialized).toContain(sessionId)
+    expect(serialized).not.toMatch(/prompt|soul_content/i)
+  })
+})
+
+describe('isValidClaudeSessionId', () => {
+  it('accepts UUIDs and rejects everything else', () => {
+    expect(isValidClaudeSessionId('11111111-2222-4333-8444-555555555555')).toBe(true)
+    expect(isValidClaudeSessionId('gggggggg-2222-4333-8444-555555555555')).toBe(false)
+    expect(isValidClaudeSessionId('')).toBe(false)
+    expect(isValidClaudeSessionId(null)).toBe(false)
+    expect(isValidClaudeSessionId('11111111222243338444555555555555')).toBe(false)
+  })
+})

--- a/src/lib/__tests__/task-dispatch-claude-runtime.test.ts
+++ b/src/lib/__tests__/task-dispatch-claude-runtime.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// Source-contract tests in the style of background-dispatch-isolation.test.ts:
+// the #602 claude-runtime branch has ordering and no-fallback guarantees that
+// are structural properties of task-dispatch.ts. These assertions pin them so
+// a refactor cannot silently reorder the branch below the gateway/direct
+// selection or reintroduce a fallback path.
+const source = readFileSync(join(process.cwd(), 'src', 'lib', 'task-dispatch.ts'), 'utf8')
+
+function sliceBetween(start: string, end: string): string {
+  const from = source.indexOf(start)
+  const to = source.indexOf(end, from)
+  expect(from, `anchor missing: ${start}`).toBeGreaterThan(-1)
+  expect(to, `anchor missing: ${end}`).toBeGreaterThan(from)
+  return source.slice(from, to)
+}
+
+describe('claude runtime dispatch routing (#602)', () => {
+  it('selects agent_runtime_type in the dispatch query', () => {
+    const dispatchLoop = sliceBetween('export async function dispatchAssignedTasks()', '// Auto-routing:')
+    expect(dispatchLoop).toContain('a.runtime_type as agent_runtime_type')
+  })
+
+  it('routes claude-runtime agents before the gateway/direct selection', () => {
+    const dispatchLoop = sliceBetween('export async function dispatchAssignedTasks()', '// Auto-routing:')
+    const claudeBranch = dispatchLoop.indexOf("=== 'claude'")
+    const directBranch = dispatchLoop.indexOf('useDirectApi && !targetSession')
+    expect(claudeBranch).toBeGreaterThan(-1)
+    expect(directBranch).toBeGreaterThan(-1)
+    expect(claudeBranch).toBeLessThan(directBranch)
+    expect(dispatchLoop).toContain('dispatchViaClaudeSession(task, prompt)')
+  })
+
+  it('never falls back from the claude session path to another provider', () => {
+    const fn = sliceBetween('async function dispatchViaClaudeSession(', 'async function callOpenAICompatible(')
+    expect(fn).not.toContain('callDirectly(')
+    expect(fn).not.toContain('callClaudeDirectly(')
+    expect(fn).not.toContain('callOpenClawGateway')
+    expect(fn).toContain('refusing to fall back')
+    expect(fn).toContain('ensureClaudeBaseSession')
+    expect(fn).toContain('markClaudeBaseSessionMaterialized')
+    expect(fn).toContain('auditClaudeSessionDispatch')
+  })
+
+  it('creates with --session-id and forks with --resume --fork-session', () => {
+    const fn = sliceBetween('async function callClaudeViaCli(', 'async function dispatchViaClaudeSession(')
+    expect(fn).toContain("args.push('--session-id', session.create)")
+    expect(fn).toContain("args.push('--resume', session.resume, '--fork-session')")
+  })
+
+  it('bounds claude CLI output', () => {
+    const fn = sliceBetween('const CLAUDE_CLI_MAX_OUTPUT_BYTES', 'async function dispatchViaClaudeSession(')
+    expect(fn).toContain('CLAUDE_CLI_MAX_OUTPUT_BYTES = 1_000_000')
+    expect(fn).toContain('output exceeded')
+  })
+})

--- a/src/lib/claude-code-sessions.ts
+++ b/src/lib/claude-code-sessions.ts
@@ -1,0 +1,164 @@
+// Per-agent Claude Code base-session lifecycle (#602).
+//
+// Agents that opt in via `runtime_type: 'claude'` get a server-generated UUID
+// base session, created lazily on first dispatch. Every task dispatch either
+// materializes the base session (`claude --session-id <uuid>`) or forks from it
+// (`claude --resume <uuid> --fork-session`); the forked per-task id is stored
+// on the task (`metadata.dispatch_session_id`), never on the agent.
+//
+// Hard rules from the acceptance contract:
+// - authority comes from the explicit opt-in, never from an installed binary
+// - base ids are server-generated UUIDs; anything else is rejected
+// - a base session belongs to exactly one agent; cross-agent reuse is refused
+// - dispatch failures never fall back to a less restrictive provider
+// - audit records carry ids and flags only — no prompt or soul contents
+
+import { randomUUID } from 'crypto'
+import { getDatabase, logAuditEvent } from './db'
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export function isValidClaudeSessionId(id: unknown): id is string {
+  return typeof id === 'string' && UUID_RE.test(id)
+}
+
+export interface ClaudeBaseSession {
+  /** Server-generated UUID for `--session-id` / `--resume`. */
+  sessionId: string
+  /** False until a first dispatch has materialized the session on disk. */
+  materialized: boolean
+}
+
+interface AgentSessionRow {
+  id: number
+  claude_base_session_id: string | null
+  claude_base_session_created_at: string | null
+}
+
+function readAgentSessionRow(agentId: number): AgentSessionRow | undefined {
+  const db = getDatabase()
+  return db
+    .prepare(`SELECT id, claude_base_session_id, claude_base_session_created_at FROM agents WHERE id = ?`)
+    .get(agentId) as AgentSessionRow | undefined
+}
+
+/**
+ * Lazily claim the agent's base session id. Concurrent first dispatches race
+ * safely: the guarded UPDATE lets exactly one claim win, and every caller
+ * re-reads the winner. Rows with a non-UUID id (hand-edited DB) are refused
+ * rather than silently regenerated — that is a rotation decision, not ours.
+ */
+export function ensureClaudeBaseSession(agentId: number, actor = 'scheduler'): ClaudeBaseSession {
+  const row = readAgentSessionRow(agentId)
+  if (!row) throw new Error(`claude session: agent ${agentId} not found`)
+
+  if (row.claude_base_session_id) {
+    if (!isValidClaudeSessionId(row.claude_base_session_id)) {
+      throw new Error(`claude session: agent ${agentId} has a non-UUID base session id; rotate it before dispatching`)
+    }
+    return {
+      sessionId: row.claude_base_session_id,
+      materialized: row.claude_base_session_created_at !== null,
+    }
+  }
+
+  const candidate = randomUUID()
+  const db = getDatabase()
+  const claimed = db
+    .prepare(`UPDATE agents SET claude_base_session_id = ? WHERE id = ? AND claude_base_session_id IS NULL`)
+    .run(candidate, agentId)
+
+  const winner = readAgentSessionRow(agentId)
+  if (!winner?.claude_base_session_id || !isValidClaudeSessionId(winner.claude_base_session_id)) {
+    throw new Error(`claude session: failed to claim a base session for agent ${agentId}`)
+  }
+  if (claimed.changes === 1) {
+    logAuditEvent({
+      action: 'claude_session.base_created',
+      actor,
+      target_type: 'agent',
+      target_id: agentId,
+      detail: { base_session_id: winner.claude_base_session_id },
+    })
+  }
+  return {
+    sessionId: winner.claude_base_session_id,
+    materialized: winner.claude_base_session_created_at !== null,
+  }
+}
+
+/**
+ * Stamp the base session as materialized after the create-path dispatch
+ * succeeds. The guard tolerates the concurrent-first-dispatch race: only the
+ * first success stamps; later calls are no-ops.
+ */
+export function markClaudeBaseSessionMaterialized(agentId: number, sessionId: string): void {
+  if (!isValidClaudeSessionId(sessionId)) return
+  const db = getDatabase()
+  db.prepare(
+    `UPDATE agents SET claude_base_session_created_at = datetime('now')
+     WHERE id = ? AND claude_base_session_id = ? AND claude_base_session_created_at IS NULL`,
+  ).run(agentId, sessionId)
+}
+
+/**
+ * Refuse a session id that belongs to a different agent (or to no agent).
+ * Cross-agent session reuse is a hard negative in the acceptance contract.
+ */
+export function assertSessionOwnedByAgent(agentId: number, sessionId: string): void {
+  if (!isValidClaudeSessionId(sessionId)) {
+    throw new Error('claude session: invalid session id')
+  }
+  const db = getDatabase()
+  const owner = db
+    .prepare(`SELECT id FROM agents WHERE claude_base_session_id = ?`)
+    .get(sessionId) as { id: number } | undefined
+  if (!owner || owner.id !== agentId) {
+    throw new Error(`claude session: session is not owned by agent ${agentId}`)
+  }
+}
+
+/**
+ * Rotate (clear) the agent's base session, e.g. when runtime_type moves away
+ * from 'claude' or the on-disk session is unrecoverable. The next opt-in
+ * dispatch claims a fresh UUID.
+ */
+export function rotateClaudeBaseSession(agentId: number, actor: string, reason: string): void {
+  const row = readAgentSessionRow(agentId)
+  if (!row?.claude_base_session_id) return
+  const db = getDatabase()
+  db.prepare(
+    `UPDATE agents SET claude_base_session_id = NULL, claude_base_session_created_at = NULL WHERE id = ?`,
+  ).run(agentId)
+  logAuditEvent({
+    action: 'claude_session.rotated',
+    actor,
+    target_type: 'agent',
+    target_id: agentId,
+    detail: { previous_base_session_id: row.claude_base_session_id, reason },
+  })
+}
+
+export function auditClaudeSessionDispatch(args: {
+  agentId: number
+  baseSessionId: string
+  taskId: number
+  outcome: 'resumed' | 'failed'
+  forkedSessionId?: string | null
+  error?: string
+  actor?: string
+}): void {
+  logAuditEvent({
+    action: args.outcome === 'resumed' ? 'claude_session.resumed' : 'claude_session.failed',
+    actor: args.actor || 'scheduler',
+    target_type: 'agent',
+    target_id: args.agentId,
+    detail: {
+      base_session_id: args.baseSessionId,
+      task_id: args.taskId,
+      ...(args.forkedSessionId ? { forked_session_id: args.forkedSessionId } : {}),
+      // Errors are bounded and never include prompt/soul contents by contract.
+      ...(args.error ? { error: String(args.error).slice(0, 300) } : {}),
+    },
+  })
+}

--- a/src/lib/migrations.ts
+++ b/src/lib/migrations.ts
@@ -1535,6 +1535,21 @@ const migrations: Migration[] = [
         CREATE INDEX idx_agents_source ON agents(source);
       `)
     }
+  },
+  {
+    // #602: per-agent Claude Code base sessions. The base id is a server-generated
+    // UUID owned by exactly one agent; created_at doubles as the created-on-disk
+    // marker (NULL = base session not yet materialized by a first dispatch).
+    id: '055_agent_claude_base_session',
+    up: (db) => {
+      const cols = db.prepare(`PRAGMA table_info(agents)`).all() as Array<{ name: string }>
+      if (!cols.some(c => c.name === 'claude_base_session_id')) {
+        db.exec(`ALTER TABLE agents ADD COLUMN claude_base_session_id TEXT DEFAULT NULL`)
+      }
+      if (!cols.some(c => c.name === 'claude_base_session_created_at')) {
+        db.exec(`ALTER TABLE agents ADD COLUMN claude_base_session_created_at TEXT DEFAULT NULL`)
+      }
+    }
   }
 ]
 

--- a/src/lib/task-dispatch.ts
+++ b/src/lib/task-dispatch.ts
@@ -2,6 +2,11 @@ import { existsSync, realpathSync, statSync } from 'node:fs'
 import path from 'node:path'
 import { spawn } from 'node:child_process'
 import { getDatabase, db_helpers } from './db'
+import {
+  auditClaudeSessionDispatch,
+  ensureClaudeBaseSession,
+  markClaudeBaseSessionMaterialized,
+} from './claude-code-sessions'
 import { callOpenClawGateway } from './openclaw-gateway'
 import { eventBus } from './event-bus'
 import { logger } from './logger'
@@ -40,6 +45,8 @@ interface DispatchableTask {
   agent_name: string
   agent_id: number
   agent_config: string | null
+  /** From agents.runtime_type — 'claude' opts into per-agent CLI session dispatch (#602). */
+  agent_runtime_type?: string | null
   ticket_prefix: string | null
   project_ticket_no: number | null
   project_id: number | null
@@ -919,14 +926,28 @@ function isDirectDispatchAvailable(provider?: DirectProvider): boolean {
  * `classifyDirectModel`), and fall back to the alias derived from the family
  * keyword so a stale `claude-opus-4-5` mapping still routes correctly.
  */
+/** Session routing for #602: create materializes the agent's base session under
+ * a server-generated UUID; resume forks a fresh per-task session from it. */
+interface ClaudeCliSessionOptions {
+  create?: string
+  resume?: string
+}
+
+// Bounded CLI output (#602 contract): a runaway child cannot grow dispatch
+// memory without limit. Applies to every claude CLI dispatch path.
+const CLAUDE_CLI_MAX_OUTPUT_BYTES = 1_000_000
+
 async function callClaudeViaCli(
   task: DispatchableTask,
   prompt: string,
   model: string,
+  session?: ClaudeCliSessionOptions,
 ): Promise<AgentResponseParsed> {
   const soul = getAgentSoulContent(task)
   const sandbox = resolveCliSandboxOptions(task)
   const args = ['--print', '--output-format', 'json', '--model', model]
+  if (session?.create) args.push('--session-id', session.create)
+  else if (session?.resume) args.push('--resume', session.resume, '--fork-session')
   if (sandbox.allowedTools) args.push('--allowedTools', sandbox.allowedTools.join(','))
   if (sandbox.maxBudgetUsd !== null) args.push('--max-budget-usd', String(sandbox.maxBudgetUsd))
   if (soul) args.push('--append-system-prompt', soul)
@@ -935,6 +956,8 @@ async function callClaudeViaCli(
   logger.info(
     {
       taskId: task.id, model, agent: task.agent_name,
+      ...(session?.create ? { sessionCreate: session.create } : {}),
+      ...(session?.resume ? { sessionResume: session.resume } : {}),
       ...(sandboxApplied ? { sandbox: { allowedTools: sandbox.allowedTools, maxBudgetUsd: sandbox.maxBudgetUsd, cwd: sandbox.cwd } } : {}),
     },
     'Dispatching task via Claude CLI',
@@ -948,14 +971,25 @@ async function callClaudeViaCli(
     })
     let stdout = ''
     let stderr = ''
+    let outputBytes = 0
     const timeoutMs = 180_000
     const timer = setTimeout(() => {
       proc.kill('SIGTERM')
       reject(new Error(`Claude CLI timed out after ${timeoutMs / 1000}s`))
     }, timeoutMs)
+    const guardOutput = (chunk: Buffer) => {
+      outputBytes += chunk.length
+      if (outputBytes > CLAUDE_CLI_MAX_OUTPUT_BYTES) {
+        clearTimeout(timer)
+        proc.kill('SIGKILL')
+        reject(new Error(`Claude CLI output exceeded ${CLAUDE_CLI_MAX_OUTPUT_BYTES} bytes`))
+        return false
+      }
+      return true
+    }
 
-    proc.stdout.on('data', (d) => { stdout += d.toString() })
-    proc.stderr.on('data', (d) => { stderr += d.toString() })
+    proc.stdout.on('data', (d) => { if (guardOutput(d)) stdout += d.toString() })
+    proc.stderr.on('data', (d) => { if (guardOutput(d)) stderr += d.toString() })
     proc.on('error', (err) => { clearTimeout(timer); reject(err) })
     proc.on('close', (code) => {
       clearTimeout(timer)
@@ -993,6 +1027,64 @@ async function callClaudeViaCli(
     proc.stdin.write(prompt)
     proc.stdin.end()
   })
+}
+
+/**
+ * #602: dispatch through the agent's persistent Claude Code base session.
+ * First successful dispatch materializes the base session under a
+ * server-generated UUID (`--session-id`); every later dispatch forks a
+ * per-task session from it (`--resume <base> --fork-session`), and the forked
+ * id flows through the normal completion tail into
+ * `tasks.metadata.dispatch_session_id`.
+ *
+ * No-fallback rule: any failure here (missing CLI, auth, expired or damaged
+ * session) is a dispatch failure. We never reroute to the API-key or gateway
+ * paths — those run with different authority than the operator's CLI login.
+ */
+async function dispatchViaClaudeSession(
+  task: DispatchableTask,
+  prompt: string,
+): Promise<AgentResponseParsed> {
+  if (!isClaudeCliAvailable()) {
+    auditClaudeSessionDispatch({
+      agentId: task.agent_id,
+      baseSessionId: '',
+      taskId: task.id,
+      outcome: 'failed',
+      error: 'claude CLI unavailable for runtime_type=claude agent',
+    })
+    throw new Error(
+      `claude runtime dispatch: CLI unavailable for agent ${task.agent_name}; refusing to fall back to a less restrictive provider`,
+    )
+  }
+
+  const base = ensureClaudeBaseSession(task.agent_id)
+  const model = stripProviderPrefix(classifyDirectModel(task))
+  const session = base.materialized ? { resume: base.sessionId } : { create: base.sessionId }
+
+  try {
+    const response = await callClaudeViaCli(task, prompt, model, session)
+    if (!base.materialized) {
+      markClaudeBaseSessionMaterialized(task.agent_id, base.sessionId)
+    }
+    auditClaudeSessionDispatch({
+      agentId: task.agent_id,
+      baseSessionId: base.sessionId,
+      taskId: task.id,
+      outcome: 'resumed',
+      forkedSessionId: base.materialized ? response.sessionId : null,
+    })
+    return response
+  } catch (err) {
+    auditClaudeSessionDispatch({
+      agentId: task.agent_id,
+      baseSessionId: base.sessionId,
+      taskId: task.id,
+      outcome: 'failed',
+      error: err instanceof Error ? err.message : String(err),
+    })
+    throw err
+  }
 }
 
 async function callOpenAICompatible(
@@ -1493,6 +1585,7 @@ export async function dispatchAssignedTasks(): Promise<{ ok: boolean; message: s
 
   const tasks = db.prepare(`
     SELECT t.*, a.name as agent_name, a.id as agent_id, a.config as agent_config,
+           a.runtime_type as agent_runtime_type,
            p.ticket_prefix, t.project_ticket_no
     FROM tasks t
     JOIN agents a ON a.name = t.assigned_to AND a.workspace_id = t.workspace_id
@@ -1579,7 +1672,13 @@ export async function dispatchAssignedTasks(): Promise<{ ok: boolean; message: s
       let agentResponse: AgentResponseParsed
       const useDirectApi = !isGatewayAvailable() && isDirectDispatchAvailable()
 
-      if (useDirectApi && !targetSession) {
+      if (String(task.agent_runtime_type || '').toLowerCase() === 'claude') {
+        // #602: explicit opt-in per-agent Claude Code session dispatch. This
+        // branch deliberately outranks gateway availability, target_session,
+        // and callDirectly — a claude-runtime agent never falls back to a
+        // less restrictive provider; failures surface as dispatch failures.
+        agentResponse = await dispatchViaClaudeSession(task, prompt)
+      } else if (useDirectApi && !targetSession) {
         // Direct API dispatch — provider chosen by `dispatchModel` prefix
         // (Anthropic / OpenAI / OpenAI-compatible local). No gateway needed.
         agentResponse = await callDirectly(task, prompt)


### PR DESCRIPTION
Implements #602 per the acceptance contract in the 2026-07-15 maintainer comment — the resume/fork-per-task first slice, not a long-lived child process.

## How it works
- Agent opts in with `runtime_type: 'claude'` (create form already had the selector; the edit modal now has it too, and `PUT /api/agents` accepts the field with enum validation + base-session rotation on opt-out).
- First dispatch lazily claims a **server-generated UUID** base session (guarded UPDATE, concurrent-safe) and materializes it with `claude --session-id <uuid>`.
- Every later dispatch runs `claude --resume <base> --fork-session`; the forked per-task id flows through the existing completion tail into `tasks.metadata.dispatch_session_id`.
- The claude branch sits **before** the gateway/target-session/direct 3-way and never reroutes: CLI missing, auth, or session failures surface as dispatch failures with audit records (`claude_session.base_created/.resumed/.failed/.rotated` — ids and flags only, never prompt/soul contents).
- Existing #720 sandbox controls (allowed-tools, budget, cwd) apply unchanged on every create/resume; CLI output now hard-capped at 1MB on all claude dispatches.

## Contract coverage
| Requirement | Where |
|---|---|
| explicit opt-in, never inferred | dispatch branch keys on `agents.runtime_type` only |
| UUID-only base ids, server-side | `claude-code-sessions.ts` (`ensureClaudeBaseSession`, non-UUID refused) |
| lazy base creation | first dispatch, not agent create |
| fork id stored separately | `tasks.metadata.dispatch_session_id` vs `agents.claude_base_session_id` (migration 055, nullable, replay-tested) |
| bounded IO / timeout / cleanup | 1MB output cap + existing 180s SIGTERM |
| no fallback | branch precedence + source-contract test pinning it |
| audit without contents | audit-hygiene test asserts no prompt/soul in records |
| negative tests | invalid ids, cross-agent reuse, unknown agent, tamper refusal |

## Verification
15 new tests; full suite **1539/1539**; typecheck; lint; leak-scan clean (pre-existing infra strings allowlisted). Source-contract tests pin branch precedence and the session args so refactors can't silently reintroduce a fallback.

Closes #602