### PR TITLE
fix(install): install pnpm without root when corepack cannot write shims

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -121,9 +121,41 @@ check_prerequisites() {
   fi
   if [[ "$DEPLOY_MODE" == "local" ]] && ! command_exists pnpm; then
     info "Installing pnpm via corepack..."
-    corepack enable && corepack prepare pnpm@latest --activate
-    ok "pnpm installed"
+    install_pnpm || die "Could not install pnpm automatically. Install it manually (https://pnpm.io/installation) and re-run this script."
+    ok "pnpm installed ($(pnpm --version))"
   fi
+}
+
+# Install pnpm through corepack.
+#
+# `corepack enable` writes its shims next to the corepack binary, which for a
+# system-wide Node.js install is /usr/bin — so it fails with EACCES unless the
+# script runs as root. Fall back to a user-writable directory in that case.
+install_pnpm() {
+  # stderr is hidden on the first attempt: a failure here is expected on
+  # non-root installs and is handled by the fallback below.
+  if corepack enable 2>/dev/null && corepack prepare pnpm@latest --activate; then
+    hash -r
+    command_exists pnpm && return 0
+  fi
+
+  local user_bin="$HOME/.local/bin"
+  local path_before="$PATH"
+  warn "corepack could not install its shims system-wide (root required)"
+  info "Falling back to $user_bin"
+
+  mkdir -p "$user_bin"
+  corepack enable --install-directory "$user_bin" || return 1
+
+  export PATH="$user_bin:$PATH"
+  hash -r
+  corepack prepare pnpm@latest --activate || return 1
+  command_exists pnpm || return 1
+
+  case ":$path_before:" in
+    *":$user_bin:"*) ;;
+    *) warn "Add $user_bin to your PATH to use pnpm in new shells" ;;
+  esac
 }
 
 # ── Clone or update repo ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

On a Linux box with a system-wide Node.js, `bash install.sh --local` fails:

```
[MC] Installing pnpm via corepack...
Internal Error: EACCES: permission denied, symlink '../lib/node_modules/corepack/dist/pnpm.js' -> '/usr/bin/pnpm'
    at async Object.symlink (node:internal/fs/promises:1002:10)
    ...
[OK] pnpm installed
[MC] Running from existing clone at /home/simone/_Workspace/mission-control
[MC] Generating secure .env configuration...
[OK] Secure .env generated
[MC] Starting local deployment...
install.sh: line 239: pnpm: command not found
```

`corepack enable` installs its shims next to the corepack binary — `/usr/bin` when
`npm config get prefix` is `/usr` — so it needs root. The installer never runs as root,
so on any distro-packaged or NodeSource Node.js install this is the default outcome.

Two separate defects in `install.sh:123-125`:

```bash
corepack enable && corepack prepare pnpm@latest --activate
ok "pnpm installed"
```

1. **The failure is silent.** `corepack enable` exits 1 (verified), but bash `set -e`
   does not abort on a non-final command of an `&&` list:

   ```console
   $ bash -c 'set -euo pipefail; false && echo never; echo survived'; echo "exit=$?"
   survived
   exit=0
   ```

   And `ok "pnpm installed"` is a separate statement, outside the `&&`. So the installer
   prints a green `[OK]` for something that did not happen and runs for another ~100
   lines before dying with a confusing `pnpm: command not found`.

2. **There is no fallback** for the non-root case, which is the common one.

## Fix

Move the bootstrap into `install_pnpm()`:

- try `corepack enable` as before (stderr hidden — a failure here is expected and handled);
- on failure, retry with `corepack enable --install-directory "$HOME/.local/bin"`, which
  needs no privileges;
- prepend that directory to `PATH` for the rest of the run, and `warn` if it is not on the
  user's PATH for future shells;
- `die` with an actionable message if pnpm is still missing, instead of failing 100 lines later;
- print the version actually installed in the success line.

## Verification

`bash -n install.sh` clean; `shellcheck -S warning` reports only the pre-existing
`SC2034 MC_DATA_DIR`.

The function was exercised in isolation with a throwaway `$HOME` and `pnpm` removed from
`PATH`, on Linux Mint / Node v24.18.0 / corepack 0.35.0, npm prefix `/usr`:

```
[!!] corepack could not install its shims system-wide (root required)
[MC] Falling back to /tmp/tmp.hufGSdxAIq/home/.local/bin
Preparing pnpm@latest for immediate activation...
[!!] Add /tmp/tmp.hufGSdxAIq/home/.local/bin to your PATH to use pnpm in new shells
RESULT: OK -> /tmp/tmp.hufGSdxAIq/home/.local/bin/pnpm -> 10.29.3
```

10.29.3 is the repo's pinned `packageManager`, so the shim resolves the right pnpm.

After applying the same fix by hand, `bash install.sh --local` completed the install and
build on that machine.

## Notes

The root-writable path is unchanged, so `sudo bash install.sh --local` and CI behave exactly
as before. This only adds a fallback where the current code hard-fails.
