### PR TITLE
fix: use resolved CLI path for spawn on Windows (#933)

### DIFF
--- a/src/lib/__tests__/task-dispatch-cli-resolution.test.ts
+++ b/src/lib/__tests__/task-dispatch-cli-resolution.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Source-contract tests in the style of task-dispatch-claude-runtime.test.ts:
+// The #933 fix has ordering and path-use guarantees that are structural
+// properties of task-dispatch.ts. These assertions pin them so a refactor
+// cannot silently revert to spawning bare 'claude' when a concrete path was found.
+const source = readFileSync(join(process.cwd(), 'src', 'lib', 'task-dispatch.ts'), 'utf8')
+
+describe('CLI binary path resolution (#933)', () => {
+  it('defines getClaudeCliBinaryPath() that caches and returns the resolved path', () => {
+    expect(source).toContain('function getClaudeCliBinaryPath()')
+    expect(source).toContain('claudeCliBinaryPath: string | false | null')
+    
+    // Verify it checks Docker paths first
+    expect(source).toContain("'/home/nextjs/.local/bin/claude'")
+    expect(source).toContain("'/usr/local/bin/claude'")
+    expect(source).toContain("'/usr/bin/claude'")
+    
+    // Verify it checks Windows path
+    expect(source).toContain("'.local', 'bin', 'claude.exe'")
+    
+    // Verify it falls back to PATH check
+    expect(source).toContain("spawnSync('claude', ['--version']")
+    
+    // Verify it caches all outcomes (path string, or false)
+    expect(source).toContain('claudeCliBinaryPath = p')
+    expect(source).toContain('claudeCliBinaryPath = windowsPath')
+    expect(source).toContain("claudeCliBinaryPath = 'claude'")
+    expect(source).toContain('claudeCliBinaryPath = false')
+  })
+
+  it('defines getCodexCliBinaryPath() with similar structure', () => {
+    expect(source).toContain('function getCodexCliBinaryPath()')
+    expect(source).toContain('codexCliBinaryPath: string | false | null')
+    expect(source).toContain("spawnSync('codex', ['--version']")
+    expect(source).toContain("codexCliBinaryPath = 'codex'")
+    expect(source).toContain('codexCliBinaryPath = false')
+  })
+
+  it('isClaudeCliAvailable delegates to getClaudeCliBinaryPath', () => {
+    expect(source).toContain('function isClaudeCliAvailable()')
+    expect(source).toContain('return getClaudeCliBinaryPath() !== null')
+  })
+
+  it('isCodexCliAvailable delegates to getCodexCliBinaryPath', () => {
+    expect(source).toContain('function isCodexCliAvailable()')
+    expect(source).toContain('return getCodexCliBinaryPath() !== null')
+  })
+})
+
+describe('spawn uses resolved path (#933 regression)', () => {
+  it('verifies spawn receives the resolved path, not bare "claude"', () => {
+    // This is a source-level contract test similar to task-dispatch-claude-runtime.test.ts
+    const fs = require('node:fs')
+    const path = require('node:path')
+    const source = fs.readFileSync(
+      path.join(process.cwd(), 'src', 'lib', 'task-dispatch.ts'),
+      'utf8'
+    )
+
+    // Verify getClaudeCliBinaryPath exists and returns a path
+    expect(source).toContain('function getClaudeCliBinaryPath()')
+    expect(source).toContain('claudeCliBinaryPath = p')
+    expect(source).toContain('claudeCliBinaryPath = windowsPath')
+    expect(source).toContain("claudeCliBinaryPath = 'claude'")
+
+    // Verify spawn uses the resolved path
+    expect(source).toContain('const claudePath = getClaudeCliBinaryPath()')
+    expect(source).toContain('spawn(claudePath, args')
+
+    // Verify same pattern for codex
+    expect(source).toContain('function getCodexCliBinaryPath()')
+    expect(source).toContain('const codexPath = getCodexCliBinaryPath()')
+    expect(source).toContain('spawn(codexPath, args')
+  })
+
+  it('verifies availability check uses the same resolution logic', () => {
+    const fs = require('node:fs')
+    const path = require('node:path')
+    const source = fs.readFileSync(
+      path.join(process.cwd(), 'src', 'lib', 'task-dispatch.ts'),
+      'utf8'
+    )
+
+    // isClaudeCliAvailable must delegate to getClaudeCliBinaryPath
+    expect(source).toContain('function isClaudeCliAvailable()')
+    expect(source).toContain('return getClaudeCliBinaryPath() !== null')
+
+    // Same for codex
+    expect(source).toContain('function isCodexCliAvailable()')
+    expect(source).toContain('return getCodexCliBinaryPath() !== null')
+  })
+})

--- a/src/lib/task-dispatch.ts
+++ b/src/lib/task-dispatch.ts
@@ -870,27 +870,61 @@ function stripProviderPrefix(model: string): string {
  * the operator's existing login, plan, and rate limits without requiring
  * an `ANTHROPIC_API_KEY` to be exported into the container.
  */
-let claudeCliAvailableCache: boolean | null = null
-function isClaudeCliAvailable(): boolean {
+let claudeCliBinaryPath: string | false | null = null
+
+/**
+ * Resolve the Claude CLI binary path. Returns the absolute path when found
+ * at a known location, or 'claude' (bare command name) when it's in PATH.
+ * Prefers Docker paths, then Windows native install, then PATH resolution.
+ * Cached — spawnSync costs ~1s and existsSync results are stable per boot.
+ */
+function getClaudeCliBinaryPath(): string | null {
+  if (claudeCliBinaryPath !== null) {
+    return claudeCliBinaryPath || null
+  }
+
   try {
-    if (existsSync('/home/nextjs/.local/bin/claude')
-      || existsSync('/usr/local/bin/claude')
-      || existsSync('/usr/bin/claude')) return true
-    // Windows native install (~/.local/bin/claude.exe) or any PATH-resolvable
-    // binary: the container paths above never exist outside Docker, so fall
-    // back to actually resolving the CLI. Cached — spawnSync costs ~1s.
-    if (claudeCliAvailableCache !== null) return claudeCliAvailableCache
+    // Docker paths (preferred per #933 — container bind-mounts)
+    const dockerPaths = [
+      '/home/nextjs/.local/bin/claude',
+      '/usr/local/bin/claude',
+      '/usr/bin/claude',
+    ]
+    for (const p of dockerPaths) {
+      if (existsSync(p)) {
+        claudeCliBinaryPath = p
+        return p
+      }
+    }
+
+    // Windows native install (~/.local/bin/claude.exe)
     const os = require('node:os')
     const path = require('node:path')
-    if (existsSync(path.join(os.homedir(), '.local', 'bin', 'claude.exe'))) {
-      claudeCliAvailableCache = true
-      return true
+    const windowsPath = path.join(os.homedir(), '.local', 'bin', 'claude.exe')
+    if (existsSync(windowsPath)) {
+      claudeCliBinaryPath = windowsPath
+      return windowsPath
     }
+
+    // Try PATH resolution as fallback
     const { spawnSync } = require('node:child_process')
     const r = spawnSync('claude', ['--version'], { stdio: 'ignore', timeout: 5000 })
-    claudeCliAvailableCache = r.status === 0
-    return claudeCliAvailableCache
-  } catch { return false }
+    if (r.status === 0) {
+      // It's in PATH, use the bare name (let OS resolve)
+      claudeCliBinaryPath = 'claude'
+      return 'claude'
+    }
+
+    claudeCliBinaryPath = false
+    return null
+  } catch {
+    claudeCliBinaryPath = false
+    return null
+  }
+}
+
+function isClaudeCliAvailable(): boolean {
+  return getClaudeCliBinaryPath() !== null
 }
 
 /**
@@ -898,15 +932,34 @@ function isClaudeCliAvailable(): boolean {
  * OpenAI-model tasks can dispatch through `codex exec` without an
  * OPENAI_API_KEY — same idea as the Claude Code CLI path above.
  */
-let codexCliAvailableCache: boolean | null = null
-function isCodexCliAvailable(): boolean {
+let codexCliBinaryPath: string | false | null = null
+
+/**
+ * Resolve the Codex CLI binary path. Returns 'codex' (bare command name) when
+ * it's in PATH. Cached — spawnSync costs ~1s.
+ */
+function getCodexCliBinaryPath(): string | null {
+  if (codexCliBinaryPath !== null) {
+    return codexCliBinaryPath || null
+  }
+
   try {
-    if (codexCliAvailableCache !== null) return codexCliAvailableCache
     const { spawnSync } = require('node:child_process')
     const r = spawnSync('codex', ['--version'], { stdio: 'ignore', timeout: 5000 })
-    codexCliAvailableCache = r.status === 0
-    return codexCliAvailableCache
-  } catch { return false }
+    if (r.status === 0) {
+      codexCliBinaryPath = 'codex'
+      return 'codex'
+    }
+    codexCliBinaryPath = false
+    return null
+  } catch {
+    codexCliBinaryPath = false
+    return null
+  }
+}
+
+function isCodexCliAvailable(): boolean {
+  return getCodexCliBinaryPath() !== null
 }
 
 function isDirectDispatchAvailable(provider?: DirectProvider): boolean {
@@ -964,7 +1017,11 @@ async function callClaudeViaCli(
   )
 
   return await new Promise<AgentResponseParsed>((resolve, reject) => {
-    const proc = spawn('claude', args, {
+    const claudePath = getClaudeCliBinaryPath()
+    if (!claudePath) {
+      return reject(new Error('Claude CLI not available'))
+    }
+    const proc = spawn(claudePath, args, {
       stdio: ['pipe', 'pipe', 'pipe'],
       env: { ...process.env, CI: '1' },
       ...(sandbox.cwd ? { cwd: sandbox.cwd } : {}),
@@ -1184,7 +1241,11 @@ async function callCodexViaCli(
   )
 
   return await new Promise<AgentResponseParsed>((resolve, reject) => {
-    const proc = spawn('codex', args, {
+    const codexPath = getCodexCliBinaryPath()
+    if (!codexPath) {
+      return reject(new Error('Codex CLI not available'))
+    }
+    const proc = spawn(codexPath, args, {
       stdio: ['pipe', 'pipe', 'pipe'],
       env: { ...process.env },
       ...(dispatchCwd ? { cwd: dispatchCwd } : {}),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #933

## Problem
`runtime_type=claude` tasks fail with `spawn claude ENOENT` on Windows. Availability checks resolve an absolute path (`~/.local/bin/claude.exe`) but invocation does `spawn('claude', …)` by PATH name.

## Solution
When availability finds a concrete binary path, spawn uses that path instead of the bare command name.

### Changes
- Replace boolean availability caches with path caches (`string | false | null`)
- Add `getClaudeCliBinaryPath()` and `getCodexCliBinaryPath()` helpers that return the resolved path
- Update spawn calls in `callClaudeViaCli()` and `callCodexViaCli()` to use resolved paths
- Prefer Docker paths (`/home/nextjs/.local/bin/claude`) where applicable (per issue requirement)
- Add regression tests verifying spawn uses resolved paths (source-contract tests)

### Outcome
Same host: if availability is true, spawn uses that resolved path. Task can reach done/success when the CLI exists at the resolved path but not on PATH.

### No-Fallback Rule
The no-fallback rule remains unchanged: `runtime_type=claude` agents still refuse to fall back to less restrictive providers when CLI is unavailable.

### Tests
- All existing task-dispatch tests pass
- New regression test suite (`task-dispatch-cli-resolution.test.ts`) verifies:
  - Path resolution logic (Docker → Windows → PATH)
  - Spawn calls use resolved paths, not bare command names
  - Availability checks delegate to path resolution

### Verification
- ✅ Typecheck passes
- ✅ Lint passes
- ✅ All tests pass (50 tests across 5 test files)
- ✅ `postcss.config.js` unchanged (71 bytes)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-31cd1195-b591-46fb-8b57-479cf6aa1f1e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31cd1195-b591-46fb-8b57-479cf6aa1f1e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

