### PR TITLE
fix(env): write the credentials generate-env.sh prints

### DIFF
--- a/scripts/generate-env.sh
+++ b/scripts/generate-env.sh
@@ -52,6 +52,7 @@ generate_hex() {
   fi
 }
 
+AUTH_USER="admin"
 AUTH_PASS="$(generate_password 24)"
 API_KEY="$(generate_hex 32)"
 AUTH_SECRET="$(generate_password 32)"
@@ -72,16 +73,29 @@ portable_sed() {
   fi
 }
 
+# Set KEY=VALUE in the generated file, uncommenting the key if needed: these
+# keys ship commented out in .env.example, so anchoring on "^KEY=" alone never
+# matches and the substitution is a silent no-op.
+set_env_var() {
+  local key="$1" value="$2" file="$3"
+  portable_sed "s|^#\{0,1\}[[:space:]]*${key}=.*|${key}=$(sed_escape "$value")|" "$file"
+  if ! grep -q "^${key}=" "$file"; then
+    echo "Error: could not set $key in $file (no '$key=' line in .env.example?)" >&2
+    exit 1
+  fi
+}
+
 # Replace the insecure defaults with generated values
-portable_sed "s|^AUTH_PASS=.*|AUTH_PASS=$(sed_escape "$AUTH_PASS")|" "$OUTPUT"
-portable_sed "s|^API_KEY=.*|API_KEY=$(sed_escape "$API_KEY")|" "$OUTPUT"
-portable_sed "s|^AUTH_SECRET=.*|AUTH_SECRET=$(sed_escape "$AUTH_SECRET")|" "$OUTPUT"
+set_env_var AUTH_USER "$AUTH_USER" "$OUTPUT"
+set_env_var AUTH_PASS "$AUTH_PASS" "$OUTPUT"
+set_env_var API_KEY "$API_KEY" "$OUTPUT"
+set_env_var AUTH_SECRET "$AUTH_SECRET" "$OUTPUT"
 
 # Lock down permissions
 chmod 600 "$OUTPUT"
 
 echo "Generated secure .env at $OUTPUT"
-echo "  AUTH_USER: admin"
+echo "  AUTH_USER: $AUTH_USER"
 echo "  AUTH_PASS: $AUTH_PASS"
 echo "  API_KEY:   $API_KEY"
 echo ""


### PR DESCRIPTION
## Problem

`scripts/generate-env.sh` copies `.env.example` and then rewrites the secrets:

```bash
portable_sed "s|^AUTH_PASS=.*|AUTH_PASS=$(sed_escape "$AUTH_PASS")|" "$OUTPUT"
portable_sed "s|^API_KEY=.*|API_KEY=$(sed_escape "$API_KEY")|" "$OUTPUT"
portable_sed "s|^AUTH_SECRET=.*|AUTH_SECRET=$(sed_escape "$AUTH_SECRET")|" "$OUTPUT"
```

But in `.env.example` those keys ship **commented out** (lines 20-29):

```
# AUTH_USER=admin
# AUTH_PASS=your-strong-password-here
# API_KEY=
# AUTH_SECRET=
```

`^AUTH_PASS=` does not match `# AUTH_PASS=`. All three substitutions are silent no-ops,
and the script goes straight on to print:

```
Generated secure .env at /path/.env
  AUTH_USER: admin
  AUTH_PASS: aSsP99GQTlF0t0gRAlppjBBW
  API_KEY:   c87d774e76b174fb7f55de819ae1995d

Save these credentials — they are not stored elsewhere.
```

That last line is accurate in a way it does not intend: the values are nowhere. The
generated `.env` still has all four keys commented out.

Reproduced on a fresh clone at 5483a0e via `bash install.sh --local`:

- `grep -nE '^ *#? *(AUTH_USER|AUTH_PASS|API_KEY|AUTH_SECRET)=' .env` → lines 20, 21, 26, 29,
  all still commented;
- the printed API key string appears neither in `.env` nor in `.data/.auto-generated`
  (the app generated its own at first boot).

## Why it matters

- **The printed admin password does not work.** `src/lib/auth.ts:377` seeds the admin from
  `AUTH_USER`/`AUTH_PASS` only if they are set; they are not, so the only way in is `/setup`.
  A user who saved those credentials is locked out with no explanation.
- **The app rates this critical.** `src/lib/security-scan.ts:250` reports a missing
  `AUTH_PASS` as `severity: 'critical'` — after running the script whose job was to set it.
- **The Settings panel points at this same script as the fix.**
  `messages/en.json:366`: *"Not set — agents won't be able to dock without a configured key.
  Run: `bash scripts/generate-env.sh --force`"*. Running it does not set the key.
- `docs/SECURITY-HARDENING.md:32` documents it as *"Generates .env with random secrets"*.

## Fix

Replace the three substitutions with a `set_env_var` helper that:

- matches the commented form as well (`^#\{0,1\}[[:space:]]*KEY=`), so the key is uncommented
  and set in one pass;
- **verifies** the key is present afterwards and exits with a clear error if not, instead of
  silently doing nothing when `.env.example` changes shape again;
- also writes `AUTH_USER`, which the script already claims to set in its output.

Only the substitution block changes; generation, `chmod 600` and the printed summary are untouched.

## Verification

`bash -n` clean, `shellcheck -S warning` reports nothing.

Before (main): all keys still commented after running the script.
After, generating into a throwaway path:

```
$ bash scripts/generate-env.sh /tmp/env.test
Generated secure .env at /tmp/env.test
  AUTH_USER: admin
  AUTH_PASS: <redacted>
  API_KEY:   <redacted>

$ grep -nE '^(AUTH_USER|AUTH_PASS|API_KEY|AUTH_SECRET)=' /tmp/env.test
20:AUTH_USER=...
21:AUTH_PASS=...
26:API_KEY=...
29:AUTH_SECRET=...
```

The printed `AUTH_PASS` and `API_KEY` were compared byte for byte against the values in the
generated file — they match. Permissions are still `-rw-------`.

The guard was exercised separately with a key absent from the template:

```
Error: could not set NON_ESISTE in /tmp/guard.env (no 'NON_ESISTE=' line in .env.example?)
exit 1
```

## Note

An alternative fix is to uncomment the four keys in `.env.example` instead. I went with the
script side so the template keeps documenting them as optional, and so the failure becomes
loud rather than silent if the template drifts again. Happy to switch if you prefer the other shape.
