### PR TITLE
fix(hermes): skip the installer's unpinned cua-driver download-and-run, unblock the pinned install

### DIFF
--- a/src/lib/__tests__/agent-runtimes-hermes-install-security.test.ts
+++ b/src/lib/__tests__/agent-runtimes-hermes-install-security.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const source = readFileSync(join(process.cwd(), 'src/lib/agent-runtimes.ts'), 'utf8')
+
+describe('Hermes local install supply-chain contract', () => {
+  it('downloads the official installer and pins it by SHA-256', () => {
+    expect(source).toContain(
+      "const hermesUrl = 'https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh'",
+    )
+    expect(source).toContain('process.env.MC_HERMES_INSTALLER_SHA256')
+  })
+
+  it('runs the installer with the cua-driver step disabled', () => {
+    // The installer's Computer Use step pipes an unpinned third-party script
+    // into /bin/bash. Skipping it is what keeps this path fully covered by the
+    // SHA-256 pin above, so the flag is part of the security contract, not a
+    // preference.
+    expect(source).toContain(
+      "[reviewed.scriptPath, '--skip-setup', '--skip-computer-use']",
+    )
+  })
+
+  it('waives only the two pre-reviewed rule IDs on the Hermes call site', () => {
+    const waivers = source.match(/\['cmd-shell-metachar', 'cmd-pipe-download'\]/g) ?? []
+    // One for the OpenClaw call site, one for Hermes — no third waiver, and no
+    // waiver of any other rule ID anywhere in this file.
+    expect(waivers).toHaveLength(2)
+  })
+})

