### PR TITLE
fix: reconnect the OpenClaw gateway instantly on launch and refresh

### DIFF
--- a/src/app/[[...panel]]/page.tsx
+++ b/src/app/[[...panel]]/page.tsx
@@ -145,10 +145,10 @@ export default function Home() {
   }
 
   useEffect(() => {
-    if (!bootComplete && initSteps.every(s => s.status === 'done')) {
+    if (!bootComplete && stepStatuses.auth === 'done') {
       setBootComplete()
     }
-  }, [initSteps, bootComplete, setBootComplete])
+  }, [stepStatuses.auth, bootComplete, setBootComplete])
 
   // Security console warning (anti-self-XSS)
   useEffect(() => {
@@ -326,22 +326,15 @@ export default function Home() {
           }
           setCapabilitiesChecked(true)
           markStep('capabilities')
-          const primaryConnect = await connectWithPrimaryGateway(localGatewayUrl)
-          if (!primaryConnect.connected) {
-            connect(localGatewayUrl)
-          }
-          markStep('connect')
           return
         }
 
-        // No user-chosen URL — use server's gateway flag to decide
+        // A missed TCP probe is "unknown", not "no gateway". Keep retrying WS.
         if (data && data.gateway === false) {
           setDashboardMode('local')
           setGatewayAvailable(false)
           setCapabilitiesChecked(true)
           markStep('capabilities')
-          markStep('connect')
-          // Skip WebSocket connect — no gateway to talk to
           return
         }
         if (data && data.gateway === true) {
@@ -353,21 +346,22 @@ export default function Home() {
         }
         setCapabilitiesChecked(true)
         markStep('capabilities')
-
-        // No user choice + server gateway flag false → try primary gateway / env fallback
-        const primaryConnect = await connectWithPrimaryGateway()
-        if (!primaryConnect.connected && !primaryConnect.attempted) {
-          connectWithEnvFallback(null)
-        }
-        markStep('connect')
       })
       .catch(() => {
-        // If capabilities check fails, still try to connect
         setCapabilitiesChecked(true)
         markStep('capabilities')
-        markStep('connect')
-        connectWithEnvFallback(null)
       })
+
+    void connectWithPrimaryGateway(typeof window !== 'undefined' ? localStorage.getItem(STORAGE_GATEWAY_URL) : null)
+      .then((primaryConnect) => {
+        if (!primaryConnect.connected && !primaryConnect.attempted) {
+          connectWithEnvFallback(typeof window !== 'undefined' ? localStorage.getItem(STORAGE_GATEWAY_URL) : null)
+        }
+      })
+      .catch(() => {
+        connectWithEnvFallback(typeof window !== 'undefined' ? localStorage.getItem(STORAGE_GATEWAY_URL) : null)
+      })
+      .finally(() => { markStep('connect') })
 
     // Check onboarding state.
     // Original mapped non-ok → data=null → getOnboardingSessionDecision with all-false
@@ -401,38 +395,32 @@ export default function Home() {
     // setter. apiFetch throws on non-ok instead; the rejection is absorbed by
     // Promise.allSettled and the guarded .then is skipped — same net effect (no setter,
     // step still marked via .finally / pre-fetch markStep). Panels lazy-load as fallback.
+    markStep('agents')
+    markStep('sessions')
+    markStep('projects')
+    markStep('memory')
+    markStep('skills')
     Promise.allSettled([
       apiFetch<{ agents?: unknown }>('/api/agents')
         .then((agentsData) => {
           if (agentsData?.agents) setAgents(agentsData.agents as Parameters<typeof setAgents>[0])
-        })
-        .finally(() => { markStep('agents') }),
-      // Sessions can be slow with many JSONL files — don't block boot
-      (() => {
-        markStep('sessions')
-        return apiFetch<{ sessions?: unknown }>('/api/sessions')
-          .then((sessionsData) => {
-            if (sessionsData?.sessions) setSessions(sessionsData.sessions as Parameters<typeof setSessions>[0])
-          })
-      })(),
+        }),
+      apiFetch<{ sessions?: unknown }>('/api/sessions')
+        .then((sessionsData) => {
+          if (sessionsData?.sessions) setSessions(sessionsData.sessions as Parameters<typeof setSessions>[0])
+        }),
       apiFetch<{ projects?: unknown }>('/api/projects')
         .then((projectsData) => {
           if (projectsData?.projects) setProjects(projectsData.projects as Parameters<typeof setProjects>[0])
-        })
-        .finally(() => { markStep('projects') }),
-      // Memory graph can be slow — don't block boot
-      (() => {
-        markStep('memory')
-        return apiFetch<{ agents?: unknown }>('/api/memory/graph?agent=all')
-          .then((graphData) => {
-            if (graphData?.agents) setMemoryGraphAgents(graphData.agents as Parameters<typeof setMemoryGraphAgents>[0])
-          })
-      })(),
+        }),
+      apiFetch<{ agents?: unknown }>('/api/memory/graph?agent=all')
+        .then((graphData) => {
+          if (graphData?.agents) setMemoryGraphAgents(graphData.agents as Parameters<typeof setMemoryGraphAgents>[0])
+        }),
       apiFetch<{ skills?: unknown; groups?: unknown; total?: unknown }>('/api/skills')
         .then((skillsData) => {
           if (skillsData?.skills) setSkillsData(skillsData.skills as Parameters<typeof setSkillsData>[0], (skillsData.groups || []) as Parameters<typeof setSkillsData>[1], (skillsData.total || 0) as number)
-        })
-        .finally(() => { markStep('skills') }),
+        }),
     ]).catch(() => { /* panels will lazy-load as fallback */ })
 
   // eslint-disable-next-line react-hooks/exhaustive-deps -- boot once on mount, not on every pathname change

--- a/src/app/api/gateways/connect/route.ts
+++ b/src/app/api/gateways/connect/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { requireRole, ROLE_LEVELS } from '@/lib/auth'
 import { getDatabase } from '@/lib/db'
 import { buildGatewayWebSocketUrl } from '@/lib/gateway-url'
