### PR TITLE
feat: add secure reverse proxy support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,15 @@
 MC_COOKIE_SECURE=
 MC_COOKIE_SAMESITE=strict
 
+# Canonical browser-visible URL when HTTPS is terminated by a reverse proxy.
+# Keep the path at `/`; subpath hosting is not supported by Next.js asset routes.
+# MC_PUBLIC_URL=https://mission-control.example.com
+# MC_PUBLIC_BASE_URL=https://mission-control.example.com  # legacy alias
+
+# Forwarded/X-Forwarded origin headers are ignored unless the nearest proxy is
+# listed here and appears as the right-most X-Forwarded-For hop.
+# MC_TRUSTED_PROXY_IPS=127.0.0.1,::1
+
 # Network access control (production: blocked unless host is explicitly allowed)
 # Patterns: exact "app.example.com", subdomain "*.example.com", prefix "100.*"
 # MC_ALLOW_ANY_HOST=

--- a/.env.example
+++ b/.env.example
@@ -37,7 +37,9 @@ MC_COOKIE_SAMESITE=strict
 # MC_PUBLIC_BASE_URL=https://mission-control.example.com  # legacy alias
 
 # Forwarded/X-Forwarded origin headers are ignored unless the nearest proxy is
-# listed here and appears as the right-most X-Forwarded-For hop.
+# listed here, appears as the transport peer IP, and this explicit opt-in is set.
+# The backend must be private/reachable only through that proxy.
+# MC_TRUSTED_PROXY_HEADERS=1
 # MC_TRUSTED_PROXY_IPS=127.0.0.1,::1
 
 # Network access control (production: blocked unless host is explicitly allowed)

--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,7 @@ MC_COOKIE_SAMESITE=strict
 # The backend must be private/reachable only through that proxy.
 # MC_TRUSTED_PROXY_HEADERS=1
 # MC_TRUSTED_PROXY_IPS=127.0.0.1,::1
+# MC_PROXY_HEADER_SECRET=generate-a-long-random-secret
 
 # Network access control (production: blocked unless host is explicitly allowed)
 # Patterns: exact "app.example.com", subdomain "*.example.com", prefix "100.*"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -333,6 +333,9 @@ This adds: JSON logging, strict hostname allowlist, secure cookies, HSTS, intern
 
 ## Environment Variables
 
+For a complete HTTPS reverse proxy setup, including Nginx, Caddy, Traefik and
+Tailscale Serve examples, see [Reverse proxy deployment](reverse-proxy.md).
+
 See `.env.example` for the full list. Key variables:
 
 | Variable | Required | Default | Description |
@@ -352,6 +355,8 @@ See `.env.example` for the full list. Key variables:
 | `OPENCLAW_SECURITY_SANDBOX_ALL` | No | `1` | Force `agents.defaults.sandbox.mode="all"` when set (env-driven) |
 | `MISSION_CONTROL_DATA_DIR` | No | `.data/` | Directory for all Mission Control data files (DB, tokens, etc.). Use an absolute path with the standalone server to survive rebuilds. |
 | `MC_ALLOWED_HOSTS` | No | `localhost,127.0.0.1` | Allowed hosts in production |
+| `MC_PUBLIC_URL` | No | request URL | Canonical browser URL behind HTTPS termination (for example `https://mc.example.com`) |
+| `MC_TRUSTED_PROXY_IPS` | No | unset | Proxy IPs permitted to provide Forwarded/X-Forwarded origin headers |
 | `MC_PORT` | No | `3000` | Host-side port that the bundled `docker-compose.yml` publishes the container's `PORT` on. The bundled `Makefile` expects `7012`. |
 | `ANTHROPIC_API_KEY` | No (Yes for direct dispatch) | - | Used when `dispatchModel` matches `claude-*` / `anthropic/*` and no gateway is available. |
 | `OPENAI_API_KEY` | No | - | Used when `dispatchModel` matches `gpt-*` / `o1-*` / `o3-*` / `openai/*`. |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -357,6 +357,7 @@ See `.env.example` for the full list. Key variables:
 | `MC_ALLOWED_HOSTS` | No | `localhost,127.0.0.1` | Allowed hosts in production |
 | `MC_PUBLIC_URL` | No | request URL | Canonical browser URL behind HTTPS termination (for example `https://mc.example.com`) |
 | `MC_TRUSTED_PROXY_IPS` | No | unset | Proxy IPs permitted to provide Forwarded/X-Forwarded origin headers |
+| `MC_TRUSTED_PROXY_HEADERS` | No | unset | Explicitly opt in to forwarded origins; requires private backend and verified transport peer IP |
 | `MC_PORT` | No | `3000` | Host-side port that the bundled `docker-compose.yml` publishes the container's `PORT` on. The bundled `Makefile` expects `7012`. |
 | `ANTHROPIC_API_KEY` | No (Yes for direct dispatch) | - | Used when `dispatchModel` matches `claude-*` / `anthropic/*` and no gateway is available. |
 | `OPENAI_API_KEY` | No | - | Used when `dispatchModel` matches `gpt-*` / `o1-*` / `o3-*` / `openai/*`. |

--- a/docs/reverse-proxy.md
+++ b/docs/reverse-proxy.md
@@ -1,11 +1,13 @@
 # Reverse proxy deployment
 
 Set the canonical URL and the address of the proxy that connects to Mission