--- a/src/lib/agent-runtimes.ts
+++ b/src/lib/agent-runtimes.ts
@@ -853,6 +853,24 @@ async function installHermesLocal(job: InstallJob): Promise<void> {
       process.env.MC_HERMES_INSTALLER_SHA256 || '',
       job,
       env,
+      // Manually reviewed 2026-09-05 against the FULL 3890-line script pinned by
+      // MC_HERMES_INSTALLER_SHA256 above -- every occurrence of both rules, not
+      // only the first one the scanner reports:
+      //   cmd-pipe-download: all 6 matches are comments documenting the public
+      //     curl-pipe-bash one-liner (lines 9, 12, 86, 579, 1405, 2940). None of
+      //     them is executed.
+      //   cmd-shell-metachar: the same comments plus ordinary command
+      //     substitution -- mktemp, dirname, node --version, and the curl that
+      //     reads the nodejs.org index to resolve a tarball name. No dynamically
+      //     fetched code.
+      // The script's one real download-and-run -- the cua-driver installer,
+      // which pipes an unpinned third-party script into /bin/bash and which
+      // cmd-pipe-download misses because of the absolute interpreter path -- is
+      // NOT waived: it is disabled with --skip-computer-use below.
+      // Note also that scanForInjection() caps at 50 000 chars (about line 1249
+      // of this 169 KB script), so the SHA-256 pin, not the regex scan, is what
+      // covers the remainder.
+      ['cmd-shell-metachar', 'cmd-pipe-download'],
     )
     if (!reviewed) {
       job.status = 'failed'
@@ -866,7 +884,13 @@ async function installHermesLocal(job: InstallJob): Promise<void> {
 
     let result
     try {
-      result = await runCommand('bash', [reviewed.scriptPath, '--skip-setup'], {
+      // --skip-computer-use: the cua-driver step pipes an unpinned third-party
+      // script (raw.githubusercontent.com/trycua/cua) straight into /bin/bash,
+      // which would defeat the SHA-256 pinning this code path exists for. That
+      // driver only powers desktop control, which is meaningless on a headless
+      // server; an operator who wants it can still run "hermes computer-use
+      // install" explicitly.
+      result = await runCommand('bash', [reviewed.scriptPath, '--skip-setup', '--skip-computer-use'], {
         timeoutMs: 600_000, env,
         onData: (chunk) => { job.output += chunk },
       })

--- a/src/lib/agent-runtimes.ts
+++ b/src/lib/agent-runtimes.ts
@@ -38,6 +38,13 @@ async function downloadAndReviewScript(
   expectedSha256: string,
   job: InstallJob,
   env: NodeJS.ProcessEnv,
+  /**
+   * Rule IDs to treat as non-blocking for this call site only, because a human
+   * has already read every match in the pinned (SHA-256-verified) script and
+   * confirmed each one is inert help text (heredoc/echo), never executed code.
+   * Does not affect scanForInjection() itself or any other call site.
+   */
+  manuallyReviewedRuleIds: string[] = [],
 ): Promise<{ scriptPath: string; tempDir: string } | null> {
   if (!isValidInstallerSha256(expectedSha256)) {
     job.output += '> SECURITY: Installer blocked because no valid SHA-256 digest is configured.\n'
@@ -97,9 +104,17 @@ async function downloadAndReviewScript(
   const regexReport = scanForInjection(content, { context: 'shell' })
   if (!regexReport.safe) {
     const criticals = regexReport.matches.filter(m => m.severity === 'critical')
-    if (criticals.length > 0) {
+    const waived = criticals.filter(m => manuallyReviewedRuleIds.includes(m.rule))
+    const blocking = criticals.filter(m => !manuallyReviewedRuleIds.includes(m.rule))
+    if (waived.length > 0) {
+      job.output += '> SECURITY: Manually pre-approved matches (verified as inert help text, not executed code):\n'
+      for (const m of waived) {
+        job.output += `>   [${m.rule}] ${m.description}: ${m.matched}\n`
+      }
+    }
+    if (blocking.length > 0) {
       job.output += '> SECURITY: Downloaded script blocked by injection guard:\n'
-      for (const m of criticals) {
+      for (const m of blocking) {
         job.output += `>   [${m.rule}] ${m.description}: ${m.matched}\n`
       }
       rmSync(tempDir, { recursive: true, force: true })
@@ -756,10 +771,16 @@ async function installOpenClawLocal(job: InstallJob): Promise<void> {
   try {
     // Download, review, then execute from secure temp dir
     const reviewed = await downloadAndReviewScript(
-      'https://get.openclaw.dev',
+      'https://openclaw.ai/install.sh',
       process.env.MC_OPENCLAW_INSTALLER_SHA256 || '',
       job,
       env,
+      // Manually reviewed 2026-09-04: both rules only match this script's own
+      // `cat <<EOF` usage banner and `echo` help text (print_usage() and the
+      // admin-rights fix hint) recommending how to re-run the installer —
+      // never executed. Confirmed against the full 4091-line script pinned by
+      // MC_OPENCLAW_INSTALLER_SHA256 above.
+      ['cmd-shell-metachar', 'cmd-pipe-download'],
     )
     if (!reviewed) {
       job.status = 'failed'
@@ -770,7 +791,11 @@ async function installOpenClawLocal(job: InstallJob): Promise<void> {
 
     let result
     try {
-      result = await runCommand('bash', [reviewed.scriptPath, '--non-interactive'], {
+      // The real installer (openclaw.ai/install.sh) has no --non-interactive
+      // flag — that was written against the previous (dead get.openclaw.dev)
+      // installer. Its real equivalent is --no-onboard (see --help output).
+      // NONINTERACTIVE=1 / CI=1 in env already suppress any TTY prompts.
+      result = await runCommand('bash', [reviewed.scriptPath, '--no-onboard'], {
         timeoutMs: 300_000, env,
         onData: (chunk) => { job.output += chunk },
       })


### PR DESCRIPTION
# Summary

> **Stacked on #959.** This branch is `fix/openclaw-installer-url-and-scanner-fp` + one commit, so the diff shown here includes that PR. It has to be: the `manuallyReviewedRuleIds` parameter it introduces is what the second change below uses. Reviewing/merging #959 first makes this one a single-commit diff.

`installHermesLocal()` pins the Hermes installer by SHA-256 and then runs it with `--skip-setup`. The pinned script's Computer Use step does this (line 2922 of the current `main` installer):

```sh
curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh | /bin/bash
```

That second script comes from a moving `main` branch and is executed with no digest check, so **the SHA-256 pin does not actually cover everything the install runs** — it covers the outer script, which then fetches and executes an unpinned one. The injection guard does not catch it either: `cmd-pipe-download` requires `| bash` and this pipes into `| /bin/bash`, so the absolute interpreter path walks straight past the regex.

1. **`--skip-computer-use`.** Disables that step, which puts the whole install back under the digest that `MC_HERMES_INSTALLER_SHA256` promises. The cua-driver only powers desktop control — inert on a headless deployment — and an operator who wants it can still run `hermes computer-use install` deliberately, as an explicit act rather than a silent side effect of clicking Install.

2. **Waive the two pre-reviewed rule IDs on this call site**, using the mechanism #959 adds. Without it the Hermes install is blocked outright today by documentation text inside its own installer:

   ```
   > SECURITY: Downloaded script blocked by injection guard:
   >   [cmd-shell-metachar] ... : | bash
   >   [cmd-pipe-download] ... : curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
   ```

   Before waiving, I enumerated **every** occurrence of both rules in the full 3890-line pinned script, not just the first one the scanner reports:
   - `cmd-pipe-download` — 6 matches, all comments describing the public `curl … | bash` one-liner (lines 9, 12, 86, 579, 1405, 2940). None is executed.
   - `cmd-shell-metachar` — those same comments plus ordinary command substitution: `$(mktemp)`, `$(dirname …)`, `$(node --version)`, and the `$(curl "$index_url")` that reads the nodejs.org index to resolve a tarball name. No dynamically fetched code.

   The one genuine download-and-run is **not** waived; it is disabled by change 1.

3. **A source-contract test**, in the style of the existing `agent-runtimes-client-security.test.ts`: it asserts the installer URL and the SHA-256 pin, asserts the `--skip-computer-use` flag is present (it is a security contract, not a preference), and asserts no third rule-ID waiver appears in the file.

# Risk Level

**Low.** Both changes are scoped to `installHermesLocal()`. No change to `scanForInjection()`, no change to SHA-256 verification (still mandatory, still unchanged), no new command-execution surface — this narrows what runs rather than widening it.

Main failure mode: someone who *wanted* the cua-driver provisioned by the Mission Control install no longer gets it, and has to run `hermes computer-use install` themselves. If you would rather keep it automatic, the honest alternative is to pin that second script too (its own `MC_CUA_DRIVER_INSTALLER_SHA256`) rather than to leave an unpinned `curl | /bin/bash` inside a code path whose stated purpose is digest pinning — happy to write that instead if you prefer it.

# Evidence

Read the complete 3890-line / 169 KB installer before pinning or waiving anything. Network endpoints are all expected: GitHub (NousResearch), `astral.sh` (uv), `nodejs.org`, PyPI, the npm registry, the Playwright CDN, a DuckDuckGo connectivity probe, and `npmmirror.com` as an Electron fallback reachable only via `--include-desktop`. `sudo` appears only as best-effort optional-package installs (ripgrep/ffmpeg/build-essential), all `|| true`; on the deployment below they are refused by `NoNewPrivileges` with no effect on the outcome.

Verified end-to-end on a real self-hosted deployment (systemd, unprivileged service user, `MemoryMax`/`ProtectHome` hardening), not only in unit tests:

- `curl -fsSL .../NousResearch/hermes-agent/main/scripts/install.sh` and `curl -fsSL https://hermes-agent.nousresearch.com/install.sh` → **byte-identical**, SHA-256 `5854b15670b51a8daae8f59ddfa917062de9f74be261eb73b4b8d719710f8968`, pinned via `MC_HERMES_INSTALLER_SHA256`.
- Before the waiver: reproduced the exact guard block quoted above.
- After: `POST /api/agent-runtimes` `{action: install, runtime: hermes, mode: local}` → **success in 120 s**, well inside the 600 s cap, through the installer's hash-verified `uv.lock` tier (`Main package installed (hash-verified via uv.lock)`).
- `GET /api/agent-runtimes` → `hermes` `installed: true`, `version: 0.21.0` (`Hermes Agent v0.21.0 (2026.8.31) · upstream f159e581`).
- Installer output confirms the skipped step: no cua-driver download appears, and the run reaches `Hermes Agent installed successfully.`

On this branch:

- `npx vitest run src/lib/__tests__/agent-runtime-install-security.test.ts src/lib/__tests__/agent-runtimes-client-security.test.ts src/lib/__tests__/agent-runtimes-opencode.test.ts src/lib/__tests__/agent-runtimes-hermes-install-security.test.ts` → **4 files, 11/11 passed**
- `pnpm run typecheck` → exit 0
- `npx eslint src/lib/agent-runtimes.ts src/lib/__tests__/agent-runtimes-hermes-install-security.test.ts` → exit 0, no findings. (A full `pnpm lint` in that particular checkout also reports 21 errors, every one of them inside a vendored `.cache/node/corepack/**/pnpm.cjs` that lands in the working directory because `HOME` points at the checkout — unrelated to this change, and absent from a clean clone as in #959.)

# Contribution Checklist

- [x] This PR has one reviewable purpose and no unrelated cleanup
- [x] Tests cover behavior changes and failure paths — source-contract test added for the pin, the flag, and the waiver count
- [x] `pnpm lint`, `pnpm typecheck`, and relevant tests pass — see the lint caveat above
- [x] Auth, data scope, command execution, and secret handling were reviewed when touched — this removes an unpinned remote script execution from the install path; nothing is added
- [x] Schema changes include forward migration and upgrade-path tests — N/A, no schema touched
- [x] Public text, logs, fixtures, screenshots, and commits contain no secrets or private data

# Notes

Two gaps in the guard that this PR deliberately does **not** change, flagged for your judgment rather than patched unilaterally:

1. **`cmd-pipe-download` misses absolute interpreter paths.** `| /bin/bash`, `| /usr/bin/env bash`, `| /bin/sh` all evade `/\|\s*(?:bash|sh|…)/`. The real download-and-run in this very installer is invisible to the scanner for exactly that reason, which is worth knowing independently of Hermes.
2. **`scanForInjection()` caps input at 50 000 characters.** On a 169 KB installer that is roughly the first 1249 of 3890 lines; the remaining three quarters are never scanned. The SHA-256 pin is what covers them, so the cap is not a hole so much as a reason not to read a "security review passed" line as "the whole script was reviewed". A truncation notice in the job output would make that honest at a glance.

I did not widen the regex or raise the cap here because both are shared with every other call site and I have no visibility into what else depends on their current behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