-import { getDetectedGatewayToken } from '@/lib/gateway-runtime'
+import { getDetectedGatewayToken, isUsableGatewayToken } from '@/lib/gateway-runtime'
 import { denyUnscopedResourceForStrictWorkspace } from '@/lib/workspace-isolation'
 import {
   isTailscaleServe,
@@ -169,10 +169,12 @@ export async function POST(request: NextRequest) {
 
   const dbToken = (gateway.token || '').trim()
   const detectedToken = gateway.is_primary === 1 ? getDetectedGatewayToken() : ''
-  const token = detectedToken || dbToken
+  const token = isUsableGatewayToken(detectedToken)
+    ? detectedToken
+    : (isUsableGatewayToken(dbToken) ? dbToken : '')
 
   // Keep runtime DB aligned with detected OpenClaw gateway token for primary gateway.
-  if (gateway.is_primary === 1 && detectedToken && detectedToken !== dbToken) {
+  if (gateway.is_primary === 1 && isUsableGatewayToken(detectedToken) && detectedToken !== dbToken) {
     try {
       db.prepare('UPDATE gateways SET token = ?, updated_at = (unixepoch()) WHERE id = ?').run(detectedToken, gateway.id)
     } catch {

--- a/src/app/api/openclaw/doctor/route.ts
+++ b/src/app/api/openclaw/doctor/route.ts
@@ -63,7 +63,7 @@ interface DoctorCacheModule {
 const doctorCache: DoctorCacheModule = (() => {
   // Allow operators to tune the TTL (e.g. CI smoke tests set it to 0).
   const fromEnv = Number.parseInt(process.env.MC_DOCTOR_TTL_MS || '', 10)
-  const ttlMs = Number.isFinite(fromEnv) && fromEnv >= 0 ? fromEnv : 30_000
+  const ttlMs = Number.isFinite(fromEnv) && fromEnv >= 0 ? fromEnv : 300_000
   return { cached: null, inFlight: null, ttlMs }
 })()
 
@@ -74,9 +74,9 @@ function invalidateDoctorCache(): void {
 
 async function runAndCacheDoctor(): Promise<CachedDoctor> {
   try {
-    const result = await runOpenClaw(['doctor'], { timeoutMs: 15000 })
+    const result = await runOpenClaw(['doctor'], { timeoutMs: 30000 })
     const payload = parseOpenClawDoctorOutput(
-      `${result.stdout}\n${result.stderr}`,
+      result.stdout,
       result.code ?? 0,
       { stateDir: config.openclawStateDir },
     )
@@ -86,9 +86,6 @@ async function runAndCacheDoctor(): Promise<CachedDoctor> {
   } catch (error) {
     const { detail, code } = getCommandDetail(error)
     if (isMissingOpenClaw(detail)) {
-      // Don't cache "not installed" — the operator may install OpenClaw and
-      // we want the next poll to pick that up immediately rather than waiting
-      // out the TTL.
       const entry: CachedDoctor = {
         payload: { error: 'OpenClaw is not installed or not reachable' },
         status: 400,
@@ -96,11 +93,11 @@ async function runAndCacheDoctor(): Promise<CachedDoctor> {
       }
       return entry
     }
-    const payload = parseOpenClawDoctorOutput(detail, code ?? 1, {
+    const err = error as { stdout?: string; stderr?: string }
+    const raw = [err.stdout, err.stderr].filter(Boolean).join('\n').trim() || detail.replace(/^Command failed[^:]*:\s*/i, '')
+    const payload = parseOpenClawDoctorOutput(raw, code ?? 1, {
       stateDir: config.openclawStateDir,
     })
-    // Cache the parsed-error payload (status 200) so a flapping doctor doesn't
-    // re-spawn on every poll. The payload itself carries the failure detail.
     const entry: CachedDoctor = { payload, status: 200, fetchedAt: Date.now() }
     doctorCache.cached = entry
     return entry

--- a/src/app/api/status/route.ts
+++ b/src/app/api/status/route.ts
@@ -10,7 +10,7 @@ import { getAllGatewaySessions, getAgentLiveStatuses } from '@/lib/sessions'
 import { requireRole } from '@/lib/auth'
 import { MODEL_CATALOG } from '@/lib/models'
 import { logger } from '@/lib/logger'
-import { detectProviderSubscriptions, getPrimarySubscription } from '@/lib/provider-subscriptions'
+import { detectProviderSubscriptions } from '@/lib/provider-subscriptions'
 import { APP_VERSION } from '@/lib/version'
 import { isHermesInstalled, scanHermesSessions } from '@/lib/hermes-sessions'
 import { registerMcAsDashboard } from '@/lib/gateway-runtime'
@@ -658,8 +658,12 @@ async function getCapabilities(request?: NextRequest, includeGlobalRuntime = tru
     }
   }
 
-  const subscriptions = detectProviderSubscriptions().active
-  const primary = getPrimarySubscription()
+  const detectedSubscriptions = detectProviderSubscriptions(false, false).active ?? {}
+  const subscriptions = detectedSubscriptions
+  const primary = detectedSubscriptions.anthropic
+    || detectedSubscriptions.openai
+    || Object.values(detectedSubscriptions)[0]
+    || null
   const subscription = primary ? {
     type: primary.type,
     provider: primary.provider,
@@ -728,7 +732,7 @@ async function getCapabilities(request?: NextRequest, includeGlobalRuntime = tru
 function isPortOpen(host: string, port: number): Promise<boolean> {
   return new Promise((resolve) => {
     const socket = new net.Socket()
-    const timeoutMs = 1500
+    const timeoutMs = 200
 
     const cleanup = () => {
       socket.removeAllListeners()

--- a/src/components/layout/openclaw-doctor-banner.tsx
+++ b/src/components/layout/openclaw-doctor-banner.tsx
@@ -55,7 +55,13 @@ export function OpenClawDoctorBanner() {
   }
 
   useEffect(() => {
-    void loadDoctorStatus()
+    const start = () => { void loadDoctorStatus() }
+    if (typeof window.requestIdleCallback === 'function') {
+      const idle = window.requestIdleCallback(start, { timeout: 8000 })
+      return () => window.cancelIdleCallback(idle)
+    }
+    const timer = window.setTimeout(start, 2500)
+    return () => window.clearTimeout(timer)
   }, [])
 
   async function handleFix() {

--- a/src/lib/__tests__/gateway-runtime.test.ts
+++ b/src/lib/__tests__/gateway-runtime.test.ts
@@ -84,4 +84,18 @@ describe('registerMcAsDashboard', () => {
     expect(readFileSync(configPath, 'utf8')).toContain('https://mc.example.com')
     expect(() => readFileSync(`${configPath}.mc-lock`, 'utf8')).toThrow()
   })
+
+  it('adds localhost and 127.0.0.1 origin twins together', async () => {
+    writeFileSync(configPath, JSON.stringify({ gateway: { controlUi: { allowedOrigins: [] } } }), 'utf8')
+    const { registerMcAsDashboard } = await import('@/lib/gateway-runtime')
+    expect(registerMcAsDashboard('http://127.0.0.1:3000')).toEqual({
+      registered: true,
+      alreadySet: false,
+    })
+    const updated = JSON.parse(readFileSync(configPath, 'utf8'))
+    expect(updated.gateway.controlUi.allowedOrigins).toEqual([
+      'http://127.0.0.1:3000',
+      'http://localhost:3000',
+    ])
+  })
 })

--- a/src/lib/__tests__/gateway-token.test.ts
+++ b/src/lib/__tests__/gateway-token.test.ts
@@ -1,0 +1,61 @@
+import { mkdtempSync, rmSync, mkdirSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import Database from 'better-sqlite3'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  isUsableGatewayToken,
+  readSecretRefId,
+  resolveGatewayCredential,
+} from '@/lib/gateway-token'
+
+describe('gateway token resolution', () => {
+  let tempDir = ''
+
+  afterEach(() => {
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true })
+    tempDir = ''
+  })
+
+  it('rejects object-stringified and secret-ref JSON tokens', () => {
+    expect(isUsableGatewayToken('[object Object]')).toBe(false)
+    expect(isUsableGatewayToken('{"source":"store","id":"OPENCLAW_GATEWAY_TOKEN"}')).toBe(false)
+    expect(isUsableGatewayToken('short')).toBe(false)
+    expect(isUsableGatewayToken('gateway-token-value-ok')).toBe(true)
+  })
+
+  it('reads a SecretRef id without stringifying the object', () => {
+    expect(readSecretRefId({ source: 'store', id: 'OPENCLAW_GATEWAY_TOKEN' })).toBe('OPENCLAW_GATEWAY_TOKEN')
+    expect(readSecretRefId('plaintext')).toBe('')
+  })
+
+  it('resolves env SecretRefs and ignores object stringification', () => {
+    const env = { OPENCLAW_GATEWAY_TOKEN: 'env-token-from-ref-ok' }
+    expect(resolveGatewayCredential({ source: 'env', id: 'OPENCLAW_GATEWAY_TOKEN' }, env, '/tmp/mc-missing-openclaw-state')).toBe('env-token-from-ref-ok')
+    expect(resolveGatewayCredential({ source: 'store', provider: 'default', id: 'OPENCLAW_GATEWAY_TOKEN' }, {}, '/tmp/mc-missing-openclaw-state')).toBe('')
+  })
+
+  it('resolves store SecretRefs from the OpenClaw sqlite secret table', () => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), 'mc-gateway-token-'))
+    const stateDir = path.join(tempDir, 'state')
+    mkdirSync(stateDir, { recursive: true })
+    const db = new Database(path.join(tempDir, 'state', 'openclaw.sqlite'))
+    db.exec(`
+      CREATE TABLE secret_store_entries (
+        name TEXT PRIMARY KEY,
+        value TEXT,
+        deleted_at_ms INTEGER
+      )
+    `)
+    db.prepare('INSERT INTO secret_store_entries (name, value, deleted_at_ms) VALUES (?, ?, NULL)')
+      .run('OPENCLAW_GATEWAY_TOKEN', 'store-token-from-sqlite-ok')
+    db.close()
+
+    const resolved = resolveGatewayCredential(
+      { source: 'store', provider: 'default', id: 'OPENCLAW_GATEWAY_TOKEN' },
+      {},
+      tempDir,
+    )
+    expect(resolved).toBe('store-token-from-sqlite-ok')
+  })
+})

--- a/src/lib/__tests__/openclaw-doctor.test.ts
+++ b/src/lib/__tests__/openclaw-doctor.test.ts
@@ -120,6 +120,42 @@ Run "openclaw doctor --fix" to apply changes.
     expect(result.canFix).toBe(false)
   })
 
+  it('ignores informational Codex, OAuth-skip, and browser cookie notes', () => {
+    const result = parseOpenClawDoctorOutput(`
+┌  OpenClaw doctor
+◇  Doctor info
+- Personal Codex CLI assets found (64 skills, 51 plugins, 1 config file) in ~/.codex
+- To review or promote them: install the Codex plugin (openclaw plugins install npm:@openclaw/codex)
+◇  State integrity
+- OAuth dir not present (~/.openclaw/credentials). Skipping create because no WhatsApp/pairing channel config is active.
+◇  Browser
+- System browser profile cookie import is enabled (browser.allowSystemProfileImport).
+- Importable Chrome-family profile cookie databases found: 4.
+- Doctor does not access the macOS Keychain; importing asks for consent separately.
+Fix: set commands.ownerAllowFrom to your channel user id
+└  Doctor complete.
+`, 0)
+
+    expect(result.healthy).toBe(true)
+    expect(result.level).toBe('healthy')
+    expect(result.issues).toEqual([])
+  })
+
+  it('ignores unused session-logs skill tips and doctor-complete', () => {
+    const result = parseOpenClawDoctorOutput(`
+┌  OpenClaw doctor
+◇  Skills
+│  Agent "claude-20x":
+│  1 allowed skill is not usable in this environment (missing binaries).
+│  - session-logs
+│  Disable unused skills: openclaw doctor --fix
+└  Doctor complete.
+`, 0)
+
+    expect(result.healthy).toBe(true)
+    expect(result.issues).toEqual([])
+  })
+
   it('treats positive security lines as healthy, not warnings (#331)', () => {
     const result = parseOpenClawDoctorOutput(`
 ? Security
@@ -145,5 +181,65 @@ Run "openclaw doctor --fix" to apply changes.
     expect(result.issues).toEqual([
       'Channel "public" has no auth configured.',
     ])
+  })
+
+  it('treats boxed informational doctor notes as healthy', () => {
+    const result = parseOpenClawDoctorOutput(`
+┌  OpenClaw doctor
+│
+◇  Doctor info ────────────────────────────────────────────────────────────╮
+│                                                                          │
+│  - Personal Codex CLI assets found (64 skills, 52 plugins, 1 config      │
+│    file, 0 hook files) in /Users/tylerdevries/.codex and                 │
+│    /Users/tylerdevries/.agents/skills; native Codex-mode agents use      │
+│    isolated per-agent homes and will not load them.                      │
+│  - To review or promote them: install the Codex plugin (openclaw         │
+│    plugins install npm:@openclaw/codex), then run openclaw migrate plan  │
+│    codex.                                                                │
+│                                                                          │
+◇  Browser ─────────────────────────────────────────────────────────╮
+│                                                                   │
+│  - System browser profile cookie import is disabled               │
+│    (browser.allowSystemProfileImport).                            │
+│  - Importable Chrome-family profile cookie databases found: 4.    │
+│  - Doctor does not access the macOS Keychain; importing asks for  │
+│    consent separately.                                            │
+│                                                                   │
+└  Doctor complete.
+[skills] Skill precedence collision: skill="obsidian" winner=openclaw-managed
+`, 0)
+
+    expect(result.healthy).toBe(true)
+    expect(result.level).toBe('healthy')
+    expect(result.issues).toEqual([])
+  })
+
+  it('stays healthy when the Clack title is Doctor warnings but every bullet is informational', () => {
+    const result = parseOpenClawDoctorOutput(`
+◇  Doctor warnings
+- Personal Codex CLI assets found (64 skills, 52 plugins, 1 config │
+- To review or promote them: install the Codex plugin
+- System browser profile cookie import is disabled │
+- Importable Chrome-family profile cookie databases found: 4.
+- Doctor does not access the macOS Keychain
+└  Doctor complete.
+`, 0)
+
+    expect(result.healthy).toBe(true)
+    expect(result.issues).toEqual([])
+    expect(result.canFix).toBe(false)
+  })
+
+  it('does not treat a Command failed wrapper as an error when findings are informational', () => {
+    const result = parseOpenClawDoctorOutput(`
+Command failed (openclaw doctor):
+◇  Doctor info
+- Personal Codex CLI assets found (64 skills, 52 plugins, 1 config file)
+└  Doctor complete.
+`, 1)
+
+    expect(result.healthy).toBe(true)
+    expect(result.level).toBe('healthy')
+    expect(result.issues).toEqual([])
   })
 })

--- a/src/lib/__tests__/websocket-utils.test.ts
+++ b/src/lib/__tests__/websocket-utils.test.ts
@@ -4,6 +4,7 @@ import {
   readErrorDetailCode,
   isNonRetryableErrorCode,
   calculateBackoff,
+  calculateReconnectDelay,
   detectSequenceGap,
   NON_RETRYABLE_ERROR_CODES,
   shouldRetryWithoutDeviceIdentity,
@@ -86,6 +87,7 @@ describe('isNonRetryableErrorCode', () => {
       'AUTH_TOKEN_MISSING',
       'AUTH_PASSWORD_MISSING',
       'AUTH_PASSWORD_MISMATCH',
+      'AUTH_TOKEN_MISMATCH',
       'AUTH_RATE_LIMITED',
       'ORIGIN_NOT_ALLOWED',
       'DEVICE_SIGNATURE_INVALID',
@@ -95,8 +97,8 @@ describe('isNonRetryableErrorCode', () => {
     }
   })
 
-  it('returns false for AUTH_TOKEN_MISMATCH (retryable)', () => {
-    expect(isNonRetryableErrorCode('AUTH_TOKEN_MISMATCH')).toBe(false)
+  it('treats AUTH_TOKEN_MISMATCH as non-retryable', () => {
+    expect(isNonRetryableErrorCode('AUTH_TOKEN_MISMATCH')).toBe(true)
   })
 
   it('returns false for unknown codes', () => {
@@ -125,6 +127,17 @@ describe('calculateBackoff', () => {
     expect(calculateBackoff(10)).toBe(15000)
     expect(calculateBackoff(20)).toBe(15000)
     expect(calculateBackoff(100)).toBe(15000)
+  })
+})
+
+describe('calculateReconnectDelay', () => {
+  it('retries immediately on the first attempt', () => {
+    expect(calculateReconnectDelay(0)).toBe(0)
+  })
+
+  it('uses backoff after the first retry', () => {
+    expect(calculateReconnectDelay(1)).toBe(1000)
+    expect(calculateReconnectDelay(2)).toBeCloseTo(1700, 0)
   })
 })
 
@@ -238,7 +251,7 @@ describe('ConnectErrorDetailCodes', () => {
     }
   })
 
-  it('NON_RETRYABLE_ERROR_CODES does not include AUTH_TOKEN_MISMATCH', () => {
-    expect(NON_RETRYABLE_ERROR_CODES.has('AUTH_TOKEN_MISMATCH')).toBe(false)
+  it('NON_RETRYABLE_ERROR_CODES includes AUTH_TOKEN_MISMATCH', () => {
+    expect(NON_RETRYABLE_ERROR_CODES.has('AUTH_TOKEN_MISMATCH')).toBe(true)
   })
 })

--- a/src/lib/gateway-runtime.ts
+++ b/src/lib/gateway-runtime.ts
@@ -2,6 +2,21 @@ import fs from 'node:fs'
 import { config } from '@/lib/config'
 import { logger } from '@/lib/logger'
 import { acquireFileLockSync, atomicReplaceFileSync } from '@/lib/atomic-file'
+import { cachedGatewayToken, isUsableGatewayToken, resolveGatewayCredential } from '@/lib/gateway-token'
+
+export { isUsableGatewayToken } from '@/lib/gateway-token'
+
+export function dashboardOriginAliases(mcUrl: string): string[] {
+  const parsed = new URL(mcUrl)
+  const hosts = new Set([parsed.hostname])
+  if (parsed.hostname === 'localhost') hosts.add('127.0.0.1')
+  if (parsed.hostname === '127.0.0.1') hosts.add('localhost')
+  return [...hosts].map((hostname) => {
+    const alias = new URL(parsed.href)
+    alias.hostname = hostname
+    return alias.origin
+  })
+}
 
 interface OpenClawGatewayConfig {
   gateway?: {
@@ -44,22 +59,20 @@ export function registerMcAsDashboard(mcUrl: string): { registered: boolean; alr
     if (!parsed.gateway) parsed.gateway = {}
     if (!parsed.gateway.controlUi) parsed.gateway.controlUi = {}
 
-    const origin = new URL(mcUrl).origin
+    const aliases = dashboardOriginAliases(mcUrl)
     const origins: string[] = parsed.gateway.controlUi.allowedOrigins || []
-    const alreadyInOrigins = origins.includes(origin)
+    const missing = aliases.filter((origin) => !origins.includes(origin))
 
-    if (alreadyInOrigins) {
+    if (missing.length === 0) {
       return { registered: false, alreadySet: true }
     }
 
-    // Add MC origin to allowedOrigins only — do NOT touch dangerouslyDisableDeviceAuth.
-    // MC authenticates via gateway token, but forcing device auth off is a security
-    // downgrade that the operator should control, not Mission Control.
-    origins.push(origin)
+    // Add MC origin aliases only — do NOT touch dangerouslyDisableDeviceAuth.
+    origins.push(...missing)
     parsed.gateway.controlUi.allowedOrigins = origins
 
     atomicReplaceFileSync(configPath, JSON.stringify(parsed, null, 2) + '\n')
-    logger.info({ origin }, 'Registered MC origin in gateway config')
+    logger.info({ origins: missing }, 'Registered MC origin in gateway config')
     return { registered: true, alreadySet: false }
   } catch (err: any) {
     // Read-only filesystem (e.g. Docker read_only: true, or intentional mount) —
@@ -86,23 +99,24 @@ export function registerMcAsDashboard(mcUrl: string): { registered: boolean; alr
  * From config: uses gateway.auth.token when mode is "token", gateway.auth.password when mode is "password".
  */
 export function getDetectedGatewayToken(): string {
-  const envToken = (process.env.OPENCLAW_GATEWAY_TOKEN || process.env.GATEWAY_TOKEN || '').trim()
-  if (envToken) return envToken
-  
-  const envPassword = (process.env.OPENCLAW_GATEWAY_PASSWORD || process.env.GATEWAY_PASSWORD || '').trim()
-  if (envPassword) return envPassword
+  return cachedGatewayToken(() => {
+    const envToken = (process.env.OPENCLAW_GATEWAY_TOKEN || process.env.GATEWAY_TOKEN || '').trim()
+    if (isUsableGatewayToken(envToken)) return envToken
 
-  const parsed = readOpenClawConfig()
-  const auth = parsed?.gateway?.auth
-  const mode = auth?.mode === 'password' ? 'password' : 'token'
-  const credential =
-    mode === 'password'
-      ? String(auth?.password ?? '').trim()
-      : String(auth?.token ?? '').trim()
-  if (credential) {
-    logger.debug('Gateway token loaded from openclaw.json (set OPENCLAW_GATEWAY_TOKEN env var to override)')
-  }
-  return credential
+    const envPassword = (process.env.OPENCLAW_GATEWAY_PASSWORD || process.env.GATEWAY_PASSWORD || '').trim()
+    if (isUsableGatewayToken(envPassword)) return envPassword
+
+    const parsed = readOpenClawConfig()
+    const auth = parsed?.gateway?.auth
+    const mode = auth?.mode === 'password' ? 'password' : 'token'
+    const credential = resolveGatewayCredential(
+      mode === 'password' ? auth?.password : auth?.token,
+    )
+    if (credential) {
+      logger.debug('Gateway token loaded from OpenClaw secret ref')
+    }
+    return credential
+  })
 }
 
 export function getDetectedGatewayPort(): number | null {

--- a/src/lib/gateway-token.ts
+++ b/src/lib/gateway-token.ts
@@ -1,0 +1,88 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import Database from 'better-sqlite3'
+import { config } from '@/lib/config'
+
+const TOKEN_CACHE_MS = 30_000
+const OBJECT_STRING = '[object Object]'
+
+interface SecretRef {
+  source?: unknown
+  id?: unknown
+}
+
+let cachedToken: { value: string; at: number } | null = null
+
+export function isUsableGatewayToken(token: unknown): token is string {
+  if (typeof token !== 'string') return false
+  const value = token.trim()
+  if (value.length < 8) return false
+  if (value === OBJECT_STRING) return false
+  if (value.startsWith('{') && /"source"\s*:/.test(value)) return false
+  return true
+}
+
+export function readSecretRefId(value: unknown): string {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return ''
+  const id = (value as SecretRef).id
+  return typeof id === 'string' ? id.trim() : ''
+}
+
+export function resolveGatewayCredential(
+  value: unknown,
+  env: NodeJS.ProcessEnv = process.env,
+  stateDir = config.openclawStateDir,
+): string {
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    return isUsableGatewayToken(trimmed) ? trimmed : ''
+  }
+
+  const id = readSecretRefId(value)
+  if (!id) return ''
+
+  const fromEnv = String(env[id] || '').trim()
+  if (isUsableGatewayToken(fromEnv)) return fromEnv
+
+  const source = (value as SecretRef).source
+  if (source === 'store') {
+    const fromStore = readStoreSecret(id, stateDir)
+    if (isUsableGatewayToken(fromStore)) return fromStore
+  }
+
+  return ''
+}
+
+export function readStoreSecret(name: string, stateDir = config.openclawStateDir): string {
+  if (!name || !stateDir) return ''
+  const dbPath = path.join(stateDir, 'state', 'openclaw.sqlite')
+  if (!fs.existsSync(dbPath)) return ''
+
+  try {
+    const db = new Database(dbPath, { readonly: true, fileMustExist: true, timeout: 500 })
+    try {
+      const row = db.prepare(
+        'SELECT value FROM secret_store_entries WHERE name = ? AND deleted_at_ms IS NULL LIMIT 1',
+      ).get(name) as { value?: unknown } | undefined
+      return typeof row?.value === 'string' ? row.value.trim() : ''
+    } finally {
+      db.close()
+    }
+  } catch {
+    return ''
+  }
+}
+
+export function cachedGatewayToken(resolve: () => string): string {
+  const now = Date.now()
+  if (cachedToken && now - cachedToken.at < TOKEN_CACHE_MS && isUsableGatewayToken(cachedToken.value)) {
+    return cachedToken.value
+  }
+  const value = resolve()
+  if (isUsableGatewayToken(value)) {
+    cachedToken = { value, at: now }
+    return value
+  }
+  cachedToken = null
+  return ''
+}

--- a/src/lib/openclaw-doctor-info.ts
+++ b/src/lib/openclaw-doctor-info.ts
@@ -1,0 +1,34 @@
+export function isInformationalDoctorLine(line: string): boolean {
+  return /^personal codex cli assets found/i.test(line) ||
+    /^to review or promote them:/i.test(line) ||
+    /^system browser profile cookie import is /i.test(line) ||
+    /^importable chrome-family profile cookie databases found/i.test(line) ||
+    /^doctor does not access the macos keychain/i.test(line) ||
+    /^oauth dir not present \(.*\)\. skipping create/i.test(line) ||
+    /^disable unused skills:/i.test(line) ||
+    /^inspect details:/i.test(line) ||
+    /^memory search is explicitly disabled/i.test(line) ||
+    /^tip: back up the agent workspace/i.test(line) ||
+    /^no command owner is configured/i.test(line) ||
+    /^prefer gateway\.controlui\.github\.token/i.test(line) ||
+    /^service argv:/i.test(line) ||
+    /^disabled; enable the desktop lab/i.test(line) ||
+    /^skill precedence collision:/i.test(line) ||
+    /^\d+ allowed skill is not usable/i.test(line) ||
+    /^session-logs\b/i.test(line) ||
+    /^fix:\s/i.test(line) ||
+    /^fix \(pick one\):/i.test(line) ||
+    /^set openai_api_key/i.test(line)
+}
+
+export function isDoctorTitleLine(line: string): boolean {
+  return /^(doctor (info|warnings?|complete)|gateway heap|command owner|host desktop|github projects|browser|memory search|workspace|skills)\b/i.test(line)
+}
+
+export function stripDoctorGutter(line: string): string {
+  return line
+    .replace(/\u001b\[[0-9;]*m/g, '')
+    .replace(/^[\s│┃║┆┊╎╏]+/, '')
+    .replace(/[\s│┃║┆┊╎╏]+$/, '')
+    .trim()
+}

--- a/src/lib/openclaw-doctor.ts
+++ b/src/lib/openclaw-doctor.ts
@@ -1,4 +1,5 @@
 import path from 'node:path'
+import { isDoctorTitleLine, isInformationalDoctorLine, stripDoctorGutter } from '@/lib/openclaw-doctor-info'
 
 export type OpenClawDoctorLevel = 'healthy' | 'warning' | 'error'
 export type OpenClawDoctorCategory = 'config' | 'state' | 'security' | 'general'
@@ -14,10 +15,7 @@ export interface OpenClawDoctorStatus {
 }
 
 function normalizeLine(line: string): string {
-  return line
-    .replace(/\u001b\[[0-9;]*m/g, '')
-    .replace(/^[\s│┃║┆┊╎╏]+/, '')
-    .trim()
+  return stripDoctorGutter(line)
 }
 
 function isSessionAgingLine(line: string): boolean {
@@ -28,11 +26,15 @@ function isPositiveOrInstructionalLine(line: string): boolean {
   return /^no .* warnings? detected/i.test(line) ||
     /^no issues/i.test(line) ||
     /^run:\s/i.test(line) ||
+    /^fix:\s/i.test(line) ||
     /^all .* (healthy|ok|valid|passed)/i.test(line)
 }
 
 function isDecorativeLine(line: string): boolean {
-  return /^[▄█▀░\s]+$/.test(line) || /openclaw doctor/i.test(line) || /🦞\s*openclaw\s*🦞/i.test(line)
+  return /^[▄█▀░\s]+$/.test(line) ||
+    /openclaw doctor/i.test(line) ||
+    /🦞\s*openclaw\s*🦞/i.test(line) ||
+    isDoctorTitleLine(line)
 }
 
 function isStateDirectoryListLine(line: string): boolean {
@@ -137,19 +139,18 @@ export function parseOpenClawDoctorOutput(
   const issues = lines
     .filter(line => /^[-*]\s+/.test(line))
     .map(line => line.replace(/^[-*]\s+/, '').trim())
-    .filter(line => !isSessionAgingLine(line) && !isStateDirectoryListLine(line) && !isPositiveOrInstructionalLine(line))
+    .filter(line =>
+      !isSessionAgingLine(line) &&
+      !isStateDirectoryListLine(line) &&
+      !isPositiveOrInstructionalLine(line) &&
+      !isInformationalDoctorLine(line)
+    )
 
-  // Strip positive/negated phrases before checking for warning keywords
-  const rawForWarningCheck = raw.replace(/\bno\s+\w+\s+(?:security\s+)?warnings?\s+detected\b/gi, '')
-  const mentionsWarnings = /\bwarning|warnings|problem|problems|invalid config|fix\b/i.test(rawForWarningCheck)
-  const mentionsHealthy = /\bok\b|\bhealthy\b|\bno issues\b|\bno\b.*\bwarnings?\s+detected\b|\bvalid\b/i.test(raw)
-
+  const findingText = issues.join('\n')
   let level: OpenClawDoctorLevel = 'healthy'
-  if (exitCode !== 0 || /invalid config|failed|error/i.test(raw)) {
+  if (issues.length > 0 && (exitCode !== 0 || /invalid config/i.test(findingText))) {
     level = 'error'
-  } else if (issues.length > 0 || mentionsWarnings) {
-    level = 'warning'
-  } else if (!mentionsHealthy && lines.length > 0) {
+  } else if (issues.length > 0) {
     level = 'warning'
   }
 
@@ -167,7 +168,7 @@ export function parseOpenClawDoctorOutput(
         ) ||
         'OpenClaw doctor reported configuration issues.'
 
-  const canFix = level !== 'healthy' || /openclaw doctor --fix/i.test(raw)
+  const canFix = level !== 'healthy'
 
   return {
     level,

--- a/src/lib/openclaw-gateway.ts
+++ b/src/lib/openclaw-gateway.ts
@@ -3,10 +3,10 @@ import { APP_VERSION } from './version'
 import { config } from './config'
 import { buildGatewayWebSocketUrl } from './gateway-url'
 import { getDetectedGatewayToken } from './gateway-runtime'
+import { buildProtocolNegotiation, GATEWAY_OPERATOR_SCOPES } from './websocket-utils'
 
-const GATEWAY_PROTOCOL_VERSION = 3
 const GATEWAY_CLIENT_ID = process.env.GATEWAY_CLIENT_ID || 'gateway-client'
-const GATEWAY_SCOPES = ['operator.admin', 'operator.write', 'operator.read']
+const GATEWAY_SCOPES = [...GATEWAY_OPERATOR_SCOPES]
 
 interface GatewayFrame {
   type?: string
@@ -140,8 +140,7 @@ export async function callOpenClawGateway<T = unknown>(
         method: 'connect',
         id: connectId,
         params: {
-          minProtocol: GATEWAY_PROTOCOL_VERSION,
-          maxProtocol: GATEWAY_PROTOCOL_VERSION,
+          ...buildProtocolNegotiation(),
           client: {
             id: GATEWAY_CLIENT_ID,
             displayName: 'Mission Control',

--- a/src/lib/provider-subscriptions.ts
+++ b/src/lib/provider-subscriptions.ts
@@ -72,7 +72,7 @@ function findNestedString(root: unknown, keys: string[]): string | null {
   return null
 }
 
-function detectAnthropicFromFile(): ProviderSubscription | null {
+function detectAnthropicFromFile(allowCli = true): ProviderSubscription | null {
   // Try credentials file first (legacy Claude Code 1.x)
   const credsPath = path.join(config.claudeHome, '.credentials.json')
   const creds = parseJsonFile(credsPath) as Record<string, unknown> | null
@@ -84,11 +84,13 @@ function detectAnthropicFromFile(): ProviderSubscription | null {
     }
   }
 
+  if (!allowCli) return null
+
   // Fallback: Claude Code 2.x stores OAuth in keychain — use CLI to query
   try {
     const raw = execFileSync('claude', ['auth', 'status'], {
       encoding: 'utf-8',
-      timeout: 5000,
+      timeout: 500,
       stdio: ['pipe', 'pipe', 'pipe'],
       env: { ...process.env, HOME: os.homedir() },
     })
@@ -179,7 +181,7 @@ function detectFromEnv(): Record<string, ProviderSubscription> {
   return active
 }
 
-export function detectProviderSubscriptions(forceRefresh = false): SubscriptionDetectionResult {
+export function detectProviderSubscriptions(forceRefresh = false, allowCli = true): SubscriptionDetectionResult {
   const now = Date.now()
   if (!forceRefresh && detectionCache && (now - detectionCache.ts) < CACHE_TTL_MS) {
     return detectionCache.value
@@ -187,14 +189,16 @@ export function detectProviderSubscriptions(forceRefresh = false): SubscriptionD
 
   const active = detectFromEnv()
 
-  const anthropic = detectAnthropicFromFile()
+  const anthropic = detectAnthropicFromFile(allowCli)
   if (anthropic) active.anthropic = anthropic
 
   const openai = detectOpenAIFromFile()
   if (openai) active.openai = openai
 
   const value = { active }
-  detectionCache = { ts: now, value }
+  if (allowCli) {
+    detectionCache = { ts: now, value }
+  }
   return value
 }
 

--- a/src/lib/websocket-utils.ts
+++ b/src/lib/websocket-utils.ts
@@ -57,10 +57,13 @@ export function readErrorDetailCode(error: GatewayErrorDetail | null | undefined
 }
 
 /** Error codes that should never trigger auto-reconnect. */
+export const GATEWAY_OPERATOR_SCOPES = ['operator.admin', 'operator.write', 'operator.read'] as const
+
 export const NON_RETRYABLE_ERROR_CODES = new Set<string>([
   ConnectErrorDetailCodes.AUTH_TOKEN_MISSING,
   ConnectErrorDetailCodes.AUTH_PASSWORD_MISSING,
   ConnectErrorDetailCodes.AUTH_PASSWORD_MISMATCH,
+  ConnectErrorDetailCodes.AUTH_TOKEN_MISMATCH,
   ConnectErrorDetailCodes.AUTH_RATE_LIMITED,
   ConnectErrorDetailCodes.ORIGIN_NOT_ALLOWED,
   ConnectErrorDetailCodes.DEVICE_SIGNATURE_INVALID,
@@ -102,6 +105,12 @@ export function shouldRetryWithoutDeviceIdentity(
  */
 export function calculateBackoff(attempt: number): number {
   return Math.min(1000 * Math.pow(1.7, attempt), 15000)
+}
+
+/** First retry is immediate; later attempts use exponential backoff. */
+export function calculateReconnectDelay(attempt: number): number {
+  if (attempt <= 0) return 0
+  return calculateBackoff(attempt - 1)
 }
 
 /**

--- a/src/lib/websocket.ts
+++ b/src/lib/websocket.ts
@@ -19,6 +19,8 @@ import {
   NON_RETRYABLE_ERROR_CODES,
   shouldRetryWithoutDeviceIdentity,
   buildProtocolNegotiation,
+  calculateReconnectDelay,
+  GATEWAY_OPERATOR_SCOPES,
 } from '@/lib/websocket-utils'
 
 const log = createClientLogger('WebSocket')
@@ -73,6 +75,20 @@ const lastSeqRef: { current: number | null } = { current: null }
 const tokenOnlyFallbackRef: { current: boolean } = { current: false }
 const tokenOnlyFallbackTriedRef: { current: boolean } = { current: false }
 const wsPathFallbackTriedRef: { current: Set<string> } = { current: new Set() }
+const handshakeTimerRef: { current: ReturnType<typeof setTimeout> | undefined } = { current: undefined }
+const handshakeDeadlineRef: { current: ReturnType<typeof setTimeout> | undefined } = { current: undefined }
+const connectSentRef: { current: boolean } = { current: false }
+
+function clearHandshakeTimers() {
+  if (handshakeTimerRef.current) {
+    clearTimeout(handshakeTimerRef.current)
+    handshakeTimerRef.current = undefined
+  }
+  if (handshakeDeadlineRef.current) {
+    clearTimeout(handshakeDeadlineRef.current)
+    handshakeDeadlineRef.current = undefined
+  }
+}
 
 export function useWebSocket() {
   const maxReconnectAttempts = 10
@@ -215,6 +231,9 @@ export function useWebSocket() {
 
   // Send the connect handshake (async for Ed25519 device identity signing)
   const sendConnectHandshake = useCallback(async (ws: WebSocket, nonce?: string) => {
+    if (connectSentRef.current && !nonce) return
+    if (ws.readyState !== WebSocket.OPEN) return
+
     let device: {
       id: string
       publicKey: string
@@ -228,7 +247,7 @@ export function useWebSocket() {
     const clientId = DEFAULT_GATEWAY_CLIENT_ID
     const clientMode = 'ui'
     const role = 'operator'
-    const scopes = ['operator.admin']
+    const scopes = [...GATEWAY_OPERATOR_SCOPES]
     const authToken = authTokenRef.current || undefined
     const tokenForSignature = authToken ?? cachedToken ?? ''
 
@@ -284,8 +303,14 @@ export function useWebSocket() {
         deviceToken: tokenOnlyFallbackRef.current ? undefined : (cachedToken || undefined),
       }
     }
+    if (ws.readyState !== WebSocket.OPEN) return
+    connectSentRef.current = true
     log.info('Sending connect handshake')
-    ws.send(JSON.stringify(connectRequest))
+    try {
+      ws.send(JSON.stringify(connectRequest))
+    } catch (err) {
+      log.warn('Failed to send connect handshake:', err)
+    }
   }, [])
 
   // Parse and handle different gateway message types
@@ -375,6 +400,8 @@ export function useWebSocket() {
     // Handle connect challenge
     if (frame.type === 'event' && frame.event === 'connect.challenge') {
       log.info('Received connect challenge, sending handshake')
+      clearHandshakeTimers()
+      connectSentRef.current = false
       sendConnectHandshake(ws, frame.payload?.nonce)
       return
     }
@@ -382,6 +409,7 @@ export function useWebSocket() {
     // Handle connect response (handshake success)
     if (frame.type === 'res' && frame.ok && !handshakeCompleteRef.current) {
       log.info('Handshake complete')
+      clearHandshakeTimers()
       handshakeCompleteRef.current = true
       reconnectAttemptsRef.current = 0
       // Cache device token if returned by gateway
@@ -694,9 +722,11 @@ export function useWebSocket() {
     }
     reconnectUrl.current = normalizedUrl
     handshakeCompleteRef.current = false
+    connectSentRef.current = false
     manualDisconnectRef.current = false
     nonRetryableErrorRef.current = null
     lastSeqRef.current = null
+    clearHandshakeTimers()
 
     try {
       const ws = new WebSocket(normalizedUrl)
@@ -709,8 +739,17 @@ export function useWebSocket() {
           url: normalizedUrl,
           reconnectAttempts: 0
         })
-        // Wait for connect.challenge from server
         log.debug('Waiting for connect challenge')
+        handshakeTimerRef.current = setTimeout(() => {
+          if (!handshakeCompleteRef.current && ws.readyState === WebSocket.OPEN) {
+            sendConnectHandshake(ws)
+          }
+        }, 80)
+        handshakeDeadlineRef.current = setTimeout(() => {
+          if (!handshakeCompleteRef.current && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) {
+            ws.close(4000, 'Handshake timeout')
+          }
+        }, 2000)
       }
 
       ws.onmessage = (event) => {
@@ -734,6 +773,8 @@ export function useWebSocket() {
         const wasHandshakeComplete = handshakeCompleteRef.current
         setConnection({ isConnected: false })
         handshakeCompleteRef.current = false
+        connectSentRef.current = false
+        clearHandshakeTimers()
         stopHeartbeat()
 
         // Skip auto-reconnect if this was a manual disconnect
@@ -745,7 +786,8 @@ export function useWebSocket() {
         // tunnel connections that drop later are misclassified as initial
         // handshake failures and reconnect to /gateway-ws or /gw instead of
         // the last known-good URL.
-        if (!wasHandshakeComplete) {
+        const skipPathFallback = Boolean(nonRetryableErrorRef.current) || event.code === 4001 || event.code === 4002
+        if (!wasHandshakeComplete && !skipPathFallback) {
           const fallback = buildGatewayPathFallbackUrls(normalizedUrl).find(
             (candidate) => !wsPathFallbackTriedRef.current.has(candidate),
           )
@@ -761,7 +803,7 @@ export function useWebSocket() {
             })
             reconnectTimeoutRef.current = setTimeout(() => {
               connectRef.current(fallback, authTokenRef.current)
-            }, 250)
+            }, 0)
             return
           }
         }
@@ -782,8 +824,7 @@ export function useWebSocket() {
         // Auto-reconnect with exponential backoff (uses connectRef to avoid stale closure)
         const attempts = reconnectAttemptsRef.current
         if (attempts < maxReconnectAttempts) {
-          const base = Math.min(1000 * Math.pow(1.7, attempts), 15000)
-          const timeout = Math.round(base + Math.random() * base * 0.5)
+          const timeout = calculateReconnectDelay(attempts)
           log.info(`Reconnecting in ${timeout}ms (attempt ${attempts + 1}/${maxReconnectAttempts})`)
 
           reconnectAttemptsRef.current = attempts + 1
@@ -874,9 +915,11 @@ export function useWebSocket() {
   }, [])
 
   const reconnect = useCallback(() => {
+    tokenOnlyFallbackTriedRef.current = false
+    tokenOnlyFallbackRef.current = false
     disconnect()
     if (reconnectUrl.current) {
-      setTimeout(() => connect(reconnectUrl.current, authTokenRef.current), 1000)
+      setTimeout(() => connect(reconnectUrl.current, authTokenRef.current), 0)
     }
   }, [connect, disconnect])
 


### PR DESCRIPTION
## Summary
- Resolve OpenClaw `gateway.auth.token` SecretRefs instead of stringifying them to `[object Object]` and poisoning the primary gateway row.
- Send the browser `connect` handshake after 80ms if no challenge arrives, request `operator.read`/`write`/`admin`, and retry the first reconnect immediately.
- Paint the dashboard after auth instead of waiting on skills/agents/capabilities, and treat informational OpenClaw doctor notes as healthy.

## Test plan
- [x] `vitest` for gateway-token, gateway-runtime, openclaw-doctor, websocket-utils (57 tests)
- [ ] Refresh Mission Control and confirm the gateway pill connects without backoff
- [ ] Confirm `/api/gateways/connect` returns `token_set: true` with a real token length, not `[object Object]`
- [ ] Confirm the OpenClaw doctor banner stays hidden for Codex-asset / cookie-import info notes