-Control. Forwarded headers are ignored unless the nearest proxy appears as the
-right-most `X-Forwarded-For` hop.
+Control. `MC_TRUSTED_PROXY_HEADERS=1` is optional and should only be enabled
+when the backend is private and the runtime supplies a verified transport peer
+IP. An X-Forwarded-For value alone never proves proxy trust.
 
 ```env
 MC_PUBLIC_URL=https://mc.example.com
+MC_TRUSTED_PROXY_HEADERS=1
 MC_TRUSTED_PROXY_IPS=127.0.0.1
 MC_ALLOWED_HOSTS=mc.example.com,localhost,127.0.0.1
 MC_COOKIE_SECURE=1

--- a/docs/reverse-proxy.md
+++ b/docs/reverse-proxy.md
@@ -1,0 +1,73 @@
+# Reverse proxy deployment
+
+Set the canonical URL and the address of the proxy that connects to Mission
+Control. Forwarded headers are ignored unless the nearest proxy appears as the
+right-most `X-Forwarded-For` hop.
+
+```env
+MC_PUBLIC_URL=https://mc.example.com
+MC_TRUSTED_PROXY_IPS=127.0.0.1
+MC_ALLOWED_HOSTS=mc.example.com,localhost,127.0.0.1
+MC_COOKIE_SECURE=1
+```
+
+Configure the proxy to overwrite the forwarding headers and preserve streaming
+responses. The gateway WebSocket can be on `/gateway-ws`; set
+`NEXT_PUBLIC_GATEWAY_URL=wss://mc.example.com/gateway-ws` at image build time.
+
+## Nginx
+
+```nginx
+location / {
+  proxy_pass http://127.0.0.1:3000;
+  proxy_set_header Host $host;
+  proxy_set_header X-Forwarded-For $remote_addr;
+  proxy_set_header X-Forwarded-Proto $scheme;
+  proxy_set_header X-Forwarded-Port $server_port;
+  proxy_buffering off;
+}
+location /gateway-ws {
+  proxy_pass http://127.0.0.1:18789;
+  proxy_http_version 1.1;
+  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Connection "upgrade";
+  proxy_set_header Host $host;
+  proxy_read_timeout 86400;
+}
+```
+
+## Caddy
+
+```caddyfile
+mc.example.com {
+  reverse_proxy /gateway-ws 127.0.0.1:18789
+  reverse_proxy 127.0.0.1:3000 {
+    header_up Host {host}
+    header_up X-Forwarded-For {remote_host}
+    header_up X-Forwarded-Proto {scheme}
+    flush_interval -1
+  }
+}
+```
+
+## Traefik
+
+Use a secure entrypoint on `websecure`, a router for `mc.example.com`, and a
+second service for the gateway path. Enable the `headers` middleware with
+`customRequestHeaders` for `X-Forwarded-For`, `X-Forwarded-Proto`, and
+`X-Forwarded-Port`, replacing client supplied values at the edge.
+
+## Tailscale Serve
+
+```sh
+tailscale serve --https=443 http://127.0.0.1:3000
+```
+
+For a gateway on a separate path, configure a second Serve handler forwarding
+`/gateway-ws` to `http://127.0.0.1:18789` and set the explicit WebSocket URL
+above. Tailscale's local proxy address must be included in
+`MC_TRUSTED_PROXY_IPS` when forwarded origin headers are used.
+
+Subpath hosting (for example `/mission-control`) is not supported because
+Next.js static assets and API routes are rooted at `/`. Use a hostname or a
+dedicated proxy location instead.

--- a/docs/reverse-proxy.md
+++ b/docs/reverse-proxy.md
@@ -2,13 +2,15 @@
 
 Set the canonical URL and the address of the proxy that connects to Mission
 Control. `MC_TRUSTED_PROXY_HEADERS=1` is optional and should only be enabled
-when the backend is private and the runtime supplies a verified transport peer
-IP. An X-Forwarded-For value alone never proves proxy trust.
+when the backend is private and the proxy overwrites
+`X-Mission-Control-Proxy-Secret` with the matching server-side secret. A
+transport verified peer IP plus `MC_TRUSTED_PROXY_IPS` is also supported where
+the runtime provides it. An X-Forwarded-For value alone never proves trust.
 
 ```env
 MC_PUBLIC_URL=https://mc.example.com
 MC_TRUSTED_PROXY_HEADERS=1
-MC_TRUSTED_PROXY_IPS=127.0.0.1
+MC_PROXY_HEADER_SECRET=generate-a-long-random-secret
 MC_ALLOWED_HOSTS=mc.example.com,localhost,127.0.0.1
 MC_COOKIE_SECURE=1
 ```

--- a/docs/reverse-proxy.md
+++ b/docs/reverse-proxy.md
@@ -3,7 +3,10 @@
 Set the canonical URL and the address of the proxy that connects to Mission
 Control. `MC_TRUSTED_PROXY_HEADERS=1` is optional and should only be enabled
 when the backend is private and the proxy overwrites
-`X-Mission-Control-Proxy-Secret` with the matching server-side secret. A
+`X-Mission-Control-Proxy-Secret` with the matching server-side secret. The
+example below shows this only for Nginx; other proxies should use
+`MC_PUBLIC_URL` without header trust unless their secret injection is
+configured explicitly. A
 transport verified peer IP plus `MC_TRUSTED_PROXY_IPS` is also supported where
 the runtime provides it. An X-Forwarded-For value alone never proves trust.
 
