### PR TITLE
fix: prevent Claude session wedging on first dispatch failure

### DIFF
--- a/src/lib/task-dispatch.ts
+++ b/src/lib/task-dispatch.ts
@@ -1076,6 +1076,13 @@ async function dispatchViaClaudeSession(
     })
     return response
   } catch (err) {
+    // If this was a first-dispatch create attempt that failed, mark the session
+    // as materialized anyway. This allows retry to resume instead of attempting
+    // create again with the same id, which would collision-loop forever (#934).
+    // The original error is preserved in the audit and thrown upward unchanged.
+    if (!base.materialized) {
+      markClaudeBaseSessionMaterialized(task.agent_id, base.sessionId)
+    }
     auditClaudeSessionDispatch({
       agentId: task.agent_id,
       baseSessionId: base.sessionId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #934

## Problem

When `runtime_type=claude`, the base session is marked as materialized only on success. If the first dispatch fails, the session remains unmarked, causing every retry to attempt creating with the same session ID, resulting in a permanent "Session ID already in use" wedge.

## Solution

Mark the base session as materialized even when the first create attempt fails. This allows subsequent retries to resume (`--resume --fork-session`) instead of attempting to create again with the colliding session ID.

## Changes

- Modified `dispatchViaClaudeSession` in `task-dispatch.ts` to call `markClaudeBaseSessionMaterialized` in the catch block when `base.materialized` is false
- Original error is preserved in the audit log and propagated unchanged
- Added inline comment explaining the fix and referencing issue #934

## Testing

- ✅ All existing tests pass
- ✅ `task-dispatch-claude-runtime.test.ts` - structural contract tests
- ✅ `claude-code-sessions.test.ts` - session lifecycle tests  
- ✅ `task-dispatch.test.ts` - dispatch behavior tests
- ✅ TypeScript type checking passes
- ✅ ESLint passes

## Success Criteria

- ✅ Failed first dispatch no longer permanently disables the agent
- ✅ Retry attempts resume instead of creating a colliding session
- ✅ Original error remains recorded in audit trail
- ✅ No fallback to API-key/gateway
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b35a8725-25c9-4c1e-ae1c-2402654fe59b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b35a8725-25c9-4c1e-ae1c-2402654fe59b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

