### PR TITLE
fix: correct dead OpenClaw installer URL and CLI flag, fix scanner false positive

### DIFF
--- a/src/lib/agent-runtimes.ts
+++ b/src/lib/agent-runtimes.ts
@@ -38,6 +38,13 @@ async function downloadAndReviewScript(
   expectedSha256: string,
   job: InstallJob,
   env: NodeJS.ProcessEnv,
+  /**
+   * Rule IDs to treat as non-blocking for this call site only, because a human
+   * has already read every match in the pinned (SHA-256-verified) script and
+   * confirmed each one is inert help text (heredoc/echo), never executed code.
+   * Does not affect scanForInjection() itself or any other call site.
+   */
+  manuallyReviewedRuleIds: string[] = [],
 ): Promise<{ scriptPath: string; tempDir: string } | null> {
   if (!isValidInstallerSha256(expectedSha256)) {
     job.output += '> SECURITY: Installer blocked because no valid SHA-256 digest is configured.\n'
@@ -97,9 +104,17 @@ async function downloadAndReviewScript(
   const regexReport = scanForInjection(content, { context: 'shell' })
   if (!regexReport.safe) {
     const criticals = regexReport.matches.filter(m => m.severity === 'critical')
-    if (criticals.length > 0) {
+    const waived = criticals.filter(m => manuallyReviewedRuleIds.includes(m.rule))
+    const blocking = criticals.filter(m => !manuallyReviewedRuleIds.includes(m.rule))
+    if (waived.length > 0) {
+      job.output += '> SECURITY: Manually pre-approved matches (verified as inert help text, not executed code):\n'
+      for (const m of waived) {
+        job.output += `>   [${m.rule}] ${m.description}: ${m.matched}\n`
+      }
+    }
+    if (blocking.length > 0) {
       job.output += '> SECURITY: Downloaded script blocked by injection guard:\n'
-      for (const m of criticals) {
+      for (const m of blocking) {
         job.output += `>   [${m.rule}] ${m.description}: ${m.matched}\n`
       }
       rmSync(tempDir, { recursive: true, force: true })
@@ -756,10 +771,16 @@ async function installOpenClawLocal(job: InstallJob): Promise<void> {
   try {
     // Download, review, then execute from secure temp dir
     const reviewed = await downloadAndReviewScript(
-      'https://get.openclaw.dev',
+      'https://openclaw.ai/install.sh',
       process.env.MC_OPENCLAW_INSTALLER_SHA256 || '',
       job,
       env,
+      // Manually reviewed 2026-09-04: both rules only match this script's own
+      // `cat <<EOF` usage banner and `echo` help text (print_usage() and the
+      // admin-rights fix hint) recommending how to re-run the installer —
+      // never executed. Confirmed against the full 4091-line script pinned by
+      // MC_OPENCLAW_INSTALLER_SHA256 above.
+      ['cmd-shell-metachar', 'cmd-pipe-download'],
     )
     if (!reviewed) {
       job.status = 'failed'
@@ -770,7 +791,11 @@ async function installOpenClawLocal(job: InstallJob): Promise<void> {
 
     let result
     try {
-      result = await runCommand('bash', [reviewed.scriptPath, '--non-interactive'], {
+      // The real installer (openclaw.ai/install.sh) has no --non-interactive
+      // flag — that was written against the previous (dead get.openclaw.dev)
+      // installer. Its real equivalent is --no-onboard (see --help output).
+      // NONINTERACTIVE=1 / CI=1 in env already suppress any TTY prompts.
+      result = await runCommand('bash', [reviewed.scriptPath, '--no-onboard'], {
         timeoutMs: 300_000, env,
         onData: (chunk) => { job.output += chunk },
       })


### PR DESCRIPTION
# Summary
`get.openclaw.dev` (hardcoded in `installOpenClawLocal()`) no longer resolves — confirmed NXDOMAIN while general DNS resolution (e.g. `registry.npmjs.org`) works fine, so this isn't a network issue on my end. The real, currently-live installer is `https://openclaw.ai/install.sh` (per the official `openclaw/openclaw` repo and `docs.openclaw.ai/install`). This PR points Mission Control at the real URL and fixes two follow-on issues that surfaced once the real script could actually run.

1. **Dead URL → real URL.** `get.openclaw.dev` → `https://openclaw.ai/install.sh`.
2. **Wrong CLI flag.** The code invoked the installer with `--non-interactive`, which isn't a flag the real `install.sh` recognizes (`Unknown option: --non-interactive`). That flag belongs to the `openclaw doctor` subcommand, not the installer. The installer's own `--help` shows the correct non-interactive-onboarding flag is `--no-onboard`.
3. **Injection-guard false positive.** With the real URL and SHA-256 pinned, the download passed, but the regex injection guard (`cmd-shell-metachar` / `cmd-pipe-download`) blocked the script. Both matches are inside the script's own `cat <<EOF` usage banner and an `echo` admin-rights hint — both show `curl ... | bash` purely as documentation text for the reader, never executed. Rather than loosen the shared `scanForInjection()` rules (which would also weaken the Hermes installer path), I added an optional `manuallyReviewedRuleIds` parameter to `downloadAndReviewScript()` so a specific call site can waive specific rule IDs after a human has read the full pinned script and confirmed the matches are inert. It's opt-in per call site — `installHermesLocal()` is untouched and still enforces the full guard with no waivers.

# Risk Level
**Low.** All three changes are scoped to the OpenClaw local-install path only (`installOpenClawLocal()` and the one new optional parameter on `downloadAndReviewScript()`, which defaults to `[]` — a no-op for every other existing call site). No change to `scanForInjection()` itself, no change to the Hermes path, no change to SHA-256 verification (still mandatory and unchanged). Worst-case failure mode: a maintainer disagrees with the specific rule IDs waived for OpenClaw and asks for a narrower/different mechanism — easy to revert or adjust, nothing else depends on it.

# Evidence
Manually downloaded and read the full 4091-line `openclaw.ai/install.sh` before pinning its SHA-256 — confirmed no malicious behavior (no exfiltration, no backdoors; the `sudo apt-get/pacman/dnf/apk` calls are gated behind a missing-Node.js check, standard installer behavior).

Verified end-to-end on a real self-hosted Mission Control deployment (not just unit tests):
- `curl -fsSL -o install.sh https://openclaw.ai/install.sh` → HTTP 200, SHA-256 computed and pinned via `MC_OPENCLAW_INSTALLER_SHA256`.
- Install job via the dashboard API (`POST /api/agent-runtimes`, `action: install`, `runtime: openclaw`) → **success**, real installer output captured end-to-end (`🦞 OpenClaw installed successfully (2026.9.1)!`), installed via its npm method, no `sudo` triggered (Node.js already present).
- Post-install detection confirms `openclaw --version` → `OpenClaw 2026.9.1 (ad6fe23)`, `GET /api/agent-runtimes` reports `installed: true`.
- Before the flag fix: reproduced the exact `Unknown option: --non-interactive` failure from the old code against the real script.
- Before the guard fix: reproduced the exact false-positive block (`[cmd-shell-metachar]`, `[cmd-pipe-download]`) against the real script's help text.

On this branch, on a fresh `pnpm install --frozen-lockfile`:
- `pnpm run typecheck` → exit 0
- `pnpm run lint` → exit 0
- `npx vitest run src/lib/__tests__/agent-runtime-install-security.test.ts src/lib/__tests__/agent-runtimes-client-security.test.ts src/lib/__tests__/agent-runtimes-opencode.test.ts` → 3 files, 8/8 tests passed

# Contribution Checklist
- [x] This PR has one reviewable purpose and no unrelated cleanup
- [ ] Tests cover behavior changes and failure paths — existing tests pass unchanged; I did not add a new test for the `manuallyReviewedRuleIds` waiver path itself. Happy to add one (e.g. asserting a waived rule ID is logged but not blocking, while a non-waived critical still blocks) if useful — flagging this so a maintainer can decide rather than assuming it's not wanted.
- [x] `pnpm lint`, `pnpm typecheck`, and relevant tests pass
- [x] Auth, data scope, command execution, and secret handling were reviewed when touched — this PR narrows, not widens, what runs: same SHA-256 gate, same regex scan (minus 2 specific pre-reviewed rule IDs on one call site), no new command execution surface.
- [ ] Schema changes include forward migration and upgrade-path tests — N/A, no schema touched
- [x] Public text, logs, fixtures, screenshots, and commits contain no secrets or private data

# Notes
Flagging for maintainer judgment rather than deciding unilaterally: the `manuallyReviewedRuleIds` mechanism is a reasonable narrow escape hatch for exactly this kind of documentation-text false positive, but it's still a human trusting their own read of a script over the automated scanner. If you'd rather fix this by making `scanForInjection()` itself heredoc/echo-aware (so it doesn't flag documentation strings as executable commands), that would remove the need for any waiver list — I kept my change narrower and reversible, but I don't have visibility into how `scanForInjection()` is used elsewhere or whether that's a change you'd want to make more broadly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)