@@ -22,12 +25,17 @@ responses. The gateway WebSocket can be on `/gateway-ws`; set
 ## Nginx
 
 ```nginx
+# Put this in the main Nginx context. Do not use $http_x_mission_control_proxy_secret:
+# that would forward a client-supplied value.
+env MC_PROXY_HEADER_SECRET;
+
 location / {
   proxy_pass http://127.0.0.1:3000;
   proxy_set_header Host $host;
   proxy_set_header X-Forwarded-For $remote_addr;
   proxy_set_header X-Forwarded-Proto $scheme;
   proxy_set_header X-Forwarded-Port $server_port;
+  proxy_set_header X-Mission-Control-Proxy-Secret $MC_PROXY_HEADER_SECRET;
   proxy_buffering off;
 }
 location /gateway-ws {
@@ -57,9 +65,10 @@ mc.example.com {
 ## Traefik
 
 Use a secure entrypoint on `websecure`, a router for `mc.example.com`, and a
-second service for the gateway path. Enable the `headers` middleware with
-`customRequestHeaders` for `X-Forwarded-For`, `X-Forwarded-Proto`, and
-`X-Forwarded-Port`, replacing client supplied values at the edge.
+second service for the gateway path. Use `MC_PUBLIC_URL` without enabling
+forwarded-header trust. If dynamic origins are required, configure a secret
+middleware that overwrites `X-Mission-Control-Proxy-Secret` from a server-side
+secret store; never copy the incoming client header.
 
 ## Tailscale Serve
 

--- a/src/lib/__tests__/public-origin.test.ts
+++ b/src/lib/__tests__/public-origin.test.ts
@@ -27,7 +27,8 @@ describe('public origin and proxy trust', () => {
     const request = new Request('http://internal:3000', { headers: { 'x-forwarded-proto': 'http', 'x-forwarded-host': 'evil.test' } })
     expect(configuredPublicOrigin()?.origin).toBe('https://control.example.test')
     expect(resolvePublicOrigin(request).origin).toBe('https://control.example.test')
-    expect(publicOriginHostCandidates(request)).toContain('control.example.test')
+    expect(publicOriginHostCandidates(request)).toEqual(['internal:3000'])
+    expect(publicOriginHostCandidates(request)).not.toContain('control.example.test')
   })
 
   it('does not treat the configured public URL as the observed host', () => {

--- a/src/lib/__tests__/public-origin.test.ts
+++ b/src/lib/__tests__/public-origin.test.ts
@@ -104,4 +104,24 @@ describe('public origin and proxy trust', () => {
     expect(isTrustedForwardedRequest(request)).toBe(false)
     expect(resolvePublicOrigin(request).origin).toBe('http://internal:3000')
   })
+
+  it('accepts dynamic forwarded origin with the explicit proxy secret', () => {
+    process.env.MC_TRUSTED_PROXY_HEADERS = '1'
+    process.env.MC_PROXY_HEADER_SECRET = 'correct-secret'
+    const request = new Request('http://internal:3000', {
+      headers: { 'x-mission-control-proxy-secret': 'correct-secret', 'x-forwarded-host': 'control.test', 'x-forwarded-proto': 'https' },
+    })
+    expect(resolvePublicOrigin(request).origin).toBe('https://control.test')
+  })
+
+  it('rejects missing or incorrect proxy secrets', () => {
+    process.env.MC_TRUSTED_PROXY_HEADERS = '1'
+    process.env.MC_PROXY_HEADER_SECRET = 'correct-secret'
+    for (const value of ['', 'wrong-secret']) {
+      const request = new Request('http://internal:3000', {
+        headers: { 'x-mission-control-proxy-secret': value, 'x-forwarded-host': 'evil.test', 'x-forwarded-proto': 'https' },
+      })
+      expect(resolvePublicOrigin(request).origin).toBe('http://internal:3000')
+    }
+  })
 })

--- a/src/lib/__tests__/public-origin.test.ts
+++ b/src/lib/__tests__/public-origin.test.ts
@@ -31,13 +31,14 @@ describe('public origin and proxy trust', () => {
   })
 
   it('accepts standardized and X-Forwarded values only for a trusted nearest proxy', () => {
+    process.env.MC_TRUSTED_PROXY_HEADERS = '1'
     process.env.MC_TRUSTED_PROXY_IPS = '10.0.0.2'
-    const request = new Request('http://internal:3000', {
+    const request = Object.assign(new Request('http://internal:3000', {
       headers: {
         'x-forwarded-for': '203.0.113.8, 10.0.0.2',
         forwarded: 'for=203.0.113.8;proto=https;host=control.example.test',
       },
-    })
+    }), { ip: '10.0.0.2' })
     expect(isTrustedForwardedRequest(request)).toBe(true)
     expect(resolvePublicOrigin(request).origin).toBe('https://control.example.test')
   })
@@ -56,15 +57,51 @@ describe('public origin and proxy trust', () => {
   })
 
   it('supports forwarded port for non-default public endpoints', () => {
+    process.env.MC_TRUSTED_PROXY_HEADERS = '1'
     process.env.MC_TRUSTED_PROXY_IPS = '127.0.0.1'
-    const request = new Request('http://127.0.0.1:3000', {
+    const request = Object.assign(new Request('http://127.0.0.1:3000', {
       headers: {
         'x-forwarded-for': '127.0.0.1',
         'x-forwarded-host': 'control.example.test',
         'x-forwarded-proto': 'https',
         'x-forwarded-port': '8443',
       },
-    })
+    }), { ip: '127.0.0.1' })
     expect(resolvePublicOrigin(request).origin).toBe('https://control.example.test:8443')
+  })
+
+  it('uses the nearest Forwarded element in a proxy chain', () => {
+    process.env.MC_TRUSTED_PROXY_HEADERS = '1'
+    process.env.MC_TRUSTED_PROXY_IPS = '10.0.0.2'
+    const request = Object.assign(new Request('http://internal:3000', {
+      headers: {
+        'x-forwarded-for': '203.0.113.8, 10.0.0.2',
+        forwarded: 'for=203.0.113.8;proto=http;host=spoof.example.test, for=10.0.0.2;proto=https;host=control.example.test',
+      },
+    }), { ip: '10.0.0.2' })
+    expect(resolvePublicOrigin(request).origin).toBe('https://control.example.test')
+  })
+
+  it('preserves IPv6 origins', () => {
+    process.env.MC_TRUSTED_PROXY_HEADERS = '1'
+    process.env.MC_TRUSTED_PROXY_IPS = '::1'
+    const request = Object.assign(new Request('http://[::1]:3000', {
+      headers: {
+        'x-forwarded-for': '::1',
+        'x-forwarded-host': '[2001:db8::10]',
+        'x-forwarded-proto': 'https',
+      },
+    }), { ip: '::1' })
+    expect(resolvePublicOrigin(request).origin).toBe('https://[2001:db8::10]')
+  })
+
+  it('rejects a trusted IP forged only in X-Forwarded-For without peer info', () => {
+    process.env.MC_TRUSTED_PROXY_HEADERS = '1'
+    process.env.MC_TRUSTED_PROXY_IPS = '10.0.0.2'
+    const request = new Request('http://internal:3000', {
+      headers: { 'x-forwarded-for': '10.0.0.2', 'x-forwarded-host': 'evil.test', 'x-forwarded-proto': 'https' },
+    })
+    expect(isTrustedForwardedRequest(request)).toBe(false)
+    expect(resolvePublicOrigin(request).origin).toBe('http://internal:3000')
   })
 })

--- a/src/lib/__tests__/public-origin.test.ts
+++ b/src/lib/__tests__/public-origin.test.ts
@@ -30,6 +30,18 @@ describe('public origin and proxy trust', () => {
     expect(publicOriginHostCandidates(request)).toContain('control.example.test')
   })
 
+  it('does not treat the configured public URL as the observed host', () => {
+    process.env.MC_PUBLIC_URL = 'https://mc.example.test'
+    const request = new Request('https://evil.example.test/login')
+    expect(publicOriginHostCandidates(request)).toEqual(['evil.example.test'])
+  })
+
+  it('accepts a direct request whose observed host matches the public URL', () => {
+    process.env.MC_PUBLIC_URL = 'https://mc.example.test'
+    const request = new Request('https://mc.example.test/login')
+    expect(publicOriginHostCandidates(request)).toEqual(['mc.example.test'])
+  })
+
   it('accepts standardized and X-Forwarded values only for a trusted nearest proxy', () => {
     process.env.MC_TRUSTED_PROXY_HEADERS = '1'
     process.env.MC_TRUSTED_PROXY_IPS = '10.0.0.2'
@@ -112,6 +124,7 @@ describe('public origin and proxy trust', () => {
       headers: { 'x-mission-control-proxy-secret': 'correct-secret', 'x-forwarded-host': 'control.test', 'x-forwarded-proto': 'https' },
     })
     expect(resolvePublicOrigin(request).origin).toBe('https://control.test')
+    expect(publicOriginHostCandidates(request)).toContain('control.test')
   })
 
   it('rejects missing or incorrect proxy secrets', () => {

--- a/src/lib/__tests__/public-origin.test.ts
+++ b/src/lib/__tests__/public-origin.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  configuredPublicOrigin,
+  isRequestSecureWithTrust,
+  isTrustedForwardedRequest,
+  publicOriginHostCandidates,
+  resolvePublicOrigin,
+} from '../public-origin'
+
+const originalEnv = { ...process.env }
+
+afterEach(() => {
+  process.env = { ...originalEnv }
+})
+
+describe('public origin and proxy trust', () => {
+  it('uses the direct request origin by default', () => {
+    delete process.env.MC_PUBLIC_URL
+    delete process.env.MC_TRUSTED_PROXY_IPS
+    const request = new Request('http://internal:3000/api/status')
+    expect(resolvePublicOrigin(request).origin).toBe('http://internal:3000')
+    expect(isRequestSecureWithTrust(request)).toBe(false)
+  })
+
+  it('uses an explicit public URL without trusting request headers', () => {
+    process.env.MC_PUBLIC_URL = 'https://control.example.test/base/'
+    const request = new Request('http://internal:3000', { headers: { 'x-forwarded-proto': 'http', 'x-forwarded-host': 'evil.test' } })
+    expect(configuredPublicOrigin()?.origin).toBe('https://control.example.test')
+    expect(resolvePublicOrigin(request).origin).toBe('https://control.example.test')
+    expect(publicOriginHostCandidates(request)).toContain('control.example.test')
+  })
+
+  it('accepts standardized and X-Forwarded values only for a trusted nearest proxy', () => {
+    process.env.MC_TRUSTED_PROXY_IPS = '10.0.0.2'
+    const request = new Request('http://internal:3000', {
+      headers: {
+        'x-forwarded-for': '203.0.113.8, 10.0.0.2',
+        forwarded: 'for=203.0.113.8;proto=https;host=control.example.test',
+      },
+    })
+    expect(isTrustedForwardedRequest(request)).toBe(true)
+    expect(resolvePublicOrigin(request).origin).toBe('https://control.example.test')
+  })
+
+  it('rejects spoofed forwarded headers when the nearest hop is untrusted', () => {
+    process.env.MC_TRUSTED_PROXY_IPS = '10.0.0.2'
+    const request = new Request('http://internal:3000', {
+      headers: {
+        'x-forwarded-for': '10.0.0.2, 198.51.100.7',
+        'x-forwarded-proto': 'https',
+        'x-forwarded-host': 'evil.example.test',
+      },
+    })
+    expect(isTrustedForwardedRequest(request)).toBe(false)
+    expect(resolvePublicOrigin(request).origin).toBe('http://internal:3000')
+  })
+
+  it('supports forwarded port for non-default public endpoints', () => {
+    process.env.MC_TRUSTED_PROXY_IPS = '127.0.0.1'
+    const request = new Request('http://127.0.0.1:3000', {
+      headers: {
+        'x-forwarded-for': '127.0.0.1',
+        'x-forwarded-host': 'control.example.test',
+        'x-forwarded-proto': 'https',
+        'x-forwarded-port': '8443',
+      },
+    })
+    expect(resolvePublicOrigin(request).origin).toBe('https://control.example.test:8443')
+  })
+})

--- a/src/lib/public-origin.ts
+++ b/src/lib/public-origin.ts
@@ -1,0 +1,115 @@
+/**
+ * Resolve the browser-visible origin of a request.
+ *
+ * Forwarded headers are untrusted input by default. They are considered only
+ * when MC_TRUSTED_PROXY_IPS (or the legacy MC_PROXY_AUTH_TRUSTED_IPS) is set
+ * and the right-most X-Forwarded-For hop identifies one of those proxies.
+ * Operators should configure their proxy to overwrite, rather than append to,
+ * the forwarding headers at the network boundary.
+ */
+
+export type PublicOrigin = { protocol: 'http:' | 'https:'; host: string; origin: string }
+
+function envList(...names: string[]): string[] {
+  for (const name of names) {
+    const value = String(process.env[name] || '').trim()
+    if (value) return value.split(',').map((item) => item.trim()).filter(Boolean)
+  }
+  return []
+}
+
+function normalizeHost(value: string): string {
+  return value.trim().replace(/^\[|\]$/g, '').replace(/\.$/, '').toLowerCase()
+}
+
+function matchesTrusted(value: string, trusted: string[]): boolean {
+  const normalized = normalizeHost(value)
+  return Boolean(normalized && trusted.some((candidate) => {
+    const pattern = normalizeHost(candidate)
+    if (!pattern) return false
+    if (pattern.endsWith('.*')) return normalized.startsWith(pattern.slice(0, -1))
+    return normalized === pattern
+  }))
+}
+
+function trustedForwardedRequest(request: Request): boolean {
+  const trusted = envList('MC_TRUSTED_PROXY_IPS', 'MC_PROXY_TRUSTED_IPS', 'MC_PROXY_AUTH_TRUSTED_IPS')
+  if (!trusted.length) return false
+  // NextRequest may expose the actual peer address. When available, require
+  // it to be trusted; this prevents a direct client from forging the XFF chain.
+  const peerIp = (request as Request & { ip?: string }).ip?.trim()
+  if (peerIp && !matchesTrusted(peerIp, trusted)) return false
+  const xff = request.headers.get('x-forwarded-for') || ''
+  const hops = xff.split(',').map((item) => item.trim()).filter(Boolean)
+  // The nearest proxy is the right-most XFF hop. A configured proxy must be
+  // present there before any forwarded origin data is used.
+  return hops.length > 0 && matchesTrusted(hops[hops.length - 1], trusted)
+}
+
+function firstForwardedValue(value: string | null): string {
+  return String(value || '').split(',')[0]?.trim() || ''
+}
+
+function forwardedHost(request: Request): string {
+  const forwarded = firstForwardedValue(request.headers.get('forwarded'))
+  const fromStandard = /(?:^|;)\s*host="?([^";]+)"?/i.exec(forwarded)?.[1] || ''
+  return fromStandard || firstForwardedValue(request.headers.get('x-forwarded-host'))
+}
+
+function forwardedParameter(request: Request, name: string): string {
+  const value = firstForwardedValue(request.headers.get('forwarded'))
+  return new RegExp(`(?:^|;)\\s*${name}="?([^";]+)"?`, 'i').exec(value)?.[1]?.trim() || ''
+}
+
+function parseOrigin(value: string): PublicOrigin | null {
+  try {
+    const parsed = new URL(value)
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null
+    if (!parsed.host || parsed.username || parsed.password) return null
+    return { protocol: parsed.protocol, host: parsed.host.toLowerCase(), origin: parsed.origin }
+  } catch {
+    return null
+  }
+}
+
+export function configuredPublicOrigin(): PublicOrigin | null {
+  return parseOrigin(
+    String(process.env.MC_PUBLIC_URL || process.env.MC_PUBLIC_BASE_URL || process.env.MISSION_CONTROL_PUBLIC_URL || '').trim(),
+  )
+}
+
+export function resolvePublicOrigin(request: Request): PublicOrigin {
+  const configured = configuredPublicOrigin()
+  if (configured) return configured
+
+  if (trustedForwardedRequest(request)) {
+    const host = forwardedHost(request)
+    const protocol = (forwardedParameter(request, 'proto') || firstForwardedValue(request.headers.get('x-forwarded-proto'))).toLowerCase()
+    if (host && (protocol === 'http' || protocol === 'https')) {
+      const port = forwardedParameter(request, 'port') || firstForwardedValue(request.headers.get('x-forwarded-port'))
+      const hostWithPort = port && !host.includes(':') && !host.endsWith(`:${port}`) ? `${host}:${port}` : host
+      const resolved = parseOrigin(`${protocol}://${hostWithPort}`)
+      if (resolved) return resolved
+    }
+  }
+
+  const direct = parseOrigin(request.url)
+  return direct || { protocol: 'http:', host: 'localhost', origin: 'http://localhost' }
+}
+
+export function isRequestSecureWithTrust(request: Request): boolean {
+  return resolvePublicOrigin(request).protocol === 'https:'
+}
+
+export function publicOriginHostCandidates(request: Request): string[] {
+  const result = new Set<string>()
+  const resolved = resolvePublicOrigin(request)
+  result.add(normalizeHost(resolved.host))
+  const direct = parseOrigin(request.url)
+  if (direct) result.add(normalizeHost(direct.host))
+  return [...result].filter(Boolean)
+}
+
+export function isTrustedForwardedRequest(request: Request): boolean {
+  return trustedForwardedRequest(request)
+}

