### PR TITLE
feat: add OrcaRouter as a named LLM provider integration

### DIFF
--- a/src/app/api/integrations/route.ts
+++ b/src/app/api/integrations/route.ts
@@ -46,6 +46,7 @@ const INTEGRATIONS: IntegrationDef[] = [
   { id: 'anthropic', name: 'Anthropic', category: 'ai', envVars: ['ANTHROPIC_API_KEY'], vaultItem: 'openclaw-anthropic-api-key', testable: true },
   { id: 'openai', name: 'OpenAI', category: 'ai', envVars: ['OPENAI_API_KEY'], vaultItem: 'openclaw-openai-api-key', testable: true },
   { id: 'openrouter', name: 'OpenRouter', category: 'ai', envVars: ['OPENROUTER_API_KEY'], vaultItem: 'openclaw-openrouter-api-key', testable: true },
+  { id: 'orcarouter', name: 'OrcaRouter', category: 'ai', envVars: ['ORCAROUTER_API_KEY'], vaultItem: 'openclaw-orcarouter-api-key', testable: true },
   { id: 'venice', name: 'Venice AI', category: 'ai', envVars: ['VENICE_API_KEY'], vaultItem: 'openclaw-venice-api-key', testable: true },
   { id: 'nvidia', name: 'NVIDIA', category: 'ai', envVars: ['NVIDIA_API_KEY'], vaultItem: 'openclaw-nvidia-api-key' },
   { id: 'moonshot', name: 'Moonshot / Kimi', category: 'ai', envVars: ['MOONSHOT_API_KEY'], vaultItem: 'openclaw-moonshot-api-key' },
@@ -736,6 +737,19 @@ async function handleTest(
         const key = getEffectiveEnvValue(envMap, 'OPENROUTER_API_KEY')
         if (!key) return NextResponse.json({ ok: false, detail: 'API key not set' })
         const res = await fetch('https://openrouter.ai/api/v1/models', {
+          headers: { Authorization: `Bearer ${key}` },
+          signal: AbortSignal.timeout(5000),
+        })
+        result = res.ok
+          ? { ok: true, detail: 'API key valid' }
+          : { ok: false, detail: `HTTP ${res.status}` }
+        break
+      }
+
+      case 'orcarouter': {
+        const key = getEffectiveEnvValue(envMap, 'ORCAROUTER_API_KEY')
+        if (!key) return NextResponse.json({ ok: false, detail: 'API key not set' })
+        const res = await fetch('https://api.orcarouter.ai/v1/models', {
           headers: { Authorization: `Bearer ${key}` },
           signal: AbortSignal.timeout(5000),
         })

--- a/src/components/onboarding/runtime-setup-modal.tsx
+++ b/src/components/onboarding/runtime-setup-modal.tsx
@@ -249,7 +249,7 @@ function HermesSetup({ onClose, onComplete }: { onClose: () => void; onComplete:
   const [error, setError] = useState<string | null>(null)
   const [hermesStatus, setHermesStatus] = useState<any>(null)
   const [providerKey, setProviderKey] = useState('')
-  const [providerType, setProviderType] = useState<'anthropic' | 'openai' | 'openrouter' | 'nous' | 'google' | 'xai'>('anthropic')
+  const [providerType, setProviderType] = useState<'anthropic' | 'openai' | 'openrouter' | 'orcarouter' | 'nous' | 'google' | 'xai'>('anthropic')
   const [selectedModel, setSelectedModel] = useState('claude-sonnet-4-6')
   const [customModel, setCustomModel] = useState('')
   const [authMethod, setAuthMethod] = useState<'api_key' | 'device_code'>('api_key')
@@ -449,6 +449,7 @@ function HermesSetup({ onClose, onComplete }: { onClose: () => void; onComplete:
               { id: 'anthropic', label: 'Anthropic', hint: 'Claude', env: 'ANTHROPIC_API_KEY', hermesProvider: 'anthropic', models: ['claude-sonnet-4-6', 'claude-opus-4-6', 'claude-haiku-4-5', 'claude-sonnet-4-5'] },
               { id: 'openai', label: 'OpenAI', hint: 'GPT / o-series / Codex', env: 'OPENAI_API_KEY', hermesProvider: 'openai-codex', oauthHermesProvider: 'openai-codex', supportsDeviceCode: true, models: ['gpt-4.1', 'gpt-4.1-mini', 'gpt-4.1-nano', 'o3', 'o4-mini', 'codex-mini-latest', 'gpt-5.3-codex'] },
               { id: 'openrouter', label: 'OpenRouter', hint: '200+ models', env: 'OPENROUTER_API_KEY', hermesProvider: 'openrouter', models: ['anthropic/claude-sonnet-4-6', 'openai/gpt-4.1', 'google/gemini-2.5-pro', 'meta-llama/llama-4-maverick', 'deepseek/deepseek-r1'] },
+              { id: 'orcarouter', label: 'OrcaRouter', hint: 'Smart-routed gateway', env: 'ORCAROUTER_API_KEY', hermesProvider: 'orcarouter', models: ['orcarouter/auto', 'orcarouter/fusion', 'orcarouter/fusion-flash', 'orcarouter/fusion-mini'] },
               { id: 'google', label: 'Google AI', hint: 'Gemini', env: 'GOOGLE_API_KEY', hermesProvider: 'google', models: ['gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-2.0-flash'] },
               { id: 'nous', label: 'Nous Portal', hint: 'Free tier', env: 'NOUS_API_KEY', hermesProvider: 'nous', models: ['hermes-3-llama-3.1-70b', 'hermes-3-llama-3.1-8b', 'deephermes-3-llama-3.3-70b'] },
               { id: 'xai', label: 'xAI', hint: 'Grok', env: 'XAI_API_KEY', hermesProvider: 'xai', models: ['grok-3', 'grok-3-mini', 'grok-2'] },
@@ -711,6 +712,7 @@ function HermesSetup({ onClose, onComplete }: { onClose: () => void; onComplete:
                     anthropic: 'ANTHROPIC_API_KEY',
                     openai: 'OPENAI_API_KEY',
                     openrouter: 'OPENROUTER_API_KEY',
+                    orcarouter: 'ORCAROUTER_API_KEY',
                     nous: 'NOUS_API_KEY',
                     google: 'GOOGLE_API_KEY',
                     xai: 'XAI_API_KEY',

--- a/src/lib/__tests__/hermes-route-security.test.ts
+++ b/src/lib/__tests__/hermes-route-security.test.ts
@@ -34,6 +34,7 @@ describe('Hermes route security boundary', () => {
 
   it('strictly validates action-specific bodies and secret sizes', () => {
     expect(hermesMutationSchema.safeParse({ action: 'set-env', key: 'OPENAI_API_KEY', value: 'key' }).success).toBe(true)
+    expect(hermesMutationSchema.safeParse({ action: 'set-env', key: 'ORCAROUTER_API_KEY', value: 'sk-orca-key' }).success).toBe(true)
     expect(hermesMutationSchema.safeParse({ action: 'set-env', key: 'PATH', value: '/tmp' }).success).toBe(false)
     expect(hermesMutationSchema.safeParse({ action: 'install-hook', unexpected: true }).success).toBe(false)
     expect(hermesMutationSchema.safeParse({ action: 'run-command', command: 'x'.repeat(501) }).success).toBe(false)

--- a/src/lib/hermes-route-security.ts
+++ b/src/lib/hermes-route-security.ts
@@ -9,7 +9,7 @@ export const hermesMutationSchema = z.discriminatedUnion('action', [
   z.object({ action: z.literal('uninstall-hook') }).strict(),
   z.object({
     action: z.literal('set-env'),
-    key: z.enum(['ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'OPENROUTER_API_KEY', 'NOUS_API_KEY', 'GOOGLE_API_KEY', 'XAI_API_KEY']),
+    key: z.enum(['ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'OPENROUTER_API_KEY', 'ORCAROUTER_API_KEY', 'NOUS_API_KEY', 'GOOGLE_API_KEY', 'XAI_API_KEY']),
     value: z.string().min(1).max(20_000),
   }).strict(),
   z.object({


### PR DESCRIPTION
# Summary

Add **[OrcaRouter](https://www.orcarouter.ai)** as a named LLM provider integration, mirroring the existing OpenRouter wiring. OrcaRouter is an OpenAI-compatible gateway that gives you a single endpoint with smart routing to 200+ frontier models (`orcarouter/auto`). It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

This adds OrcaRouter to the two places Mission Control registers LLM providers:

- **Integrations registry** (`src/app/api/integrations/route.ts`) — new `orcarouter` entry under *AI Providers* with its own `ORCAROUTER_API_KEY` env var, a 1Password vault item, and a `test` probe against `https://api.orcarouter.ai/v1/models` (same shape as the OpenRouter probe).
- **Hermes onboarding** (`src/components/onboarding/runtime-setup-modal.tsx`) — new selectable OrcaRouter provider card (`model.provider orcarouter`) with gateway models `orcarouter/auto`, `orcarouter/fusion`, `orcarouter/fusion-flash`, `orcarouter/fusion-mini`.
- **Hermes set-env allow-list** (`src/lib/hermes-route-security.ts`) — `ORCAROUTER_API_KEY` is now a permitted env var for the setup wizard, with a unit test covering it.

# Risk Level

Low — additive registry entries that mirror the existing OpenRouter provider exactly. No existing behavior or dispatch paths are touched.

# Evidence

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- Unit tests: `hermes-route-security.test.ts` + `runtime-configuration-isolation.test.ts` pass (11/11). The broader suite's failures are all better-sqlite3 native-binding failures in this container (no `make`/`gcc`); they reproduce identically on a clean checkout.
- Live check with a real key:
  - `GET https://api.orcarouter.ai/v1/models` (the probe path) → `HTTP 200`, `orcarouter/auto` present in the 205-model catalog
  - `POST https://api.orcarouter.ai/v1/chat/completions` with `orcarouter/auto` → `HTTP 200`

# Contribution Checklist

- [x] This PR has one reviewable purpose and no unrelated cleanup
- [x] Tests cover behavior changes and failure paths
- [x] `pnpm lint`, `pnpm typecheck`, and relevant tests pass
- [x] Auth, data scope, command execution, and secret handling were reviewed when touched
- [ ] Schema changes include forward migration and upgrade-path tests (no schema change)
- [x] Public text, logs, fixtures, screenshots, and commits contain no secrets or private data

# Notes

The `hermesProvider: 'orcarouter'` value is passed through to the Hermes Agent runtime's `model.provider` setting, exactly as `'openrouter'` and `'nous'` already are. No direct-dispatch changes are included — this is purely the named-provider registration surface.

Disclosure: I'm an engineer on the OrcaRouter team.
