### PR TITLE
fix(security): harden env ignore, host allowlist, and logout cookies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,12 @@ dist/
 # Misc
 .DS_Store
 *.pem
-.env*.local
-.env.production
+
+# Secrets — ignore all env variants by default (incl. .env.bak*, .env.local, etc.)
+# Re-allow only the intentionally committed sample/test files.
+.env*
+!.env.example
+!.env.test
 
 # npm (project uses pnpm)
 package-lock.json
@@ -29,7 +33,6 @@ yarn-error.log*
 # TypeScript
 *.tsbuildinfo
 next-env.d.ts
-.env
 .data/
 aegis/
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
+# pnpm 10+ reads these settings from this file (not package.json "pnpm" field).
 onlyBuiltDependencies:
   - '@parcel/watcher'
   - '@swc/core'

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,14 +1,18 @@
 import { NextResponse } from 'next/server'
 import { destroySession, getUserFromRequest } from '@/lib/auth'
 import { logAuditEvent } from '@/lib/db'
-import { getMcSessionCookieName, getMcSessionCookieOptions, isRequestSecure, parseMcSessionCookieHeader } from '@/lib/session-cookie'
+import {
+  expireAllMcSessionCookies,
+  isRequestSecure,
+  parseAllMcSessionCookieTokens,
+} from '@/lib/session-cookie'
 
 export async function POST(request: Request) {
   const user = getUserFromRequest(request)
   const cookieHeader = request.headers.get('cookie') || ''
-  const token = parseMcSessionCookieHeader(cookieHeader)
 
-  if (token) {
+  // Revoke every presented token (secure + legacy names can both be present).
+  for (const token of parseAllMcSessionCookieTokens(cookieHeader)) {
     destroySession(token)
   }
 
@@ -18,11 +22,7 @@ export async function POST(request: Request) {
   }
 
   const response = NextResponse.json({ ok: true })
-  const isSecureRequest = isRequestSecure(request)
-  const cookieName = getMcSessionCookieName(isSecureRequest)
-  response.cookies.set(cookieName, '', {
-    ...getMcSessionCookieOptions({ maxAgeSeconds: 0, isSecureRequest }),
-  })
+  expireAllMcSessionCookies(response, isRequestSecure(request))
 
   return response
 }

--- a/src/lib/__tests__/session-cookie.test.ts
+++ b/src/lib/__tests__/session-cookie.test.ts
@@ -1,5 +1,41 @@
 import { afterEach, describe, expect, it } from 'vitest'
-import { getMcSessionCookieOptions } from '../session-cookie'
+import {
+  LEGACY_MC_SESSION_COOKIE_NAME,
+  MC_SESSION_COOKIE_NAME,
+  expireAllMcSessionCookies,
+  getMcSessionCookieOptions,
+  parseAllMcSessionCookieTokens,
+  parseMcSessionCookieHeader,
+} from '../session-cookie'
+
+describe('session cookie parsing and expiry', () => {
+  it('collects both secure and legacy session tokens', () => {
+    const header = `${MC_SESSION_COOKIE_NAME}=secure-token; ${LEGACY_MC_SESSION_COOKIE_NAME}=legacy-token`
+    expect(parseAllMcSessionCookieTokens(header)).toEqual(['secure-token', 'legacy-token'])
+    // First match remains the preferred token for request auth.
+    expect(parseMcSessionCookieHeader(header)).toBe('secure-token')
+  })
+
+  it('expires both session cookie names on logout', () => {
+    const setCalls: Array<{ name: string; value: string; options?: Record<string, unknown> }> = []
+    const response = {
+      cookies: {
+        set: (name: string, value: string, options?: Record<string, unknown>) => {
+          setCalls.push({ name, value, options })
+        },
+      },
+    }
+
+    expireAllMcSessionCookies(response, true)
+
+    expect(setCalls.map((c) => c.name)).toEqual([
+      MC_SESSION_COOKIE_NAME,
+      LEGACY_MC_SESSION_COOKIE_NAME,
+    ])
+    expect(setCalls.every((c) => c.value === '' && c.options?.maxAge === 0)).toBe(true)
+    expect(setCalls[0].options?.secure).toBe(true)
+  })
+})
 
 describe('getMcSessionCookieOptions', () => {
   const env = process.env as Record<string, string | undefined>

--- a/src/lib/session-cookie.ts
+++ b/src/lib/session-cookie.ts
@@ -14,14 +14,42 @@ export function isRequestSecure(request: Request): boolean {
 }
 
 export function parseMcSessionCookieHeader(cookieHeader: string): string | null {
-  if (!cookieHeader) return null
+  const tokens = parseAllMcSessionCookieTokens(cookieHeader)
+  return tokens[0] ?? null
+}
+
+/** Return every presented Mission Control session token (secure + legacy names). */
+export function parseAllMcSessionCookieTokens(cookieHeader: string): string[] {
+  if (!cookieHeader) return []
+  const tokens: string[] = []
   for (const cookieName of MC_SESSION_COOKIE_NAMES) {
     const match = cookieHeader.match(new RegExp(`(?:^|;\\s*)${cookieName}=([^;]*)`))
-    if (match) {
-      return decodeURIComponent(match[1])
+    if (!match) continue
+    try {
+      tokens.push(decodeURIComponent(match[1]))
+    } catch {
+      tokens.push(match[1])
     }
   }
-  return null
+  return tokens
+}
+
+/**
+ * Expire both the __Host- and legacy session cookies so HTTP→HTTPS transitions
+ * cannot leave a valid session behind after logout.
+ */
+export function expireAllMcSessionCookies(
+  response: { cookies: { set: (name: string, value: string, options?: Partial<ResponseCookie>) => void } },
+  isSecureRequest: boolean,
+): void {
+  // __Host- cookies require Secure; always clear with that attribute.
+  response.cookies.set(MC_SESSION_COOKIE_NAME, '', {
+    ...getMcSessionCookieOptions({ maxAgeSeconds: 0, isSecureRequest: true }),
+    secure: true,
+  })
+  response.cookies.set(LEGACY_MC_SESSION_COOKIE_NAME, '', {
+    ...getMcSessionCookieOptions({ maxAgeSeconds: 0, isSecureRequest }),
+  })
 }
 
 function envFlag(name: string): boolean | undefined {

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -171,4 +171,42 @@ describe('proxy host matching', () => {
     const response = proxy(request)
     expect(response.status).toBe(401)
   })
+
+  it('fails closed in production when MC_ALLOWED_HOSTS is empty (implicit local only)', async () => {
+    vi.resetModules()
+    vi.doMock('node:os', () => ({
+      default: { hostname: () => 'hetzner-jarv' },
+      hostname: () => 'hetzner-jarv',
+    }))
+
+    const { proxy } = await import('./proxy')
+
+    setNodeEnv('production')
+    delete process.env.MC_ALLOWED_HOSTS
+    delete process.env.MC_ALLOW_ANY_HOST
+
+    const blocked = proxy({
+      headers: new Headers({ host: 'evil.example.com' }),
+      nextUrl: { host: 'evil.example.com', hostname: 'evil.example.com', pathname: '/login', clone: () => ({ pathname: '/login' }) },
+      method: 'GET',
+      cookies: { get: () => undefined },
+    } as any)
+    expect(blocked.status).toBe(403)
+
+    const allowedLocal = proxy({
+      headers: new Headers({ host: 'localhost:3000' }),
+      nextUrl: { host: 'localhost:3000', hostname: 'localhost', pathname: '/login', clone: () => ({ pathname: '/login' }) },
+      method: 'GET',
+      cookies: { get: () => undefined },
+    } as any)
+    expect(allowedLocal.status).not.toBe(403)
+
+    const allowedHostname = proxy({
+      headers: new Headers({ host: 'hetzner-jarv' }),
+      nextUrl: { host: 'hetzner-jarv', hostname: 'hetzner-jarv', pathname: '/login', clone: () => ({ pathname: '/login' }) },
+      method: 'GET',
+      cookies: { get: () => undefined },
+    } as any)
+    expect(allowedHostname.status).not.toBe(403)
+  })
 })

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -167,7 +167,10 @@ export function proxy(request: NextRequest) {
     .filter(Boolean)
   const implicitAllowedHosts = getImplicitAllowedHosts()
 
-  const enforceAllowlist = !allowAnyHost && allowedPatterns.length > 0
+  // Production is always fail-closed: even with an empty/missing MC_ALLOWED_HOSTS,
+  // only implicit local hosts (localhost / 127.0.0.1 / ::1 / os.hostname) are allowed.
+  // Deliberate open access still requires MC_ALLOW_ANY_HOST=1 (or non-production).
+  const enforceAllowlist = !allowAnyHost
   const isAllowedHost = !enforceAllowlist
     || requestHosts.some((hostName) =>
       implicitAllowedHosts.some((candidate) => hostMatches(candidate, hostName))


### PR DESCRIPTION
## Summary
- Ignore all `.env*` variants by default (including `.env.bak*`) so backup env files with secrets cannot be accidentally committed; keep `.env.example` and `.env.test` trackable.
- Make production host filtering fail-closed when `MC_ALLOWED_HOSTS` is empty (only implicit local hosts), unless `MC_ALLOW_ANY_HOST=1` is set.
- On logout, revoke and expire both `__Host-mc-session` and legacy `mc-session` cookies so HTTP→HTTPS transitions cannot leave a valid session behind.
- Add regression tests for the host gate and dual-cookie session helpers.

## Context
These changes came from a local security audit of Mission Control. They are small, high-value hardening fixes with unit test coverage.

## Test plan
- [x] `vitest run src/proxy.test.ts` (includes empty `MC_ALLOWED_HOSTS` fail-closed case)
- [x] `vitest run src/lib/__tests__/session-cookie.test.ts`
- [ ] CI green on this PR
- [ ] Manual: production-mode host with empty allowlist blocks unrelated Host header; localhost still works
- [ ] Manual: logout clears both cookie names