--- a/src/lib/public-origin.ts
+++ b/src/lib/public-origin.ts
@@ -2,8 +2,8 @@
  * Resolve the browser-visible origin of a request.
  *
  * Forwarded headers are untrusted input by default. They are considered only
- * when MC_TRUSTED_PROXY_IPS (or the legacy MC_PROXY_AUTH_TRUSTED_IPS) is set
- * and the right-most X-Forwarded-For hop identifies one of those proxies.
+ * when MC_TRUSTED_PROXY_HEADERS=1 and MC_TRUSTED_PROXY_IPS is set. The
+ * transport adapter must also expose the actual peer IP (NextRequest.ip).
  * Operators should configure their proxy to overwrite, rather than append to,
  * the forwarding headers at the network boundary.
  */
@@ -22,6 +22,12 @@ function normalizeHost(value: string): string {
   return value.trim().replace(/^\[|\]$/g, '').replace(/\.$/, '').toLowerCase()
 }
 
+const MAX_HEADER_LENGTH = 4096
+
+function validHeader(value: string): boolean {
+  return value.length <= MAX_HEADER_LENGTH && !/[\u0000-\u001f\u007f]/.test(value)
+}
+
 function matchesTrusted(value: string, trusted: string[]): boolean {
   const normalized = normalizeHost(value)
   return Boolean(normalized && trusted.some((candidate) => {
@@ -33,13 +39,15 @@ function matchesTrusted(value: string, trusted: string[]): boolean {
 }
 
 function trustedForwardedRequest(request: Request): boolean {
-  const trusted = envList('MC_TRUSTED_PROXY_IPS', 'MC_PROXY_TRUSTED_IPS', 'MC_PROXY_AUTH_TRUSTED_IPS')
+  if (String(process.env.MC_TRUSTED_PROXY_HEADERS || '').trim().toLowerCase() !== '1') return false
+  const trusted = envList('MC_TRUSTED_PROXY_IPS', 'MC_PROXY_TRUSTED_IPS')
   if (!trusted.length) return false
   // NextRequest may expose the actual peer address. When available, require
   // it to be trusted; this prevents a direct client from forging the XFF chain.
   const peerIp = (request as Request & { ip?: string }).ip?.trim()
-  if (peerIp && !matchesTrusted(peerIp, trusted)) return false
+  if (!peerIp || !matchesTrusted(peerIp, trusted)) return false
   const xff = request.headers.get('x-forwarded-for') || ''
+  if (!validHeader(xff)) return false
   const hops = xff.split(',').map((item) => item.trim()).filter(Boolean)
   // The nearest proxy is the right-most XFF hop. A configured proxy must be
   // present there before any forwarded origin data is used.
@@ -50,18 +58,24 @@ function firstForwardedValue(value: string | null): string {
   return String(value || '').split(',')[0]?.trim() || ''
 }
 
+function nearestForwardedValue(value: string | null): string {
+  const values = String(value || '').split(',').map((item) => item.trim()).filter(Boolean)
+  return values[values.length - 1] || ''
+}
+
 function forwardedHost(request: Request): string {
-  const forwarded = firstForwardedValue(request.headers.get('forwarded'))
+  const forwarded = nearestForwardedValue(request.headers.get('forwarded'))
   const fromStandard = /(?:^|;)\s*host="?([^";]+)"?/i.exec(forwarded)?.[1] || ''
-  return fromStandard || firstForwardedValue(request.headers.get('x-forwarded-host'))
+  return fromStandard || nearestForwardedValue(request.headers.get('x-forwarded-host'))
 }
 
 function forwardedParameter(request: Request, name: string): string {
-  const value = firstForwardedValue(request.headers.get('forwarded'))
+  const value = nearestForwardedValue(request.headers.get('forwarded'))
   return new RegExp(`(?:^|;)\\s*${name}="?([^";]+)"?`, 'i').exec(value)?.[1]?.trim() || ''
 }
 
 function parseOrigin(value: string): PublicOrigin | null {
+  if (!validHeader(value)) return null
   try {
     const parsed = new URL(value)
     if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null
@@ -83,10 +97,19 @@ export function resolvePublicOrigin(request: Request): PublicOrigin {
   if (configured) return configured
 
   if (trustedForwardedRequest(request)) {
+    const forwardedHeader = request.headers.get('forwarded') || ''
+    const forwardedHostHeader = request.headers.get('x-forwarded-host') || ''
+    if (!validHeader(forwardedHeader) || !validHeader(forwardedHostHeader)) {
+      const direct = parseOrigin(request.url)
+      return direct || { protocol: 'http:', host: 'localhost', origin: 'http://localhost' }
+    }
     const host = forwardedHost(request)
-    const protocol = (forwardedParameter(request, 'proto') || firstForwardedValue(request.headers.get('x-forwarded-proto'))).toLowerCase()
+    const forwardedProto = request.headers.get('x-forwarded-proto') || ''
+    const forwardedPort = request.headers.get('x-forwarded-port') || ''
+    if (!validHeader(forwardedProto) || !validHeader(forwardedPort)) return parseOrigin(request.url) || { protocol: 'http:', host: 'localhost', origin: 'http://localhost' }
+    const protocol = (forwardedParameter(request, 'proto') || nearestForwardedValue(forwardedProto)).toLowerCase()
     if (host && (protocol === 'http' || protocol === 'https')) {
-      const port = forwardedParameter(request, 'port') || firstForwardedValue(request.headers.get('x-forwarded-port'))
+      const port = forwardedParameter(request, 'port') || nearestForwardedValue(forwardedPort)
       const hostWithPort = port && !host.includes(':') && !host.endsWith(`:${port}`) ? `${host}:${port}` : host
       const resolved = parseOrigin(`${protocol}://${hostWithPort}`)
       if (resolved) return resolved
@@ -103,10 +126,14 @@ export function isRequestSecureWithTrust(request: Request): boolean {
 
 export function publicOriginHostCandidates(request: Request): string[] {
   const result = new Set<string>()
-  const resolved = resolvePublicOrigin(request)
-  result.add(normalizeHost(resolved.host))
   const direct = parseOrigin(request.url)
-  if (direct) result.add(normalizeHost(direct.host))
+  // Do not expose the localhost fallback as a host candidate when a malformed
+  // test adapter or framework wrapper has no usable request URL.
+  if (direct) result.add(normalizeHost(resolvePublicOrigin(request).host))
+  else {
+    const configured = configuredPublicOrigin()
+    if (configured) result.add(normalizeHost(configured.host))
+  }
   return [...result].filter(Boolean)
 }
 

--- a/src/lib/public-origin.ts
+++ b/src/lib/public-origin.ts
@@ -18,14 +18,14 @@ function envList(...names: string[]): string[] {
   return []
 }
 
-function normalizeHost(value: string): string {
-  return value.trim().replace(/^\[|\]$/g, '').replace(/\.$/, '').toLowerCase()
+function normalizeHost(value: unknown): string {
+  return String(value || '').trim().replace(/^\[|\]$/g, '').replace(/\.$/, '').toLowerCase()
 }
 
 const MAX_HEADER_LENGTH = 4096
 
-function validHeader(value: string): boolean {
-  return value.length <= MAX_HEADER_LENGTH && !/[\u0000-\u001f\u007f]/.test(value)
+function validHeader(value: unknown): value is string {
+  return typeof value === 'string' && value.length <= MAX_HEADER_LENGTH && !/[\u0000-\u001f\u007f]/.test(value)
 }
 
 function matchesTrusted(value: string, trusted: string[]): boolean {
@@ -41,17 +41,29 @@ function matchesTrusted(value: string, trusted: string[]): boolean {
 function trustedForwardedRequest(request: Request): boolean {
   if (String(process.env.MC_TRUSTED_PROXY_HEADERS || '').trim().toLowerCase() !== '1') return false
   const trusted = envList('MC_TRUSTED_PROXY_IPS', 'MC_PROXY_TRUSTED_IPS')
-  if (!trusted.length) return false
+  const secret = String(process.env.MC_PROXY_HEADER_SECRET || '')
+  const suppliedSecret = request.headers?.get?.('x-mission-control-proxy-secret') || ''
+  const secretTrusted = Boolean(secret && constantTimeEqual(suppliedSecret, secret))
+  if (!trusted.length && !secretTrusted) return false
   // NextRequest may expose the actual peer address. When available, require
   // it to be trusted; this prevents a direct client from forging the XFF chain.
   const peerIp = (request as Request & { ip?: string }).ip?.trim()
-  if (!peerIp || !matchesTrusted(peerIp, trusted)) return false
+  if (!secretTrusted && (!peerIp || !matchesTrusted(peerIp, trusted))) return false
   const xff = request.headers.get('x-forwarded-for') || ''
   if (!validHeader(xff)) return false
   const hops = xff.split(',').map((item) => item.trim()).filter(Boolean)
   // The nearest proxy is the right-most XFF hop. A configured proxy must be
   // present there before any forwarded origin data is used.
-  return hops.length > 0 && matchesTrusted(hops[hops.length - 1], trusted)
+  return secretTrusted || (hops.length > 0 && matchesTrusted(hops[hops.length - 1], trusted))
+}
+
+function constantTimeEqual(a: string, b: string): boolean {
+  const left = new TextEncoder().encode(a)
+  const right = new TextEncoder().encode(b)
+  let diff = left.length ^ right.length
+  const length = Math.max(left.length, right.length)
+  for (let i = 0; i < length; i++) diff |= (left[i % (left.length || 1)] || 0) ^ (right[i % (right.length || 1)] || 0)
+  return diff === 0
 }
 
 function firstForwardedValue(value: string | null): string {
@@ -100,13 +112,13 @@ export function resolvePublicOrigin(request: Request): PublicOrigin {
     const forwardedHeader = request.headers.get('forwarded') || ''
     const forwardedHostHeader = request.headers.get('x-forwarded-host') || ''
     if (!validHeader(forwardedHeader) || !validHeader(forwardedHostHeader)) {
-      const direct = parseOrigin(request.url)
+      const direct = parseOrigin(request?.url)
       return direct || { protocol: 'http:', host: 'localhost', origin: 'http://localhost' }
     }
     const host = forwardedHost(request)
     const forwardedProto = request.headers.get('x-forwarded-proto') || ''
     const forwardedPort = request.headers.get('x-forwarded-port') || ''
-    if (!validHeader(forwardedProto) || !validHeader(forwardedPort)) return parseOrigin(request.url) || { protocol: 'http:', host: 'localhost', origin: 'http://localhost' }
+    if (!validHeader(forwardedProto) || !validHeader(forwardedPort)) return parseOrigin(request?.url) || { protocol: 'http:', host: 'localhost', origin: 'http://localhost' }
     const protocol = (forwardedParameter(request, 'proto') || nearestForwardedValue(forwardedProto)).toLowerCase()
     if (host && (protocol === 'http' || protocol === 'https')) {
       const port = forwardedParameter(request, 'port') || nearestForwardedValue(forwardedPort)
@@ -116,7 +128,7 @@ export function resolvePublicOrigin(request: Request): PublicOrigin {
     }
   }
 
-  const direct = parseOrigin(request.url)
+  const direct = parseOrigin(request?.url)
   return direct || { protocol: 'http:', host: 'localhost', origin: 'http://localhost' }
 }
 
@@ -126,7 +138,7 @@ export function isRequestSecureWithTrust(request: Request): boolean {
 
 export function publicOriginHostCandidates(request: Request): string[] {
   const result = new Set<string>()
-  const direct = parseOrigin(request.url)
+  const direct = parseOrigin(request?.url)
   // Do not expose the localhost fallback as a host candidate when a malformed
   // test adapter or framework wrapper has no usable request URL.
   if (direct) result.add(normalizeHost(resolvePublicOrigin(request).host))

--- a/src/lib/public-origin.ts
+++ b/src/lib/public-origin.ts
@@ -139,12 +139,12 @@ export function isRequestSecureWithTrust(request: Request): boolean {
 export function publicOriginHostCandidates(request: Request): string[] {
   const result = new Set<string>()
   const direct = parseOrigin(request?.url)
-  // Do not expose the localhost fallback as a host candidate when a malformed
-  // test adapter or framework wrapper has no usable request URL.
-  if (direct) result.add(normalizeHost(resolvePublicOrigin(request).host))
-  else {
-    const configured = configuredPublicOrigin()
-    if (configured) result.add(normalizeHost(configured.host))
+  // The configured public URL is deliberately not an observed host. Otherwise
+  // a direct request for evil.example would pass an allowlist for mc.example.
+  if (direct) result.add(normalizeHost(direct.host))
+  if (trustedForwardedRequest(request)) {
+    const forwarded = normalizeHost(forwardedHost(request))
+    if (forwarded) result.add(forwarded)
   }
   return [...result].filter(Boolean)
 }

--- a/src/lib/session-cookie.ts
+++ b/src/lib/session-cookie.ts
@@ -1,4 +1,5 @@
 import type { ResponseCookie } from 'next/dist/compiled/@edge-runtime/cookies'
+import { isRequestSecureWithTrust } from '@/lib/public-origin'
 
 export const MC_SESSION_COOKIE_NAME = '__Host-mc-session'
 export const LEGACY_MC_SESSION_COOKIE_NAME = 'mc-session'
@@ -9,8 +10,7 @@ export function getMcSessionCookieName(isSecureRequest: boolean): string {
 }
 
 export function isRequestSecure(request: Request): boolean {
-  return request.headers.get('x-forwarded-proto') === 'https'
-    || new URL(request.url).protocol === 'https:'
+  return isRequestSecureWithTrust(request)
 }
 
 export function parseMcSessionCookieHeader(cookieHeader: string): string | null {

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -217,4 +217,27 @@ describe('proxy host matching', () => {
     const response = proxy(request)
     expect(response.status).not.toBe(403)
   })
+
+  it('allows IPv6 loopback in production', async () => {
+    vi.resetModules()
+    vi.doMock('node:os', () => ({
+      default: { hostname: () => 'local-box' },
+      hostname: () => 'local-box',
+    }))
+
+    const { proxy } = await import('./proxy')
+    const request = {
+      headers: new Headers({ host: '[::1]:3000' }),
+      nextUrl: { host: '[::1]:3000', hostname: '::1', pathname: '/login', clone: () => ({ pathname: '/login' }) },
+      method: 'GET',
+      cookies: { get: () => undefined },
+    } as any
+
+    setNodeEnv('production')
+    delete process.env.MC_ALLOWED_HOSTS
+    delete process.env.MC_ALLOW_ANY_HOST
+
+    const response = proxy(request)
+    expect(response.status).not.toBe(403)
+  })
 })

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -23,7 +23,14 @@ function envFlag(name: string): boolean {
 }
 
 function normalizeHostname(raw: string): string {
-  return raw.trim().replace(/^\[|\]$/g, '').split(':')[0].replace(/\.$/, '').toLowerCase()
+  const value = raw.trim().toLowerCase().replace(/\.$/, '')
+  // Preserve IPv6 literals; only strip a port from bracketed or simple hosts.
+  if (value.startsWith('[')) {
+    const closingBracket = value.indexOf(']')
+    return closingBracket > 0 ? value.slice(1, closingBracket) : value
+  }
+  if ((value.match(/:/g) || []).length > 1) return value
+  return value.split(':')[0]
 }
 
 function getRequestHostCandidates(request: NextRequest): string[] {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,6 +4,7 @@ import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { buildMissionControlCsp, buildNonceRequestHeaders } from '@/lib/csp'
 import { MC_SESSION_COOKIE_NAME, LEGACY_MC_SESSION_COOKIE_NAME } from '@/lib/session-cookie'
+import { publicOriginHostCandidates } from '@/lib/public-origin'
 
 /** Constant-time string comparison using Node.js crypto. */
 function safeCompare(a: string, b: string): boolean {
@@ -25,22 +26,11 @@ function normalizeHostname(raw: string): string {
   return raw.trim().replace(/^\[|\]$/g, '').split(':')[0].replace(/\.$/, '').toLowerCase()
 }
 
-function parseForwardedHost(forwarded: string | null): string[] {
-  if (!forwarded) return []
-  const hosts: string[] = []
-  for (const part of forwarded.split(',')) {
-    const match = /(?:^|;)\s*host="?([^";]+)"?/i.exec(part)
-    if (match?.[1]) hosts.push(match[1])
-  }
-  return hosts
-}
-
 function getRequestHostCandidates(request: NextRequest): string[] {
+  // Forwarded values enter this list only after public-origin has verified an
+  // explicitly trusted proxy chain. Direct Host remains a valid candidate.
   const rawCandidates = [
-    ...(request.headers.get('x-forwarded-host') || '').split(','),
-    ...(request.headers.get('x-original-host') || '').split(','),
-    ...(request.headers.get('x-forwarded-server') || '').split(','),
-    ...parseForwardedHost(request.headers.get('forwarded')),
+    ...publicOriginHostCandidates(request),
     request.headers.get('host') || '',
     request.nextUrl.host || '',
     request.nextUrl.hostname || '',


### PR DESCRIPTION
## Problem

Mission Control is difficult to run behind a reverse proxy because public origin, forwarded headers, CSRF checks, and session-cookie behavior are handled inconsistently.

## What changed

- Add MC_PUBLIC_URL as the canonical public origin.
- Support forwarded origins only with explicit trusted-proxy configuration and a shared secret or verified peer IP.
- Use the closest forwarded value and validate hosts, ports, and IPv6 literals.
- Keep secure defaults and reject untrusted direct Host headers.
- Document nginx, Caddy, Traefik, and Tailscale setups.

## Validation

- 22 focused reverse-proxy and public-origin tests pass.
- git diff --check passes.

No merge or deployment is included.